### PR TITLE
Specialty assets: on-site energy + vertical-farm revenue (v0.1.11)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.10"
+version = "0.1.11"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -725,6 +725,13 @@ export class ApiClient {
     return this.json<{ cost_lines: { category: string; name: string; amount: number; curve: string }[]; summary: DevBudgetSummary }>(
       `/projects/${pid}/dev-budget/cost-lines`);
   }
+  /** Specialty assets (on-site energy + vertical-farm/PFAL) params + computed summary + deltas. */
+  specialty(pid: string) {
+    return this.json<SpecialtyResponse>(`/projects/${pid}/specialty`);
+  }
+  saveSpecialty(pid: string, params: Record<string, unknown>) {
+    return this.json<SpecialtyResponse>(`/projects/${pid}/specialty`, { method: "PUT", body: JSON.stringify(params) });
+  }
   /** Proforma seed metrics derived from the project's source IFC (areas / space + storey counts). */
   proformaModelMetrics(pid: string) {
     return this.json<{ space_count: number; spaces_with_area: number; storey_count: number; net_floor_area_m2: number; net_floor_area_sf: number }>(
@@ -791,6 +798,18 @@ export interface DevBudgetSummary {
 export interface DevBudgetResponse {
   budget: { lines: DevBudgetLine[]; contingency: Record<string, number> };
   summary: DevBudgetSummary;
+}
+export interface SpecialtySummary {
+  capex_total: number; annual_revenue: number; annual_opex: number;
+  annual_energy_offset: number; annual_net_contribution: number;
+  energy: { solar_panels: number; capex: number; generation_kwh_yr: number; annual_energy_offset: number } | null;
+  pfal: { towers: number; annual_revenue: number; annual_opex: number; startup_capex: number } | null;
+}
+export interface SpecialtyResponse {
+  params: Record<string, unknown>;
+  summary: SpecialtySummary;
+  deltas: { cost_line: { category: string; name: string; amount: number; curve: string } | null;
+    other_income_annual_add: number; opex_annual_add: number };
 }
 export interface FamilyItem {
   key: string; label: string; ifc_class: string; category: string; dims: [number, number, number];

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -102,6 +102,7 @@ export class ProformaUI {
     this.root.appendChild(form);
     this.renderMassing();
     this.renderBudget();
+    this.renderSpecialty();
     this.renderModelLink();
     const out = document.createElement("div"); out.id = "pf-out";
     this.root.appendChild(out);
@@ -218,6 +219,79 @@ export class ProformaUI {
     };
     btnRow.append(estBtn, genBtn); host.append(btnRow, out);
     this.root.appendChild(host);
+  }
+
+  /** Specialty assets: on-site energy (solar/wind/battery/rainwater) + vertical-farm (PFAL) tower
+   *  revenue. Capex + annual revenue/opex/energy-offset flow into the proforma — the thesis-grounded
+   *  differentiator tying the physical program to the deal economics. */
+  private renderSpecialty() {
+    const host = document.createElement("div"); host.id = "pf-specialty";
+    host.style.cssText = "margin:8px 0;padding:8px 10px;border:1px dashed var(--line);border-radius:8px";
+    const pid = this.projectId();
+    host.innerHTML = `<div class="section-title" style="margin:0 0 6px">⚡ Specialty: energy & vertical farm</div>`;
+    if (!pid) { host.insertAdjacentHTML("beforeend", `<div class="meta">Open a project to model on-site energy + farm revenue.</div>`); this.root.appendChild(host); return; }
+    const bodyEl = document.createElement("div"); host.appendChild(bodyEl); this.root.appendChild(host);
+    bodyEl.innerHTML = `<div class="meta">loading…</div>`;
+
+    void this.api.specialty(pid).then((resp) => {
+      const params = resp.params as Record<string, Record<string, number> & { [k: string]: unknown }> & { energy_enabled?: boolean; pfal_enabled?: boolean };
+      let timer = 0;
+      const save = () => { clearTimeout(timer); timer = window.setTimeout(() => void this.api.saveSpecialty(pid, params).then((r) => paint(r.summary)), 500); };
+      // [label, group, key]
+      const FIELDS: [string, "energy" | "pfal", string][] = [
+        ["Solar SF", "energy", "solar_sf"], ["$/panel", "energy", "cost_per_panel"],
+        ["Battery units", "energy", "battery_units"], ["Rainwater $", "energy", "rainwater_capex"],
+        ["PFAL SF", "pfal", "pfal_sf"], ["Greens $/lb", "pfal", "green_price_lb"], ["Herbs $/lb", "pfal", "herb_price_lb"],
+      ];
+      const paint = (sum?: import("../api/client").SpecialtySummary) => {
+        bodyEl.innerHTML = "";
+        // enable toggles
+        const tog = document.createElement("div"); tog.style.cssText = "display:flex;gap:14px;margin-bottom:6px";
+        for (const [k, lbl] of [["energy_enabled", "On-site energy"], ["pfal_enabled", "Vertical farm (PFAL)"]] as const) {
+          const w = document.createElement("label"); w.style.cssText = "display:flex;align-items:center;gap:5px;font-size:12px";
+          const cb = document.createElement("input"); cb.type = "checkbox"; cb.checked = params[k] !== false;
+          cb.onchange = () => { (params as Record<string, unknown>)[k] = cb.checked; save(); paint(); };
+          w.append(cb, document.createTextNode(lbl)); tog.appendChild(w);
+        }
+        bodyEl.appendChild(tog);
+        const grid = document.createElement("div"); grid.className = "pf-form";
+        for (const [label, group, key] of FIELDS) {
+          params[group] = params[group] || {};
+          const wrap = document.createElement("label"); wrap.className = "pf-field"; wrap.innerHTML = `<span>${label}</span>`;
+          const inp = document.createElement("input"); inp.type = "number"; inp.step = "any";
+          inp.value = String((params[group] as Record<string, number>)[key] ?? 0);
+          inp.oninput = () => { (params[group] as Record<string, number>)[key] = parseFloat(inp.value) || 0; save(); };
+          wrap.appendChild(inp); grid.appendChild(wrap);
+        }
+        bodyEl.appendChild(grid);
+        if (sum) {
+          const s = document.createElement("div"); s.className = "meta"; s.style.marginTop = "6px";
+          s.innerHTML = `Capex <b>${money(sum.capex_total)}</b>`
+            + (sum.energy ? ` · ${sum.energy.solar_panels.toLocaleString()} panels` : "")
+            + (sum.pfal ? ` · ${sum.pfal.towers.toLocaleString()} towers` : "")
+            + `<br>Produce revenue <b>${money(sum.annual_revenue)}</b>/yr · energy offset ${money(sum.annual_energy_offset)}/yr · farm opex ${money(sum.annual_opex)}/yr`
+            + `<br>Net operating contribution <b>${money(sum.annual_net_contribution)}</b>/yr`;
+          bodyEl.appendChild(s);
+        }
+        const apply = document.createElement("button"); apply.className = "file-btn"; apply.style.marginTop = "6px";
+        apply.textContent = "Apply to proforma";
+        apply.onclick = async () => {
+          const r = await this.api.saveSpecialty(pid, params);
+          const d = r.deltas;
+          const a = this.a as { cost_lines: { category: string; name: string; amount: number }[]; operations: { other_income_annual: number; opex_annual: number } };
+          if (d.cost_line) {
+            const ex = a.cost_lines.find((c) => c.name === d.cost_line!.name);
+            if (ex) ex.amount = d.cost_line.amount; else a.cost_lines.push({ ...d.cost_line, start_month: 0, end_month: 0 } as never);
+          }
+          a.operations.other_income_annual = (a.operations.other_income_annual || 0) + d.other_income_annual_add;
+          a.operations.opex_annual = (a.operations.opex_annual || 0) + d.opex_annual_add;
+          this.render(); void this.solve();
+          this.setStatus(`applied specialty assets: ${money(r.summary.capex_total)} capex, ${money(r.summary.annual_net_contribution)}/yr net`);
+        };
+        bodyEl.appendChild(apply);
+      };
+      paint(resp.summary);
+    }).catch(() => { bodyEl.innerHTML = `<div class="meta">specialty assets unavailable (API offline)</div>`; });
   }
 
   /** Developer cost budget: line-item hard/soft/acquisition costs (description × $/unit × qty) with

--- a/docs/developer-portal-roadmap.md
+++ b/docs/developer-portal-roadmap.md
@@ -68,4 +68,10 @@ These attach to generated massing (areas → counts) so feasibility flows model 
   `GET /projects/{id}/investment-memo.pdf`: cover · executive summary · Sources & Uses · cost
   budget · returns (from the latest solved scenario) · risk read. "📄 Investment memo" button in
   Finance. *Next: pitch-deck (slide) variant, market/timeline sections, property photos.*
-- ⏳ 2 Sources & Uses (first-class view) · 3 property/tax assumptions · 4 specialty energy/PFAL — next.
+- ✅ **DONE — 4. Specialty assets (energy + vertical farm)** — `specialty.py` /
+  `GET/PUT /projects/{id}/specialty`: on-site solar/wind/battery/rainwater → capex + annual energy
+  offset; PFAL towers (from area) → produce revenue + lighting opex + startup capex. Rolls into the
+  proforma (capex→hard line, revenue+offset→other income, opex→opex). "⚡ Specialty" Finance panel
+  with toggles + Apply. Thesis-grounded defaults. Verified end-to-end. *Next: wind generation curve,
+  crop-mix presets, energy storage dispatch.*
+- ⏳ 2 Sources & Uses (first-class view) · 3 property/tax assumptions — next.

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -19,7 +19,7 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_serving", "test_api",
-         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget"]
+         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty"]
 
 
 def main() -> int:

--- a/services/api/src/aec_api/models.py
+++ b/services/api/src/aec_api/models.py
@@ -29,6 +29,8 @@ class Project(Base):
     source_ifc: Mapped[str | None] = mapped_column(String, nullable=True)
     # developer cost budget: line-item hard/soft/acquisition costs + contingencies (dev_budget.py)
     dev_budget: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    # specialty assets: on-site energy + vertical-farm (PFAL) revenue params (specialty.py)
+    dev_specialty: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
 
     topics: Mapped[list["Topic"]] = relationship(back_populates="project", cascade="all, delete-orphan")

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -134,6 +134,32 @@ def put_dev_budget(pid: str, body: DevBudgetIn, db: Session = Depends(get_db)):
     return {"budget": budget, "summary": dvb.summarize(budget)}
 
 
+@router.get("/projects/{pid}/specialty")
+def get_specialty(pid: str, db: Session = Depends(get_db)):
+    """Specialty assets (on-site energy + vertical-farm/PFAL) params + computed summary (capex,
+    annual revenue/opex/energy-offset). Starter params if none saved."""
+    from .. import specialty as sp
+    from ..models import Project as _P
+    p = db.get(_P, pid)
+    if not p:
+        raise HTTPException(404, "project not found")
+    params = p.dev_specialty or sp.starter()
+    return {"params": params, "summary": sp.summarize(params), "deltas": sp.to_proforma_deltas(params)}
+
+
+@router.put("/projects/{pid}/specialty")
+def put_specialty(pid: str, body: dict, db: Session = Depends(get_db)):
+    """Save specialty-asset params; returns the recomputed summary + proforma deltas."""
+    from .. import specialty as sp
+    from ..models import Project as _P
+    p = db.get(_P, pid)
+    if not p:
+        raise HTTPException(404, "project not found")
+    p.dev_specialty = body
+    db.commit()
+    return {"params": body, "summary": sp.summarize(body), "deltas": sp.to_proforma_deltas(body)}
+
+
 @router.get("/projects/{pid}/investment-memo.pdf")
 def investment_memo(pid: str, db: Session = Depends(get_db)):
     """Confidential investment memorandum (PDF) composed from live project data — executive summary,

--- a/services/api/src/aec_api/specialty.py
+++ b/services/api/src/aec_api/specialty.py
@@ -1,0 +1,111 @@
+"""Specialty assets — on-site energy generation and vertical-farm (PFAL) revenue, beyond rent.
+
+Ties a project's *physical* program to its economics: solar/wind/battery/rainwater drive capex and
+an annual energy-cost offset; a Plant-Factory-Artificial-Lighting (PFAL) tower farm drives produce
+revenue and a lighting-electricity opex load. The differentiator from the thesis model — feasibility
+flows model area → tower/panel counts → a specialty proforma. Pure functions over plain dicts.
+
+`summarize()` returns capex + annual revenue/opex/energy-offset; `to_proforma_deltas()` expresses
+those as adjustments to the proforma's cost line + operations block (other income / opex)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def energy(p: dict[str, Any]) -> dict[str, Any]:
+    """On-site generation. Inputs: solar_sf or solar_panels, sf_per_panel, cost_per_panel,
+    watt_per_panel, sun_hours_day, price_per_kwh; wind_turbines/wind_cost/wind_kwh_yr_each;
+    battery_units/battery_cost; rainwater_capex."""
+    sf_per_panel = float(p.get("sf_per_panel", 20) or 20)
+    panels = float(p.get("solar_panels") or (float(p.get("solar_sf", 0) or 0) / sf_per_panel if sf_per_panel else 0))
+    cost_per_panel = float(p.get("cost_per_panel", 330))
+    price_kwh = float(p.get("price_per_kwh", 0.12))
+    solar_capex = panels * cost_per_panel
+    solar_kwh_yr = panels * float(p.get("watt_per_panel", 400)) / 1000 * float(p.get("sun_hours_day", 4.5)) * 365
+
+    wind = float(p.get("wind_turbines", 0) or 0)
+    wind_capex = wind * float(p.get("wind_cost", 5000))
+    wind_kwh_yr = wind * float(p.get("wind_kwh_yr_each", 3000))
+
+    battery_capex = float(p.get("battery_units", 0) or 0) * float(p.get("battery_cost", 15000))
+    rainwater_capex = float(p.get("rainwater_capex", 0) or 0)
+
+    gen_kwh_yr = solar_kwh_yr + wind_kwh_yr
+    return {
+        "solar_panels": round(panels),
+        "capex": round(solar_capex + wind_capex + battery_capex + rainwater_capex),
+        "generation_kwh_yr": round(gen_kwh_yr),
+        "annual_energy_offset": round(gen_kwh_yr * price_kwh),
+        "breakdown": {"solar": round(solar_capex), "wind": round(wind_capex),
+                      "battery": round(battery_capex), "rainwater": round(rainwater_capex)},
+    }
+
+
+def pfal(p: dict[str, Any]) -> dict[str, Any]:
+    """Vertical farm. Inputs: pfal_sf or towers, sf_per_tower, green_pct, green/herb lbs_per_tower_yr
+    and $/lb, watt_per_tower, light_hours_day, price_per_kwh, startup_per_tower, labor_per_tower_yr."""
+    sf_per_tower = float(p.get("sf_per_tower", 1.7) or 1.7)
+    towers = float(p.get("towers") or (float(p.get("pfal_sf", 0) or 0) / sf_per_tower if sf_per_tower else 0))
+    green_pct = float(p.get("green_pct", 0.4))
+    greens, herbs = towers * green_pct, towers * (1 - green_pct)
+    green_rev = greens * float(p.get("green_lbs_per_tower_yr", 60)) * float(p.get("green_price_lb", 5))
+    herb_rev = herbs * float(p.get("herb_lbs_per_tower_yr", 45)) * float(p.get("herb_price_lb", 16))
+    revenue = green_rev + herb_rev
+
+    price_kwh = float(p.get("price_per_kwh", 0.12))
+    light_kwh_yr = towers * float(p.get("watt_per_tower", 60)) / 1000 * float(p.get("light_hours_day", 18)) * 365
+    opex = light_kwh_yr * price_kwh + towers * float(p.get("labor_per_tower_yr", 0) or 0)
+    return {
+        "towers": round(towers),
+        "annual_revenue": round(revenue),
+        "annual_opex": round(opex),
+        "lighting_kwh_yr": round(light_kwh_yr),
+        "startup_capex": round(towers * float(p.get("startup_per_tower", 370))),
+    }
+
+
+def summarize(params: dict[str, Any]) -> dict[str, Any]:
+    """Combine the enabled specialty assets into capex + annual revenue/opex/energy-offset."""
+    e = energy(params.get("energy", {})) if params.get("energy_enabled") else None
+    f = pfal(params.get("pfal", {})) if params.get("pfal_enabled") else None
+    capex = (e["capex"] if e else 0) + (f["startup_capex"] if f else 0)
+    annual_revenue = (f["annual_revenue"] if f else 0)
+    annual_opex = (f["annual_opex"] if f else 0)
+    energy_offset = (e["annual_energy_offset"] if e else 0)
+    return {
+        "energy": e, "pfal": f,
+        "capex_total": round(capex),
+        "annual_revenue": round(annual_revenue),
+        "annual_opex": round(annual_opex),
+        "annual_energy_offset": round(energy_offset),
+        # net first-year operating contribution (produce revenue + energy saved − farm opex)
+        "annual_net_contribution": round(annual_revenue + energy_offset - annual_opex),
+    }
+
+
+def to_proforma_deltas(params: dict[str, Any]) -> dict[str, Any]:
+    """How the specialty assets adjust a proforma: a hard-cost capex line, plus operations deltas
+    (produce revenue + energy savings → other income; farm lighting/labor → opex)."""
+    s = summarize(params)
+    return {
+        "cost_line": {"category": "hard", "name": "Specialty assets (energy + farm)",
+                      "amount": s["capex_total"], "curve": "scurve"} if s["capex_total"] else None,
+        "other_income_annual_add": s["annual_revenue"] + s["annual_energy_offset"],
+        "opex_annual_add": s["annual_opex"],
+        "summary": s,
+    }
+
+
+def starter() -> dict[str, Any]:
+    """Thesis-grounded starter parameters (editable)."""
+    return {
+        "energy_enabled": True, "pfal_enabled": True,
+        "energy": {"solar_sf": 500_000, "sf_per_panel": 20, "cost_per_panel": 330, "watt_per_panel": 400,
+                   "sun_hours_day": 4.5, "price_per_kwh": 0.12, "wind_turbines": 0, "wind_cost": 5000,
+                   "battery_units": 7, "battery_cost": 15000, "rainwater_capex": 780_000},
+        "pfal": {"pfal_sf": 40_000, "sf_per_tower": 1.7, "green_pct": 0.4,
+                 "green_lbs_per_tower_yr": 60, "green_price_lb": 5,
+                 "herb_lbs_per_tower_yr": 45, "herb_price_lb": 16,
+                 "watt_per_tower": 60, "light_hours_day": 18, "price_per_kwh": 0.12,
+                 "startup_per_tower": 370, "labor_per_tower_yr": 0},
+    }

--- a/services/api/test_specialty.py
+++ b/services/api/test_specialty.py
@@ -1,0 +1,53 @@
+"""Specialty assets — on-site energy + vertical-farm (PFAL) revenue engine + persistence.
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_specialty.py"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_specialty.db"
+os.environ["STORAGE_DIR"] = "./test_storage_specialty"
+os.environ.pop("AEC_RBAC", None)
+for f in ("./test_specialty.db",):
+    if os.path.exists(f):
+        os.remove(f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from aec_api import specialty as sp  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+# --- energy: solar capex + generation offset --------------------------------
+e = sp.energy({"solar_sf": 500_000, "sf_per_panel": 20, "cost_per_panel": 330,
+               "battery_units": 7, "rainwater_capex": 780_000})
+assert e["solar_panels"] == 25_000, e["solar_panels"]
+assert e["breakdown"]["solar"] == 25_000 * 330, e["breakdown"]
+assert e["capex"] == 25_000 * 330 + 7 * 15_000 + 780_000, e["capex"]
+assert e["generation_kwh_yr"] > 0 and e["annual_energy_offset"] > 0, e
+
+# --- PFAL: towers from area, revenue, lighting opex --------------------------
+f = sp.pfal({"pfal_sf": 40_000, "sf_per_tower": 1.7, "green_pct": 0.4})
+assert f["towers"] == round(40_000 / 1.7), f["towers"]
+assert f["annual_revenue"] > 0 and f["annual_opex"] > 0 and f["lighting_kwh_yr"] > 0, f
+
+# --- summary + proforma deltas ----------------------------------------------
+params = sp.starter()
+s = sp.summarize(params)
+assert s["capex_total"] == s["energy"]["capex"] + s["pfal"]["startup_capex"], s["capex_total"]
+assert s["annual_net_contribution"] == s["annual_revenue"] + s["annual_energy_offset"] - s["annual_opex"]
+d = sp.to_proforma_deltas(params)
+assert d["cost_line"]["category"] == "hard" and d["cost_line"]["amount"] == s["capex_total"]
+assert d["other_income_annual_add"] == s["annual_revenue"] + s["annual_energy_offset"]
+
+# disabled assets contribute nothing
+none = sp.summarize({"energy_enabled": False, "pfal_enabled": False})
+assert none["capex_total"] == 0 and none["annual_revenue"] == 0, none
+
+# --- persistence round-trip --------------------------------------------------
+with TestClient(app) as c:
+    pid = c.post("/projects", json={"name": "Vert Farm"}).json()["id"]
+    g0 = c.get(f"/projects/{pid}/specialty").json()
+    assert g0["summary"]["capex_total"] > 0 and "deltas" in g0, g0     # starter served
+    r = c.put(f"/projects/{pid}/specialty", json=params)
+    assert r.status_code == 200 and r.json()["summary"]["capex_total"] == s["capex_total"], r.text
+    assert c.get(f"/projects/{pid}/specialty").json()["summary"]["capex_total"] == s["capex_total"]
+
+print(f"SPECIALTY OK - energy {sp.starter()['energy']['solar_sf']:,} sf solar -> {e['solar_panels']:,} panels "
+      f"${e['capex']:,} capex; PFAL {f['towers']:,} towers -> ${f['annual_revenue']:,}/yr; "
+      f"net contribution ${s['annual_net_contribution']:,}/yr; deltas + persistence verified")


### PR DESCRIPTION
On-site energy (solar/wind/battery/rainwater) + PFAL tower revenue -> capex/revenue/opex into the proforma. Engine + API + Finance panel + test (gate 25/25). Roadmap item 4; thesis-grounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)