### PR TITLE
Developer cost budgets (hard/soft) → proforma (v0.1.9)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.8"
+version = "0.1.9"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -714,6 +714,17 @@ export class ApiClient {
     return this.json<{ project_duration: number; activity_count: number; critical_count: number; has_cycle: boolean; critical_path: string[]; activities: { ref: string | null; name: string; duration: number; es: number; ef: number; total_float: number; critical: boolean }[] }>(
       `/projects/${pid}/schedule/cpm`);
   }
+  /** Developer cost budget (line-item hard/soft/acquisition + contingencies) + computed summary. */
+  devBudget(pid: string) {
+    return this.json<DevBudgetResponse>(`/projects/${pid}/dev-budget`);
+  }
+  saveDevBudget(pid: string, budget: { lines: DevBudgetLine[]; contingency: Record<string, number> }) {
+    return this.json<DevBudgetResponse>(`/projects/${pid}/dev-budget`, { method: "PUT", body: JSON.stringify(budget) });
+  }
+  devBudgetCostLines(pid: string) {
+    return this.json<{ cost_lines: { category: string; name: string; amount: number; curve: string }[]; summary: DevBudgetSummary }>(
+      `/projects/${pid}/dev-budget/cost-lines`);
+  }
   /** Proforma seed metrics derived from the project's source IFC (areas / space + storey counts). */
   proformaModelMetrics(pid: string) {
     return this.json<{ space_count: number; spaces_with_area: number; storey_count: number; net_floor_area_m2: number; net_floor_area_sf: number }>(
@@ -765,6 +776,22 @@ export class ApiClient {
   }
 }
 
+export interface DevBudgetLine {
+  category: "acquisition" | "hard" | "soft";
+  description: string; unit_cost: number; quantity: number; cost_code?: string | null;
+}
+export interface DevBudgetCategory {
+  subtotal: number; contingency: number; contingency_pct: number; total: number;
+  lines: { description: string; unit_cost: number; quantity: number; total: number; cost_code?: string | null }[];
+}
+export interface DevBudgetSummary {
+  categories: Record<string, DevBudgetCategory>;
+  grand_total: number; hard_pct: number; soft_pct: number; line_count: number;
+}
+export interface DevBudgetResponse {
+  budget: { lines: DevBudgetLine[]; contingency: Record<string, number> };
+  summary: DevBudgetSummary;
+}
 export interface FamilyItem {
   key: string; label: string; ifc_class: string; category: string; dims: [number, number, number];
 }

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -101,6 +101,7 @@ export class ProformaUI {
     sizingField("Min DSCR", "debt.min_dscr", 1, "off");
     this.root.appendChild(form);
     this.renderMassing();
+    this.renderBudget();
     this.renderModelLink();
     const out = document.createElement("div"); out.id = "pf-out";
     this.root.appendChild(out);
@@ -217,6 +218,83 @@ export class ProformaUI {
     };
     btnRow.append(estBtn, genBtn); host.append(btnRow, out);
     this.root.appendChild(host);
+  }
+
+  /** Developer cost budget: line-item hard/soft/acquisition costs (description × $/unit × qty) with
+   *  per-category contingency, that roll into the proforma's cost_lines. The institutional gap the
+   *  flat cost drivers don't cover. */
+  private renderBudget() {
+    const host = document.createElement("div"); host.id = "pf-budget";
+    host.style.cssText = "margin:8px 0;padding:8px 10px;border:1px dashed var(--line);border-radius:8px";
+    const pid = this.projectId();
+    host.innerHTML = `<div class="section-title" style="margin:0 0 6px">🧱 Cost budget (hard / soft)</div>`;
+    if (!pid) { host.insertAdjacentHTML("beforeend", `<div class="meta">Open a project to build a line-item cost budget.</div>`); this.root.appendChild(host); return; }
+    const body = document.createElement("div"); host.appendChild(body); this.root.appendChild(host);
+    body.innerHTML = `<div class="meta">loading…</div>`;
+
+    const CATS: [string, string][] = [["acquisition", "Acquisition"], ["hard", "Hard costs"], ["soft", "Soft costs"]];
+    void this.api.devBudget(pid).then((resp) => {
+      const lines = resp.budget.lines.slice();
+      const contingency: Record<string, number> = { hard: 0.1, soft: 0.1, acquisition: 0, ...resp.budget.contingency };
+      let timer = 0;
+      const save = () => { clearTimeout(timer); timer = window.setTimeout(() => void this.api.saveDevBudget(pid, { lines, contingency }).then(paint), 500); };
+      const num = (v: string) => { const n = parseFloat(v); return isNaN(n) ? 0 : n; };
+
+      const paint = (r?: import("../api/client").DevBudgetResponse) => {
+        const sum = r?.summary;
+        body.innerHTML = "";
+        for (const [cat, label] of CATS) {
+          const head = document.createElement("div"); head.className = "section-title"; head.style.cssText = "margin:8px 0 2px;font-size:12px";
+          const subtotal = sum?.categories[cat];
+          head.innerHTML = `${label} <span class="meta" style="font-weight:400">${subtotal ? "· " + money(subtotal.subtotal) + (subtotal.contingency ? " + " + money(subtotal.contingency) + " contingency" : "") : ""}</span>`;
+          body.appendChild(head);
+          const tbl = document.createElement("table"); tbl.className = "sens-table"; tbl.style.fontSize = "12px";
+          tbl.innerHTML = `<tr><th style="text-align:left">Description</th><th>$/unit</th><th>Qty</th><th>Total</th><th></th></tr>`;
+          lines.forEach((ln, i) => {
+            if (ln.category !== cat) return;
+            const tr = document.createElement("tr");
+            const tot = (ln.unit_cost || 0) * (ln.quantity || 1);
+            tr.innerHTML = `<td><input data-i="${i}" data-k="description" value="${(ln.description || "").replace(/"/g, "&quot;")}" style="width:150px"></td>`
+              + `<td><input data-i="${i}" data-k="unit_cost" type="number" step="any" value="${ln.unit_cost || 0}" style="width:90px"></td>`
+              + `<td><input data-i="${i}" data-k="quantity" type="number" step="any" value="${ln.quantity ?? 1}" style="width:60px"></td>`
+              + `<td style="text-align:right">${money(tot)}</td><td><button class="tool-btn" data-rm="${i}" title="Remove">✕</button></td>`;
+            tbl.appendChild(tr);
+          });
+          body.appendChild(tbl);
+          const addRow = document.createElement("div"); addRow.style.cssText = "display:flex;gap:8px;align-items:center;margin:3px 0 2px";
+          const add = document.createElement("button"); add.className = "tool-btn"; add.textContent = "+ line";
+          add.onclick = () => { lines.push({ category: cat as "hard", description: "New line", unit_cost: 0, quantity: 1 }); save(); paint(); };
+          const cw = document.createElement("label"); cw.className = "meta"; cw.style.fontSize = "11px";
+          cw.innerHTML = `contingency % <input type="number" step="any" value="${+(contingency[cat] * 100).toFixed(2)}" style="width:56px">`;
+          (cw.querySelector("input") as HTMLInputElement).oninput = (e) => { contingency[cat] = num((e.target as HTMLInputElement).value) / 100; save(); };
+          addRow.append(add, cw); body.appendChild(addRow);
+        }
+        body.querySelectorAll<HTMLInputElement>("input[data-i]").forEach((inp) => {
+          inp.oninput = () => {
+            const i = +inp.dataset.i!, k = inp.dataset.k!;
+            (lines[i] as unknown as Record<string, unknown>)[k] = k === "description" ? inp.value : num(inp.value);
+            save();
+            if (k !== "description") paint();   // refresh totals
+          };
+        });
+        body.querySelectorAll<HTMLButtonElement>("button[data-rm]").forEach((b) => {
+          b.onclick = () => { lines.splice(+b.dataset.rm!, 1); save(); paint(); };
+        });
+        const foot = document.createElement("div"); foot.style.cssText = "display:flex;justify-content:space-between;align-items:center;margin-top:8px";
+        foot.innerHTML = `<b>Total uses ${money(sum?.grand_total ?? 0)}</b>`
+          + `<span class="meta" style="font-size:11px">${sum ? `hard ${(sum.hard_pct * 100).toFixed(0)}% / soft ${(sum.soft_pct * 100).toFixed(0)}%` : ""}</span>`;
+        const apply = document.createElement("button"); apply.className = "file-btn"; apply.textContent = "Apply to proforma";
+        apply.onclick = async () => {
+          const r = await this.api.devBudgetCostLines(pid);
+          (this.a as { cost_lines: unknown[] }).cost_lines = r.cost_lines.map((c) => ({ ...c, start_month: 0, end_month: 0 }));
+          this.render(); void this.solve();
+          this.setStatus(`applied cost budget: ${money(r.summary.grand_total)} total uses`);
+        };
+        const fwrap = document.createElement("div"); fwrap.style.marginTop = "6px"; fwrap.appendChild(apply);
+        body.append(foot, fwrap);
+      };
+      paint(resp);
+    }).catch(() => { body.innerHTML = `<div class="meta">cost budget unavailable (API offline)</div>`; });
   }
 
   /** Model → proforma: pull GFA from the project's source IFC and seed hard cost + rent from it,

--- a/docs/developer-portal-roadmap.md
+++ b/docs/developer-portal-roadmap.md
@@ -1,0 +1,67 @@
+# Developer portal — institutional budgeting, specialty assets & investor materials
+
+Derived from a real institutional development model (M. Emma, *Conversion of Retail Using the
+Vertical Farm Method of Indoor Agriculture*, Georgetown 2021) and current CRE practice. The gap:
+today the proforma takes flat `cost_lines`; it does **not** model **line-item hard/soft cost
+budgets**, a grouped **Sources & Uses**, property/tax assumptions, **specialty revenue/energy**
+assets, or **investor-facing materials**. This roadmap builds the developer side out to that depth.
+
+## Grounding (sources)
+- Hard vs soft costs, ratios, contingency: [Feldman Equities](https://www.feldmanequities.com/education/hard-costs-vs-soft-costs-in-real-estate-development/),
+  [Young Architect](https://academy2.youngarchitect.com/hard-costs-vs-soft-costs/),
+  [Willowdale Equity](https://willowdaleequity.com/blog/hard-vs-soft-costs-in-real-estate/),
+  [Linneman/Kirsch Ch.10](https://textbook.getrefm.com/chapter-10-development-pro-forma-analysis/).
+- Sources & Uses / proforma structure: [LeadDeveloper](https://leaddeveloper.com/real-estate-development-proforma/),
+  [Adventures in CRE](https://www.adventuresincre.com/glossary/soft-costs/).
+- Offering memorandum / pitch deck: [VIP Graphics](https://vip.graphics/what-to-include-in-a-real-estate-investor-memo/),
+  [FocusedCRE](https://focusedcre.com/real-estate-investment-memorandum),
+  [RealCapAnalytics](https://www.realcapanalytics.com/blog/a-comprehensive-guide-to-creating-an-effective-real-estate-pitch-deck).
+
+Practice norms to encode: hard ≈ 70–80% / soft ≈ 20–30% of budget; hard contingency 5–10%, soft
+("design") contingency ~10%; Uses = Acquisition + Hard + Soft + Financing; Sources = Debt + Equity.
+
+## 1 — Line-item hard / soft cost budgets ★ (the explicit gap)
+A structured budget that rolls into the proforma's `cost_lines`. Each line: **category**
+(acquisition | hard | soft) · **description** · **$/unit** · **quantity (SF/unit)** · **total =
+$/unit × qty** · optional **CSI/cost code**. Per-category **contingency %** on the subtotal.
+- Engine `dev_budget.py` (pure): `summarize(lines, contingency)` → per-category subtotals +
+  contingency + grand totals; `to_cost_lines()` → the proforma cost tree.
+- Storage + endpoints: GET/PUT `/projects/{id}/dev-budget`; `…/dev-budget/cost-lines` (proforma
+  seed). Finance UI: a category-grouped editable table with live totals; "Apply to proforma".
+- Mirrors the thesis model's **Hard Cost Breakdown** (re-roof, solar, turbines, battery, HVAC,
+  chiller, market…) and **Soft Cost Breakdown** (architect, structural/mech/energy/ag consultants,
+  expeditor, T&B, design contingency).
+
+## 2 — Sources & Uses
+Grouped Uses (Acquisition: purchase, transfer tax, legal/DD, survey/title · Hard · Soft incl.
+construction-loan interest) vs Sources (senior debt by LTC/LTV, mezz, LP/GP equity). Endpoint
+`…/dev-budget/sources-uses`; balances Uses against sized debt + equity. Per-period draw spread
+(reuse the S-curve engine) so financing interest is solved, not hand-keyed.
+
+## 3 — Property & tax assumptions
+A project "development assumptions" record: address, block/lot, appraisal, purchase price,
+land/building/parking SF, and a **tax table** (school/county/town/fire → total) feeding OPEX.
+(Thesis: 2000 Hempstead Tpke — 598,668 land SF, 249,749 building SF, $1.50M taxes.)
+
+## 4 — Specialty assets (differentiator: tie revenue to the model)
+Pluggable revenue/energy modules beyond rent, driven off model areas:
+- **On-site energy** — solar (SF × $/panel, generation), wind turbines, battery storage,
+  rainwater collection → capex + an energy-offset operating credit.
+- **Vertical farm / PFAL** — towers × crop cycle × yield × $/lb (wholesale/retail) → revenue;
+  lighting kWh load → opex. (Thesis: 23,760 ZipGrow towers, greens + herbs.)
+These attach to generated massing (areas → counts) so feasibility flows model → specialty proforma.
+
+## 5 — Investor materials ★ ("generate a presentation with financials")
+- **Investment memo (PDF)** — cover · executive summary (location, sponsor, plan, headline IRR/EM/
+  yield-on-cost) · property & market · Sources & Uses · hard/soft budget · proforma cash flows &
+  returns · JV waterfall · risks & mitigations · timeline/milestones. ~15–25 pp.
+- **Pitch deck (10–20 slides)** — the high-level summary version (reuse the memo data).
+- Compose from live project data so the deck never drifts from the model.
+
+## Build order
+1 (budgets) → 2 (S&U) → 5 (memo PDF) → 3 (assumptions) → 4 (specialty). Each ships independently;
+1, 2 and 5 are the headline asks.
+
+## Status
+- ✅ **DONE — 1. Line-item hard/soft cost budgets** (see dev_budget.py / `/projects/{id}/dev-budget`).
+- ⏳ 2 Sources & Uses · 5 Investment memo PDF · 3 assumptions · 4 specialty — next.

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -19,7 +19,7 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_serving", "test_api",
-         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security"]
+         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget"]
 
 
 def main() -> int:

--- a/services/api/src/aec_api/dev_budget.py
+++ b/services/api/src/aec_api/dev_budget.py
@@ -1,0 +1,93 @@
+"""Developer cost budget — line-item hard/soft/acquisition costs that roll into the proforma.
+
+Each line: category (acquisition|hard|soft) · description · unit_cost ($/unit) · quantity (SF/unit)
+· total = unit_cost × quantity · optional cost_code. Per-category contingency % applies to that
+category's subtotal (hard "construction contingency", soft "design contingency") — matching
+institutional practice (hard ≈ 70–80% of budget, soft ≈ 20–30%, contingency 5–10%).
+
+Pure functions over plain dicts so the math is testable without a DB. `summarize()` aggregates;
+`to_cost_lines()` emits the proforma cost tree (the seed the Finance view applies)."""
+from __future__ import annotations
+
+from typing import Any
+
+CATEGORIES = ("acquisition", "hard", "soft")
+# proforma cost_lines use land/hard/soft/contingency/fee — map our categories onto those
+_PROFORMA_CAT = {"acquisition": "land", "hard": "hard", "soft": "soft"}
+_DEFAULT_CONTINGENCY = {"hard": 0.10, "soft": 0.10, "acquisition": 0.0}
+
+
+def line_total(line: dict) -> float:
+    """unit_cost × quantity (quantity defaults to 1 so flat lump sums work)."""
+    return round(float(line.get("unit_cost", 0) or 0) * float(line.get("quantity", 1) or 1), 2)
+
+
+def summarize(budget: dict[str, Any]) -> dict[str, Any]:
+    """budget = {lines: [{category, description, unit_cost, quantity, cost_code}], contingency:{cat:pct}}.
+    Returns per-category subtotals, contingency amounts, category totals, and the grand total."""
+    lines = budget.get("lines") or []
+    contingency = {**_DEFAULT_CONTINGENCY, **(budget.get("contingency") or {})}
+    cats: dict[str, dict[str, Any]] = {
+        c: {"subtotal": 0.0, "contingency_pct": float(contingency.get(c, 0.0)), "lines": []}
+        for c in CATEGORIES}
+    for ln in lines:
+        cat = ln.get("category") if ln.get("category") in CATEGORIES else "hard"
+        t = line_total(ln)
+        cats[cat]["subtotal"] += t
+        cats[cat]["lines"].append({
+            "description": ln.get("description") or "(line)",
+            "unit_cost": float(ln.get("unit_cost", 0) or 0),
+            "quantity": float(ln.get("quantity", 1) or 1),
+            "cost_code": ln.get("cost_code"),
+            "total": t,
+        })
+    grand = 0.0
+    for c in CATEGORIES:
+        sub = round(cats[c]["subtotal"], 2)
+        cont = round(sub * cats[c]["contingency_pct"], 2)
+        cats[c]["subtotal"] = sub
+        cats[c]["contingency"] = cont
+        cats[c]["total"] = round(sub + cont, 2)
+        grand += cats[c]["total"]
+    grand = round(grand, 2)
+    hard_total = cats["hard"]["total"]
+    soft_total = cats["soft"]["total"]
+    hs = hard_total + soft_total
+    return {
+        "categories": cats,
+        "grand_total": grand,
+        # institutional sanity ratios (of hard+soft, excl. acquisition)
+        "hard_pct": round(hard_total / hs, 3) if hs else 0.0,
+        "soft_pct": round(soft_total / hs, 3) if hs else 0.0,
+        "line_count": len(lines),
+    }
+
+
+def to_cost_lines(budget: dict[str, Any]) -> list[dict[str, Any]]:
+    """Emit the proforma's four canonical cost_lines in fixed order — land, hard, soft, contingency
+    — so they line up with the proforma's positional driver fields. Contingency combines the hard
+    (construction) + soft (design) + acquisition contingencies. Reconciles to the grand total."""
+    s = summarize(budget)
+    cats = s["categories"]
+    contingency = round(sum(cats[c]["contingency"] for c in CATEGORIES), 2)
+    return [
+        {"category": "land", "name": "Acquisition", "amount": cats["acquisition"]["subtotal"], "curve": "upfront"},
+        {"category": "hard", "name": "Hard costs", "amount": cats["hard"]["subtotal"], "curve": "scurve"},
+        {"category": "soft", "name": "Soft costs", "amount": cats["soft"]["subtotal"], "curve": "linear"},
+        {"category": "contingency", "name": "Contingency (construction + design)", "amount": contingency, "curve": "scurve"},
+    ]
+
+
+def starter_budget() -> dict[str, Any]:
+    """A small, sensible starter so the UI isn't empty (editable; conceptual placeholders)."""
+    return {
+        "contingency": {"hard": 0.10, "soft": 0.10, "acquisition": 0.0},
+        "lines": [
+            {"category": "acquisition", "description": "Purchase price", "unit_cost": 0, "quantity": 1},
+            {"category": "acquisition", "description": "Transfer taxes & closing", "unit_cost": 0, "quantity": 1},
+            {"category": "hard", "description": "Shell & core ($/sf)", "unit_cost": 0, "quantity": 0, "cost_code": "—"},
+            {"category": "hard", "description": "MEP", "unit_cost": 0, "quantity": 1},
+            {"category": "soft", "description": "Architecture & engineering", "unit_cost": 0, "quantity": 1},
+            {"category": "soft", "description": "Permits & legal", "unit_cost": 0, "quantity": 1},
+        ],
+    }

--- a/services/api/src/aec_api/models.py
+++ b/services/api/src/aec_api/models.py
@@ -27,6 +27,8 @@ class Project(Base):
     origin: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     # server-side path to the source IFC, used by the data-export endpoints (guide §8)
     source_ifc: Mapped[str | None] = mapped_column(String, nullable=True)
+    # developer cost budget: line-item hard/soft/acquisition costs + contingencies (dev_budget.py)
+    dev_budget: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
 
     topics: Mapped[list["Topic"]] = relationship(back_populates="project", cascade="all, delete-orphan")

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -102,6 +102,50 @@ def solve_stateless(a: Assumptions):
     return solve(a.model_dump())
 
 
+@router.get("/projects/{pid}/dev-budget")
+def get_dev_budget(pid: str, db: Session = Depends(get_db)):
+    """The project's developer cost budget (line-item hard/soft/acquisition + contingencies) plus a
+    computed summary. Returns a starter budget if none is saved yet."""
+    from .. import dev_budget as dvb
+    from ..models import Project as _P
+    p = db.get(_P, pid)
+    if not p:
+        raise HTTPException(404, "project not found")
+    budget = p.dev_budget or dvb.starter_budget()
+    return {"budget": budget, "summary": dvb.summarize(budget)}
+
+
+class DevBudgetIn(BaseModel):
+    lines: list[dict] = Field(default_factory=list)
+    contingency: dict[str, float] = Field(default_factory=dict)
+
+
+@router.put("/projects/{pid}/dev-budget")
+def put_dev_budget(pid: str, body: DevBudgetIn, db: Session = Depends(get_db)):
+    """Save the developer cost budget; returns the recomputed summary."""
+    from .. import dev_budget as dvb
+    from ..models import Project as _P
+    p = db.get(_P, pid)
+    if not p:
+        raise HTTPException(404, "project not found")
+    budget = body.model_dump()
+    p.dev_budget = budget
+    db.commit()
+    return {"budget": budget, "summary": dvb.summarize(budget)}
+
+
+@router.get("/projects/{pid}/dev-budget/cost-lines")
+def dev_budget_cost_lines(pid: str, db: Session = Depends(get_db)):
+    """The budget rolled into proforma cost_lines (the seed the Finance view applies)."""
+    from .. import dev_budget as dvb
+    from ..models import Project as _P
+    p = db.get(_P, pid)
+    if not p:
+        raise HTTPException(404, "project not found")
+    budget = p.dev_budget or dvb.starter_budget()
+    return {"cost_lines": dvb.to_cost_lines(budget), "summary": dvb.summarize(budget)}
+
+
 @router.get("/projects/{pid}/proforma/model-metrics")
 def proforma_model_metrics(pid: str, db: Session = Depends(get_db)):
     """Metrics from the project's source IFC, so the proforma can underwrite against the real

--- a/services/api/test_dev_budget.py
+++ b/services/api/test_dev_budget.py
@@ -1,0 +1,60 @@
+"""Developer cost budget — engine math + persistence + proforma cost-line mapping.
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_dev_budget.py"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_devbudget.db"
+os.environ["STORAGE_DIR"] = "./test_storage_devbudget"
+os.environ.pop("AEC_RBAC", None)
+for f in ("./test_devbudget.db",):
+    if os.path.exists(f):
+        os.remove(f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from aec_api import dev_budget as dvb  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+# --- pure engine: line totals, contingency, category rollups -----------------
+budget = {
+    "contingency": {"hard": 0.10, "soft": 0.10, "acquisition": 0.0},
+    "lines": [
+        {"category": "acquisition", "description": "Purchase", "unit_cost": 15_744_700, "quantity": 1},
+        {"category": "hard", "description": "Solar panels", "unit_cost": 330, "quantity": 25_000},
+        {"category": "hard", "description": "Wind turbines", "unit_cost": 5_000, "quantity": 1_161},
+        {"category": "soft", "description": "Architect", "unit_cost": 350_000, "quantity": 1},
+        {"category": "soft", "description": "Energy consultant", "unit_cost": 75_000, "quantity": 1},
+    ],
+}
+s = dvb.summarize(budget)
+assert s["categories"]["hard"]["subtotal"] == 330 * 25_000 + 5_000 * 1_161, s["categories"]["hard"]
+assert s["categories"]["hard"]["contingency"] == round(s["categories"]["hard"]["subtotal"] * 0.10, 2)
+assert s["categories"]["soft"]["subtotal"] == 425_000.0
+assert s["categories"]["acquisition"]["contingency"] == 0.0
+expect_grand = (s["categories"]["acquisition"]["total"] + s["categories"]["hard"]["total"]
+                + s["categories"]["soft"]["total"])
+assert abs(s["grand_total"] - round(expect_grand, 2)) < 0.01, (s["grand_total"], expect_grand)
+assert 0 < s["soft_pct"] < s["hard_pct"] < 1, (s["hard_pct"], s["soft_pct"])   # hard dominates
+
+# --- cost_lines mapping: rolled category line + its contingency as a separate line ---
+cl = dvb.to_cost_lines(budget)
+cats = [c["category"] for c in cl]
+assert "land" in cats and "hard" in cats and "soft" in cats and "contingency" in cats, cats
+assert sum(c["amount"] for c in cl) == s["grand_total"], "cost_lines must reconcile to grand total"
+
+# --- persistence round-trip via the API --------------------------------------
+with TestClient(app) as c:
+    pid = c.post("/projects", json={"name": "Dev Tower"}).json()["id"]
+    # starter budget served when none saved
+    g0 = c.get(f"/projects/{pid}/dev-budget").json()
+    assert g0["budget"]["lines"] and "summary" in g0, g0
+    # save + recompute
+    r = c.put(f"/projects/{pid}/dev-budget", json={"lines": budget["lines"], "contingency": budget["contingency"]})
+    assert r.status_code == 200, r.text
+    assert r.json()["summary"]["grand_total"] == s["grand_total"]
+    # persisted
+    assert c.get(f"/projects/{pid}/dev-budget").json()["summary"]["grand_total"] == s["grand_total"]
+    # cost-lines endpoint reconciles
+    clr = c.get(f"/projects/{pid}/dev-budget/cost-lines").json()
+    assert round(sum(x["amount"] for x in clr["cost_lines"]), 2) == s["grand_total"], clr
+
+print(f"DEV-BUDGET OK - line totals + per-category contingency + grand ${s['grand_total']:,.0f}; "
+      f"hard {s['hard_pct']*100:.0f}% / soft {s['soft_pct']*100:.0f}%; cost_lines reconcile; persisted via API")


### PR DESCRIPTION
Line-item hard/soft/acquisition cost budgets with per-category contingency that roll into the proforma cost tree. Engine + API + Finance UI + test (gate 24/24). Developer-portal roadmap (S&U, assumptions, specialty revenue, investment memo) added. Grounded in an institutional thesis model + CRE practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)