### PR TITLE
Generative optimize (A5) + real lot polygons (A6) — v0.1.14

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.13"
+version = "0.1.14"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -739,6 +739,11 @@ export class ApiClient {
     return this.json<{ best: string | null; schemes: { name: string; total_units: number; efficiency: number; total_nsf: number; total_gsf: number; avg_unit_sf: number; parking_stalls: number; mix: Record<string, number> }[] }>(
       "/test-fit/compare", { method: "POST", body: JSON.stringify(params) });
   }
+  /** Generative design: sweep schemes, filter by targets, rank by yield-on-cost. */
+  testFitOptimize(params: { plate_w: number; plate_d: number; floors: number; targets?: Record<string, number | string>; econ?: Record<string, number> }) {
+    return this.json<{ considered: number; feasible: number; objective: string; best: OptScheme | null; ranked: OptScheme[] }>(
+      "/test-fit/optimize", { method: "POST", body: JSON.stringify(params) });
+  }
   /** Sources & Uses built from the project's cost budget (grouped uses vs sized debt + equity). */
   sourcesUses(pid: string) {
     return this.json<{ uses: { label: string; amount: number }[]; sources: { label: string; amount: number }[];
@@ -818,6 +823,10 @@ export interface DevBudgetSummary {
 export interface DevBudgetResponse {
   budget: { lines: DevBudgetLine[]; contingency: Record<string, number> };
   summary: DevBudgetSummary;
+}
+export interface OptScheme {
+  name: string; mix_preset: string; parking_ratio: number; total_units: number;
+  efficiency: number; total_nsf: number; parking_stalls: number; yield_on_cost: number;
 }
 export interface SpecialtySummary {
   capex_total: number; annual_revenue: number; annual_opex: number;

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -245,6 +245,21 @@ export class ProformaUI {
     const wi = inp("Plate width (m)", 40), di = inp("Plate depth (m)", 18), fi = inp("Floors", 6);
     host.appendChild(grid);
     const out = document.createElement("div"); out.style.marginTop = "6px";
+    const opt = document.createElement("button"); opt.className = "tool-btn"; opt.style.marginLeft = "6px";
+    opt.textContent = "⚡ Optimize (find the deal that pencils)";
+    opt.onclick = async () => {
+      out.innerHTML = `<span class="meta">sweeping schemes…</span>`;
+      try {
+        const r = await this.api.testFitOptimize({ plate_w: +wi.value, plate_d: +di.value, floors: +fi.value, targets: { min_units: 1 } });
+        if (!r.best) { out.innerHTML = `<div class="meta">no feasible scheme for these targets</div>`; return; }
+        const rows = r.ranked.map((s, n) => `<tr${n === 0 ? ' style="font-weight:700"' : ""}>`
+          + `<th style="text-align:left">${s.name}${n === 0 ? " ★" : ""}</th>`
+          + `<td style="text-align:right">${s.total_units}</td><td style="text-align:right">${(s.efficiency * 100).toFixed(0)}%</td>`
+          + `<td style="text-align:right">${s.parking_stalls}</td><td style="text-align:right">${(s.yield_on_cost * 100).toFixed(1)}%</td></tr>`).join("");
+        out.innerHTML = `<div class="meta" style="margin-bottom:2px">Swept ${r.considered} schemes · ${r.feasible} feasible · ranked by ${r.objective.replace(/_/g, " ")}</div>`
+          + `<table class="sens-table" style="font-size:12px"><tr><th style="text-align:left">Scheme</th><th>Units</th><th>Eff.</th><th>Stalls</th><th>YoC</th></tr>${rows}</table>`;
+      } catch { out.innerHTML = `<div class="meta">optimize unavailable (API offline)</div>`; }
+    };
     const run = document.createElement("button"); run.className = "file-btn"; run.textContent = "Compare schemes";
     run.onclick = async () => {
       out.innerHTML = `<span class="meta">fitting…</span>`;
@@ -260,7 +275,7 @@ export class ProformaUI {
           + `<div class="meta" style="margin-top:4px">Best by units: <b>${r.best}</b></div>`;
       } catch { out.innerHTML = `<div class="meta">test-fit unavailable (API offline)</div>`; }
     };
-    host.append(run, out); this.root.appendChild(host);
+    host.append(run, opt, out); this.root.appendChild(host);
   }
 
   /** Property & tax assumptions: parcel/areas/purchase/taxes; taxes → OPEX, price → acquisition. */

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,8 +57,12 @@ Grounded in [TestFit Site Solver](https://www.testfit.io/product/site-solver),
   units/acre, parking ratio, FAR achieved, **yield-on-cost** — multiple fits compared side-by-side.
 - **A5 — Generative design (targets).** Define targets/filters (FAR, parking ratio, yield-on-cost)
   → search massing/unit-mix/parking permutations and rank — "find the deal that pencils."
-- **A6 — Site test-fit (urban/parcel).** Real lot polygon (not a rectangle) → place building
-  footprint(s) + parking + drive aisles + setbacks on the actual parcel.
+- ✅ **DONE — A5 generative design (targets).** `test_fit.optimize()` sweeps unit-mix × parking
+  presets, scores yield-on-cost, filters by targets (units/efficiency/parking/YoC), ranks. `POST
+  /test-fit/optimize` + "⚡ Optimize" button. *Next: tie YoC to the live proforma vs the proxy.*
+- ✅ **DONE — A6 (lite) real lot polygons.** `compute_massing(lot_polygon=[[x,y],…])` — shoelace
+  area drives the program (L-shaped parcels yield less than their bbox). *Next: true polygon-offset
+  footprint + parking/drive-aisle placement on the parcel.*
 
 ## B. Developer / finance portal
 Grounded in an institutional model (M. Emma thesis) + CRE practice (hard 70–80% / soft 20–30%,

--- a/services/api/src/aec_api/routers/generate.py
+++ b/services/api/src/aec_api/routers/generate.py
@@ -170,6 +170,24 @@ def test_fit_compare(body: TestFitIn):
     return tf.compare(body.plate_w, body.plate_d, body.floors, schemes)
 
 
+class OptimizeIn(BaseModel):
+    """Generative design: sweep schemes and rank by an objective, filtered by targets."""
+    plate_w: float = Field(gt=0)
+    plate_d: float = Field(gt=0)
+    floors: int = Field(default=1, ge=1)
+    targets: dict = Field(default_factory=dict)   # min_units, min_efficiency, max_parking_ratio, min_yoc, objective
+    econ: dict = Field(default_factory=dict)       # rent_psf_yr, hard_psf, stall_cost, opex_ratio, land
+
+
+@router.post("/test-fit/optimize")
+def test_fit_optimize(body: OptimizeIn):
+    """Generative design — sweep unit-mix × parking presets, filter by targets, rank by yield-on-cost
+    (or another objective). Returns the ranked feasible schemes + the winner ("find the deal that
+    pencils")."""
+    from .. import test_fit as tf
+    return tf.optimize(body.plate_w, body.plate_d, body.floors, body.targets, body.econ)
+
+
 @router.post("/generate/massing/preview")
 def preview_massing(body: MassingIn):
     """Compute the program + proforma WITHOUT writing an IFC or touching a project — for the

--- a/services/api/src/aec_api/routers/generate.py
+++ b/services/api/src/aec_api/routers/generate.py
@@ -38,6 +38,7 @@ class MassingIn(BaseModel):
     lot_width: float | None = Field(default=None, gt=0)
     lot_depth: float | None = Field(default=None, gt=0)
     lot_area: float | None = Field(default=None, gt=0)        # use if width/depth unknown
+    lot_polygon: list[list[float]] | None = Field(default=None)  # real parcel [[x,y],…] in metres
     far: float = Field(default=2.0, gt=0)
     coverage_max: float = Field(default=0.6, gt=0, le=1)
     front_setback: float = Field(default=6.0, ge=0)

--- a/services/api/src/aec_api/test_fit.py
+++ b/services/api/src/aec_api/test_fit.py
@@ -86,6 +86,54 @@ def parking(units: int, ratio: float = 1.2, kind: str = "surface") -> dict[str, 
             "area_sf": stalls * sf_per, "cost": stalls * cost_per}
 
 
+# candidate unit-mix presets the optimizer sweeps
+_PRESETS: dict[str, list[dict]] = {
+    "Studio-heavy": [{"name": "Studio", "target_sf": 480, "mix_pct": 0.6}, {"name": "1BR", "target_sf": 720, "mix_pct": 0.4}],
+    "1BR-heavy": [{"name": "Studio", "target_sf": 480, "mix_pct": 0.2}, {"name": "1BR", "target_sf": 720, "mix_pct": 0.6}, {"name": "2BR", "target_sf": 1000, "mix_pct": 0.2}],
+    "Balanced": DEFAULT_MIX,
+    "2BR-heavy": [{"name": "1BR", "target_sf": 750, "mix_pct": 0.3}, {"name": "2BR", "target_sf": 1050, "mix_pct": 0.5}, {"name": "3BR", "target_sf": 1350, "mix_pct": 0.2}],
+    "Family": [{"name": "2BR", "target_sf": 1100, "mix_pct": 0.6}, {"name": "3BR", "target_sf": 1400, "mix_pct": 0.4}],
+}
+
+
+def optimize(plate_w: float, plate_d: float, floors: int, targets: dict | None = None,
+             econ: dict | None = None) -> dict[str, Any]:
+    """Generative design — sweep unit-mix presets × parking ratios, score each on a yield-on-cost
+    proxy, filter by `targets` (min_units, min_efficiency, max_parking_ratio, min_yoc), and rank.
+    `econ`: rent_psf_yr, hard_psf, stall_cost, opex_ratio, land. "Find the deal that pencils.\""""
+    t = targets or {}
+    e = {"rent_psf_yr": 34.0, "hard_psf": 220.0, "stall_cost": 12_000.0, "opex_ratio": 0.35, "land": 0.0,
+         **(econ or {})}
+    candidates = []
+    for mix_name, mix in _PRESETS.items():
+        for pr in (0.5, 1.0, 1.5):
+            lay = layout(plate_w, plate_d, floors, mix)
+            m = lay["metrics"]
+            pk = parking(m["total_units"], pr)
+            nsf, gsf = m["total_nsf"], m["total_gsf"]
+            revenue = nsf * e["rent_psf_yr"]
+            noi = revenue * (1 - e["opex_ratio"])
+            cost = gsf * e["hard_psf"] + pk["cost"] + e["land"]
+            yoc = round(noi / cost, 4) if cost else 0.0
+            candidates.append({
+                "name": f"{mix_name} · {pr:g}/unit pkg", "mix_preset": mix_name, "parking_ratio": pr,
+                "total_units": m["total_units"], "efficiency": m["efficiency"],
+                "total_nsf": nsf, "parking_stalls": pk["stalls"], "yield_on_cost": yoc,
+            })
+    # filter by targets
+    def passes(c: dict) -> bool:
+        return (c["total_units"] >= t.get("min_units", 0)
+                and c["efficiency"] >= t.get("min_efficiency", 0)
+                and c["parking_ratio"] <= t.get("max_parking_ratio", 99)
+                and c["yield_on_cost"] >= t.get("min_yoc", 0))
+    feasible = [c for c in candidates if passes(c)]
+    objective = t.get("objective", "yield_on_cost")
+    feasible.sort(key=lambda c: c.get(objective, 0), reverse=True)
+    return {"considered": len(candidates), "feasible": len(feasible),
+            "ranked": feasible[:8], "best": feasible[0] if feasible else None,
+            "objective": objective}
+
+
 def compare(plate_w: float, plate_d: float, floors: int, schemes: list[dict]) -> dict[str, Any]:
     """Evaluate several schemes side-by-side. Each scheme: {name, unit_types?, parking_ratio?,
     parking_kind?}. Returns per-scheme yield metrics + parking, ranked by total units."""

--- a/services/api/test_testfit.py
+++ b/services/api/test_testfit.py
@@ -40,6 +40,18 @@ b = next(s for s in cmp["schemes"] if s["name"] == "B")
 assert a["total_units"] > b["total_units"], (a["total_units"], b["total_units"])
 assert cmp["best"] == "A", cmp["best"]
 
+# --- generative optimize: sweep + rank by yield-on-cost ----------------------
+opt = tf.optimize(40, 18, 6, targets={"min_units": 1}, econ={"rent_psf_yr": 34, "hard_psf": 220})
+assert opt["considered"] == 15, opt["considered"]            # 5 presets × 3 parking ratios
+assert opt["feasible"] >= 1 and opt["best"], opt
+assert opt["best"]["yield_on_cost"] == max(c["yield_on_cost"] for c in opt["ranked"]), "best ranks top"
+# targets filter: an impossible yield floor yields nothing feasible
+none_feasible = tf.optimize(40, 18, 6, targets={"min_yoc": 9.99})
+assert none_feasible["feasible"] == 0 and none_feasible["best"] is None, none_feasible
+# objective switch: rank by units
+by_units = tf.optimize(40, 18, 6, targets={"objective": "total_units"})
+assert by_units["best"]["total_units"] == max(c["total_units"] for c in by_units["ranked"]), by_units
+
 # --- property & tax summary ----------------------------------------------------
 ps = dp.summarize({"purchase_price": 15_744_700, "building_sf": 249_749, "land_sf": 598_668,
                    "taxes": {"school": 955_533, "county": 239_731, "town": 228_906, "fire": 79_055}})
@@ -51,6 +63,8 @@ with TestClient(app) as c:
     pid = c.post("/projects", json={"name": "Fit"}).json()["id"]
     r = c.post("/test-fit/compare", json={"plate_w": 40, "plate_d": 18, "floors": 5, "schemes": []})
     assert r.status_code == 200 and len(r.json()["schemes"]) == 3, r.text   # default schemes
+    o = c.post("/test-fit/optimize", json={"plate_w": 40, "plate_d": 18, "floors": 6, "targets": {"min_units": 1}})
+    assert o.status_code == 200 and o.json()["best"] and o.json()["considered"] == 15, o.text
     pr = c.put(f"/projects/{pid}/property", json={"purchase_price": 15_744_700, "building_sf": 249_749,
                                                   "taxes": {"school": 955_533}})
     assert pr.status_code == 200 and pr.json()["summary"]["total_taxes"] == 955_533, pr.text
@@ -58,4 +72,5 @@ with TestClient(app) as c:
 
 print(f"TESTFIT OK - corridor layout {m['units_per_floor']} units/floor @ {m['efficiency']*100:.0f}% eff; "
       f"parking {pk['stalls']} stalls; compare ranks studio>2BR ({a['total_units']}>{b['total_units']}); "
+      f"optimize swept {opt['considered']} schemes -> best YoC {opt['best']['yield_on_cost']*100:.1f}%; "
       f"property taxes ${ps['total_taxes']:,} -> opex; endpoints ok")

--- a/services/data/src/aec_data/massing.py
+++ b/services/data/src/aec_data/massing.py
@@ -15,13 +15,30 @@ from typing import Any
 M2_TO_SF = 10.7639
 
 
+def _polygon_area(poly: list) -> float:
+    """Shoelace area (m²) of a closed polygon given as [[x,y],...] in metres."""
+    n = len(poly)
+    a = 0.0
+    for i in range(n):
+        x1, y1 = poly[i]
+        x2, y2 = poly[(i + 1) % n]
+        a += x1 * y2 - x2 * y1
+    return abs(a) / 2.0
+
+
 def compute_massing(p: dict) -> dict[str, Any]:
-    """Zoning envelope → program. Inputs (metres): lot_width/lot_depth or lot_area, far,
-    coverage_max, front/side/rear_setback, height_limit, floor_to_floor, efficiency, avg_unit_m2."""
+    """Zoning envelope → program. Inputs (metres): lot_width/lot_depth or lot_area or lot_polygon
+    ([[x,y],…]), far, coverage_max, front/side/rear_setback, height_limit, floor_to_floor,
+    efficiency, avg_unit_m2."""
     lot_w, lot_d = float(p.get("lot_width") or 0), float(p.get("lot_depth") or 0)
     lot_area = float(p.get("lot_area") or (lot_w * lot_d))
+    poly = p.get("lot_polygon")
+    if poly and len(poly) >= 3:                  # real parcel: area from shoelace, dims from bbox
+        lot_area = _polygon_area(poly)
+        xs = [float(pt[0]) for pt in poly]; ys = [float(pt[1]) for pt in poly]
+        lot_w, lot_d = max(xs) - min(xs), max(ys) - min(ys)
     if lot_area <= 0:
-        raise ValueError("provide lot_area or lot_width × lot_depth")
+        raise ValueError("provide lot_area, lot_width × lot_depth, or a lot_polygon")
     far = float(p.get("far", 1.0))
     coverage = float(p.get("coverage_max", 0.6))
     f2f = float(p.get("floor_to_floor", 3.5))

--- a/services/data/test_massing.py
+++ b/services/data/test_massing.py
@@ -31,6 +31,13 @@ assert mh["floors"] == 4 and mh["binding_constraint"] == "height", mh
 ma = massing.compute_massing({"lot_area": 1000, "far": 2.0})
 assert ma["floors"] >= 1 and ma["buildable_gfa_m2"] > 0, ma
 
+# lot polygon (real parcel): shoelace area drives the program — a 50×40 rect polygon == lot_area 2000
+mp = massing.compute_massing({"lot_polygon": [[0, 0], [50, 0], [50, 40], [0, 40]], "far": 3.0})
+assert abs(mp["lot_area_m2"] - 2000.0) < 1.0, mp["lot_area_m2"]
+# an L-shaped parcel has less area than its bounding box (1600 vs 2500)
+lshape = massing.compute_massing({"lot_polygon": [[0, 0], [50, 0], [50, 20], [20, 20], [20, 50], [0, 50]], "far": 2.0})
+assert abs(lshape["lot_area_m2"] - 1600.0) < 1.0, lshape["lot_area_m2"]
+
 # bad input is rejected
 try:
     massing.compute_massing({"far": 2.0})


### PR DESCRIPTION
A5: test_fit.optimize() sweeps unit-mix×parking, ranks by yield-on-cost, filters by targets (POST /test-fit/optimize + ⚡ Optimize button). A6: compute_massing(lot_polygon) — shoelace-area parcels. Gate 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)