### PR TITLE
Test Fit (unit-mix/parking/compare) + property & tax assumptions (v0.1.13)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.12"
+version = "0.1.13"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -725,6 +725,20 @@ export class ApiClient {
     return this.json<{ cost_lines: { category: string; name: string; amount: number; curve: string }[]; summary: DevBudgetSummary }>(
       `/projects/${pid}/dev-budget/cost-lines`);
   }
+  /** Property & tax assumptions + computed summary (totals, per-SF ratios, proforma deltas). */
+  property(pid: string) {
+    return this.json<{ property: Record<string, unknown>; summary: { total_taxes: number; purchase_price: number; price_per_building_sf: number; tax_per_building_sf: number; far_existing: number; deltas: { opex_annual_add: number; acquisition_amount: number } } }>(
+      `/projects/${pid}/property`);
+  }
+  saveProperty(pid: string, body: Record<string, unknown>) {
+    return this.json<{ property: Record<string, unknown>; summary: { total_taxes: number; purchase_price: number; deltas: { opex_annual_add: number; acquisition_amount: number } } }>(
+      `/projects/${pid}/property`, { method: "PUT", body: JSON.stringify(body) });
+  }
+  /** Test-fit: compare unit-mix schemes on a floor plate (yield + parking, ranked). */
+  testFitCompare(params: { plate_w: number; plate_d: number; floors: number; schemes?: unknown[] }) {
+    return this.json<{ best: string | null; schemes: { name: string; total_units: number; efficiency: number; total_nsf: number; total_gsf: number; avg_unit_sf: number; parking_stalls: number; mix: Record<string, number> }[] }>(
+      "/test-fit/compare", { method: "POST", body: JSON.stringify(params) });
+  }
   /** Sources & Uses built from the project's cost budget (grouped uses vs sized debt + equity). */
   sourcesUses(pid: string) {
     return this.json<{ uses: { label: string; amount: number }[]; sources: { label: string; amount: number }[];
@@ -827,6 +841,7 @@ export interface MassingParams {
   side_setback?: number; height_limit?: number | null; floor_to_floor?: number;
   efficiency?: number; avg_unit_m2?: number;
   frame?: boolean; bay_m?: number; units?: boolean; envelope?: boolean; wwr?: number; core?: boolean;
+  unit_layout?: "grid" | "corridor";
   land_cost?: number; hard_cost_psf?: number; rent_per_unit_month?: number; rent_psf_year?: number;
   exit_cap?: number; ltc?: number; rate?: number;
 }

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -101,6 +101,8 @@ export class ProformaUI {
     sizingField("Min DSCR", "debt.min_dscr", 1, "off");
     this.root.appendChild(form);
     this.renderMassing();
+    this.renderTestFit();
+    this.renderProperty();
     this.renderBudget();
     this.renderSourcesUses();
     this.renderSpecialty();
@@ -170,6 +172,11 @@ export class ProformaUI {
     const coreChk = document.createElement("input"); coreChk.type = "checkbox";
     coreWrap.append(coreChk, document.createTextNode("Add service core (elevator + stair + MEP risers)"));
     host.appendChild(coreWrap);
+    const corrWrap = document.createElement("label");
+    corrWrap.style.cssText = "display:flex;align-items:center;gap:6px;margin:4px 0;font-size:13px";
+    const corrChk = document.createElement("input"); corrChk.type = "checkbox";
+    corrWrap.append(corrChk, document.createTextNode("Double-loaded corridor unit layout (test-fit)"));
+    host.appendChild(corrWrap);
 
     const params = (): MassingParams => {
       const p: MassingParams = { use_type: useSel.value as "residential" | "commercial", name: "Massing Study" };
@@ -182,6 +189,7 @@ export class ProformaUI {
       p.units = unitChk.checked;
       p.envelope = envChk.checked;
       p.core = coreChk.checked;
+      if (corrChk.checked) { p.units = true; p.unit_layout = "corridor"; }
       return p;
     };
     const out = document.createElement("div"); out.style.marginTop = "6px";
@@ -220,6 +228,75 @@ export class ProformaUI {
     };
     btnRow.append(estBtn, genBtn); host.append(btnRow, out);
     this.root.appendChild(host);
+  }
+
+  /** Test Fit: compare unit-mix schemes on a floor plate — yield (units, efficiency, NSF) + parking,
+   *  ranked. The TestFit-style "explore scenarios, find the deal that pencils" surface. */
+  private renderTestFit() {
+    const host = document.createElement("div"); host.id = "pf-testfit";
+    host.style.cssText = "margin:8px 0;padding:8px 10px;border:1px dashed var(--line);border-radius:8px";
+    host.innerHTML = `<div class="section-title" style="margin:0 0 6px">📐 Test Fit — compare unit-mix schemes</div>`
+      + `<div class="meta" style="margin-bottom:6px">Fit a unit mix to a floor plate; compare yield + parking across schemes.</div>`;
+    const grid = document.createElement("div"); grid.className = "pf-form";
+    const inp = (label: string, val: number) => {
+      const w = document.createElement("label"); w.className = "pf-field"; w.innerHTML = `<span>${label}</span>`;
+      const i = document.createElement("input"); i.type = "number"; i.step = "any"; i.value = String(val); w.appendChild(i); grid.appendChild(w); return i;
+    };
+    const wi = inp("Plate width (m)", 40), di = inp("Plate depth (m)", 18), fi = inp("Floors", 6);
+    host.appendChild(grid);
+    const out = document.createElement("div"); out.style.marginTop = "6px";
+    const run = document.createElement("button"); run.className = "file-btn"; run.textContent = "Compare schemes";
+    run.onclick = async () => {
+      out.innerHTML = `<span class="meta">fitting…</span>`;
+      try {
+        const r = await this.api.testFitCompare({ plate_w: +wi.value, plate_d: +di.value, floors: +fi.value });
+        const rows = r.schemes.map((s) => `<tr${s.name === r.best ? ' style="font-weight:700"' : ""}>`
+          + `<th style="text-align:left">${s.name}${s.name === r.best ? " ★" : ""}</th>`
+          + `<td style="text-align:right">${s.total_units}</td><td style="text-align:right">${(s.efficiency * 100).toFixed(0)}%</td>`
+          + `<td style="text-align:right">${s.avg_unit_sf.toLocaleString()}</td><td style="text-align:right">${s.total_nsf.toLocaleString()}</td>`
+          + `<td style="text-align:right">${s.parking_stalls}</td></tr>`).join("");
+        out.innerHTML = `<table class="sens-table" style="font-size:12px"><tr><th style="text-align:left">Scheme</th>`
+          + `<th>Units</th><th>Eff.</th><th>Avg SF</th><th>NSF</th><th>Stalls</th></tr>${rows}</table>`
+          + `<div class="meta" style="margin-top:4px">Best by units: <b>${r.best}</b></div>`;
+      } catch { out.innerHTML = `<div class="meta">test-fit unavailable (API offline)</div>`; }
+    };
+    host.append(run, out); this.root.appendChild(host);
+  }
+
+  /** Property & tax assumptions: parcel/areas/purchase/taxes; taxes → OPEX, price → acquisition. */
+  private renderProperty() {
+    const host = document.createElement("div"); host.id = "pf-property";
+    host.style.cssText = "margin:8px 0;padding:8px 10px;border:1px dashed var(--line);border-radius:8px";
+    const pid = this.projectId();
+    host.innerHTML = `<div class="section-title" style="margin:0 0 6px">🏢 Property & tax assumptions</div>`;
+    if (!pid) { host.insertAdjacentHTML("beforeend", `<div class="meta">Open a project to set property facts.</div>`); this.root.appendChild(host); return; }
+    const body = document.createElement("div"); body.innerHTML = `<div class="meta">loading…</div>`; host.appendChild(body); this.root.appendChild(host);
+    void this.api.property(pid).then((resp) => {
+      const prop = resp.property as Record<string, number> & { taxes?: Record<string, number> };
+      let timer = 0; const save = () => { clearTimeout(timer); timer = window.setTimeout(() => void this.api.saveProperty(pid, prop).then((r) => { sumEl.textContent = summary(r.summary.total_taxes, r.summary.purchase_price); }), 500); };
+      const grid = document.createElement("div"); grid.className = "pf-form";
+      const field = (label: string, key: string, taxes = false) => {
+        const w = document.createElement("label"); w.className = "pf-field"; w.innerHTML = `<span>${label}</span>`;
+        const i = document.createElement("input"); i.type = "number"; i.step = "any";
+        i.value = String(taxes ? (prop.taxes?.[key] ?? 0) : (prop[key] ?? 0));
+        i.oninput = () => { const v = parseFloat(i.value) || 0; if (taxes) { prop.taxes = prop.taxes || {}; prop.taxes[key] = v; } else prop[key] = v; save(); };
+        w.appendChild(i); grid.appendChild(w);
+      };
+      field("Purchase price $", "purchase_price"); field("Building SF", "building_sf"); field("Land SF", "land_sf");
+      field("School tax $", "school", true); field("County tax $", "county", true); field("Town tax $", "town", true); field("Fire tax $", "fire", true);
+      const summary = (tax: number, price: number) => `Total taxes ${money(tax)}/yr → OPEX · purchase ${money(price)} → acquisition`;
+      const sumEl = document.createElement("div"); sumEl.className = "meta"; sumEl.style.marginTop = "4px";
+      sumEl.textContent = summary(resp.summary.total_taxes, resp.summary.purchase_price);
+      const apply = document.createElement("button"); apply.className = "file-btn"; apply.style.marginTop = "6px"; apply.textContent = "Apply to proforma";
+      apply.onclick = async () => {
+        const r = await this.api.saveProperty(pid, prop); const d = r.summary.deltas;
+        const a = this.a as { cost_lines: { name: string; amount: number }[]; operations: { opex_annual: number } };
+        if (d.acquisition_amount) { const land = a.cost_lines.find((c) => /acquisition|land/i.test(c.name)); if (land) land.amount = d.acquisition_amount; }
+        a.operations.opex_annual = (a.operations.opex_annual || 0) + d.opex_annual_add;
+        this.render(); void this.solve(); this.setStatus(`applied property: ${money(d.acquisition_amount)} acquisition, ${money(d.opex_annual_add)}/yr taxes`);
+      };
+      body.innerHTML = ""; body.append(grid, sumEl, apply);
+    }).catch(() => { body.innerHTML = `<div class="meta">property unavailable (API offline)</div>`; });
   }
 
   /** Sources & Uses: the capital plan from the cost budget — grouped uses vs sized debt + equity. */

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,13 @@ Grounded in [TestFit Site Solver](https://www.testfit.io/product/site-solver),
 [Generative Design](https://www.testfit.io/blog/unleash-boundless-building-optimization-with-testfit-generative-design).
 
 - ✅ **DONE — generative massing** (zoning → massing/frame/units/envelope/core).
-- **A1 — Unit-mix configurator.** Define unit *types* (studio/1BR/2BR… target SF + mix %/count) and
+- ✅ **DONE — A1 unit-mix configurator + corridor layout.** `test_fit.layout()` tiles a unit mix on a
+  double-loaded corridor (units both sides) → placed rects + yield; `generate_ifc(unit_layout=
+  "corridor")` builds real corridor + unit IfcSpaces. "Double-loaded corridor" toggle on the form.
+- ✅ **DONE — A3 parking (lite) + A4 yield compare.** `test_fit.parking()` (stalls/unit ratio →
+  count/area/cost) and `compare()` rank schemes; `POST /test-fit/compare` + a "📐 Test Fit" Finance
+  panel (units/efficiency/avg-SF/NSF/stalls, best ★). *Next: parking as real IFC geometry, egress.*
+- **A1b/A2 — Circulation & egress (full).** Define unit *types* (studio/1BR/2BR… target SF + mix %/count) and
   tile them along a **double-loaded corridor** on the floor plate (not a naive grid) — real unit
   modules + demising walls + corridor. Import/save unit presets.
 - **A2 — Circulation & egress.** Auto corridors, egress stairs, elevators positioned for code
@@ -63,8 +69,9 @@ contingency 5–10%; Uses = Acquisition + Hard + Soft + Financing; Sources = Deb
 - **B2 — Sources & Uses (first-class view).** ★ *in progress* — grouped Uses (from the cost budget +
   acquisition + financing) vs Sources (senior debt sized by LTC/LTV/DSCR/debt-yield, mezz, LP/GP
   equity); per-period draw spread feeding interest reserve. Endpoint + Finance S&U view + memo section.
-- **B3 — Property & tax assumptions.** Address/block-lot, land/building/parking SF, appraisal,
-  purchase price, and a tax table (school/county/town/fire → total) feeding OPEX.
+- ✅ **DONE — B3 property & tax assumptions.** `dev_property.py` + GET/PUT `/projects/{id}/property`
+  + "🏢 Property & tax" Finance panel: parcel/areas/purchase + tax table (school/county/town/fire →
+  total) → OPEX, purchase → acquisition line; per-SF ratios. *Next: appraisal/market comps section.*
 - **B6 — Pitch-deck variant** of the memo (10–20 slides) + market/timeline sections, photos.
 
 ## C. Lifecycle / construction depth

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -19,7 +19,7 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_serving", "test_api",
-         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty"]
+         "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit"]
 
 
 def main() -> int:

--- a/services/api/src/aec_api/dev_property.py
+++ b/services/api/src/aec_api/dev_property.py
@@ -1,0 +1,39 @@
+"""Property & tax assumptions — the acquisition/operating facts a deal underwrites against:
+address, parcel, areas, purchase price, and the tax table (school/county/town/fire → total) that
+feeds OPEX. Pure summary over a plain dict so it's testable without a DB."""
+from __future__ import annotations
+
+from typing import Any
+
+M2_TO_SF = 10.7639
+
+
+def summarize(prop: dict[str, Any]) -> dict[str, Any]:
+    """prop: {address, block_lot, appraisal, purchase_price, land_sf, building_sf, parking_sf,
+    taxes:{school,county,town,fire,other}}. Returns totals + per-SF ratios + a proforma delta."""
+    taxes = prop.get("taxes") or {}
+    total_taxes = round(sum(float(v or 0) for v in taxes.values()), 2)
+    bsf = float(prop.get("building_sf", 0) or 0)
+    lsf = float(prop.get("land_sf", 0) or 0)
+    price = float(prop.get("purchase_price", 0) or 0)
+    return {
+        "total_taxes": total_taxes,
+        "purchase_price": round(price),
+        "building_sf": round(bsf), "land_sf": round(lsf),
+        "parking_sf": round(float(prop.get("parking_sf", 0) or 0)),
+        "price_per_building_sf": round(price / bsf, 2) if bsf else 0.0,
+        "price_per_land_sf": round(price / lsf, 2) if lsf else 0.0,
+        "tax_per_building_sf": round(total_taxes / bsf, 2) if bsf else 0.0,
+        "far_existing": round(bsf / lsf, 2) if lsf else 0.0,
+        # how it adjusts a proforma: taxes → opex; price → acquisition cost line
+        "deltas": {"opex_annual_add": total_taxes, "acquisition_amount": round(price)},
+    }
+
+
+def starter() -> dict[str, Any]:
+    """Thesis-grounded starter (2000 Hempstead Tpke), editable."""
+    return {
+        "address": "", "block_lot": "", "appraisal": 0, "purchase_price": 0,
+        "land_sf": 0, "building_sf": 0, "parking_sf": 0,
+        "taxes": {"school": 0, "county": 0, "town": 0, "fire": 0, "other": 0},
+    }

--- a/services/api/src/aec_api/models.py
+++ b/services/api/src/aec_api/models.py
@@ -31,6 +31,8 @@ class Project(Base):
     dev_budget: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     # specialty assets: on-site energy + vertical-farm (PFAL) revenue params (specialty.py)
     dev_specialty: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    # property & tax assumptions: parcel/areas/purchase/taxes (dev_property.py)
+    dev_property: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
 
     topics: Mapped[list["Topic"]] = relationship(back_populates="project", cascade="all, delete-orphan")

--- a/services/api/src/aec_api/routers/generate.py
+++ b/services/api/src/aec_api/routers/generate.py
@@ -53,6 +53,7 @@ class MassingIn(BaseModel):
     envelope: bool = Field(default=False)                     # wrap floors in facade walls + windows
     wwr: float = Field(default=0.4, gt=0, le=0.95)            # window-to-wall ratio
     core: bool = Field(default=False)                         # service core: shafts + stair + MEP risers
+    unit_layout: str = Field(default="grid")                  # "grid" | "corridor" (double-loaded test-fit)
     # --- acquisition proforma seed ---
     land_cost: float = Field(default=2_500_000.0, ge=0)
     hard_cost_psf: float = Field(default=225.0, ge=0)         # $/sf GFA
@@ -123,7 +124,8 @@ def generate_massing(pid: str, body: MassingIn, db: Session = Depends(get_db),
     _IFC_DIR.joinpath(pid).mkdir(parents=True, exist_ok=True)
     ifc_path = _IFC_DIR / pid / "source.ifc"
     generate_ifc(metrics, str(ifc_path), name=body.name, frame=body.frame, bay=body.bay_m,
-                 units=body.units, envelope=body.envelope, wwr=body.wwr, core=body.core)
+                 units=body.units, envelope=body.envelope, wwr=body.wwr, core=body.core,
+                 unit_layout=body.unit_layout)
     metrics["framed"] = body.frame
     metrics["unitized"] = body.units
     metrics["enclosed"] = body.envelope
@@ -138,6 +140,34 @@ def generate_massing(pid: str, body: MassingIn, db: Session = Depends(get_db),
     _publish_bg(pid)                                            # convert→.frag + reindex off-thread
     return {"metrics": metrics, "proforma": _proforma_seed(body, metrics),
             "source_ifc": str(ifc_path), "publish": "running"}
+
+
+class TestFitIn(BaseModel):
+    """Fit a unit mix to a floor plate and compare schemes (TestFit-style)."""
+    plate_w: float = Field(gt=0)
+    plate_d: float = Field(gt=0)
+    floors: int = Field(default=1, ge=1)
+    schemes: list[dict] = Field(default_factory=list)   # [{name, unit_types?, parking_ratio?, parking_kind?}]
+
+
+@router.post("/test-fit/compare")
+def test_fit_compare(body: TestFitIn):
+    """Compare unit-mix schemes on a floor plate — yield metrics (units, efficiency, NSF/GSF, mix)
+    + parking — ranked so you can find the scheme that pencils. Stateless; the rects also feed the
+    IFC massing generator (unit_layout='corridor')."""
+    from .. import test_fit as tf
+    schemes = body.schemes or [
+        {"name": "Efficient (more 1BR)", "unit_types": [
+            {"name": "Studio", "target_sf": 480, "mix_pct": 0.3},
+            {"name": "1BR", "target_sf": 720, "mix_pct": 0.55},
+            {"name": "2BR", "target_sf": 1000, "mix_pct": 0.15}], "parking_ratio": 1.0},
+        {"name": "Balanced", "unit_types": None, "parking_ratio": 1.2},
+        {"name": "Family (more 2BR)", "unit_types": [
+            {"name": "1BR", "target_sf": 780, "mix_pct": 0.35},
+            {"name": "2BR", "target_sf": 1100, "mix_pct": 0.45},
+            {"name": "3BR", "target_sf": 1400, "mix_pct": 0.2}], "parking_ratio": 1.5},
+    ]
+    return tf.compare(body.plate_w, body.plate_d, body.floors, schemes)
 
 
 @router.post("/generate/massing/preview")

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -160,6 +160,31 @@ def put_specialty(pid: str, body: dict, db: Session = Depends(get_db)):
     return {"params": body, "summary": sp.summarize(body), "deltas": sp.to_proforma_deltas(body)}
 
 
+@router.get("/projects/{pid}/property")
+def get_property(pid: str, db: Session = Depends(get_db)):
+    """Property & tax assumptions + computed summary (totals, per-SF ratios, proforma deltas)."""
+    from .. import dev_property as dp
+    from ..models import Project as _P
+    p = db.get(_P, pid)
+    if not p:
+        raise HTTPException(404, "project not found")
+    prop = p.dev_property or dp.starter()
+    return {"property": prop, "summary": dp.summarize(prop)}
+
+
+@router.put("/projects/{pid}/property")
+def put_property(pid: str, body: dict, db: Session = Depends(get_db)):
+    """Save property & tax assumptions; returns the recomputed summary."""
+    from .. import dev_property as dp
+    from ..models import Project as _P
+    p = db.get(_P, pid)
+    if not p:
+        raise HTTPException(404, "project not found")
+    p.dev_property = body
+    db.commit()
+    return {"property": body, "summary": dp.summarize(body)}
+
+
 @router.get("/projects/{pid}/sources-uses")
 def get_sources_uses(pid: str, ltc: float = 0.65, rate: float = 0.075,
                      construction_months: int = 18, lp_pct: float = 0.9,

--- a/services/api/src/aec_api/test_fit.py
+++ b/services/api/src/aec_api/test_fit.py
@@ -1,0 +1,107 @@
+"""Test fitting (TestFit-style) — fit a unit mix to a floor plate and optimize yield.
+
+`layout()` tiles a unit mix along a double-loaded corridor on a rectangular floor plate (units on
+both sides of a central corridor) and returns placed unit rectangles + yield metrics. `parking()`
+sizes parking to a stalls/unit ratio. `compare()` evaluates several schemes side-by-side so the
+team can find the one that pencils. Pure — no IFC needed (the geometry rects feed massing).
+
+IFC-native is the differentiator: the same placed rectangles become real IfcSpaces in the model."""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+M2_TO_SF = 10.7639
+DEFAULT_MIX = [
+    {"name": "Studio", "target_sf": 500, "mix_pct": 0.2},
+    {"name": "1BR", "target_sf": 750, "mix_pct": 0.5},
+    {"name": "2BR", "target_sf": 1050, "mix_pct": 0.3},
+]
+
+
+def layout(plate_w: float, plate_d: float, floors: int = 1, unit_types: list[dict] | None = None,
+           corridor_w: float = 1.8, efficiency_target: float = 0.85) -> dict[str, Any]:
+    """Double-loaded corridor fit on a plate_w × plate_d (m) plate. Returns placed units (metres,
+    centred at plate origin), corridor, and yield metrics (units, NSF/GSF, efficiency, mix)."""
+    types = unit_types or DEFAULT_MIX
+    total_pct = sum(t.get("mix_pct", 0) for t in types) or 1.0
+    bay_d = max(2.5, (plate_d - corridor_w) / 2)          # unit depth per side (m)
+    bay_d_sf = bay_d / 1  # depth in m; unit width derived from target area below
+    units: list[dict] = []
+    by_type: dict[str, int] = {t["name"]: 0 for t in types}
+
+    # build a repeating sequence of unit *widths* weighted by mix; tile each side along X
+    seq: list[tuple[str, float]] = []
+    for t in types:
+        w_m = max(2.5, (float(t["target_sf"]) / M2_TO_SF) / bay_d)   # width so width×depth = target SF
+        n = max(1, round((t.get("mix_pct", 0) / total_pct) * 12))    # weight in a 12-slot cycle
+        seq += [(t["name"], w_m)] * n
+    if not seq:
+        seq = [("Unit", 8.0)]
+
+    for side, y_sign in (("N", 1), ("S", -1)):
+        x = -plate_w / 2
+        i = 0
+        cy = y_sign * (corridor_w / 2 + bay_d / 2)
+        while True:
+            name, w_m = seq[i % len(seq)]
+            if x + w_m > plate_w / 2 + 0.01:
+                break
+            units.append({"name": name, "cx": round(x + w_m / 2, 2), "cy": round(cy, 2),
+                          "w": round(w_m, 2), "d": round(bay_d, 2)})
+            by_type[name] = by_type.get(name, 0) + 1
+            x += w_m
+            i += 1
+
+    units_per_floor = len(units)
+    total_units = units_per_floor * max(1, floors)
+    nsf_floor = sum(u["w"] * u["d"] for u in units) * M2_TO_SF
+    gsf_floor = plate_w * plate_d * M2_TO_SF
+    by_type_total = {k: v * max(1, floors) for k, v in by_type.items()}
+    return {
+        "units": units,                                  # one floor's placed rects (metres)
+        "corridor": {"w": corridor_w, "length": round(plate_w, 2)},
+        "bay_depth": round(bay_d, 2),
+        "metrics": {
+            "units_per_floor": units_per_floor,
+            "total_units": total_units,
+            "nsf_per_floor": round(nsf_floor),
+            "gsf_per_floor": round(gsf_floor),
+            "total_nsf": round(nsf_floor * max(1, floors)),
+            "total_gsf": round(gsf_floor * max(1, floors)),
+            "efficiency": round(nsf_floor / gsf_floor, 3) if gsf_floor else 0.0,
+            "avg_unit_sf": round(nsf_floor / units_per_floor) if units_per_floor else 0,
+            "mix": by_type_total,
+        },
+    }
+
+
+def parking(units: int, ratio: float = 1.2, kind: str = "surface") -> dict[str, Any]:
+    """Size parking to a stalls/unit ratio. SF/stall by type: surface ~320, structured ~350 (incl.
+    drive aisles/ramps). Returns stall count + footprint + a rough cost."""
+    stalls = math.ceil(units * ratio)
+    sf_per = {"surface": 320, "podium": 360, "structured": 350}.get(kind, 320)
+    cost_per = {"surface": 5_000, "podium": 28_000, "structured": 32_000}.get(kind, 5_000)
+    return {"stalls": stalls, "ratio": ratio, "kind": kind,
+            "area_sf": stalls * sf_per, "cost": stalls * cost_per}
+
+
+def compare(plate_w: float, plate_d: float, floors: int, schemes: list[dict]) -> dict[str, Any]:
+    """Evaluate several schemes side-by-side. Each scheme: {name, unit_types?, parking_ratio?,
+    parking_kind?}. Returns per-scheme yield metrics + parking, ranked by total units."""
+    out = []
+    for sc in schemes:
+        lay = layout(plate_w, plate_d, floors, sc.get("unit_types"),
+                     corridor_w=float(sc.get("corridor_w", 1.8)))
+        m = lay["metrics"]
+        pk = parking(m["total_units"], float(sc.get("parking_ratio", 1.2)), sc.get("parking_kind", "surface"))
+        out.append({
+            "name": sc.get("name", "Scheme"),
+            "total_units": m["total_units"], "efficiency": m["efficiency"],
+            "total_nsf": m["total_nsf"], "total_gsf": m["total_gsf"],
+            "avg_unit_sf": m["avg_unit_sf"], "mix": m["mix"],
+            "parking_stalls": pk["stalls"], "parking_area_sf": pk["area_sf"],
+        })
+    out.sort(key=lambda s: s["total_units"], reverse=True)
+    return {"schemes": out, "best": out[0]["name"] if out else None,
+            "plate": {"w": plate_w, "d": plate_d, "floors": floors}}

--- a/services/api/test_testfit.py
+++ b/services/api/test_testfit.py
@@ -1,0 +1,61 @@
+"""Test fitting (unit-mix layout + parking + scheme compare) and property/tax assumptions.
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_testfit.py"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_testfit.db"
+os.environ["STORAGE_DIR"] = "./test_storage_testfit"
+os.environ.pop("AEC_RBAC", None)
+for f in ("./test_testfit.db",):
+    if os.path.exists(f):
+        os.remove(f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from aec_api import test_fit as tf, dev_property as dp  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+# --- unit-mix layout: double-loaded corridor, yield metrics ------------------
+lay = tf.layout(40, 18, floors=5)
+assert lay["units"], "should place units"
+m = lay["metrics"]
+assert m["units_per_floor"] > 0 and m["total_units"] == m["units_per_floor"] * 5
+assert 0 < m["efficiency"] < 1, m["efficiency"]                # NSF < GSF (corridor + walls)
+assert m["total_nsf"] < m["total_gsf"], m
+# units sit on both sides of the corridor
+assert any(u["cy"] > 0 for u in lay["units"]) and any(u["cy"] < 0 for u in lay["units"]), "double-loaded"
+assert sum(m["mix"].values()) == m["total_units"], m["mix"]
+
+# --- parking: stalls to ratio --------------------------------------------------
+pk = tf.parking(100, ratio=1.25, kind="structured")
+assert pk["stalls"] == 125 and pk["area_sf"] > 0 and pk["cost"] > 0, pk
+
+# --- compare: ranked schemes ---------------------------------------------------
+cmp = tf.compare(40, 18, 5, [
+    {"name": "A", "unit_types": [{"name": "Studio", "target_sf": 480, "mix_pct": 1.0}], "parking_ratio": 1.0},
+    {"name": "B", "unit_types": [{"name": "2BR", "target_sf": 1100, "mix_pct": 1.0}], "parking_ratio": 1.5},
+])
+assert len(cmp["schemes"]) == 2 and cmp["best"] in ("A", "B")
+# all-studio packs more units than all-2BR on the same plate
+a = next(s for s in cmp["schemes"] if s["name"] == "A")
+b = next(s for s in cmp["schemes"] if s["name"] == "B")
+assert a["total_units"] > b["total_units"], (a["total_units"], b["total_units"])
+assert cmp["best"] == "A", cmp["best"]
+
+# --- property & tax summary ----------------------------------------------------
+ps = dp.summarize({"purchase_price": 15_744_700, "building_sf": 249_749, "land_sf": 598_668,
+                   "taxes": {"school": 955_533, "county": 239_731, "town": 228_906, "fire": 79_055}})
+assert ps["total_taxes"] == 955_533 + 239_731 + 228_906 + 79_055, ps["total_taxes"]
+assert ps["price_per_building_sf"] > 0 and ps["deltas"]["opex_annual_add"] == ps["total_taxes"]
+
+# --- endpoints -----------------------------------------------------------------
+with TestClient(app) as c:
+    pid = c.post("/projects", json={"name": "Fit"}).json()["id"]
+    r = c.post("/test-fit/compare", json={"plate_w": 40, "plate_d": 18, "floors": 5, "schemes": []})
+    assert r.status_code == 200 and len(r.json()["schemes"]) == 3, r.text   # default schemes
+    pr = c.put(f"/projects/{pid}/property", json={"purchase_price": 15_744_700, "building_sf": 249_749,
+                                                  "taxes": {"school": 955_533}})
+    assert pr.status_code == 200 and pr.json()["summary"]["total_taxes"] == 955_533, pr.text
+    assert c.get(f"/projects/{pid}/property").json()["summary"]["purchase_price"] == 15_744_700
+
+print(f"TESTFIT OK - corridor layout {m['units_per_floor']} units/floor @ {m['efficiency']*100:.0f}% eff; "
+      f"parking {pk['stalls']} stalls; compare ranks studio>2BR ({a['total_units']}>{b['total_units']}); "
+      f"property taxes ${ps['total_taxes']:,} -> opex; endpoints ok")

--- a/services/data/src/aec_data/massing.py
+++ b/services/data/src/aec_data/massing.py
@@ -67,7 +67,8 @@ def gridlines(extent: float, bay: float) -> list[float]:
 
 def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
                  frame: bool = False, bay: float = 7.5, units: bool = False,
-                 envelope: bool = False, wwr: float = 0.4, core: bool = False) -> str:
+                 envelope: bool = False, wwr: float = 0.4, core: bool = False,
+                 unit_layout: str = "grid") -> str:
     """Write an IFC4 model: site → building → one storey + slab per level. Each floor gets either a
     single floor-plate space, or — with `units=True` — the floor subdivided into per-unit IfcSpaces
     (the proforma's unit count), so areas/COBie/rent are grounded in real apartments. With
@@ -199,7 +200,23 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
                                       name=f"Level {i + 1}")
         storey.Elevation = elev
         ifcopenshell.api.run("aggregate.assign_object", model, products=[storey], relating_object=building)
-        if units_per_floor:                    # subdivide the floor into per-unit apartments
+        if units_per_floor and unit_layout == "corridor":   # double-loaded corridor test-fit layout
+            corridor_w = min(2.0, fd * 0.2)
+            bay_d = max(2.5, (fd - corridor_w) / 2)
+            per_side = math.ceil(units_per_floor / 2)
+            uw = fw / per_side
+            k = 0
+            for side in (1, -1):                  # N then S of the central corridor
+                cy = side * (corridor_w / 2 + bay_d / 2)
+                for c in range(per_side):
+                    if k >= units_per_floor:
+                        break
+                    k += 1
+                    cx = -fw / 2 + (c + 0.5) * uw
+                    make_space(storey, elev, f"L{i + 1} Unit {k:02d}", f"Unit {k:02d}",
+                               cx, cy, uw * 0.96, bay_d * 0.96, "UNIT")
+            make_space(storey, elev, f"L{i + 1} Corridor", "Corridor", 0.0, 0.0, fw, corridor_w, "CIRCULATION")
+        elif units_per_floor:                    # subdivide the floor into per-unit apartments
             cols, rows = unit_grid(units_per_floor, fw, fd)
             cw, cd = fw / cols, fd / rows
             k = 0

--- a/services/data/test_massing.py
+++ b/services/data/test_massing.py
@@ -123,6 +123,20 @@ if _have_ifc:
         finally:
             os.remove(epath)
 
+        # --- corridor (double-loaded test-fit) unit layout ------------------
+        fd6, lpath = tempfile.mkstemp(suffix=".ifc"); os.close(fd6)
+        try:
+            massing.generate_ifc(m, lpath, name="Corridor", units=True, unit_layout="corridor")
+            lm = open_model(lpath)
+            spaces = [s for s in lm.by_type("IfcSpace")]
+            corridors = [s for s in spaces if (s.LongName or "") == "Corridor"]
+            assert len(corridors) == m["floors"], "one corridor per floor"
+            assert len(spaces) > len(corridors), "units placed alongside corridors"
+            print(f"CORRIDOR OK - double-loaded layout: {len(corridors)} corridors + "
+                  f"{len(spaces) - len(corridors)} unit spaces across {m['floors']} floors")
+        finally:
+            os.remove(lpath)
+
         # --- service core + MEP risers (core=True) --------------------------
         fd5, cpath = tempfile.mkstemp(suffix=".ifc"); os.close(fd5)
         try:


### PR DESCRIPTION
Test Fit (TestFit-style A1/A3/A4): corridor unit-mix layout, parking solver, scheme compare (POST /test-fit/compare + Finance panel + corridor model option). Property & tax (B3): dev_property + endpoints + Finance panel (taxes→OPEX, purchase→acquisition). Tests in gate (26/26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)