### PR TITLE
SSO + onboarding + AI assistant + full generative lifecycle (v0.1.6)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.5"
+version = "0.1.6"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -330,6 +330,11 @@ export class ApiClient {
     return this.json<{ headline: string; risks: { level: string; text: string }[]; source: string; ai_enabled: boolean }>(
       `/projects/${pid}/ai/risk-summary`);
   }
+  /** Ask a natural-language question about the project; grounded on a live snapshot. */
+  aiAsk(pid: string, question: string) {
+    return this.json<{ answer: string; source: string; ai_enabled: boolean; snapshot?: unknown }>(
+      `/projects/${pid}/ai/ask`, { method: "POST", body: JSON.stringify({ question }) });
+  }
   login(username: string, password: string) {
     return this.json<{ token: string; username: string; role: string }>(
       "/auth/login", { method: "POST", body: JSON.stringify({ username, password }) });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -774,7 +774,7 @@ export interface MassingParams {
   far?: number; coverage_max?: number; front_setback?: number; rear_setback?: number;
   side_setback?: number; height_limit?: number | null; floor_to_floor?: number;
   efficiency?: number; avg_unit_m2?: number;
-  frame?: boolean; bay_m?: number; units?: boolean; envelope?: boolean; wwr?: number;
+  frame?: boolean; bay_m?: number; units?: boolean; envelope?: boolean; wwr?: number; core?: boolean;
   land_cost?: number; hard_cost_psf?: number; rent_per_unit_month?: number; rent_psf_year?: number;
   exit_cap?: number; ltc?: number; rate?: number;
 }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -339,7 +339,8 @@ export class ApiClient {
       "/auth/register", { method: "POST", body: JSON.stringify({ username, password }) });
   }
   me() {
-    return this.json<{ username: string; role: string | null; authenticated: boolean }>("/auth/me");
+    return this.json<{ username: string; role: string | null; authenticated: boolean;
+      tier?: string; features?: Record<string, boolean>; platform_admin?: boolean }>("/auth/me");
   }
   logout() {
     return this.json<{ ok: boolean }>("/auth/logout", { method: "POST" }).catch(() => ({ ok: false }));

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -774,6 +774,7 @@ export interface MassingParams {
   far?: number; coverage_max?: number; front_setback?: number; rear_setback?: number;
   side_setback?: number; height_limit?: number | null; floor_to_floor?: number;
   efficiency?: number; avg_unit_m2?: number;
+  frame?: boolean; bay_m?: number;
   land_cost?: number; hard_cost_psf?: number; rent_per_unit_month?: number; rent_psf_year?: number;
   exit_cap?: number; ltc?: number; rate?: number;
 }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -774,7 +774,7 @@ export interface MassingParams {
   far?: number; coverage_max?: number; front_setback?: number; rear_setback?: number;
   side_setback?: number; height_limit?: number | null; floor_to_floor?: number;
   efficiency?: number; avg_unit_m2?: number;
-  frame?: boolean; bay_m?: number; units?: boolean;
+  frame?: boolean; bay_m?: number; units?: boolean; envelope?: boolean; wwr?: number;
   land_cost?: number; hard_cost_psf?: number; rent_per_unit_month?: number; rent_psf_year?: number;
   exit_cap?: number; ltc?: number; rate?: number;
 }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -774,7 +774,7 @@ export interface MassingParams {
   far?: number; coverage_max?: number; front_setback?: number; rear_setback?: number;
   side_setback?: number; height_limit?: number | null; floor_to_floor?: number;
   efficiency?: number; avg_unit_m2?: number;
-  frame?: boolean; bay_m?: number;
+  frame?: boolean; bay_m?: number; units?: boolean;
   land_cost?: number; hard_cost_psf?: number; rent_per_unit_month?: number; rent_psf_year?: number;
   exit_cap?: number; ltc?: number; rate?: number;
 }

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -5,6 +5,7 @@ import { ProformaUI } from "./proforma/proforma";
 import { ApiClient } from "./api/client";
 import { toast } from "./ui/feedback";
 import { autoCheck, checkForUpdates, currentVersion } from "./ui/update";
+import { maybeWelcome, showWelcome } from "./ui/onboarding";
 import type { Settings, ViewerApp } from "./viewer/app";
 
 // ---- shell DOM + shared state (no three/@thatopen here — those load lazily) --
@@ -356,6 +357,20 @@ async function openPortfolioTab() {
 // tracked (those need the paid Autodesk bridge and convert to IFC/frag first), so a project is
 // only ever ".frag" (published tile), ".ifc" (source IFC on disk), or has no model yet.
 const MODEL_TAG: Record<string, string> = { frag: " (.frag)", ifc: " (.ifc)" };
+/** Onboarding quick-start actions, shared by the welcome modal and the empty state. */
+function onboardCtx() {
+  return {
+    connected,
+    newProject: () => void newProject(),
+    openSample: () => { setWorkspace("model"); withViewer((v) => void v.loadSample("/basichouse.frag", "BasicHouse")); },
+    generate: () => {
+      setWorkspace("finance");
+      // let the proforma render, then reveal the "Generate from zoning" panel
+      setTimeout(() => document.getElementById("pf-massing")?.scrollIntoView({ behavior: "smooth", block: "center" }), 400);
+    },
+  };
+}
+
 /** Create a blank project (no IFC) and switch to it — GC portal + proforma work immediately. */
 async function newProject() {
   const name = prompt("New project name:");
@@ -367,7 +382,7 @@ async function newProject() {
 function buildProjectPicker(projects: { id: string; name: string; model_kind?: string | null }[]) {
   if (projects.length) {
     const sel = document.createElement("select");
-    sel.className = "tool-btn"; sel.title = "Project";
+    sel.className = "tool-btn"; sel.title = "Project"; sel.dataset.tour = "projects";
     for (const p of projects) {
       const o = document.createElement("option");
       o.value = p.id;
@@ -382,6 +397,7 @@ function buildProjectPicker(projects: { id: string; name: string; model_kind?: s
   const add = document.createElement("button");
   add.className = "tool-btn"; add.style.marginLeft = "4px"; add.textContent = "＋ New"; add.title = "New project (no IFC needed)";
   add.onclick = () => void newProject();
+  if (!projects.length) add.dataset.tour = "projects";   // anchor the tour here when there's no picker yet
   toolbar.insertBefore(add, statusEl);
   if (!projects.length) return;   // nothing more to render (no current project to delete)
   // delete the current project (rows + geometry); confirm, then reload to the next one
@@ -462,13 +478,17 @@ function resetModal() {
 
 async function buildAuthControl() {
   const el = document.createElement("button");
-  el.className = "tool-btn"; el.style.marginLeft = "6px";
+  el.className = "tool-btn"; el.style.marginLeft = "6px"; el.dataset.tour = "account";
   if (api.authed) {
-    let name = "account", role: string | null = null;
-    try { const m = await api.me(); if (m.authenticated) { name = m.username; role = m.role; } else api.setToken(""); }
+    let name = "account", platformAdmin = false, tier = "free";
+    try {
+      const m = await api.me();
+      if (m.authenticated) { name = m.username; platformAdmin = !!m.platform_admin; tier = m.tier || "free"; }
+      else api.setToken("");
+    }
     catch { /* keep token; offline */ }
     el.textContent = `${name} ▾`; el.title = "Account";
-    el.onclick = () => accountMenu(el, role);
+    el.onclick = () => accountMenu(el, platformAdmin, tier);
   } else {
     el.textContent = "Sign in"; el.title = "Sign in";
     el.onclick = loginModal;
@@ -476,23 +496,30 @@ async function buildAuthControl() {
   toolbar.insertBefore(el, statusEl);
 }
 
-/** Small dropdown anchored to the account button: self-service + (for admins) user management. */
-function accountMenu(anchor: HTMLElement, role: string | null) {
+/** Small dropdown anchored to the account button: self-service + (for platform admins/ops) the
+ *  platform consoles. End users have no admin tier — they manage their own projects' members. */
+function accountMenu(anchor: HTMLElement, platformAdmin = false, tier = "free") {
   document.querySelector(".acct-menu")?.remove();
   const menu = document.createElement("div");
   menu.className = "acct-menu";
   const r = anchor.getBoundingClientRect();
   menu.style.cssText = `position:fixed;top:${r.bottom + 4}px;right:${window.innerWidth - r.right}px;z-index:200;`
     + "background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:5px;display:flex;flex-direction:column;min-width:160px";
+  // tier badge (everyone is Free today; the seam is ready for paid plans)
+  const badge = document.createElement("div");
+  badge.className = "meta";
+  badge.style.cssText = "padding:4px 8px;display:flex;justify-content:space-between;gap:8px;align-items:center";
+  badge.innerHTML = `<span>Plan</span><span style="text-transform:capitalize;color:var(--text)">${tier}</span>`;
+  menu.append(badge);
   const item = (label: string, fn: () => void) => {
     const b = document.createElement("button");
     b.className = "tool-btn"; b.textContent = label; b.style.cssText = "justify-content:flex-start;width:100%;text-align:left";
     b.onclick = () => { menu.remove(); fn(); };
     return b;
   };
-  if (role === "admin") menu.append(item("Manage users…", adminModal));
-  if (role === "admin") menu.append(item("Audit log…", auditModal));
-  if (role === "admin") menu.append(item("Data connections…", connectionsModal));
+  if (platformAdmin) menu.append(item("Manage users…", adminModal));
+  if (platformAdmin) menu.append(item("Audit log…", auditModal));
+  if (platformAdmin) menu.append(item("Data connections…", connectionsModal));
   if (isProjectAdmin && projectId) menu.append(item("Project members…", () => membersModal(projectId!)));
   menu.append(item("Settings…", settingsModal));
   menu.append(item("Change password…", passwordModal));
@@ -1127,6 +1154,13 @@ async function startup() {
     try { localMode = (await api.capabilities()).local_mode === true; } catch { /* default off */ }
     if (!localMode) void buildAuthControl();
   }
+  // Help (?) — relaunch the welcome / tour any time
+  const help = document.createElement("button");
+  help.className = "tool-btn"; help.style.marginLeft = "6px"; help.textContent = "?"; help.title = "Help & tour";
+  help.onclick = () => showWelcome(onboardCtx());
+  toolbar.insertBefore(help, statusEl);
+  // first run: welcome the user (skippable). Anchors must exist first, so defer a tick.
+  setTimeout(() => maybeWelcome(onboardCtx()), 600);
 }
 
 function initNav() {

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -114,6 +114,38 @@ export class PortalUI {
             + `<span>${r.text}</span></div>`).join("");
       }).catch(() => { risk.innerHTML = ""; });
 
+      // Ask AI — natural-language Q&A grounded on the live project snapshot
+      const ask = document.createElement("div"); ask.style.cssText = "margin:10px 0";
+      ask.innerHTML = `<div class="section-title">Ask AI</div>`;
+      const row = document.createElement("div"); row.style.cssText = "display:flex;gap:6px;margin:4px 0";
+      const input = document.createElement("input"); input.className = "portal-filter"; input.style.flex = "1";
+      input.placeholder = "Ask about this project — e.g. “what’s overdue?”, “open RFIs?”, “are we over budget?”";
+      const go = document.createElement("button"); go.className = "file-btn"; go.textContent = "Ask";
+      const out = document.createElement("div"); out.className = "meta"; out.style.cssText = "white-space:pre-wrap;margin-top:4px";
+      const run = async () => {
+        const q = input.value.trim(); if (!q) return;
+        out.textContent = "thinking…";
+        try {
+          const r = await this.host.api.aiAsk(pid, q);
+          let text = r.answer;
+          // graceful no-key/error path: surface the key snapshot numbers so it isn't a dead end
+          const snap = r.snapshot as { record_counts?: Record<string, number>; kpis?: Record<string, number> } | undefined;
+          if (r.source !== "claude" && snap) {
+            const k = snap.kpis || {}, c = snap.record_counts || {};
+            const line = (label: string, v: unknown) => (v ? `\n• ${label}: ${v}` : "");
+            text += line("Open RFIs", k.open_rfis) + line("Overdue", k.overdue)
+              + line("Pending change orders", k.pending_change_orders)
+              + line("Open punchlist", k.open_punchlist)
+              + line("RFIs (total)", c.rfi) + line("Change events", c.change_event);
+            if (!r.ai_enabled) text += "\n\n(Set an Anthropic API key in Settings for full plain-English answers.)";
+          }
+          out.textContent = text;
+        } catch { out.textContent = "Couldn’t reach the assistant."; }
+      };
+      go.onclick = () => void run();
+      input.onkeydown = (e) => { if (e.key === "Enter") void run(); };
+      row.append(input, go); ask.append(row, out); this.root.appendChild(ask);
+
       if (d.cost) {
         const cd = document.createElement("div"); cd.className = "meta";
         cd.style.margin = "6px 0";

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -146,6 +146,13 @@ export class ProformaUI {
     }
     host.appendChild(grid);
 
+    // structural frame option — turns the massing into a real concrete frame (columns + beams)
+    const frameWrap = document.createElement("label");
+    frameWrap.style.cssText = "display:flex;align-items:center;gap:6px;margin:4px 0;font-size:13px";
+    const frameChk = document.createElement("input"); frameChk.type = "checkbox";
+    frameWrap.append(frameChk, document.createTextNode("Generate concrete structural frame (columns + beams on a 7.5 m grid)"));
+    host.appendChild(frameWrap);
+
     const params = (): MassingParams => {
       const p: MassingParams = { use_type: useSel.value as "residential" | "commercial", name: "Massing Study" };
       for (const [, key] of fields) {
@@ -153,6 +160,7 @@ export class ProformaUI {
         if (key === "height_limit") { p.height_limit = isNaN(v) || v <= 0 ? null : v; }
         else if (!isNaN(v)) (p as Record<string, unknown>)[key] = v;
       }
+      p.frame = frameChk.checked;
       return p;
     };
     const out = document.createElement("div"); out.style.marginTop = "6px";

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -152,6 +152,11 @@ export class ProformaUI {
     const frameChk = document.createElement("input"); frameChk.type = "checkbox";
     frameWrap.append(frameChk, document.createTextNode("Generate concrete structural frame (columns + beams on a 7.5 m grid)"));
     host.appendChild(frameWrap);
+    const unitWrap = document.createElement("label");
+    unitWrap.style.cssText = "display:flex;align-items:center;gap:6px;margin:4px 0;font-size:13px";
+    const unitChk = document.createElement("input"); unitChk.type = "checkbox";
+    unitWrap.append(unitChk, document.createTextNode("Subdivide floors into units (per-apartment spaces)"));
+    host.appendChild(unitWrap);
 
     const params = (): MassingParams => {
       const p: MassingParams = { use_type: useSel.value as "residential" | "commercial", name: "Massing Study" };
@@ -161,6 +166,7 @@ export class ProformaUI {
         else if (!isNaN(v)) (p as Record<string, unknown>)[key] = v;
       }
       p.frame = frameChk.checked;
+      p.units = unitChk.checked;
       return p;
     };
     const out = document.createElement("div"); out.style.marginTop = "6px";

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -162,6 +162,11 @@ export class ProformaUI {
     const envChk = document.createElement("input"); envChk.type = "checkbox";
     envWrap.append(envChk, document.createTextNode("Wrap in facade + windows (envelope @ 40% WWR)"));
     host.appendChild(envWrap);
+    const coreWrap = document.createElement("label");
+    coreWrap.style.cssText = "display:flex;align-items:center;gap:6px;margin:4px 0;font-size:13px";
+    const coreChk = document.createElement("input"); coreChk.type = "checkbox";
+    coreWrap.append(coreChk, document.createTextNode("Add service core (elevator + stair + MEP risers)"));
+    host.appendChild(coreWrap);
 
     const params = (): MassingParams => {
       const p: MassingParams = { use_type: useSel.value as "residential" | "commercial", name: "Massing Study" };
@@ -173,6 +178,7 @@ export class ProformaUI {
       p.frame = frameChk.checked;
       p.units = unitChk.checked;
       p.envelope = envChk.checked;
+      p.core = coreChk.checked;
       return p;
     };
     const out = document.createElement("div"); out.style.marginTop = "6px";

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -157,6 +157,11 @@ export class ProformaUI {
     const unitChk = document.createElement("input"); unitChk.type = "checkbox";
     unitWrap.append(unitChk, document.createTextNode("Subdivide floors into units (per-apartment spaces)"));
     host.appendChild(unitWrap);
+    const envWrap = document.createElement("label");
+    envWrap.style.cssText = "display:flex;align-items:center;gap:6px;margin:4px 0;font-size:13px";
+    const envChk = document.createElement("input"); envChk.type = "checkbox";
+    envWrap.append(envChk, document.createTextNode("Wrap in facade + windows (envelope @ 40% WWR)"));
+    host.appendChild(envWrap);
 
     const params = (): MassingParams => {
       const p: MassingParams = { use_type: useSel.value as "residential" | "commercial", name: "Massing Study" };
@@ -167,6 +172,7 @@ export class ProformaUI {
       }
       p.frame = frameChk.checked;
       p.units = unitChk.checked;
+      p.envelope = envChk.checked;
       return p;
     };
     const out = document.createElement("div"); out.style.marginTop = "6px";

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -126,8 +126,8 @@ export class ProformaUI {
       ["Front setback (m)", "front_setback", 6, "any"], ["Rear setback (m)", "rear_setback", 6, "any"],
       ["Side setback (m)", "side_setback", 3, "any"], ["Height limit (m)", "height_limit", 0, "any"],
       ["Floor-to-floor (m)", "floor_to_floor", 3.5, "0.1"], ["Avg unit (m²)", "avg_unit_m2", 75, "any"],
-      ["Land cost $", "land_cost", 4_000_000, "any"], ["Hard $/sf", "hard_cost_psf", 225, "any"],
-      ["Rent $/unit·mo", "rent_per_unit_month", 2200, "any"], ["Exit cap", "exit_cap", 0.055, "0.005"],
+      ["Land cost $", "land_cost", 2_500_000, "any"], ["Hard $/sf", "hard_cost_psf", 225, "any"],
+      ["Rent $/unit·mo", "rent_per_unit_month", 3000, "any"], ["Exit cap", "exit_cap", 0.05, "0.005"],
     ];
     const grid = document.createElement("div"); grid.className = "pf-form";
     // use type selector

--- a/apps/web/src/ui/onboarding.ts
+++ b/apps/web/src/ui/onboarding.ts
@@ -1,0 +1,162 @@
+/**
+ * First-run onboarding: a welcome modal with quick-start paths, and a skippable coach-mark tour.
+ *
+ * Shown once (tracked in localStorage) — new users can skip everything and dive in, or take a
+ * ~60-second tour of the workspaces, Open menu, project switcher, tools rail and sign-in. Both
+ * the welcome and the tour are relaunchable from the Help (?) menu.
+ */
+const KEY = "aec-onboarded";
+
+export const onboardingDone = (): boolean => localStorage.getItem(KEY) === "1";
+export const markOnboarded = (): void => localStorage.setItem(KEY, "1");
+export const resetOnboarding = (): void => localStorage.removeItem(KEY);
+
+export interface OnboardCtx {
+  connected: boolean;
+  newProject: () => void;        // create a blank project (GC portal + proforma)
+  generate: () => void;          // Finance → generate a building from zoning
+  openSample: () => void;        // load a sample model in the viewer
+}
+
+/** Show the welcome modal on first run only. */
+export function maybeWelcome(ctx: OnboardCtx): void {
+  if (!onboardingDone()) showWelcome(ctx);
+}
+
+function backdrop(): HTMLDivElement {
+  const ov = document.createElement("div");
+  ov.style.cssText = "position:fixed;inset:0;z-index:300;background:#000b;display:flex;"
+    + "align-items:center;justify-content:center;padding:20px";
+  return ov;
+}
+
+/** The welcome dialog: three quick-start cards + Take the tour / Skip. */
+export function showWelcome(ctx: OnboardCtx): void {
+  document.querySelector(".ob-welcome")?.remove();
+  const ov = backdrop(); ov.className = "ob-welcome";
+  const card = document.createElement("div");
+  card.style.cssText = "background:var(--panel);border:1px solid var(--line);border-radius:14px;"
+    + "padding:26px;max-width:680px;width:100%;display:flex;flex-direction:column;gap:6px;box-shadow:0 18px 60px #000a";
+  card.innerHTML =
+    `<div style="font-size:22px;font-weight:650;letter-spacing:-.01em">Welcome to AEC BIM Platform 👋</div>`
+    + `<div class="meta" style="margin-bottom:14px">A BIM viewer, a general-contracting portal, and a development`
+    + ` proforma — one model, acquisition to turnover. Pick a starting point:</div>`;
+
+  const grid = document.createElement("div");
+  grid.style.cssText = "display:grid;grid-template-columns:repeat(3,1fr);gap:12px";
+  const tile = (icon: string, title: string, desc: string, onClick: () => void, enabled = true) => {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.style.cssText = "text-align:left;background:var(--panel2,#25272b);border:1px solid var(--line);"
+      + "border-radius:10px;padding:14px;display:flex;flex-direction:column;gap:6px;cursor:pointer;"
+      + "transition:border-color .12s,transform .12s;color:var(--text);min-height:128px";
+    b.innerHTML = `<div style="font-size:22px">${icon}</div>`
+      + `<div style="font-weight:600;font-size:14px">${title}</div>`
+      + `<div class="meta" style="font-size:12.5px">${desc}</div>`;
+    if (!enabled) { b.style.opacity = "0.5"; b.style.cursor = "not-allowed"; b.disabled = true; }
+    else {
+      b.onmouseenter = () => { b.style.borderColor = "var(--accent)"; b.style.transform = "translateY(-2px)"; };
+      b.onmouseleave = () => { b.style.borderColor = "var(--line)"; b.style.transform = "none"; };
+      b.onclick = () => { markOnboarded(); ov.remove(); onClick(); };
+    }
+    return b;
+  };
+  grid.append(
+    tile("🧊", "Explore a sample model", "Load a real building and try the viewer, tree, sections & measure.", ctx.openSample),
+    tile("🏗️", "Generate from zoning", "Turn a lot + FAR into a building model and an acquisition proforma.", ctx.generate, ctx.connected),
+    tile("📋", "Start a project", "RFIs, costs, schedule, dashboards — works with no model loaded.", ctx.newProject, ctx.connected),
+  );
+  card.append(grid);
+
+  if (!ctx.connected) {
+    const note = document.createElement("div");
+    note.className = "meta";
+    note.style.cssText = "margin-top:10px;font-size:12px";
+    note.textContent = "Backend not connected — the sample model works offline; connect the API to create projects.";
+    card.append(note);
+  }
+
+  const foot = document.createElement("div");
+  foot.style.cssText = "display:flex;gap:10px;justify-content:flex-end;align-items:center;margin-top:18px";
+  const skip = document.createElement("button");
+  skip.className = "tool-btn"; skip.textContent = "Skip for now";
+  skip.onclick = () => { markOnboarded(); ov.remove(); };
+  const tour = document.createElement("button");
+  tour.className = "file-btn"; tour.textContent = "Take a 60-second tour";
+  tour.onclick = () => { ov.remove(); startTour(); };
+  foot.append(skip, tour);
+  card.append(foot);
+
+  ov.append(card);
+  ov.addEventListener("pointerdown", (e) => { if (e.target === ov) { markOnboarded(); ov.remove(); } });
+  document.body.appendChild(ov);
+}
+
+// --- coach-mark tour ---------------------------------------------------------
+interface Step { sel: string; title: string; body: string; }
+
+const STEPS: Step[] = [
+  { sel: "#workspaces", title: "Three workspaces, one model",
+    body: "Switch between the 3D Model, the Construction portal (RFIs, costs, schedule), and Finance (development proforma). They all share the same project." },
+  { sel: "#open-menu", title: "Open a model",
+    body: "Load an IFC or Fragments file, try a bundled sample, or import a Revit file (via the paid bridge). IFC is the source of truth." },
+  { sel: "[data-tour=\"projects\"]", title: "Projects",
+    body: "Switch projects here, or ＋ New to start a blank one. The portal and proforma work even with no model loaded." },
+  { sel: "#rail", title: "Tools & analysis",
+    body: "Spatial tree, layers, issues/RFIs, and the Tools panel — exports, drawings, cost, energy, clash and authoring." },
+  { sel: "[data-tour=\"account\"]", title: "Sign in & your role",
+    body: "Sign in with Google, Microsoft or Procore. Pick your role (top-right) to tailor which tools show first." },
+];
+
+/** Run the skippable coach-mark tour. Steps whose target is missing are skipped gracefully. */
+export function startTour(): void {
+  document.querySelector(".ob-tour")?.remove();
+  const steps = STEPS.filter((s) => {
+    const el = document.querySelector(s.sel) as HTMLElement | null;
+    return el && el.offsetParent !== null;   // present + visible
+  });
+  if (!steps.length) { markOnboarded(); return; }
+
+  const ov = document.createElement("div");
+  ov.className = "ob-tour";
+  ov.style.cssText = "position:fixed;inset:0;z-index:300";
+  const spot = document.createElement("div");
+  spot.style.cssText = "position:fixed;border-radius:8px;box-shadow:0 0 0 9999px #000a;"
+    + "border:2px solid var(--accent);transition:all .2s ease;pointer-events:none";
+  const tip = document.createElement("div");
+  tip.style.cssText = "position:fixed;background:var(--panel);border:1px solid var(--line);border-radius:10px;"
+    + "padding:14px 16px;max-width:320px;box-shadow:0 12px 40px #000a;display:flex;flex-direction:column;gap:8px";
+  ov.append(spot, tip);
+  document.body.appendChild(ov);
+
+  let i = 0;
+  const finish = () => { markOnboarded(); ov.remove(); };
+  const render = () => {
+    const s = steps[i];
+    const el = document.querySelector(s.sel) as HTMLElement;
+    const r = el.getBoundingClientRect();
+    const pad = 6;
+    spot.style.left = `${r.left - pad}px`; spot.style.top = `${r.top - pad}px`;
+    spot.style.width = `${r.width + pad * 2}px`; spot.style.height = `${r.height + pad * 2}px`;
+    tip.innerHTML = `<div style="font-weight:650;font-size:14px">${s.title}</div>`
+      + `<div class="meta" style="font-size:13px;line-height:1.5">${s.body}</div>`;
+    const nav = document.createElement("div");
+    nav.style.cssText = "display:flex;justify-content:space-between;align-items:center;margin-top:4px";
+    const count = document.createElement("span");
+    count.className = "meta"; count.style.fontSize = "12px"; count.textContent = `${i + 1} / ${steps.length}`;
+    const btns = document.createElement("div"); btns.style.cssText = "display:flex;gap:6px";
+    const skip = document.createElement("button"); skip.className = "tool-btn"; skip.textContent = "Skip"; skip.onclick = finish;
+    const next = document.createElement("button"); next.className = "file-btn";
+    next.textContent = i === steps.length - 1 ? "Done" : "Next";
+    next.onclick = () => { if (i === steps.length - 1) finish(); else { i++; render(); } };
+    btns.append(skip, next); nav.append(count, btns); tip.append(nav);
+    // position the tooltip below the target, or above if it would overflow
+    const below = r.bottom + 12;
+    const tipTop = below + 160 > window.innerHeight ? Math.max(12, r.top - 12 - 160) : below;
+    tip.style.top = `${tipTop}px`;
+    tip.style.left = `${Math.min(Math.max(12, r.left), window.innerWidth - 340)}px`;
+  };
+  render();
+  ov.addEventListener("pointerdown", (e) => { if (e.target === ov) finish(); });
+  window.addEventListener("resize", render);
+}

--- a/docs/lifecycle-roadmap.md
+++ b/docs/lifecycle-roadmap.md
@@ -38,9 +38,13 @@ certificate:
 ### A. Design / modeling depth (biggest gap)
 The generated model is **massing-grade** (floor-plate spaces + slabs) plus whatever you author by
 hand. To carry a *real* tower to turnover it needs to be generated, not hand-placed:
-1. **Generative structural framing** — auto-frame every floor on a column grid (columns + perimeter
-   & interior beams + two-way slabs), sized from spans, not 3 hand-framed floors. *Make the massing
-   → structural model one click.*
+1. ✅ **DONE — Generative structural framing.** `generate_ifc(frame=True, bay=…)` auto-frames every
+   floor on a ~bay-metre column grid: columns at each grid intersection + beams along both axes,
+   GUID-stable and metre-scale. Exposed via the generate endpoint (`frame`, `bay_m`) and a
+   "Generate concrete structural frame" checkbox in the massing form — massing → structural model in
+   one click. Verified (test_massing: 175 columns + 290 beams on a 7×5 grid) and visually (a framed
+   tower renders columns/beams/slabs across all floors). *Next: size members from spans, two-way
+   slab bands, and a proper core (stairs/elevator shafts) instead of a single shear wall.*
 2. **Unit-layout generator** — subdivide each floor plate into real apartments (the corridor + unit
    mix the proforma already assumes), each an `IfcSpace` with the right area, so areas/COBie/rent are
    grounded in actual units rather than one plate-sized space per floor.

--- a/docs/lifecycle-roadmap.md
+++ b/docs/lifecycle-roadmap.md
@@ -90,13 +90,14 @@ hand. To carry a *real* tower to turnover it needs to be generated, not hand-pla
   register, completion certificate, final pay app.
 - **Warranty tracking** — start/expiry dates + reminders.
 
-### E. Cross-cutting consistency
-- **Module title-field inconsistency.** Modules use different required title fields — `subject`
-  (rfi/cor), `title` (submittal/as_built), `name` (om_manual/warranty/asset_register), `number`
-  (as_built), `system` (commissioning). Standardize on a primary title field (or add an alias the
-  create endpoint accepts) so integrations/scripts don't have to special-case each module.
-- **Safety TRIR/DART** reads as `None` until man-hours exist — auto-derive hours from timesheets +
-  manpower logs so the metric populates without separate entry.
+### E. Cross-cutting consistency ✅ DONE
+- ✅ **`subject` is now a universal title alias.** Modules name their title field differently
+  (`title`/`name`/`number`/`system`); `create_record` fills it from `subject` when absent, so
+  callers/scripts/integrations don't special-case each module. Verified (subject → om_manual `name`,
+  as_built `number`, commissioning `system`).
+- ✅ **Safety TRIR/DART auto-derives man-hours.** When `hours` isn't passed, hours = timesheet hours +
+  manpower-log (`count`/`headcount` × an 8h shift), so TRIR/DART populate from normal field logging.
+  Verified (20-crew log → 160 man-hours → TRIR computed).
 
 ## The artifact
 The end-to-end run saves the final model to **`samples/maple_tower.ifc`** — IFC4, metre-scale,

--- a/docs/lifecycle-roadmap.md
+++ b/docs/lifecycle-roadmap.md
@@ -45,9 +45,13 @@ hand. To carry a *real* tower to turnover it needs to be generated, not hand-pla
    one click. Verified (test_massing: 175 columns + 290 beams on a 7×5 grid) and visually (a framed
    tower renders columns/beams/slabs across all floors). *Next: size members from spans, two-way
    slab bands, and a proper core (stairs/elevator shafts) instead of a single shear wall.*
-2. **Unit-layout generator** — subdivide each floor plate into real apartments (the corridor + unit
-   mix the proforma already assumes), each an `IfcSpace` with the right area, so areas/COBie/rent are
-   grounded in actual units rather than one plate-sized space per floor.
+2. ✅ **DONE — Unit-layout generator.** `generate_ifc(units=True)` subdivides each floor into the
+   proforma's per-floor unit count — a grid of per-apartment `IfcSpace`s, each with a real
+   `Qto_SpaceBaseQuantities.NetFloorArea` and `Pset_SpaceCommon.Reference="UNIT"`, so areas / COBie /
+   rent are grounded in actual apartments instead of one plate-sized space. Endpoint `units` flag +
+   a "Subdivide floors into units" checkbox. Verified (test_massing: 65 unit spaces, 13/floor × 5
+   floors, each with area). *Next: a real double-loaded corridor + core carve-out, and a unit-mix
+   (studio/1BR/2BR) instead of uniform cells.*
 3. **Envelope** — curtain-wall / facade + windows per the WWR, so energy + elevations are real.
 4. **Core & MEP stubs** — stairs, elevator shafts, risers, and major equipment (`IfcSpace` zones +
    placeholder `IfcFlowTerminal`/`IfcDistributionElement`) so coordination/clash has something to do.

--- a/docs/lifecycle-roadmap.md
+++ b/docs/lifecycle-roadmap.md
@@ -64,11 +64,17 @@ hand. To carry a *real* tower to turnover it needs to be generated, not hand-pla
    service core" checkbox. Verified (test_massing: elevator/stair + duct/pipe risers + core walls per
    floor). *Next: connect risers floor-to-floor, add equipment (AHU/pumps), and zone the core.*
 
-### B. Estimating realism
-- Model-based estimate returns a tiny number on a massing model (sparse quantities). Until (A) lands,
-  **fall back to the proforma hard-cost / $-per-sf** when the model has < N structural elements, and
-  surface *which* source was used. Longer-term: **assembly-based estimating** (concrete m³ × $/m³,
-  formwork m², rebar tonnes) off the structural model from (A1).
+### B. Estimating realism ✅ DONE
+- **Assembly-based concrete takeoff.** The estimate now bills the superstructure by **volume**
+  (columns/beams/slabs × $/m³ in place), and `takeoff(force_geometry=True)` computes real area+volume
+  from geometry for every billable element (no cost map or Qto psets needed). On a framed tower the
+  model estimate jumped from a misleading **$5,400** (12 columns × count) to **~$906k** of actual
+  concrete (slabs/beams/columns).
+- **GFA benchmark + recommended source.** `estimate_from_takeoff(gfa_sf=…)` also returns a GFA × $/sf
+  benchmark and a `recommended` source ("model" vs "gfa") + `recommended_total`, so a sparse model
+  surfaces the honest underwriting number instead of a misleadingly tiny total. Verified live
+  (276 elements → $906k model takeoff, $8.0M GFA benchmark, recommends gfa). *Next: formwork m² +
+  rebar tonnes line items; finishes/MEP assemblies; per-CSI rollup into the budget module.*
 
 ### C. Construction depth
 - **Multi-period pay apps** — G702/G703 across draws (period N, retainage release), and **lien

--- a/docs/lifecycle-roadmap.md
+++ b/docs/lifecycle-roadmap.md
@@ -58,8 +58,11 @@ hand. To carry a *real* tower to turnover it needs to be generated, not hand-pla
    Endpoint `envelope`/`wwr` + a "Wrap in facade + windows" checkbox. Verified (test_massing: 20
    walls + 20 windows; energy WWR 0.36, UA 6318 W/K) and visually (the developed tower renders facade
    + ribbon windows). *Next: real curtain-wall mullions, punched vs. ribbon options, spandrel/shading.*
-4. **Core & MEP stubs** — stairs, elevator shafts, risers, and major equipment (`IfcSpace` zones +
-   placeholder `IfcFlowTerminal`/`IfcDistributionElement`) so coordination/clash has something to do.
+4. ✅ **DONE — Core & MEP stubs.** `generate_ifc(core=True)` adds a service core per floor — core
+   walls + an `IfcTransportElement` (ELEVATOR) + an `IfcStair` + `IfcDuctSegment`/`IfcPipeSegment`
+   risers — so coordination/clash and MEP counts have real elements. Endpoint `core` flag + an "Add
+   service core" checkbox. Verified (test_massing: elevator/stair + duct/pipe risers + core walls per
+   floor). *Next: connect risers floor-to-floor, add equipment (AHU/pumps), and zone the core.*
 
 ### B. Estimating realism
 - Model-based estimate returns a tiny number on a massing model (sparse quantities). Until (A) lands,

--- a/docs/lifecycle-roadmap.md
+++ b/docs/lifecycle-roadmap.md
@@ -52,7 +52,12 @@ hand. To carry a *real* tower to turnover it needs to be generated, not hand-pla
    a "Subdivide floors into units" checkbox. Verified (test_massing: 65 unit spaces, 13/floor × 5
    floors, each with area). *Next: a real double-loaded corridor + core carve-out, and a unit-mix
    (studio/1BR/2BR) instead of uniform cells.*
-3. **Envelope** — curtain-wall / facade + windows per the WWR, so energy + elevations are real.
+3. ✅ **DONE — Envelope.** `generate_ifc(envelope=True, wwr=…)` wraps each floor in perimeter
+   facade `IfcWall`s (IsExternal) + ribbon `IfcWindow`s at the window-to-wall ratio. The energy model
+   reads the real exterior-wall + glazing areas (UA, EUI, WWR) and elevations show an enclosure.
+   Endpoint `envelope`/`wwr` + a "Wrap in facade + windows" checkbox. Verified (test_massing: 20
+   walls + 20 windows; energy WWR 0.36, UA 6318 W/K) and visually (the developed tower renders facade
+   + ribbon windows). *Next: real curtain-wall mullions, punched vs. ribbon options, spandrel/shading.*
 4. **Core & MEP stubs** — stairs, elevator shafts, risers, and major equipment (`IfcSpace` zones +
    placeholder `IfcFlowTerminal`/`IfcDistributionElement`) so coordination/clash has something to do.
 

--- a/docs/lifecycle-roadmap.md
+++ b/docs/lifecycle-roadmap.md
@@ -77,18 +77,23 @@ hand. To carry a *real* tower to turnover it needs to be generated, not hand-pla
   rebar tonnes line items; finishes/MEP assemblies; per-CSI rollup into the budget module.*
 
 ### C. Construction depth
-- **Multi-period pay apps** — G702/G703 across draws (period N, retainage release), and **lien
-  waivers** auto-generated per pay app.
-- **Logs to PDF** — RFI log, submittal log, and the change-order log as printable registers.
-- **Field/mobile capture** — photo → daily report / punchlist with offline support (the Capacitor
-  scaffold exists). This is where GC adoption is won.
+- ✅ **DONE — Logs to PDF.** `GET /projects/{id}/modules/{key}/log.pdf` renders any module as a
+  printable register (RFI log, submittal log, change-order log, …) from the same engine —
+  ref/title/status/assignee. Verified (test_closeout).
+- **Multi-period pay apps** *(remaining)* — G702/G703 across draws (period N, retainage release) +
+  **lien waivers** auto-generated per pay app. (The single-period G702/G703 + SOV bridge already work;
+  this is the multi-draw accounting layer.)
+- **Field/mobile capture** *(remaining — separate app effort)* — photo → daily report / punchlist with
+  offline support (the Capacitor scaffold exists). Where GC adoption is won.
 
 ### D. Turnover completeness
-- **COBie should include the asset register + commissioning + warranty data**, not just spaces — the
-  closeout modules already capture it; wire it into the COBie export.
-- **Final completion package** — one ZIP: as-builts (IFC + drawings), O&M manuals, warranties, asset
-  register, completion certificate, final pay app.
-- **Warranty tracking** — start/expiry dates + reminders.
+- ✅ **DONE — Final completion package.** `GET /projects/{id}/closeout/package.zip` bundles the
+  as-built IFC, COBie / QTO / space-schedule workbooks, the status-report PDF, and a JSON manifest of
+  the closeout records (commissioning, O&M, warranties, as-builts, asset register, completion
+  certificate, punchlist). Verified (test_closeout: ZIP contents + manifest).
+- **COBie field enrichment** *(remaining)* — fold the asset register + commissioning + warranty data
+  into the COBie workbook tabs (today the package ships them as a separate manifest alongside COBie).
+- **Warranty tracking** *(remaining)* — start/expiry dates + reminders.
 
 ### E. Cross-cutting consistency ✅ DONE
 - ✅ **`subject` is now a universal title alias.** Modules name their title field differently

--- a/docs/lifecycle-roadmap.md
+++ b/docs/lifecycle-roadmap.md
@@ -1,0 +1,83 @@
+# Full-lifecycle roadmap — concrete residential tower, acquisition → turnover
+
+This doc is the output of an end-to-end drive (`services/api/e2e_tower.py`) that takes one project —
+a concrete-superstructure residential tower ("Maple Street Tower") — through **every** phase of the
+platform and records what works and what's missing. It's both a regression harness and the punch
+list for finishing the start-to-finish story.
+
+Run it against a live API: `python services/api/e2e_tower.py`. It prints PASS/FAIL per step and the
+final source-IFC path; the deliverable model is saved to `samples/maple_tower.ifc`.
+
+## What works today (verified end-to-end)
+The whole chain runs green — one project, one GUID-stable IFC, from a zoning envelope to a completion
+certificate:
+
+| Phase | Proven in the E2E |
+|---|---|
+| **0 · Acquisition / feasibility** | Zoning envelope → generative massing → **IFC model** (8 floors, 55 units) + acquisition **proforma** scenario (S&U, IRR, waterfall). |
+| **1 · Design** | Authored a real **concrete superstructure** onto the massing — 12 columns, 12 beams, 3 core shear walls — plus a **unit fit-out** (fridge/range/dishwasher/sink + sofa/table/bed), concrete material tag, published (reconvert + reindex). Metre-scale, GUID-stable, renders in the viewer. |
+| **2 · Preconstruction** | Model **takeoff → estimate**, **cost codes + budget + commitments**, **bid package → submissions → leveling → award**, **CPM schedule** (critical path). |
+| **3 · Construction** | **RFI** (submit→respond), **submittal**, full **change chain** (change event → PCO → COR submit→approve→execute), **daily report + manpower**, **inspection** (fail → NCR), **safety incident**, **SOV → G703/G702 pay app**, dashboard, AI ask. |
+| **4 · Turnover / closeout** | **Punchlist** (open→ready→**evidence-gated** verify), **commissioning** (test→accept), **O&M manual**, **warranty**, **as-built**, **asset register**, **completion certificate** (issue→accept), **COBie / QTO / space-schedule** exports, **status report PDF**. |
+
+## Bugs fixed while driving it
+- **Authoring path-length blow-up (Windows).** Each `/edit` derived the new IFC filename from the
+  *previous* versioned name, so chained edits compounded the stem (`source_<ts>_<ts>_…ifc`) until it
+  passed the 260-char limit and the write failed. Now each version is named off the original stem +
+  a microsecond stamp. *(This blocked any multi-edit authoring session — the single most important
+  fix here.)*
+- **web-ifc invisibility across all authoring recipes.** `IfcRectangleProfileDef` was created without
+  a `Position`; ifcopenshell tolerates that but web-ifc silently skips the element, so authored
+  walls/columns/beams/openings rendered invisible. Centralized a `_rect_profile()` helper that always
+  sets the placement (same fix already applied to massing + families).
+- (Earlier in the session: massing built in millimetres → 1000× too small; demo seed aborting on
+  missing required fields.)
+
+## Gaps to build out (prioritized) — to finish "start to finish for real"
+
+### A. Design / modeling depth (biggest gap)
+The generated model is **massing-grade** (floor-plate spaces + slabs) plus whatever you author by
+hand. To carry a *real* tower to turnover it needs to be generated, not hand-placed:
+1. **Generative structural framing** — auto-frame every floor on a column grid (columns + perimeter
+   & interior beams + two-way slabs), sized from spans, not 3 hand-framed floors. *Make the massing
+   → structural model one click.*
+2. **Unit-layout generator** — subdivide each floor plate into real apartments (the corridor + unit
+   mix the proforma already assumes), each an `IfcSpace` with the right area, so areas/COBie/rent are
+   grounded in actual units rather than one plate-sized space per floor.
+3. **Envelope** — curtain-wall / facade + windows per the WWR, so energy + elevations are real.
+4. **Core & MEP stubs** — stairs, elevator shafts, risers, and major equipment (`IfcSpace` zones +
+   placeholder `IfcFlowTerminal`/`IfcDistributionElement`) so coordination/clash has something to do.
+
+### B. Estimating realism
+- Model-based estimate returns a tiny number on a massing model (sparse quantities). Until (A) lands,
+  **fall back to the proforma hard-cost / $-per-sf** when the model has < N structural elements, and
+  surface *which* source was used. Longer-term: **assembly-based estimating** (concrete m³ × $/m³,
+  formwork m², rebar tonnes) off the structural model from (A1).
+
+### C. Construction depth
+- **Multi-period pay apps** — G702/G703 across draws (period N, retainage release), and **lien
+  waivers** auto-generated per pay app.
+- **Logs to PDF** — RFI log, submittal log, and the change-order log as printable registers.
+- **Field/mobile capture** — photo → daily report / punchlist with offline support (the Capacitor
+  scaffold exists). This is where GC adoption is won.
+
+### D. Turnover completeness
+- **COBie should include the asset register + commissioning + warranty data**, not just spaces — the
+  closeout modules already capture it; wire it into the COBie export.
+- **Final completion package** — one ZIP: as-builts (IFC + drawings), O&M manuals, warranties, asset
+  register, completion certificate, final pay app.
+- **Warranty tracking** — start/expiry dates + reminders.
+
+### E. Cross-cutting consistency
+- **Module title-field inconsistency.** Modules use different required title fields — `subject`
+  (rfi/cor), `title` (submittal/as_built), `name` (om_manual/warranty/asset_register), `number`
+  (as_built), `system` (commissioning). Standardize on a primary title field (or add an alias the
+  create endpoint accepts) so integrations/scripts don't have to special-case each module.
+- **Safety TRIR/DART** reads as `None` until man-hours exist — auto-derive hours from timesheets +
+  manpower logs so the metric populates without separate entry.
+
+## The artifact
+The end-to-end run saves the final model to **`samples/maple_tower.ifc`** — IFC4, metre-scale,
+GUID-stable: site → building → 8 storeys, each with a floor-plate space + slab; 12 concrete columns,
+12 beams and 3 core walls across the framed floors; and a Level-1 unit fit-out (appliances, sanitary,
+furniture). It opens in the viewer and round-trips through the converter to Fragments.

--- a/services/api/e2e_tower.py
+++ b/services/api/e2e_tower.py
@@ -1,0 +1,292 @@
+"""End-to-end lifecycle drive: a concrete-superstructure residential tower from acquisition all
+the way to turnover. Exercises every pillar over HTTP and reports PASS/FAIL/SKIP per step so gaps
+surface as a punch list. Resilient - a failing step never aborts the run.
+
+  python services/api/e2e_tower.py            # against http://localhost:8000
+
+Phases: 0 Acquisition/feasibility · 1 Design (authoring real concrete structure + unit fit-out) ·
+2 Preconstruction · 3 Construction · 4 Turnover/closeout. Prints the final source IFC path."""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.request
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--url", default="http://localhost:8000")
+ap.add_argument("--user", default="gc")
+opts = ap.parse_args()
+
+results: list[tuple[str, str, str, str]] = []   # phase, name, status, detail
+_phase = "0"
+
+
+def call(method: str, path: str, body=None, raw=False):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(opts.url + path, data=data, method=method,
+                                 headers={"Content-Type": "application/json", "X-User": opts.user})
+    with urllib.request.urlopen(req, timeout=300) as r:
+        b = r.read()
+        return b if raw else json.loads(b or "{}")
+
+
+def run(name: str, fn):
+    try:
+        out = fn()
+        results.append((_phase, name, "PASS", out if isinstance(out, str) else ""))
+        print(f"  PASS  {name}" + (f"  ->  {out}" if isinstance(out, str) else ""))
+        return out
+    except urllib.error.HTTPError as e:
+        detail = f"{e.code}: {e.read().decode()[:160]}"
+        results.append((_phase, name, "FAIL", detail))
+        print(f"  FAIL  {name}  ({detail})")
+    except Exception as e:                       # noqa: BLE001
+        results.append((_phase, name, "FAIL", str(e)[:180]))
+        print(f"  FAIL  {name}  ({str(e)[:180]})")
+    return None
+
+
+def phase(n: str, title: str):
+    global _phase
+    _phase = n
+    print(f"\n=== PHASE {n} - {title} ===")
+
+
+pid = None
+metrics = {}
+
+
+def new(mod, data, assignee=None):
+    body = {"data": data}
+    if assignee:
+        body["assignee"] = assignee
+    return call("POST", f"/projects/{pid}/modules/{mod}", body)["id"]
+
+
+def act(mod, rid, action):
+    call("POST", f"/projects/{pid}/modules/{mod}/{rid}/transition", {"action": action})
+
+
+def edit(recipe, params, publish=False):
+    return call("POST", f"/projects/{pid}/edit", {"recipe": recipe, "params": params, "publish": publish})
+
+
+def upload(mod, rid, filename="evidence.txt", content=b"verified on site"):
+    boundary = "----e2eboundary0xMaple"
+    body = (f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+            f"Content-Type: text/plain\r\n\r\n").encode() + content + f"\r\n--{boundary}--\r\n".encode()
+    req = urllib.request.Request(opts.url + f"/projects/{pid}/modules/{mod}/{rid}/attachments",
+                                 data=body, method="POST",
+                                 headers={"Content-Type": f"multipart/form-data; boundary={boundary}",
+                                          "X-User": opts.user})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read() or "{}")
+
+
+def wait_publish():
+    for _ in range(60):
+        s = call("GET", f"/projects/{pid}/publish/status")
+        if s.get("state") in ("done", "error"):
+            return s.get("state")
+        time.sleep(1)
+    return "timeout"
+
+
+# ============================================================================
+phase("0", "Acquisition / feasibility")
+pid = run("create project", lambda: call("POST", "/projects", {"name": "Maple Street Tower"})["id"])
+assert pid, "cannot continue without a project"
+
+
+def _gen():
+    global metrics
+    r = call("POST", f"/projects/{pid}/generate/massing", {
+        "name": "Maple Street Tower", "use_type": "residential",
+        "lot_width": 45, "lot_depth": 30, "far": 4.0, "height_limit": 60,
+        "floor_to_floor": 3.2, "coverage_max": 0.6, "avg_unit_m2": 80})
+    metrics = r["metrics"]
+    return f"{metrics['floors']} floors, {metrics['units']} units, {metrics['buildable_gfa_sf']:,} sf"
+
+
+run("generate massing from zoning (IFC + proforma)", _gen)
+run("  publish generated model", lambda: wait_publish())
+run("acquisition proforma scenario", lambda: call("POST", "/proforma/scenarios", {
+    "name": "Maple - acquisition", "project_id": pid, "assumptions": {
+        "timing": {"construction_months": 24, "leaseup_months": 6, "hold_years": 7},
+        "cost_lines": [{"category": "land", "name": "Land", "amount": 3_000_000, "curve": "upfront"},
+                       {"category": "hard", "name": "Hard", "amount": 28_000_000, "curve": "scurve"}],
+        "debt": {"ltc": 0.6, "rate": 0.075}, "equity": {"lp_pct": 0.9, "gp_pct": 0.1},
+        "operations": {"potential_rent_annual": 4_200_000, "opex_annual": 1_400_000, "stabilized_occ": 0.94},
+        "exit": {"exit_cap": 0.05, "selling_cost_pct": 0.02},
+        "waterfall": {"pref_rate": 0.08, "tiers": [{"hurdle": None, "lp": 0.8, "gp": 0.2}]}}})["id"])
+
+# ============================================================================
+phase("1", "Design - author concrete superstructure + unit fit-out")
+fw = float(metrics.get("plate_w", 30)); fd = float(metrics.get("plate_d", 18))
+hx, hy = fw / 2 - 1.0, fd / 2 - 1.0          # column grid inset 1 m from the plate edge
+corners = [(-hx, -hy), (hx, -hy), (hx, hy), (-hx, hy)]
+f2f = float(metrics.get("floor_to_floor", 3.2))
+floors_to_frame = min(3, int(metrics.get("floors", 1)))
+
+
+def _structure():
+    n = 0
+    for lvl in range(1, floors_to_frame + 1):
+        storey = f"Level {lvl}"
+        for (x, y) in corners:                # concrete columns
+            edit("add_column", {"point": [x, y], "height": f2f, "width": 0.6, "depth": 0.6, "storey": storey})
+            n += 1
+        for i in range(4):                    # perimeter beams
+            a, b = corners[i], corners[(i + 1) % 4]
+            edit("add_beam", {"start": list(a), "end": list(b), "width": 0.4, "depth": 0.6, "storey": storey})
+            n += 1
+        # central core shear wall
+        edit("add_wall", {"start": [-3, 0], "end": [3, 0], "height": f2f, "thickness": 0.3, "storey": storey})
+        n += 1
+    return f"{n} structural elements across {floors_to_frame} floors"
+
+
+run("author concrete structure (columns/beams/core)", _structure)
+
+
+def _fitout():
+    n = 0
+    for fam in ("fridge", "range", "dishwasher", "sink", "sofa", "table", "bed"):
+        edit("add_family", {"family": fam, "storey": "Level 1", "position": [2.0 + n, 2.0]})
+        n += 1
+    return f"{n} fixtures/furniture placed in a Level 1 unit"
+
+
+run("unit fit-out (appliances + furniture)", _fitout)
+run("set concrete material tag on columns", lambda: edit(
+    "set_pset", {"ifc_class": "IfcColumn", "pset": "Pset_ConcreteElementGeneral",
+                 "prop": "StrengthClass", "value": "C40/50"}) and "tagged")
+run("publish authored model (reconvert + reindex)", lambda: (edit("set_pset",
+    {"ifc_class": "IfcSlab", "pset": "Pset_SlabCommon", "prop": "LoadBearing", "value": True, "dtype": "bool"},
+    publish=True), wait_publish())[1])
+
+
+def _verify_render():
+    src = call("GET", f"/projects/{pid}")["source_ifc"]
+    return f"source_ifc set: {bool(src)}"
+
+
+run("verify model published", _verify_render)
+
+# ============================================================================
+phase("2", "Preconstruction - estimate, budget, bids, schedule")
+run("model takeoff -> estimate", lambda: f"${call('GET', f'/projects/{pid}/estimate/from-model')['total']:,.0f}")
+
+cc = run("cost code", lambda: new("cost_code", {"code": "03-3000", "description": "Cast-in-place concrete"}))
+run("budget line", lambda: new("budget", {"description": "Concrete superstructure", "amount": 12_000_000,
+                                          **({"cost_code": cc} if cc else {})}))
+run("commitment (subcontract value)", lambda: new("commitment", {"description": "Concrete sub", "amount": 11_200_000,
+                                                                  **({"cost_code": cc} if cc else {})}))
+bp = run("bid package", lambda: new("bid_package", {"name": "Concrete package", "trade": "Concrete", "budget": 12_000_000}))
+if bp:
+    for bidder, amt in [("ACME Concrete", 11_180_000), ("Bedrock", 11_650_000), ("PourPro", 12_010_000)]:
+        run(f"  bid: {bidder}", lambda bidder=bidder, amt=amt: new("bid_submission", {"bidder": bidder, "package": bp, "amount": amt}))
+    run("bid leveling", lambda: f"low ${call('GET', f'/projects/{pid}/bids/leveling')['packages'][0]['low']:,.0f}"
+        if call("GET", f"/projects/{pid}/bids/leveling").get("packages") else "no packages")
+    run("award bid package", lambda: act("bid_package", bp, "close") or "closed")
+
+acts = []
+for i, (nm, dur, pre) in enumerate([("Mobilize", 10, ""), ("Foundations", 30, "Mobilize"),
+                                    ("Superstructure", 90, "Foundations"), ("Envelope", 60, "Superstructure"),
+                                    ("Fit-out", 80, "Envelope"), ("Commissioning", 20, "Fit-out")]):
+    rid = run(f"schedule: {nm}", lambda nm=nm, dur=dur, pre=pre: new("schedule_activity",
+              {"name": nm, "duration": dur, "predecessors": pre}))
+    if rid:
+        acts.append(rid)
+run("CPM critical path", lambda: f"{call('GET', f'/projects/{pid}/schedule/cpm')['project_duration']} days, "
+    f"{call('GET', f'/projects/{pid}/schedule/cpm')['critical_count']} critical")
+
+# ============================================================================
+phase("3", "Construction - RFIs, submittals, changes, field, safety, pay app")
+rfi = run("RFI (submit -> respond)", lambda: new("rfi", {"subject": "Rebar congestion at core", "question": "Advise lap splice.",
+                                                        "discipline": "Structural"}, "consultant"))
+if rfi:
+    run("  RFI submit", lambda: act("rfi", rfi, "submit") or "open")
+    run("  RFI respond", lambda: act("rfi", rfi, "respond") or "answered")
+sub = run("submittal (concrete mix design)", lambda: new("submittal", {"title": "Concrete mix design",
+          "spec_section": "03 30 00"}, "sub"))
+if sub:
+    run("  submittal submit", lambda: act("submittal", sub, "submit") or "submitted")
+ce = run("change event", lambda: new("change_event", {"subject": "Added shear wall at L2"}, "pm"))
+pco = run("PCO request", lambda: new("pco_request", {"subject": "PCO - added shear wall",
+          "description": "Owner-directed shear wall", **({"change_event": ce} if ce else {})}, "owner"))
+cor = run("COR (submit -> approve -> execute)", lambda: new("cor", {"subject": "COR 001 - shear wall", "amount": 145_000,
+          **({"pco": pco} if pco else {})}))
+if cor:
+    run("  COR submit", lambda: act("cor", cor, "submit") or "submitted")
+    run("  COR approve", lambda: act("cor", cor, "approve") or "approved")
+    run("  COR execute", lambda: act("cor", cor, "execute") or "executed")
+dr = run("daily report", lambda: new("daily_report", {"report_date": "2026-07-15", "weather": "Clear"}))
+if dr:
+    run("  manpower log", lambda: new("manpower_log", {"company": "Concrete sub", "date": "2026-07-15", "count": 18,
+                                                       **({"daily_report": dr} if dr else {})}))
+insp = run("inspection (fail -> NCR)", lambda: new("inspection", {"subject": "L2 deck pre-pour", "date": "2026-07-15",
+                                                                 "result": "Fail"}, "qa"))
+if insp:
+    run("  inspection fail", lambda: act("inspection", insp, "fail") or "failed")
+    run("  NCR off inspection", lambda: new("ncr", {"subject": "Cover deficiency", "description": "Low rebar cover",
+        "severity": "Major", **({"inspection": insp} if insp else {})}, "sub"))
+run("safety incident", lambda: new("incident", {"subject": "Near miss - formwork", "date": "2026-07-16",
+                                                "classification": "Near Miss", "severity": "Near Miss"}, "safety"))
+run("safety metrics (TRIR/DART)", lambda: f"TRIR {call('GET', f'/projects/{pid}/safety/metrics').get('trir')}")
+# pay application from SOV
+sov = run("SOV line", lambda: new("sov", {"item_no": "01", "description": "Concrete superstructure",
+                                          "scheduled_value": 12_000_000, "completed_this": 3_000_000, "retainage_pct": 5}))
+run("G703 continuation sheet", lambda: f"${call('GET', f'/projects/{pid}/cost/g703')['totals']['scheduled']:,.0f}")
+run("G702 pay application", lambda: f"app current ${call('GET', f'/projects/{pid}/cost/g702?app_no=1')['current_payment_due']:,.0f}"
+    if "current_payment_due" in call("GET", f"/projects/{pid}/cost/g702?app_no=1") else "g702 ok")
+run("dashboard", lambda: f"{len(call('GET', f'/projects/{pid}/dashboard')['action_items'])} action items")
+run("AI ask (snapshot)", lambda: call("POST", f"/projects/{pid}/ai/ask", {"question": "what is open?"})["source"])
+
+# ============================================================================
+phase("4", "Turnover / closeout")
+pl = run("punchlist item (open -> ready -> verify)", lambda: new("punchlist", {"description": "Touch-up paint L1 lobby",
+                                                                             "location": "Lobby", "severity": "Minor"}))
+if pl:
+    run("  punch ready_to_inspect", lambda: act("punchlist", pl, "ready_to_inspect") or "ready")
+    run("  punch evidence photo", lambda: upload("punchlist", pl, "punch.txt", b"touch-up complete") and "attached")
+    run("  punch verify (evidence-gated)", lambda: act("punchlist", pl, "verify") or "verified")
+run("commissioning (test -> accept)", lambda: (lambda c: (act("commissioning", c, "test"),
+    act("commissioning", c, "accept"), "accepted")[2])(new("commissioning", {"system": "HVAC"})))
+run("O&M manual", lambda: new("om_manual", {"name": "HVAC O&M manual"}))
+run("warranty", lambda: new("warranty", {"name": "Roof warranty (10 yr)"}))
+run("as-built", lambda: new("as_built", {"number": "AB-001", "title": "Structural as-builts"}))
+run("asset register entry", lambda: new("asset_register", {"name": "Rooftop AHU-1"}))
+run("completion certificate (issue -> accept)", lambda: (lambda c: (act("completion_certificate", c, "issue"),
+    act("completion_certificate", c, "accept"), "accepted")[2])(new("completion_certificate", {"subject": "Substantial completion"})))
+run("COBie export", lambda: f"{len(call('GET', f'/projects/{pid}/exports/cobie.xlsx', raw=True)):,} bytes")
+run("QTO export", lambda: f"{len(call('GET', f'/projects/{pid}/exports/qto.xlsx', raw=True)):,} bytes")
+run("space schedule export", lambda: f"{len(call('GET', f'/projects/{pid}/exports/spaces.xlsx', raw=True)):,} bytes")
+run("project status report (PDF)", lambda: f"{len(call('GET', f'/projects/{pid}/report.pdf', raw=True)):,} bytes")
+
+# ============================================================================
+print("\n" + "=" * 70)
+src = None
+try:
+    src = call("GET", f"/projects/{pid}")["source_ifc"]
+except Exception:
+    pass
+by_phase: dict[str, list[int]] = {}
+for ph, _, status, _ in results:
+    b = by_phase.setdefault(ph, [0, 0])
+    b[0 if status == "PASS" else 1] += 1
+total_pass = sum(b[0] for b in by_phase.values())
+total_fail = sum(b[1] for b in by_phase.values())
+print(f"E2E TOWER - {total_pass} passed, {total_fail} failed across {len(by_phase)} phases")
+for ph in sorted(by_phase):
+    p, f = by_phase[ph]
+    print(f"  phase {ph}: {p} pass / {f} fail")
+if total_fail:
+    print("\nFAILURES:")
+    for ph, name, status, detail in results:
+        if status == "FAIL":
+            print(f"  [{ph}] {name}: {detail}")
+print(f"\nproject: {pid}")
+print(f"source_ifc: {src}")

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -19,7 +19,7 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_serving", "test_api",
-         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate"]
+         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso"]
 
 
 def main() -> int:

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -19,7 +19,7 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_serving", "test_api",
-         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso"]
+         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai"]
 
 
 def main() -> int:

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -19,7 +19,7 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_serving", "test_api",
-         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai"]
+         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout"]
 
 
 def main() -> int:

--- a/services/api/seed_demo.py
+++ b/services/api/seed_demo.py
@@ -87,9 +87,9 @@ new("cor", {"subject": "COR 001 — steel", "amount": 92_500, "justification": "
 new("proposal", {"subject": "Proposal — steel add", "amount": 92_500, "pco": pco})
 
 # --- QA / inspection chain ---------------------------------------------------
-insp = new("inspection", {"subject": "Level 2 deck pour", "location": "Grid C-E", "result": "Fail"}, "qa")
-new("ncr", {"subject": "Honeycomb at column", "description": "Voids on north face", "inspection": insp}, "sub")
-new("deficiency", {"description": "Cold joint", "location": "Grid D3", "inspection": insp})
+insp = new("inspection", {"subject": "Level 2 deck pour", "location": "Grid C-E", "result": "Fail", "date": "2026-06-14"}, "qa")
+new("ncr", {"subject": "Honeycomb at column", "description": "Voids on north face", "severity": "Major", "inspection": insp}, "sub")
+new("deficiency", {"description": "Cold joint", "location": "Grid D3", "severity": "Minor", "inspection": insp})
 
 # --- bidding chain -----------------------------------------------------------
 bp = new("bid_package", {"name": "Concrete package", "trade": "Concrete", "budget": 5_000_000})
@@ -103,6 +103,7 @@ for d, weather, crews in [("2026-06-13", "Clear", [12, 8]), ("2026-06-14", "Rain
         new("manpower_log", {"company": "Self-perform", "date": d, "count": c, "daily_report": dr})
 
 # --- safety ------------------------------------------------------------------
-new("incident", {"subject": "Near miss — dropped tool", "description": "No injury", "severity": "Low"}, "safety")
+new("incident", {"subject": "Near miss — dropped tool", "description": "No injury",
+                 "date": "2026-06-13", "classification": "Near Miss", "severity": "Near Miss"}, "safety")
 
 print("seed complete — open the Construction workspace to see populated dashboard / board / search")

--- a/services/api/src/aec_api/ai.py
+++ b/services/api/src/aec_api/ai.py
@@ -129,6 +129,40 @@ def risk_summary(kpis: dict[str, Any], cost: dict[str, Any] | None = None) -> di
         return _template_risks(kpis, cost)
 
 
+_ASK_SYSTEM = (
+    "You are an assistant embedded in an AEC project platform. Answer the user's question about "
+    "THIS project using only the supplied JSON snapshot (dashboard KPIs, cost, open items, model "
+    "metrics). Be concise and concrete — cite the numbers. If the snapshot doesn't contain the "
+    "answer, say so plainly and suggest where in the app to look. Never invent figures."
+)
+
+
+def ask(question: str, context: dict[str, Any]) -> dict[str, Any]:
+    """Natural-language Q&A grounded in a project snapshot. Uses Claude when configured; without a
+    key it returns the snapshot so the user still gets the underlying data (graceful degradation)."""
+    if not ai_enabled():
+        return {"answer": "The AI assistant isn't configured yet — set an Anthropic API key in "
+                          "Settings to ask questions in plain English. Meanwhile, here is the "
+                          "current project snapshot the assistant would use.",
+                "snapshot": context, "source": "disabled"}
+    try:
+        from anthropic import Anthropic  # lazy: only when a key is configured
+
+        client = Anthropic(api_key=settings_store.get("ANTHROPIC_API_KEY"))
+        msg = ("Project snapshot (JSON):\n" + json.dumps(context, default=str)
+               + f"\n\nQuestion: {question.strip()}\n\nAnswer using only this data.")
+        resp = client.messages.create(
+            model=settings_store.get("AEC_AI_MODEL", "claude-opus-4-8"), max_tokens=1024,
+            system=_ASK_SYSTEM, messages=[{"role": "user", "content": msg}],
+            output_config={"effort": "low"})
+        text = "".join(getattr(b, "text", "") for b in resp.content if getattr(b, "type", None) == "text")
+        return {"answer": text.strip(), "source": "claude"}
+    except Exception as e:           # noqa: BLE001 — never fail the request over an AI assist
+        _log.warning("AI ask failed (%s)", e)
+        return {"answer": "Couldn't reach the AI service just now. Here is the project snapshot.",
+                "snapshot": context, "source": "error"}
+
+
 def draft_rfi(element: dict[str, Any], note: str | None = None) -> dict[str, Any]:
     """Return {subject, question, discipline, suggested_priority, source}. Uses Claude when
     configured; on any error (or no key) returns a deterministic template draft."""

--- a/services/api/src/aec_api/entitlements.py
+++ b/services/api/src/aec_api/entitlements.py
@@ -1,0 +1,34 @@
+"""Subscription-tier entitlements — the single place that decides what a tier unlocks.
+
+Product decision (2026-06): **everyone is on the free tier** and the free tier has *every*
+feature. This module exists so the eventual paid tiers are a one-line change here (and a
+`tier` set on the User) rather than scattered `if` checks across the app. Today every gate
+returns True; flip individual features per tier when the paid plans launch.
+"""
+from __future__ import annotations
+
+TIERS = ("free", "pro", "enterprise")
+DEFAULT_TIER = "free"
+
+# Feature flags per tier. Free currently unlocks everything; the paid columns are placeholders
+# for when we differentiate (e.g. seat counts, private cloud storage, SSO enforcement, AI quota).
+_MATRIX: dict[str, dict[str, bool]] = {
+    "free":       {"viewer": True, "portal": True, "proforma": True, "generate": True,
+                   "connections": True, "ai": True, "private_cloud": True},
+    "pro":        {"viewer": True, "portal": True, "proforma": True, "generate": True,
+                   "connections": True, "ai": True, "private_cloud": True},
+    "enterprise": {"viewer": True, "portal": True, "proforma": True, "generate": True,
+                   "connections": True, "ai": True, "private_cloud": True},
+}
+
+
+def normalize(tier: str | None) -> str:
+    return tier if tier in TIERS else DEFAULT_TIER
+
+
+def features_for(tier: str | None) -> dict[str, bool]:
+    return dict(_MATRIX[normalize(tier)])
+
+
+def allows(tier: str | None, feature: str) -> bool:
+    return features_for(tier).get(feature, False)

--- a/services/api/src/aec_api/estimate.py
+++ b/services/api/src/aec_api/estimate.py
@@ -9,20 +9,31 @@ from typing import Any
 # metric (m², m³, m). Editable per project via `overrides` (class -> rate). Conceptual-grade.
 DEFAULT_RATES: dict[str, tuple[str, float]] = {
     "IfcWall": ("area", 160.0), "IfcWallStandardCase": ("area", 160.0),
-    "IfcSlab": ("area", 130.0), "IfcRoof": ("area", 210.0),
+    "IfcSlab": ("volume", 550.0), "IfcRoof": ("area", 210.0),
     "IfcCovering": ("area", 55.0), "IfcCurtainWall": ("area", 600.0),
-    "IfcColumn": ("count", 450.0), "IfcBeam": ("length", 90.0), "IfcMember": ("length", 70.0),
+    # concrete superstructure billed by volume ($/m³ in place, incl. formwork + rebar)
+    "IfcColumn": ("volume", 650.0), "IfcBeam": ("volume", 700.0), "IfcMember": ("volume", 600.0),
     "IfcDoor": ("count", 1200.0), "IfcWindow": ("count", 850.0),
     "IfcStair": ("count", 6000.0), "IfcRailing": ("length", 120.0),
     "IfcFooting": ("volume", 280.0), "IfcPile": ("count", 1500.0),
     "IfcPlate": ("area", 95.0), "IfcRamp": ("area", 180.0),
+    "IfcTransportElement": ("count", 85000.0),    # elevator
 }
 _UNIT_LABEL = {"area": "m²", "length": "m", "volume": "m³", "count": "ea"}
 
+M2_TO_SF = 10.7639
+DEFAULT_PSF = 220.0          # conceptual all-in $/sf benchmark (residential concrete) for the GFA floor
 
-def estimate_from_takeoff(rows: list[dict], overrides: dict[str, float] | None = None) -> dict[str, Any]:
+
+def estimate_from_takeoff(rows: list[dict], overrides: dict[str, float] | None = None,
+                          gfa_sf: float | None = None, psf: float = DEFAULT_PSF) -> dict[str, Any]:
     """rows: aec_data.qto.takeoff output (per-element: ifc_class, area, length, volume...).
-    Returns priced line items grouped by class + a grand total + any unpriced classes."""
+    Returns priced line items grouped by class + a grand total + any unpriced classes.
+
+    When `gfa_sf` is given, also returns a GFA-based benchmark (gfa_sf × $/sf) and a `recommended`
+    source: the model takeoff is only trustworthy once it has real structure, so if the model total
+    is implausibly low vs. the benchmark (or the model is sparse) we recommend the GFA figure and
+    flag it — surfacing *which* number to feed the budget/proforma rather than a misleading $0."""
     overrides = overrides or {}
     agg: dict[str, dict[str, float]] = {}
     for r in rows:
@@ -47,5 +58,15 @@ def estimate_from_takeoff(rows: list[dict], overrides: dict[str, float] | None =
                       "quantity": qty, "rate": rate, "amount": amount})
     lines.sort(key=lambda x: x["amount"], reverse=True)
     total = round(sum(x["amount"] for x in lines), 2)
-    return {"lines": lines, "total": total, "unpriced": unpriced,
-            "element_count": sum(int(a["count"]) for a in agg.values())}
+    element_count = sum(int(a["count"]) for a in agg.values())
+    out: dict[str, Any] = {"lines": lines, "total": total, "unpriced": unpriced,
+                           "element_count": element_count, "source": "model"}
+    if gfa_sf and gfa_sf > 0:
+        benchmark = round(gfa_sf * psf)
+        out["gfa_benchmark"] = {"gfa_sf": round(gfa_sf), "psf": psf, "amount": benchmark}
+        # trust the model takeoff only if it has structure AND lands within a sane band of the
+        # GFA benchmark; otherwise the GFA figure is the honest number to underwrite against.
+        trustworthy = element_count >= 10 and total >= 0.4 * benchmark
+        out["recommended"] = "model" if trustworthy else "gfa"
+        out["recommended_total"] = total if trustworthy else benchmark
+    return out

--- a/services/api/src/aec_api/models.py
+++ b/services/api/src/aec_api/models.py
@@ -83,6 +83,9 @@ class User(Base):
     # Deactivated accounts can't log in and their existing tokens stop authenticating.
     active: Mapped[bool | None] = mapped_column(Boolean, default=True)
     email: Mapped[str | None] = mapped_column(String, nullable=True)   # for digest emails
+    # subscription tier seam — everyone is "free" today; gating lives in entitlements.py so the
+    # paid tiers are a one-place change later. Nullable for the additive schema sync; NULL = free.
+    tier: Mapped[str | None] = mapped_column(String, default="free")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
 
 

--- a/services/api/src/aec_api/modules.py
+++ b/services/api/src/aec_api/modules.py
@@ -143,9 +143,14 @@ def create_record(db: Session, key: str, project_id: str, body: dict, actor: str
     mod = get_module(key)
     t = TABLES[key]
     data = body.get("data", {})
+    title_field = mod.get("title_field") or (mod["fields"][0]["name"] if mod.get("fields") else None)
+    # `subject` is a universal title alias: modules name their title field differently
+    # (title/name/number/system); if it's absent but `subject` was supplied, fill it — so callers,
+    # scripts and integrations don't have to special-case each module's field name.
+    if title_field and title_field != "subject" and not data.get(title_field) and data.get("subject"):
+        data[title_field] = data["subject"]
     _validate_fields(mod, data)
     rid = str(uuid.uuid4())
-    title_field = mod.get("title_field") or (mod["fields"][0]["name"] if mod.get("fields") else None)
     row = {
         "id": rid, "project_id": project_id,
         "ref": _next_ref(db, key, project_id, mod),

--- a/services/api/src/aec_api/report.py
+++ b/services/api/src/aec_api/report.py
@@ -107,3 +107,50 @@ def project_status_pdf(db: Session, pid: str, project_name: str) -> bytes:
     c.showPage()
     c.save()
     return buf.getvalue()
+
+
+def module_log_pdf(db: Session, pid: str, key: str, project_name: str) -> bytes:
+    """A printable register (log) of one module's records — ref, title, status, assignee, date.
+    Drives the RFI log, submittal log, change-order log, etc. from the same engine."""
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+
+    from . import modules as me
+
+    mod = me.get_module(key)
+    recs = me.list_records(db, key, pid, limit=100000)
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=letter)
+    w, h = letter
+    margin = 40
+    y = h - 50
+    cols = [(margin, "Ref"), (margin + 80, "Title"), (w - 200, "Status"), (w - 110, "Assignee")]
+
+    def header_row():
+        nonlocal y
+        c.setFont("Helvetica-Bold", 9)
+        for x, label in cols:
+            c.drawString(x, y, label)
+        y -= 4
+        c.setStrokeColor(colors.grey); c.line(margin, y, w - margin, y); c.setStrokeColor(colors.black)
+        y -= 14
+
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(margin, y, f"{mod.get('title', key)} Log"); y -= 20
+    c.setFont("Helvetica", 10); c.drawString(margin, y, project_name or pid)
+    c.drawRightString(w - margin, y, f"{len(recs)} records"); y -= 16
+    header_row()
+    c.setFont("Helvetica", 9)
+    for r in recs:
+        if y < 50:
+            c.showPage(); y = h - 50; header_row(); c.setFont("Helvetica", 9)
+        c.drawString(cols[0][0], y, str(r.get("ref") or "")[:11])
+        c.drawString(cols[1][0], y, str(r.get("title") or "")[:62])
+        c.drawString(cols[2][0], y, str(r.get("workflow_state") or "")[:14])
+        c.drawString(cols[3][0], y, str(r.get("assignee") or "")[:14])
+        y -= 14
+    c.setFont("Helvetica-Oblique", 8)
+    c.drawString(margin, 30, "AEC BIM Platform — generated from live project data")
+    c.showPage(); c.save()
+    return buf.getvalue()

--- a/services/api/src/aec_api/routers/auth.py
+++ b/services/api/src/aec_api/routers/auth.py
@@ -20,15 +20,34 @@ from ..rbac import current_user
 router = APIRouter()
 
 
+def _platform_admin_emails() -> set[str]:
+    """Ops-controlled platform admins for the cloud build (no in-app admin tier for end users).
+    Set AEC_ADMIN_EMAILS to a comma-separated list of usernames/emails who may touch platform
+    Settings / audit. Lower-cased for case-insensitive match."""
+    raw = os.environ.get("AEC_ADMIN_EMAILS", "")
+    return {e.strip().lower() for e in raw.split(",") if e.strip()}
+
+
+def _is_platform_admin(u: User | None) -> bool:
+    """A user is a platform admin if listed in AEC_ADMIN_EMAILS, or (back-compat) carries the
+    legacy global `admin` role. Regular SSO users are never platform admins."""
+    if u is None:
+        return False
+    allow = _platform_admin_emails()
+    if (u.username or "").lower() in allow or (u.email or "").lower() in allow:
+        return True
+    return u.role == "admin"
+
+
 def require_admin_user(db: Session = Depends(get_db), user: str = Depends(current_user)) -> User:
-    """Gate user-management endpoints on a global admin account (independent of AEC_RBAC,
-    which governs per-project routes). In single-operator local mode there is no login — the
-    local user is implicitly the owner/admin, so admin features open without an account."""
+    """Gate platform settings / audit / user-management. The cloud product has **no admin tier
+    for end users** — these are ops endpoints: open in single-operator local mode, otherwise
+    allowed for AEC_ADMIN_EMAILS (or a legacy `admin` account for back-compat)."""
     if rbac.LOCAL_MODE:
         return User(username="local", password_hash="", role="admin", active=True)
     u = db.get(User, user)
-    if not u or u.role != "admin":
-        raise HTTPException(403, "an admin account is required")
+    if not _is_platform_admin(u):
+        raise HTTPException(403, "platform-admin access required (set AEC_ADMIN_EMAILS)")
     return u
 
 
@@ -115,7 +134,7 @@ def oauth_login(provider: str, request: Request):
 def oauth_callback(provider: str, request: Request, code: str | None = None,
                    state: str | None = None, db: Session = Depends(get_db)):
     """Exchange the code, map the verified email to an account, mint the session, and return
-    to the app. First SSO account bootstraps as admin (same rule as /auth/register)."""
+    to the app. SSO accounts are always plain free-tier users (no admin tier for end users)."""
     if not oauth.is_enabled(provider):
         raise HTTPException(404, f"{provider} sign-in is not configured")
     if not code or auth.verify_oauth_state(state or "") != provider:
@@ -130,9 +149,10 @@ def oauth_callback(provider: str, request: Request, code: str | None = None,
 
     u = db.get(User, email)
     if u is None:
-        bootstrap = db.query(User).count() == 0
+        # SSO accounts are always plain users — no admin tier for end users. Platform admins are
+        # ops, set via AEC_ADMIN_EMAILS. Free tier by default (entitlements seam).
         u = User(username=email, password_hash="oauth!" + provider,  # unusable for password login
-                 role="admin" if bootstrap else "user", email=email)
+                 role="user", email=email, tier="free")
         db.add(u)
     elif not u.email:
         u.email = email
@@ -148,8 +168,12 @@ def oauth_callback(provider: str, request: Request, code: str | None = None,
 
 @router.get("/auth/me")
 def me(db: Session = Depends(get_db), user: str = Depends(current_user)):
+    from .. import entitlements
     u = db.get(User, user)
-    return {"username": user, "role": (u.role if u else None), "authenticated": u is not None}
+    tier = entitlements.normalize(u.tier if u else None)
+    return {"username": user, "role": (u.role if u else None), "authenticated": u is not None,
+            "tier": tier, "features": entitlements.features_for(tier),
+            "platform_admin": _is_platform_admin(u)}
 
 
 # --- self-service -------------------------------------------------------------

--- a/services/api/src/aec_api/routers/authoring.py
+++ b/services/api/src/aec_api/routers/authoring.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -75,8 +76,12 @@ def edit(pid: str, recipe: str = Body(...), params: dict = Body(default={}),
     from aec_data import edit as ed  # type: ignore
 
     p = _project(db, pid)
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    out = str(Path(p.source_ifc).with_name(f"{Path(p.source_ifc).stem}_{stamp}.ifc"))
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
+    # Strip any prior version timestamp(s) so chained edits don't compound the filename into an
+    # ever-growing path (which blew past Windows' 260-char limit and failed the write). Each edit
+    # produces "<base>_<stamp>.ifc" off the ORIGINAL stem, not the previous versioned name.
+    base_stem = re.sub(r"(_\d{14,20})+$", "", Path(p.source_ifc).stem)
+    out = str(Path(p.source_ifc).with_name(f"{base_stem}_{stamp}.ifc"))
     result = ed.apply_recipe(p.source_ifc, recipe, params, out)
     p.source_ifc = out  # new version becomes the source of truth
     audit.record(db, action="ifc.edit", actor=actor, method="POST",

--- a/services/api/src/aec_api/routers/cost.py
+++ b/services/api/src/aec_api/routers/cost.py
@@ -40,9 +40,19 @@ def estimate_from_model(pid: str, db: Session = Depends(get_db), _: str = Depend
     class + a grand total (feeds the budget / proforma hard cost). 409 if no source IFC."""
     from ..deps import source_ifc_path
     from aec_data.qto import takeoff_file  # type: ignore
+    from aec_data.ifc_loader import open_model  # type: ignore
+    from aec_data import spaces as sp  # type: ignore
     from .. import estimate as est
-    rows = takeoff_file(source_ifc_path(db, pid))     # quantities only (no cost map needed)
-    return est.estimate_from_takeoff(rows)
+    path = source_ifc_path(db, pid)
+    rows = takeoff_file(path, force_geometry=True)    # real geometry quantities (no cost map needed)
+    # GFA (sf) from the model's spaces → a benchmark floor so a sparse model doesn't return a
+    # misleadingly tiny number; the response flags which source to trust.
+    try:
+        net_m2 = sum(r.get("net_area") or 0 for r in sp.space_schedule(open_model(path)))
+        gfa_sf = net_m2 * est.M2_TO_SF
+    except Exception:                                 # noqa: BLE001 — benchmark is best-effort
+        gfa_sf = None
+    return est.estimate_from_takeoff(rows, gfa_sf=gfa_sf)
 
 
 @router.post("/projects/{pid}/cost/tm")

--- a/services/api/src/aec_api/routers/dashboard.py
+++ b/services/api/src/aec_api/routers/dashboard.py
@@ -105,6 +105,50 @@ def risk_summary(pid: str, db: Session = Depends(get_db), _: str = Depends(requi
     return {**ai.risk_summary(d.get("kpis", {}), d.get("cost")), "ai_enabled": ai.ai_enabled()}
 
 
+_ASK_COUNT_MODULES = ("rfi", "submittal", "change_event", "pco_request", "cor", "punchlist",
+                      "ncr", "deficiency", "inspection", "incident", "daily_report", "commitment")
+
+
+def _ask_context(db: Session, pid: str) -> dict:
+    """A compact, token-bounded snapshot of the project for grounding the AI assistant: dashboard
+    KPIs + cost, per-module record counts, and a sample of open RFIs/change events."""
+    d = dashboard.build(db, pid, "GC")
+    ctx: dict = {"kpis": d.get("kpis", {}), "cost": d.get("cost")}
+    counts: dict[str, int] = {}
+    for m in _ASK_COUNT_MODULES:
+        if m in me.TABLES:
+            try:
+                counts[m] = len(me.list_records(db, m, pid, limit=1_000_000))
+            except Exception:        # noqa: BLE001 — a missing/odd module never breaks the snapshot
+                pass
+    ctx["record_counts"] = counts
+    def _sample(mod: str, n: int = 15) -> list[dict]:
+        if mod not in me.TABLES:
+            return []
+        out = []
+        for r in me.list_records(db, mod, pid, limit=n):
+            data = r.get("data") or {}
+            out.append({"ref": r.get("ref"), "title": data.get("subject") or r.get("title"),
+                        "status": r.get("workflow_state")})
+        return out
+    ctx["open_rfis"] = _sample("rfi")
+    ctx["change_events"] = _sample("change_event")
+    return ctx
+
+
+@router.post("/projects/{pid}/ai/ask")
+def ai_ask(pid: str, body: dict, db: Session = Depends(get_db),
+           _: str = Depends(require_role("viewer"))):
+    """Ask a natural-language question about the project; answered (by Claude when configured)
+    against a live snapshot of KPIs, costs and open items. Degrades to returning the snapshot."""
+    from fastapi import HTTPException
+    question = (body or {}).get("question", "").strip()
+    if not question:
+        raise HTTPException(422, "question is required")
+    ctx = _ask_context(db, pid)
+    return {**ai.ask(question, ctx), "ai_enabled": ai.ai_enabled()}
+
+
 @router.get("/projects/{pid}/report.pdf")
 def status_report(pid: str, db: Session = Depends(get_db), _: str = Depends(require_role("viewer"))):
     """One-page project status report (KPIs, cost, open items by module, ball-in-court) as a PDF."""

--- a/services/api/src/aec_api/routers/dashboard.py
+++ b/services/api/src/aec_api/routers/dashboard.py
@@ -76,9 +76,15 @@ def safety_metrics(pid: str, hours: float | None = None, db: Session = Depends(g
         except (TypeError, ValueError):
             pass
     if hours is None:                              # derive man-hours from the logs if not supplied
-        def _sum(key, field):
-            return sum(float((x.get("data") or {}).get(field) or 0) for x in me.list_records(db, key, pid, limit=1_000_000))
-        hours = _sum("timesheet", "hours") + _sum("manpower_log", "hours")
+        SHIFT = 8.0                                # standard crew shift when a log gives headcount, not hours
+        hours = sum(float((x.get("data") or {}).get("hours") or 0)
+                    for x in me.list_records(db, "timesheet", pid, limit=1_000_000))
+        for x in me.list_records(db, "manpower_log", pid, limit=1_000_000):
+            d = x.get("data") or {}
+            h = float(d.get("hours") or 0)
+            if not h:                              # crew count × an 8h shift = man-hours for the day
+                h = float(d.get("count") or d.get("headcount") or 0) * SHIFT
+            hours += h
     trir = round(recordable * 200000 / hours, 2) if hours else None
     dart = round(lost_time * 200000 / hours, 2) if hours else None
     return {"incident_count": len(incs), "by_class": by_class, "recordable_count": recordable,

--- a/services/api/src/aec_api/routers/exports.py
+++ b/services/api/src/aec_api/routers/exports.py
@@ -20,20 +20,20 @@ if str(_DATA_SRC) not in sys.path:
 router = APIRouter()
 
 
-def _xlsx_response(sheets: dict, filename: str) -> Response:
+def _xlsx_bytes(sheets: dict) -> bytes:
     from aec_data.xlsx import write_sheets  # type: ignore
-
-    buf_path = io.BytesIO()
-    # write_sheets writes to a path; use a temp file then read back
     import tempfile
 
     with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tmp:
         write_sheets(tmp.name, sheets)
         data = Path(tmp.name).read_bytes()
     Path(tmp.name).unlink(missing_ok=True)
-    buf_path.write(data)
+    return data
+
+
+def _xlsx_response(sheets: dict, filename: str) -> Response:
     return Response(
-        data,
+        _xlsx_bytes(sheets),
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
@@ -78,3 +78,54 @@ def export_schedule(pid: str, db: Session = Depends(get_db)):
     rows = [{"id": a["id"], "name": a["name"], "start": a["start"], "finish": a["finish"],
              "element_count": len(a["guids"]), "guids": _json.dumps(a["guids"])} for a in acts]
     return _xlsx_response({"Schedule": _rows_to_sheet(rows)}, "schedule.xlsx")
+
+
+_CLOSEOUT_MODULES = ("commissioning", "om_manual", "warranty", "as_built", "asset_register",
+                     "completion_certificate", "punchlist")
+
+
+@router.get("/projects/{pid}/closeout/package.zip")
+def closeout_package(pid: str, db: Session = Depends(get_db)):
+    """Turnover deliverable in one ZIP: the as-built IFC, COBie / QTO / space-schedule workbooks,
+    the status-report PDF, and a JSON manifest of the closeout records (commissioning, O&M,
+    warranties, as-builts, asset register, completion certificate, punchlist)."""
+    import json
+    import zipfile
+
+    from .. import modules as me
+    from .. import report
+    from ..models import Project
+
+    p = db.get(Project, pid)
+    if not p:
+        raise HTTPException(404, "project not found")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        # as-built model
+        if p.source_ifc and Path(p.source_ifc).exists():
+            z.writestr("as-built/model.ifc", Path(p.source_ifc).read_bytes())
+            try:
+                from aec_data import cobie, qto, spaces  # type: ignore
+                z.writestr("data/cobie.xlsx", _xlsx_bytes({k: _rows_to_sheet(v)
+                           for k, v in cobie.cobie_file(p.source_ifc).items()}))
+                z.writestr("data/qto.xlsx", _xlsx_bytes({"QTO": _rows_to_sheet(qto.takeoff_file(p.source_ifc))}))
+                z.writestr("data/spaces.xlsx", _xlsx_bytes({"Spaces": _rows_to_sheet(spaces.space_schedule_file(p.source_ifc))}))
+            except Exception as e:                # noqa: BLE001 — model exports are best-effort
+                z.writestr("data/EXPORT_ERROR.txt", str(e)[:300])
+        # status report
+        try:
+            z.writestr("report/status.pdf", report.project_status_pdf(db, pid, p.name))
+        except Exception as e:                    # noqa: BLE001
+            z.writestr("report/REPORT_ERROR.txt", str(e)[:300])
+        # closeout records manifest
+        manifest: dict = {"project": p.name, "project_id": pid, "closeout": {}}
+        for mod in _CLOSEOUT_MODULES:
+            if mod in me.TABLES:
+                recs = me.list_records(db, mod, pid, limit=100000)
+                manifest["closeout"][mod] = [{"ref": r.get("ref"), "title": r.get("title"),
+                                              "status": r.get("workflow_state"), "data": r.get("data")}
+                                             for r in recs]
+        z.writestr("closeout/manifest.json", json.dumps(manifest, indent=2, default=str))
+    return Response(buf.getvalue(), media_type="application/zip",
+                    headers={"Content-Disposition": f'attachment; filename="{p.name.replace(" ", "_")}_closeout.zip"'})

--- a/services/api/src/aec_api/routers/generate.py
+++ b/services/api/src/aec_api/routers/generate.py
@@ -48,14 +48,14 @@ class MassingIn(BaseModel):
     efficiency: float = Field(default=0.82, gt=0, le=1)       # GFA → net sellable/leasable
     avg_unit_m2: float = Field(default=75.0, ge=0)            # for unit count (residential)
     # --- acquisition proforma seed ---
-    land_cost: float = Field(default=0.0, ge=0)
+    land_cost: float = Field(default=2_500_000.0, ge=0)
     hard_cost_psf: float = Field(default=225.0, ge=0)         # $/sf GFA
     soft_cost_pct: float = Field(default=0.15, ge=0)          # of hard
     contingency_pct: float = Field(default=0.05, ge=0)        # of hard
-    rent_per_unit_month: float = Field(default=2200.0, ge=0)  # residential
-    rent_psf_year: float = Field(default=32.0, ge=0)          # commercial $/sf/yr
+    rent_per_unit_month: float = Field(default=3000.0, ge=0)  # residential
+    rent_psf_year: float = Field(default=38.0, ge=0)          # commercial $/sf/yr
     opex_ratio: float = Field(default=0.35, ge=0, le=1)       # of effective gross income
-    exit_cap: float = Field(default=0.055, gt=0)
+    exit_cap: float = Field(default=0.05, gt=0)
     ltc: float = Field(default=0.6, ge=0, le=1)
     rate: float = Field(default=0.075, ge=0)
 

--- a/services/api/src/aec_api/routers/generate.py
+++ b/services/api/src/aec_api/routers/generate.py
@@ -50,6 +50,8 @@ class MassingIn(BaseModel):
     frame: bool = Field(default=False)                        # also generate a concrete structural frame
     bay_m: float = Field(default=7.5, gt=2)                   # column-grid bay spacing (m)
     units: bool = Field(default=False)                        # subdivide floors into per-unit spaces
+    envelope: bool = Field(default=False)                     # wrap floors in facade walls + windows
+    wwr: float = Field(default=0.4, gt=0, le=0.95)            # window-to-wall ratio
     # --- acquisition proforma seed ---
     land_cost: float = Field(default=2_500_000.0, ge=0)
     hard_cost_psf: float = Field(default=225.0, ge=0)         # $/sf GFA
@@ -119,9 +121,11 @@ def generate_massing(pid: str, body: MassingIn, db: Session = Depends(get_db),
 
     _IFC_DIR.joinpath(pid).mkdir(parents=True, exist_ok=True)
     ifc_path = _IFC_DIR / pid / "source.ifc"
-    generate_ifc(metrics, str(ifc_path), name=body.name, frame=body.frame, bay=body.bay_m, units=body.units)
+    generate_ifc(metrics, str(ifc_path), name=body.name, frame=body.frame, bay=body.bay_m,
+                 units=body.units, envelope=body.envelope, wwr=body.wwr)
     metrics["framed"] = body.frame
     metrics["unitized"] = body.units
+    metrics["enclosed"] = body.envelope
     storage.put(f"{pid}/source.ifc", ifc_path.read_bytes())   # durable copy
     p.source_ifc = str(ifc_path)
     db.commit()

--- a/services/api/src/aec_api/routers/generate.py
+++ b/services/api/src/aec_api/routers/generate.py
@@ -47,6 +47,8 @@ class MassingIn(BaseModel):
     floor_to_floor: float = Field(default=3.5, gt=0)
     efficiency: float = Field(default=0.82, gt=0, le=1)       # GFA → net sellable/leasable
     avg_unit_m2: float = Field(default=75.0, ge=0)            # for unit count (residential)
+    frame: bool = Field(default=False)                        # also generate a concrete structural frame
+    bay_m: float = Field(default=7.5, gt=2)                   # column-grid bay spacing (m)
     # --- acquisition proforma seed ---
     land_cost: float = Field(default=2_500_000.0, ge=0)
     hard_cost_psf: float = Field(default=225.0, ge=0)         # $/sf GFA
@@ -116,7 +118,8 @@ def generate_massing(pid: str, body: MassingIn, db: Session = Depends(get_db),
 
     _IFC_DIR.joinpath(pid).mkdir(parents=True, exist_ok=True)
     ifc_path = _IFC_DIR / pid / "source.ifc"
-    generate_ifc(metrics, str(ifc_path), name=body.name)
+    generate_ifc(metrics, str(ifc_path), name=body.name, frame=body.frame, bay=body.bay_m)
+    metrics["framed"] = body.frame
     storage.put(f"{pid}/source.ifc", ifc_path.read_bytes())   # durable copy
     p.source_ifc = str(ifc_path)
     db.commit()

--- a/services/api/src/aec_api/routers/generate.py
+++ b/services/api/src/aec_api/routers/generate.py
@@ -52,6 +52,7 @@ class MassingIn(BaseModel):
     units: bool = Field(default=False)                        # subdivide floors into per-unit spaces
     envelope: bool = Field(default=False)                     # wrap floors in facade walls + windows
     wwr: float = Field(default=0.4, gt=0, le=0.95)            # window-to-wall ratio
+    core: bool = Field(default=False)                         # service core: shafts + stair + MEP risers
     # --- acquisition proforma seed ---
     land_cost: float = Field(default=2_500_000.0, ge=0)
     hard_cost_psf: float = Field(default=225.0, ge=0)         # $/sf GFA
@@ -122,10 +123,11 @@ def generate_massing(pid: str, body: MassingIn, db: Session = Depends(get_db),
     _IFC_DIR.joinpath(pid).mkdir(parents=True, exist_ok=True)
     ifc_path = _IFC_DIR / pid / "source.ifc"
     generate_ifc(metrics, str(ifc_path), name=body.name, frame=body.frame, bay=body.bay_m,
-                 units=body.units, envelope=body.envelope, wwr=body.wwr)
+                 units=body.units, envelope=body.envelope, wwr=body.wwr, core=body.core)
     metrics["framed"] = body.frame
     metrics["unitized"] = body.units
     metrics["enclosed"] = body.envelope
+    metrics["cored"] = body.core
     storage.put(f"{pid}/source.ifc", ifc_path.read_bytes())   # durable copy
     p.source_ifc = str(ifc_path)
     db.commit()

--- a/services/api/src/aec_api/routers/generate.py
+++ b/services/api/src/aec_api/routers/generate.py
@@ -49,6 +49,7 @@ class MassingIn(BaseModel):
     avg_unit_m2: float = Field(default=75.0, ge=0)            # for unit count (residential)
     frame: bool = Field(default=False)                        # also generate a concrete structural frame
     bay_m: float = Field(default=7.5, gt=2)                   # column-grid bay spacing (m)
+    units: bool = Field(default=False)                        # subdivide floors into per-unit spaces
     # --- acquisition proforma seed ---
     land_cost: float = Field(default=2_500_000.0, ge=0)
     hard_cost_psf: float = Field(default=225.0, ge=0)         # $/sf GFA
@@ -118,8 +119,9 @@ def generate_massing(pid: str, body: MassingIn, db: Session = Depends(get_db),
 
     _IFC_DIR.joinpath(pid).mkdir(parents=True, exist_ok=True)
     ifc_path = _IFC_DIR / pid / "source.ifc"
-    generate_ifc(metrics, str(ifc_path), name=body.name, frame=body.frame, bay=body.bay_m)
+    generate_ifc(metrics, str(ifc_path), name=body.name, frame=body.frame, bay=body.bay_m, units=body.units)
     metrics["framed"] = body.frame
+    metrics["unitized"] = body.units
     storage.put(f"{pid}/source.ifc", ifc_path.read_bytes())   # durable copy
     p.source_ifc = str(ifc_path)
     db.commit()

--- a/services/api/src/aec_api/routers/modules.py
+++ b/services/api/src/aec_api/routers/modules.py
@@ -333,6 +333,21 @@ def export_csv(pid: str, key: str, db: Session = Depends(get_db),
                     headers={"Content-Disposition": f'attachment; filename="{key}.csv"'})
 
 
+@router.get("/projects/{pid}/modules/{key}/log.pdf")
+def module_log(pid: str, key: str, db: Session = Depends(get_db),
+               _: str = Depends(require_role("viewer"))):
+    """Printable register (log) of every record in a module — the RFI log, submittal log,
+    change-order log, etc., all from the same engine."""
+    from .. import report
+    from ..models import Project
+    if key not in mod_engine.TABLES:
+        raise HTTPException(404, "unknown module")
+    p = db.get(Project, pid)
+    pdf = report.module_log_pdf(db, pid, key, p.name if p else pid)
+    return Response(pdf, media_type="application/pdf",
+                    headers={"Content-Disposition": f'inline; filename="{key}_log.pdf"'})
+
+
 # NOTE: must precede the /{rid} route so "board" isn't captured as a record id.
 @router.get("/projects/{pid}/modules/{key}/board")
 def module_board(pid: str, key: str, db: Session = Depends(get_db),

--- a/services/api/test_ai.py
+++ b/services/api/test_ai.py
@@ -1,0 +1,47 @@
+"""AI assistant — natural-language ask over a project snapshot (graceful no-key path).
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_ai.py
+
+Without ANTHROPIC_API_KEY the assistant degrades to returning the live snapshot it would feed
+the model — so the endpoint, RBAC, context gathering and graceful fallback are all exercised
+without a network call. The Claude path reuses the same seam (ai.ask)."""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_ai.db"
+os.environ["STORAGE_DIR"] = "./test_storage_ai"
+os.environ.pop("AEC_RBAC", None)
+os.environ.pop("ANTHROPIC_API_KEY", None)   # ensure the disabled/fallback path
+for f in ("./test_ai.db",):
+    if os.path.exists(f):
+        os.remove(f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from aec_api import ai  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+H = {"X-User": "gc"}
+
+with TestClient(app) as c:
+    pid = c.post("/projects", json={"name": "AI Tower"}, headers=H).json()["id"]
+    for subj in ("Beam clash", "Door schedule", "Duct routing"):
+        c.post(f"/projects/{pid}/modules/rfi", json={"data": {"subject": subj, "question": "?"}}, headers=H)
+    c.post(f"/projects/{pid}/modules/change_event", json={"data": {"subject": "Added steel"}}, headers=H)
+
+    # ask with no key -> graceful "disabled" answer that still carries the live snapshot
+    r = c.post(f"/projects/{pid}/ai/ask", json={"question": "How many RFIs are open?"}, headers=H)
+    assert r.status_code == 200, r.text
+    j = r.json()
+    assert j["source"] == "disabled" and j["ai_enabled"] is False, j
+    snap = j["snapshot"]
+    assert snap["record_counts"]["rfi"] == 3, snap["record_counts"]
+    assert snap["record_counts"]["change_event"] == 1, snap["record_counts"]
+    assert "kpis" in snap and len(snap["open_rfis"]) == 3, snap
+
+    # empty question is rejected
+    assert c.post(f"/projects/{pid}/ai/ask", json={"question": "  "}, headers=H).status_code == 422
+
+    # ai.ask is a pure seam: given a context it returns an answer dict (disabled here)
+    out = ai.ask("anything", {"kpis": {"open_rfis": 3}})
+    assert out["source"] == "disabled" and "snapshot" in out, out
+
+print("AI OK - ask endpoint grounds on a live snapshot (3 RFIs + 1 change event), "
+      "degrades gracefully with no key, rejects empty questions; ai.ask seam verified")

--- a/services/api/test_auth.py
+++ b/services/api/test_auth.py
@@ -30,7 +30,9 @@ with TestClient(app) as c:
     login = c.post("/auth/login", json={"username": "admin", "password": "supersecret"})
     assert login.status_code == 200
     me = c.get("/auth/me")                 # no Authorization header → cookie carries it
-    assert me.json() == {"username": "admin", "role": "admin", "authenticated": True}, me.text
+    mj = me.json()
+    assert (mj["username"], mj["role"], mj["authenticated"]) == ("admin", "admin", True), me.text
+    assert mj["tier"] == "free" and mj["platform_admin"] is True, mj   # legacy admin role → platform admin
     c.cookies.clear()
 
     # --- admin creates a regular user -----------------------------------------

--- a/services/api/test_closeout.py
+++ b/services/api/test_closeout.py
@@ -1,0 +1,57 @@
+"""Turnover/closeout deliverables: the closeout package ZIP + module-log PDF.
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_closeout.py"""
+import io
+import os
+import zipfile
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_closeout.db"
+os.environ["STORAGE_DIR"] = "./test_storage_closeout"
+os.environ["IFC_DIR"] = "./test_ifc_closeout"
+os.environ.pop("AEC_RBAC", None)
+for f in ("./test_closeout.db",):
+    if os.path.exists(f):
+        os.remove(f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+H = {"X-User": "gc"}
+
+with TestClient(app) as c:
+    pid = c.post("/projects", json={"name": "Turnover Tower"}, headers=H).json()["id"]
+    # a generated model so the package has an as-built IFC + COBie/QTO/spaces
+    g = c.post(f"/projects/{pid}/generate/massing",
+               json={"lot_width": 30, "lot_depth": 20, "far": 2.0, "units": True}, headers=H)
+    assert g.status_code == 200, g.text
+
+    # closeout records (subject alias fills each module's title field)
+    for mod, subj in [("commissioning", "HVAC Cx"), ("om_manual", "O&M"), ("warranty", "Roof 10yr"),
+                      ("as_built", "Structural"), ("asset_register", "AHU-1"),
+                      ("completion_certificate", "Substantial completion")]:
+        r = c.post(f"/projects/{pid}/modules/{mod}", json={"data": {"subject": subj}}, headers=H)
+        assert r.status_code == 201, (mod, r.text)
+    # a couple RFIs for the log
+    for s in ("Beam clash", "Door mismatch"):
+        c.post(f"/projects/{pid}/modules/rfi", json={"data": {"subject": s, "question": "?"}}, headers=H)
+
+    # --- closeout package ZIP -------------------------------------------------
+    z = c.get(f"/projects/{pid}/closeout/package.zip", headers=H)
+    assert z.status_code == 200 and z.headers["content-type"] == "application/zip", z.status_code
+    zf = zipfile.ZipFile(io.BytesIO(z.content))
+    names = zf.namelist()
+    assert "as-built/model.ifc" in names, names
+    assert "data/cobie.xlsx" in names and "data/qto.xlsx" in names and "data/spaces.xlsx" in names, names
+    assert "report/status.pdf" in names, names
+    assert "closeout/manifest.json" in names, names
+    import json
+    manifest = json.loads(zf.read("closeout/manifest.json"))
+    assert manifest["closeout"]["warranty"][0]["title"] == "Roof 10yr", manifest["closeout"]["warranty"]
+    assert len(manifest["closeout"]["completion_certificate"]) == 1
+
+    # --- module log PDF -------------------------------------------------------
+    log = c.get(f"/projects/{pid}/modules/rfi/log.pdf", headers=H)
+    assert log.status_code == 200 and log.content[:4] == b"%PDF", log.status_code
+    assert len(log.content) > 800, len(log.content)
+
+print("CLOSEOUT OK - package.zip bundles as-built IFC + COBie/QTO/spaces + status PDF + closeout "
+      "manifest; module log.pdf renders the RFI register")

--- a/services/api/test_estimate.py
+++ b/services/api/test_estimate.py
@@ -1,27 +1,40 @@
-"""Model estimating engine: aggregate takeoff by class, apply unit rates, total + unpriced.
-Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_estimate.py"""
+"""Model estimating engine: aggregate takeoff by class, apply unit rates, total + unpriced,
+GFA benchmark + recommended source. Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_estimate.py"""
 from aec_api import estimate as est
 
-# fake takeoff rows (as aec_data.qto.takeoff would return)
+# fake takeoff rows (as aec_data.qto.takeoff would return). Concrete is billed by volume now.
 rows = [
     {"ifc_class": "IfcWall", "area": 50.0}, {"ifc_class": "IfcWall", "area": 30.0},   # 80 m² @160 = 12800
-    {"ifc_class": "IfcColumn"}, {"ifc_class": "IfcColumn"},                            # 2 ea @450 = 900
-    {"ifc_class": "IfcBeam", "length": 10.0},                                          # 10 m @90 = 900
+    {"ifc_class": "IfcColumn", "volume": 1.0}, {"ifc_class": "IfcColumn", "volume": 1.0},  # 2 m³ @650 = 1300
+    {"ifc_class": "IfcBeam", "volume": 2.0},                                           # 2 m³ @700 = 1400
     {"ifc_class": "IfcFurniture"},                                                     # unpriced
 ]
 r = est.estimate_from_takeoff(rows)
 by = {l["ifc_class"]: l for l in r["lines"]}
 
 assert by["IfcWall"]["quantity"] == 80.0 and by["IfcWall"]["amount"] == 12800.0, by["IfcWall"]
-assert by["IfcColumn"]["count"] == 2 and by["IfcColumn"]["amount"] == 900.0, by["IfcColumn"]
-assert by["IfcBeam"]["amount"] == 900.0
-assert r["total"] == 12800.0 + 900.0 + 900.0, r["total"]
-assert r["lines"][0]["ifc_class"] == "IfcWall"                       # sorted by amount desc
-assert r["element_count"] == 6
+assert by["IfcColumn"]["amount"] == 1300.0, by["IfcColumn"]      # volume-based concrete
+assert by["IfcBeam"]["amount"] == 1400.0, by["IfcBeam"]
+assert r["total"] == 12800.0 + 1300.0 + 1400.0, r["total"]
+assert r["lines"][0]["ifc_class"] == "IfcWall"                   # sorted by amount desc
+assert r["element_count"] == 6 and r["source"] == "model"
 assert any(u["ifc_class"] == "IfcFurniture" for u in r["unpriced"]), r["unpriced"]
 
 # per-class rate override
 r2 = est.estimate_from_takeoff(rows, overrides={"IfcWall": 200.0})
 assert {l["ifc_class"]: l for l in r2["lines"]}["IfcWall"]["amount"] == 16000.0
 
-print("ESTIMATE OK - takeoff aggregated by class, priced (walls 80m² @160 = $12,800), unpriced flagged, overrides")
+# GFA benchmark + recommended source ----------------------------------------
+# sparse model (few elements) vs a large GFA -> recommend the GFA benchmark, not the tiny total
+sparse = est.estimate_from_takeoff([{"ifc_class": "IfcColumn", "volume": 1.0}], gfa_sf=60_000)
+assert sparse["gfa_benchmark"]["amount"] == round(60_000 * est.DEFAULT_PSF), sparse["gfa_benchmark"]
+assert sparse["recommended"] == "gfa", sparse                     # 1 element, total << benchmark
+assert sparse["recommended_total"] == sparse["gfa_benchmark"]["amount"]
+
+# a model whose total is in-band with the GFA benchmark -> trust the model
+big = est.estimate_from_takeoff(
+    [{"ifc_class": "IfcSlab", "volume": 30.0} for _ in range(20)], gfa_sf=2_000)  # 20×30×550 = 330k
+assert big["recommended"] == "model", big
+
+print("ESTIMATE OK - concrete by volume (cols $1,300 / beams $1,400), walls $12,800; "
+      "GFA benchmark + recommended source (sparse->gfa, in-band->model); overrides")

--- a/services/api/test_sso.py
+++ b/services/api/test_sso.py
@@ -1,0 +1,81 @@
+"""SSO (OAuth) login + free-tier + ops-only platform admin.
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_sso.py
+
+Covers: providers list reflects configured creds; the OAuth callback (driven through the
+exchange/userinfo test seams) creates a plain free-tier user — NOT an admin; /auth/me reports
+tier + features; platform-admin is ops-only via AEC_ADMIN_EMAILS (no end-user admin tier)."""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./sso_test.db"
+os.environ["STORAGE_DIR"] = "./test_storage_sso"
+os.environ.pop("AEC_RBAC", None)
+os.environ.pop("AEC_API_KEY", None)
+os.environ.pop("AEC_LOCAL_MODE", None)
+# enable Google + Microsoft by configuring (fake) creds; Procore left unconfigured
+os.environ["AEC_OAUTH_GOOGLE_CLIENT_ID"] = "gid"
+os.environ["AEC_OAUTH_GOOGLE_CLIENT_SECRET"] = "gsecret"
+os.environ["AEC_OAUTH_MICROSOFT_CLIENT_ID"] = "mid"
+os.environ["AEC_OAUTH_MICROSOFT_CLIENT_SECRET"] = "msecret"
+os.environ.pop("AEC_OAUTH_PROCORE_CLIENT_ID", None)
+os.environ.pop("AEC_ADMIN_EMAILS", None)
+for f in ("./sso_test.db",):
+    if os.path.exists(f):
+        os.remove(f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from aec_api import auth, oauth  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+with TestClient(app) as c:
+    # --- providers list: enabled = those with creds (google, microsoft; not procore) ---------
+    provs = {p["id"] for p in c.get("/auth/providers").json()["providers"]}
+    assert provs == {"google", "microsoft"}, provs
+
+    # --- drive the callback through the test seams (no real provider) -------------------------
+    oauth.exchange_code = lambda provider, code, redirect_uri: {"access_token": "fake"}
+    oauth.fetch_userinfo = lambda provider, token: {"email": "Alice@Example.com"}
+
+    state = auth.create_oauth_state("google")
+    r = c.get(f"/auth/oauth/google/callback?code=abc&state={state}", follow_redirects=False)
+    assert r.status_code == 303, (r.status_code, r.text)
+    assert "aec_token" in r.cookies, r.headers
+
+    # the account exists, is a plain free-tier USER (not admin), email normalized lower-case
+    me = c.get("/auth/me").json()          # TestClient carries the Set-Cookie automatically
+    assert me["username"] == "alice@example.com", me
+    assert me["authenticated"] is True and me["role"] == "user", me
+    assert me["tier"] == "free" and me["features"]["viewer"] is True, me
+    assert me["platform_admin"] is False, me        # SSO users are never platform admins
+
+    # --- a second SSO user is also a plain user (no first-account-admin bootstrap) ------------
+    oauth.fetch_userinfo = lambda provider, token: {"email": "bob@example.com"}
+    c.cookies.clear()
+    state2 = auth.create_oauth_state("microsoft")
+    oauth.exchange_code = lambda provider, code, redirect_uri: {"access_token": "fake2"}
+    r2 = c.get(f"/auth/oauth/microsoft/callback?code=xyz&state={state2}", follow_redirects=False)
+    assert r2.status_code == 303
+    assert c.get("/auth/me").json()["role"] == "user"
+
+    # --- bad state is rejected (CSRF) --------------------------------------------------------
+    bad = c.get("/auth/oauth/google/callback?code=abc&state=tampered", follow_redirects=False)
+    assert bad.status_code == 400, bad.text
+
+    # --- a disabled provider 404s ------------------------------------------------------------
+    assert c.get("/auth/oauth/procore/login", follow_redirects=False).status_code == 404
+
+    # --- platform admin is ops-only via AEC_ADMIN_EMAILS ------------------------------------
+    # alice is a normal user -> can't touch platform settings
+    c.cookies.clear()
+    st3 = auth.create_oauth_state("google")
+    oauth.exchange_code = lambda provider, code, redirect_uri: {"access_token": "fake"}
+    oauth.fetch_userinfo = lambda provider, token: {"email": "alice@example.com"}
+    c.get(f"/auth/oauth/google/callback?code=abc&state={st3}", follow_redirects=False)
+    assert c.get("/auth/users").status_code == 403, "regular SSO user must not access user admin"
+    # promote via the ops env allowlist -> now platform admin
+    os.environ["AEC_ADMIN_EMAILS"] = "alice@example.com"
+    assert c.get("/auth/me").json()["platform_admin"] is True
+    assert c.get("/auth/users").status_code == 200, "AEC_ADMIN_EMAILS should grant platform admin"
+    os.environ.pop("AEC_ADMIN_EMAILS", None)
+
+print("SSO OK - providers reflect creds; callback makes plain free-tier users (no admin "
+      "bootstrap); bad-state rejected; platform admin is ops-only via AEC_ADMIN_EMAILS")

--- a/services/data/src/aec_data/edit.py
+++ b/services/data/src/aec_data/edit.py
@@ -169,6 +169,17 @@ def _body_context(model):
         (model.by_type("IfcGeometricRepresentationContext") or [None])[0]
 
 
+def _rect_profile(model, xdim: float, ydim: float):
+    """An IfcRectangleProfileDef WITH a Position. web-ifc requires the profile placement to be set
+    (ifcopenshell tolerates a null Position, but web-ifc silently skips the element → it renders
+    invisible in the viewer). Always give parametric profiles an origin placement."""
+    pos = model.create_entity("IfcAxis2Placement2D",
+                              Location=model.create_entity("IfcCartesianPoint", (0.0, 0.0)),
+                              RefDirection=model.create_entity("IfcDirection", (1.0, 0.0)))
+    return model.create_entity("IfcRectangleProfileDef", ProfileType="AREA", Position=pos,
+                               XDim=float(xdim), YDim=float(ydim))
+
+
 def _first_storey(model, name=None):
     sts = sorted(model.by_type("IfcBuildingStorey"),
                  key=lambda s: float(getattr(s, "Elevation", 0) or 0))
@@ -202,8 +213,7 @@ def add_wall(model: ifcopenshell.file, start, end, height: float = 3.0,
     matrix = np.array([[c, -s, 0, mx], [s, c, 0, my],
                        [0, 0, 1, elev], [0, 0, 0, 1]], dtype=float)
     ifcopenshell.api.run("geometry.edit_object_placement", model, product=wall, matrix=matrix)
-    profile = model.create_entity("IfcRectangleProfileDef", ProfileType="AREA",
-                                  XDim=length, YDim=float(thickness))
+    profile = _rect_profile(model, length, float(thickness))
     rep = ifcopenshell.api.run("geometry.add_profile_representation", model,
                                context=body, profile=profile, depth=float(height))
     ifcopenshell.api.run("geometry.assign_representation", model, product=wall, representation=rep)
@@ -257,7 +267,7 @@ def add_column(model: ifcopenshell.file, point, height: float = 3.0, width: floa
     matrix = np.eye(4)
     matrix[0, 3] = float(point[0]); matrix[1, 3] = float(point[1]); matrix[2, 3] = elev
     ifcopenshell.api.run("geometry.edit_object_placement", model, product=col, matrix=matrix)
-    profile = model.create_entity("IfcRectangleProfileDef", ProfileType="AREA", XDim=float(width), YDim=float(depth))
+    profile = _rect_profile(model, float(width), float(depth))
     rep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body, profile=profile, depth=float(height))
     ifcopenshell.api.run("geometry.assign_representation", model, product=col, representation=rep)
     if st:
@@ -288,7 +298,7 @@ def add_beam(model: ifcopenshell.file, start, end, width: float = 0.3, depth: fl
     matrix = np.array([[-dy, 0, dx, sx], [dx, 0, dy, sy],
                        [0, 1, 0, elev], [0, 0, 0, 1]], dtype=float)
     ifcopenshell.api.run("geometry.edit_object_placement", model, product=beam, matrix=matrix)
-    profile = model.create_entity("IfcRectangleProfileDef", ProfileType="AREA", XDim=float(width), YDim=float(depth))
+    profile = _rect_profile(model, float(width), float(depth))
     rep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body, profile=profile, depth=length)
     ifcopenshell.api.run("geometry.assign_representation", model, product=beam, representation=rep)
     if st:
@@ -355,7 +365,7 @@ def add_opening(model: ifcopenshell.file, host_guid: str, width: float = 0.9, he
     opening = ifcopenshell.api.run("root.create_entity", model, ifc_class="IfcOpeningElement", name=f"{kind} opening")
     ifcopenshell.api.run("geometry.edit_object_placement", model, product=opening, matrix=opm)
     # generous Y so the box cuts fully through the wall thickness
-    cut = model.create_entity("IfcRectangleProfileDef", ProfileType="AREA", XDim=float(width), YDim=1.0)
+    cut = _rect_profile(model, float(width), 1.0)
     crep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body, profile=cut, depth=float(height))
     ifcopenshell.api.run("geometry.assign_representation", model, product=opening, representation=crep)
     ifcopenshell.api.run("feature.add_feature", model, feature=opening, element=host)
@@ -367,7 +377,7 @@ def add_opening(model: ifcopenshell.file, host_guid: str, width: float = 0.9, he
     except Exception:
         pass
     ifcopenshell.api.run("geometry.edit_object_placement", model, product=el, matrix=opm)
-    panel = model.create_entity("IfcRectangleProfileDef", ProfileType="AREA", XDim=float(width), YDim=0.06)
+    panel = _rect_profile(model, float(width), 0.06)
     prep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body, profile=panel, depth=float(height))
     ifcopenshell.api.run("geometry.assign_representation", model, product=el, representation=prep)
     ifcopenshell.api.run("feature.add_filling", model, opening=opening, element=el)

--- a/services/data/src/aec_data/massing.py
+++ b/services/data/src/aec_data/massing.py
@@ -66,11 +66,15 @@ def gridlines(extent: float, bay: float) -> list[float]:
 
 
 def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
-                 frame: bool = False, bay: float = 7.5, units: bool = False) -> str:
+                 frame: bool = False, bay: float = 7.5, units: bool = False,
+                 envelope: bool = False, wwr: float = 0.4) -> str:
     """Write an IFC4 model: site → building → one storey + slab per level. Each floor gets either a
     single floor-plate space, or — with `units=True` — the floor subdivided into per-unit IfcSpaces
     (the proforma's unit count), so areas/COBie/rent are grounded in real apartments. With
-    `frame=True`, also generate a concrete structural frame on a ~`bay`-metre column grid."""
+    `frame=True`, also generate a concrete structural frame on a ~`bay`-metre column grid. With
+    `envelope=True`, wrap each floor in perimeter facade walls + ribbon windows at the given
+    window-to-wall ratio `wwr` — so elevations show an enclosure and the energy model has real
+    exterior-wall + glazing areas."""
     import math
 
     import ifcopenshell
@@ -152,6 +156,25 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
         rows = max(1, math.ceil(n / cols))
         return cols, rows
 
+    def add_planar(cls, storey, elev, x1, y1, x2, y2, length_frac, depth, height, psets=None):
+        """A vertical planar element (wall/window) along the x1y1->x2y2 edge: a rectangular profile
+        (edge length × `depth`) extruded up by `height`, centred on the edge and rotated to it."""
+        length = math.hypot(x2 - x1, y2 - y1) or 1.0
+        ang = math.atan2(y2 - y1, x2 - x1)
+        c, s = math.cos(ang), math.sin(ang)
+        mx, my = (x1 + x2) / 2, (y1 + y2) / 2
+        el = ifcopenshell.api.run("root.create_entity", model, ifc_class=cls, name=cls.replace("Ifc", ""))
+        m = np.array([[c, -s, 0, mx], [s, c, 0, my], [0, 0, 1, elev], [0, 0, 0, 1]], dtype=float)
+        ifcopenshell.api.run("geometry.edit_object_placement", model, product=el, matrix=m)
+        rep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body,
+                                   profile=rect_profile(model, length * length_frac, depth), depth=height)
+        ifcopenshell.api.run("geometry.assign_representation", model, product=el, representation=rep)
+        ifcopenshell.api.run("spatial.assign_container", model, products=[el], relating_structure=storey)
+        for pset_name, props in (psets or {}).items():
+            ps = ifcopenshell.api.run("pset.add_pset", model, product=el, name=pset_name)
+            ifcopenshell.api.run("pset.edit_pset", model, pset=ps, properties=props)
+        return el
+
     gx = gridlines(fw, bay)
     gy = gridlines(fd, bay)
     for i in range(floors):
@@ -198,5 +221,22 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
             for x in gx:                       # beams along Y
                 for j in range(len(gy) - 1):
                     add_beam(storey, elev, x, gy[j], x, gy[j + 1])
+
+        if envelope:                           # perimeter facade walls + ribbon windows per floor
+            hw, hd = fw / 2, fd / 2
+            edges = [(-hw, -hd, hw, -hd), (hw, hd, -hw, hd),     # front, back (along X)
+                     (hw, -hd, hw, hd), (-hw, hd, -hw, -hd)]      # right, left (along Y)
+            sill = f2f * 0.1
+            for (x1, y1, x2, y2) in edges:
+                add_planar("IfcWall", storey, elev, x1, y1, x2, y2, 1.0, 0.2, f2f,
+                           psets={"Pset_WallCommon": {"IsExternal": True, "LoadBearing": False}})
+                win = add_planar("IfcWindow", storey, elev + sill, x1, y1, x2, y2, 0.9, 0.05,
+                                 max(0.3, f2f * float(wwr)))
+                length = math.hypot(x2 - x1, y2 - y1) or 1.0
+                try:
+                    win.OverallWidth = length * 0.9
+                    win.OverallHeight = max(0.3, f2f * float(wwr))
+                except Exception:                # noqa: BLE001 — attributes are optional
+                    pass
     model.write(out_path)
     return out_path

--- a/services/data/src/aec_data/massing.py
+++ b/services/data/src/aec_data/massing.py
@@ -57,8 +57,20 @@ def compute_massing(p: dict) -> dict[str, Any]:
     }
 
 
-def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study") -> str:
-    """Write an IFC4 massing model: site → building → one storey + floor-plate space per level."""
+def gridlines(extent: float, bay: float) -> list[float]:
+    """Evenly-spaced grid line positions across `extent` (centred on 0) with spacing ≈ `bay` —
+    columns land on both edges and the interior. Returns n+1 coordinates for n bays."""
+    n = max(1, round(extent / max(0.5, bay)))
+    step = extent / n
+    return [round(-extent / 2 + i * step, 3) for i in range(n + 1)]
+
+
+def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
+                 frame: bool = False, bay: float = 7.5) -> str:
+    """Write an IFC4 model: site → building → one storey + floor-plate space + slab per level.
+    With `frame=True`, also generate a concrete structural frame on a ~`bay`-metre column grid —
+    columns at every grid intersection (per floor) and beams along both axes — turning the massing
+    into a real, GUID-stable structural model in one pass."""
     import ifcopenshell
     import ifcopenshell.api
     import numpy as np
@@ -68,6 +80,7 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study") -> s
     plate_area = round(fw * fd, 2)
     SLAB_T = 0.3   # m — thin floor plate per level: physical (renders) so the massing is visible
     #              (IfcSpace is forced transparent by the Fragments importer, so spaces alone show empty)
+    COL, BEAM_W, BEAM_D = 0.6, 0.4, 0.6      # concrete column side, beam width, beam depth (m)
 
     def rect_profile(m, w, d):
         # web-ifc REQUIRES IfcProfileDef.Position (ifcopenshell tolerates None, web-ifc skips the
@@ -90,6 +103,31 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study") -> s
     ifcopenshell.api.run("aggregate.assign_object", model, products=[site], relating_object=project)
     ifcopenshell.api.run("aggregate.assign_object", model, products=[building], relating_object=site)
 
+    def add_column(storey, elev, x, y):
+        col = ifcopenshell.api.run("root.create_entity", model, ifc_class="IfcColumn", name="Column",
+                                   predefined_type="COLUMN")
+        m = np.eye(4); m[0, 3] = x; m[1, 3] = y; m[2, 3] = elev
+        ifcopenshell.api.run("geometry.edit_object_placement", model, product=col, matrix=m)
+        rep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body,
+                                   profile=rect_profile(model, COL, COL), depth=f2f)
+        ifcopenshell.api.run("geometry.assign_representation", model, product=col, representation=rep)
+        ifcopenshell.api.run("spatial.assign_container", model, products=[col], relating_structure=storey)
+
+    def add_beam(storey, elev, x1, y1, x2, y2):
+        import math
+        length = math.hypot(x2 - x1, y2 - y1) or 1.0
+        dx, dy = (x2 - x1) / length, (y2 - y1) / length
+        beam = ifcopenshell.api.run("root.create_entity", model, ifc_class="IfcBeam", name="Beam",
+                                    predefined_type="BEAM")
+        m = np.array([[-dy, 0, dx, x1], [dx, 0, dy, y1], [0, 1, 0, elev], [0, 0, 0, 1]], dtype=float)
+        ifcopenshell.api.run("geometry.edit_object_placement", model, product=beam, matrix=m)
+        rep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body,
+                                   profile=rect_profile(model, BEAM_W, BEAM_D), depth=length)
+        ifcopenshell.api.run("geometry.assign_representation", model, product=beam, representation=rep)
+        ifcopenshell.api.run("spatial.assign_container", model, products=[beam], relating_structure=storey)
+
+    gx = gridlines(fw, bay)
+    gy = gridlines(fd, bay)
     for i in range(floors):
         elev = i * f2f
         storey = ifcopenshell.api.run("root.create_entity", model, ifc_class="IfcBuildingStorey",
@@ -120,5 +158,16 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study") -> s
                                     profile=sprofile, depth=SLAB_T)
         ifcopenshell.api.run("geometry.assign_representation", model, product=slab, representation=srep)
         ifcopenshell.api.run("spatial.assign_container", model, products=[slab], relating_structure=storey)
+
+        if frame:                              # concrete frame: columns on the grid + beams both ways
+            for x in gx:
+                for y in gy:
+                    add_column(storey, elev, x, y)
+            for y in gy:                       # beams along X
+                for j in range(len(gx) - 1):
+                    add_beam(storey, elev, gx[j], y, gx[j + 1], y)
+            for x in gx:                       # beams along Y
+                for j in range(len(gy) - 1):
+                    add_beam(storey, elev, x, gy[j], x, gy[j + 1])
     model.write(out_path)
     return out_path

--- a/services/data/src/aec_data/massing.py
+++ b/services/data/src/aec_data/massing.py
@@ -66,11 +66,13 @@ def gridlines(extent: float, bay: float) -> list[float]:
 
 
 def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
-                 frame: bool = False, bay: float = 7.5) -> str:
-    """Write an IFC4 model: site → building → one storey + floor-plate space + slab per level.
-    With `frame=True`, also generate a concrete structural frame on a ~`bay`-metre column grid —
-    columns at every grid intersection (per floor) and beams along both axes — turning the massing
-    into a real, GUID-stable structural model in one pass."""
+                 frame: bool = False, bay: float = 7.5, units: bool = False) -> str:
+    """Write an IFC4 model: site → building → one storey + slab per level. Each floor gets either a
+    single floor-plate space, or — with `units=True` — the floor subdivided into per-unit IfcSpaces
+    (the proforma's unit count), so areas/COBie/rent are grounded in real apartments. With
+    `frame=True`, also generate a concrete structural frame on a ~`bay`-metre column grid."""
+    import math
+
     import ifcopenshell
     import ifcopenshell.api
     import numpy as np
@@ -78,6 +80,7 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
     floors = int(metrics["floors"])
     fw, fd, f2f = float(metrics["plate_w"]), float(metrics["plate_d"]), float(metrics["floor_to_floor"])
     plate_area = round(fw * fd, 2)
+    units_per_floor = max(1, round(int(metrics.get("units", 0)) / floors)) if units else 0
     SLAB_T = 0.3   # m — thin floor plate per level: physical (renders) so the massing is visible
     #              (IfcSpace is forced transparent by the Fragments importer, so spaces alone show empty)
     COL, BEAM_W, BEAM_D = 0.6, 0.4, 0.6      # concrete column side, beam width, beam depth (m)
@@ -126,6 +129,29 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
         ifcopenshell.api.run("geometry.assign_representation", model, product=beam, representation=rep)
         ifcopenshell.api.run("spatial.assign_container", model, products=[beam], relating_structure=storey)
 
+    def make_space(storey, elev, name, longname, cx, cy, w, d, reference):
+        sp = ifcopenshell.api.run("root.create_entity", model, ifc_class="IfcSpace", name=name)
+        sp.LongName = longname
+        m = np.eye(4); m[0, 3] = cx; m[1, 3] = cy; m[2, 3] = elev
+        ifcopenshell.api.run("geometry.edit_object_placement", model, product=sp, matrix=m)
+        rep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body,
+                                   profile=rect_profile(model, w, d), depth=f2f)
+        ifcopenshell.api.run("geometry.assign_representation", model, product=sp, representation=rep)
+        ifcopenshell.api.run("aggregate.assign_object", model, products=[sp], relating_object=storey)
+        area = round(w * d, 2)
+        qto = ifcopenshell.api.run("pset.add_qto", model, product=sp, name="Qto_SpaceBaseQuantities")
+        ifcopenshell.api.run("pset.edit_qto", model, qto=qto,
+                             properties={"NetFloorArea": area, "GrossFloorArea": area,
+                                         "NetVolume": round(area * f2f, 2), "Height": f2f})
+        ps = ifcopenshell.api.run("pset.add_pset", model, product=sp, name="Pset_SpaceCommon")
+        ifcopenshell.api.run("pset.edit_pset", model, pset=ps, properties={"Reference": reference})
+        return sp
+
+    def unit_grid(n, w, d):
+        cols = max(1, round(math.sqrt(n * w / d)))
+        rows = max(1, math.ceil(n / cols))
+        return cols, rows
+
     gx = gridlines(fw, bay)
     gy = gridlines(fd, bay)
     for i in range(floors):
@@ -134,20 +160,23 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
                                       name=f"Level {i + 1}")
         storey.Elevation = elev
         ifcopenshell.api.run("aggregate.assign_object", model, products=[storey], relating_object=building)
-        space = ifcopenshell.api.run("root.create_entity", model, ifc_class="IfcSpace",
-                                     name=f"Level {i + 1} floor plate")
-        space.LongName = f"Floor plate {i + 1}"
-        matrix = np.eye(4); matrix[2, 3] = elev
-        ifcopenshell.api.run("geometry.edit_object_placement", model, product=space, matrix=matrix)
-        profile = rect_profile(model, fw, fd)
-        rep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body,
-                                   profile=profile, depth=f2f)
-        ifcopenshell.api.run("geometry.assign_representation", model, product=space, representation=rep)
-        ifcopenshell.api.run("aggregate.assign_object", model, products=[space], relating_object=storey)
-        qto = ifcopenshell.api.run("pset.add_qto", model, product=space, name="Qto_SpaceBaseQuantities")
-        ifcopenshell.api.run("pset.edit_qto", model, qto=qto,
-                             properties={"NetFloorArea": plate_area, "GrossFloorArea": plate_area,
-                                         "NetVolume": round(plate_area * f2f, 2), "Height": f2f})
+        if units_per_floor:                    # subdivide the floor into per-unit apartments
+            cols, rows = unit_grid(units_per_floor, fw, fd)
+            cw, cd = fw / cols, fd / rows
+            k = 0
+            for r in range(rows):
+                for c in range(cols):
+                    if k >= units_per_floor:
+                        break
+                    k += 1
+                    cx = -fw / 2 + (c + 0.5) * cw
+                    cy = -fd / 2 + (r + 0.5) * cd
+                    # 0.96 leaves a hair of demising-wall gap so units read as separate volumes
+                    make_space(storey, elev, f"L{i + 1} Unit {k:02d}", f"Unit {k:02d}",
+                               cx, cy, cw * 0.96, cd * 0.96, "UNIT")
+        else:
+            make_space(storey, elev, f"Level {i + 1} floor plate", f"Floor plate {i + 1}",
+                       0.0, 0.0, fw, fd, "PLATE")
         # renderable floor plate (IfcSlab) so the massing is visible in the viewer
         slab = ifcopenshell.api.run("root.create_entity", model, ifc_class="IfcSlab",
                                     name=f"Level {i + 1} plate", predefined_type="FLOOR")

--- a/services/data/src/aec_data/massing.py
+++ b/services/data/src/aec_data/massing.py
@@ -67,7 +67,7 @@ def gridlines(extent: float, bay: float) -> list[float]:
 
 def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
                  frame: bool = False, bay: float = 7.5, units: bool = False,
-                 envelope: bool = False, wwr: float = 0.4) -> str:
+                 envelope: bool = False, wwr: float = 0.4, core: bool = False) -> str:
     """Write an IFC4 model: site → building → one storey + slab per level. Each floor gets either a
     single floor-plate space, or — with `units=True` — the floor subdivided into per-unit IfcSpaces
     (the proforma's unit count), so areas/COBie/rent are grounded in real apartments. With
@@ -156,6 +156,22 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
         rows = max(1, math.ceil(n / cols))
         return cols, rows
 
+    def add_box(cls, storey, elev, cx, cy, w, d, h, predefined=None, name=None):
+        """A vertical box element (cx,cy plan centre, extruded up by h) — for cores/MEP stubs."""
+        kw = {"predefined_type": predefined} if predefined else {}
+        try:
+            el = ifcopenshell.api.run("root.create_entity", model, ifc_class=cls,
+                                      name=name or cls.replace("Ifc", ""), **kw)
+        except Exception:                        # noqa: BLE001 — invalid predefined enum for this class
+            el = ifcopenshell.api.run("root.create_entity", model, ifc_class=cls, name=name or cls.replace("Ifc", ""))
+        m = np.eye(4); m[0, 3] = cx; m[1, 3] = cy; m[2, 3] = elev
+        ifcopenshell.api.run("geometry.edit_object_placement", model, product=el, matrix=m)
+        rep = ifcopenshell.api.run("geometry.add_profile_representation", model, context=body,
+                                   profile=rect_profile(model, w, d), depth=h)
+        ifcopenshell.api.run("geometry.assign_representation", model, product=el, representation=rep)
+        ifcopenshell.api.run("spatial.assign_container", model, products=[el], relating_structure=storey)
+        return el
+
     def add_planar(cls, storey, elev, x1, y1, x2, y2, length_frac, depth, height, psets=None):
         """A vertical planar element (wall/window) along the x1y1->x2y2 edge: a rectangular profile
         (edge length × `depth`) extruded up by `height`, centred on the edge and rotated to it."""
@@ -238,5 +254,23 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
                     win.OverallHeight = max(0.3, f2f * float(wwr))
                 except Exception:                # noqa: BLE001 — attributes are optional
                     pass
+
+        if core:                               # service core: shafts + stair + MEP risers
+            cw, cd = min(7.0, fw * 0.4), min(5.0, fd * 0.5)
+            ccx, ccy = 0.0, fd / 2 - cd / 2 - 1.0    # core to the rear, off the facade
+            half_w, half_d = cw / 2, cd / 2
+            for (x1, y1, x2, y2) in [(ccx - half_w, ccy - half_d, ccx + half_w, ccy - half_d),
+                                     (ccx + half_w, ccy + half_d, ccx - half_w, ccy + half_d),
+                                     (ccx + half_w, ccy - half_d, ccx + half_w, ccy + half_d),
+                                     (ccx - half_w, ccy + half_d, ccx - half_w, ccy - half_d)]:
+                add_planar("IfcWall", storey, elev, x1, y1, x2, y2, 1.0, 0.2, f2f,
+                           psets={"Pset_WallCommon": {"IsExternal": False, "LoadBearing": True}})
+            add_box("IfcTransportElement", storey, elev, ccx - 1.4, ccy, 2.0, 2.4, f2f,
+                    predefined="ELEVATOR", name="Elevator")
+            add_box("IfcStair", storey, elev, ccx + 1.6, ccy, 2.6, cd * 0.8, f2f, name="Stair")
+            add_box("IfcDuctSegment", storey, elev, ccx - half_w + 0.4, ccy + half_d - 0.4,
+                    0.5, 0.5, f2f, name="Supply riser")
+            add_box("IfcPipeSegment", storey, elev, ccx + half_w - 0.4, ccy + half_d - 0.4,
+                    0.3, 0.3, f2f, name="Plumbing riser")
     model.write(out_path)
     return out_path

--- a/services/data/src/aec_data/qto.py
+++ b/services/data/src/aec_data/qto.py
@@ -81,10 +81,14 @@ def takeoff(
     model: ifcopenshell.file,
     cost_map: dict[str, CostCodeRow] | None = None,
     geometry_fallback: bool = True,
+    force_geometry: bool = False,
 ) -> list[dict[str, Any]]:
+    """`force_geometry`: compute area+volume from geometry for EVERY element that lacks them
+    (independent of a cost map), so a model-based estimate prices real quantities even without
+    Qto psets or a cost-code mapping. Slightly slower; meant for on-demand estimating."""
     cost_map = cost_map or {}
     settings = None
-    if geometry_fallback and _GEOM_OK:
+    if (geometry_fallback or force_geometry) and _GEOM_OK:
         settings = _geom.settings()  # meters, triangulated
 
     rows: list[dict[str, Any]] = []
@@ -94,6 +98,10 @@ def takeoff(
         q = _quantities(el)
         el_type = ue.get_type(el)
         cc = cost_map.get(el.is_a())
+
+        if force_geometry and settings is not None and ("area" not in q or "volume" not in q):
+            for k, v in _geom_quantities(el, settings).items():
+                q.setdefault(k, v)
 
         amount = None
         if cc and cc.unit == "count":
@@ -123,5 +131,6 @@ def takeoff(
     return rows
 
 
-def takeoff_file(ifc_path: str, cost_map_path: str | None = None) -> list[dict[str, Any]]:
-    return takeoff(open_model(ifc_path), load_cost_map(cost_map_path))
+def takeoff_file(ifc_path: str, cost_map_path: str | None = None,
+                 force_geometry: bool = False) -> list[dict[str, Any]]:
+    return takeoff(open_model(ifc_path), load_cost_map(cost_map_path), force_geometry=force_geometry)

--- a/services/data/test_massing.py
+++ b/services/data/test_massing.py
@@ -106,6 +106,22 @@ if _have_ifc:
             print(f"UNITS OK - {len(uspaces)} unit spaces ({upf}/floor x {m['floors']} floors), each with area")
         finally:
             os.remove(upath)
+
+        # --- envelope (facade walls + windows feed the energy model) --------
+        fd4, epath = tempfile.mkstemp(suffix=".ifc"); os.close(fd4)
+        try:
+            massing.generate_ifc(m, epath, name="Enclosed", envelope=True, wwr=0.4)
+            em = open_model(epath)
+            assert len(em.by_type("IfcWall")) == 4 * m["floors"], len(em.by_type("IfcWall"))
+            assert len(em.by_type("IfcWindow")) == 4 * m["floors"], len(em.by_type("IfcWindow"))
+            from aec_data import energy
+            e = energy.analyze_file(epath)
+            assert e["areas_m2"]["window"] > 0 and e["areas_m2"]["exterior_wall_net"] > 0, e["areas_m2"]
+            assert e["ua_w_per_k"]["total"] > 0, e["ua_w_per_k"]
+            print(f"ENVELOPE OK - {len(em.by_type('IfcWall'))} walls + {len(em.by_type('IfcWindow'))} windows; "
+                  f"energy WWR {e['areas_m2']['window_wall_ratio']}, UA {e['ua_w_per_k']['total']} W/K")
+        finally:
+            os.remove(epath)
     finally:
         os.remove(path)
 else:

--- a/services/data/test_massing.py
+++ b/services/data/test_massing.py
@@ -90,6 +90,22 @@ if _have_ifc:
             print(f"FRAME OK - {len(cols)} columns + {len(beams)} beams on a {len(gx)}x{len(gy)} grid")
         finally:
             os.remove(fpath)
+
+        # --- unit subdivision (units=True) ----------------------------------
+        fd3, upath = tempfile.mkstemp(suffix=".ifc"); os.close(fd3)
+        try:
+            massing.generate_ifc(m, upath, name="Unitized", units=True)
+            um = open_model(upath)
+            upf = max(1, round(m["units"] / m["floors"]))
+            uspaces = [s for s in um.by_type("IfcSpace")]
+            assert len(uspaces) == upf * m["floors"], (len(uspaces), upf * m["floors"])
+            # every unit space carries a real area
+            import ifcopenshell.util.element as _ue
+            areas = [(_ue.get_pset(s, "Qto_SpaceBaseQuantities") or {}).get("NetFloorArea") for s in uspaces]
+            assert all(a and a > 0 for a in areas), "unit space missing area"
+            print(f"UNITS OK - {len(uspaces)} unit spaces ({upf}/floor x {m['floors']} floors), each with area")
+        finally:
+            os.remove(upath)
     finally:
         os.remove(path)
 else:

--- a/services/data/test_massing.py
+++ b/services/data/test_massing.py
@@ -71,6 +71,25 @@ if _have_ifc:
         assert span > 5.0, f"slab too small ({span:.3f} m) — unit/scale regression"
         print(f"IFC OK - {len(storeys)} storeys, {len(spaces)} floor-plate spaces + "
               f"{len(slabs)} renderable slabs, sited + represented")
+
+        # --- generative structural frame (frame=True) -----------------------
+        fd2, fpath = tempfile.mkstemp(suffix=".ifc"); os.close(fd2)
+        try:
+            massing.generate_ifc(m, fpath, name="Framed", frame=True, bay=7.5)
+            fm = open_model(fpath)
+            gx = massing.gridlines(m["plate_w"], 7.5); gy = massing.gridlines(m["plate_d"], 7.5)
+            exp_cols = len(gx) * len(gy) * m["floors"]
+            exp_beams = (len(gy) * (len(gx) - 1) + len(gx) * (len(gy) - 1)) * m["floors"]
+            cols, beams = fm.by_type("IfcColumn"), fm.by_type("IfcBeam")
+            assert len(cols) == exp_cols, (len(cols), exp_cols)
+            assert len(beams) == exp_beams, (len(beams), exp_beams)
+            assert all(c.Representation is not None for c in cols), "columns missing geometry"
+            ch = ifcopenshell.geom.create_shape(ifcopenshell.geom.settings(), cols[0])
+            zs = ch.geometry.verts[2::3]
+            assert max(zs) - min(zs) > 2.0, "column height not metre-scale"
+            print(f"FRAME OK - {len(cols)} columns + {len(beams)} beams on a {len(gx)}x{len(gy)} grid")
+        finally:
+            os.remove(fpath)
     finally:
         os.remove(path)
 else:

--- a/services/data/test_massing.py
+++ b/services/data/test_massing.py
@@ -122,6 +122,20 @@ if _have_ifc:
                   f"energy WWR {e['areas_m2']['window_wall_ratio']}, UA {e['ua_w_per_k']['total']} W/K")
         finally:
             os.remove(epath)
+
+        # --- service core + MEP risers (core=True) --------------------------
+        fd5, cpath = tempfile.mkstemp(suffix=".ifc"); os.close(fd5)
+        try:
+            massing.generate_ifc(m, cpath, name="Cored", core=True)
+            cm = open_model(cpath)
+            assert len(cm.by_type("IfcTransportElement")) == m["floors"], "elevator per floor"
+            assert len(cm.by_type("IfcStair")) == m["floors"], "stair per floor"
+            assert len(cm.by_type("IfcDuctSegment")) == m["floors"], "supply riser per floor"
+            assert len(cm.by_type("IfcPipeSegment")) == m["floors"], "plumbing riser per floor"
+            assert len(cm.by_type("IfcWall")) == 4 * m["floors"], "core walls"
+            print(f"CORE OK - elevator/stair + duct/pipe risers + core walls across {m['floors']} floors")
+        finally:
+            os.remove(cpath)
     finally:
         os.remove(path)
 else:


### PR DESCRIPTION
Ships a session's worth of work:

- **Auth/SSO**: Google/Microsoft/Procore login; SSO users are plain free-tier accounts; no admin tier for end users (platform admin via AEC_ADMIN_EMAILS). Tier seam (entitlements.py).
- **Onboarding**: first-run welcome + skippable coach-mark tour; "?" relaunch; viable proforma defaults.
- **AI assistant**: natural-language "Ask AI" over a live project snapshot (Claude when keyed, graceful fallback).
- **Full generative lifecycle**: massing -> structural frame + unit layout + envelope + service core, all from zoning. Assembly-based estimating + GFA benchmark. Closeout package ZIP + module-log PDFs. subject title-alias + auto man-hours TRIR.
- **Bug fixes**: authoring path-length blow-up (Windows) + web-ifc Position invisibility across all recipes; demo seed.

Verified: end-to-end lifecycle 63/63 (acquisition->turnover); API gate 22/22; web typecheck + build clean. See docs/lifecycle-roadmap.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)