### PR TITLE
Form-follows-finance: daylight-limited leasable depth (v0.1.17)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.16"
+version = "0.1.17"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -737,7 +737,7 @@ export class ApiClient {
   }
   /** Test-fit: compare unit-mix schemes on a floor plate (yield + parking, ranked). */
   testFitCompare(params: { plate_w: number; plate_d: number; floors: number; schemes?: unknown[] }) {
-    return this.json<{ best: string | null; schemes: { name: string; total_units: number; efficiency: number; total_nsf: number; total_gsf: number; avg_unit_sf: number; parking_stalls: number; mix: Record<string, number> }[] }>(
+    return this.json<{ best: string | null; schemes: { name: string; total_units: number; efficiency: number; daylight_efficiency: number; daylight_limited: boolean; total_nsf: number; total_gsf: number; avg_unit_sf: number; parking_stalls: number; mix: Record<string, number> }[] }>(
       "/test-fit/compare", { method: "POST", body: JSON.stringify(params) });
   }
   /** Generative design: sweep schemes, filter by targets, rank by yield-on-cost. */

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -302,12 +302,13 @@ export class ProformaUI {
         const r = await this.api.testFitCompare({ plate_w: +wi.value, plate_d: +di.value, floors: +fi.value });
         const rows = r.schemes.map((s) => `<tr${s.name === r.best ? ' style="font-weight:700"' : ""}>`
           + `<th style="text-align:left">${s.name}${s.name === r.best ? " ★" : ""}</th>`
-          + `<td style="text-align:right">${s.total_units}</td><td style="text-align:right">${(s.efficiency * 100).toFixed(0)}%</td>`
+          + `<td style="text-align:right">${s.total_units}</td>`
+          + `<td style="text-align:right"${s.daylight_limited ? ' title="deep plate — dark interior earns no rent"' : ""}>${(s.daylight_efficiency * 100).toFixed(0)}%${s.daylight_limited ? " ⚠" : ""}</td>`
           + `<td style="text-align:right">${s.avg_unit_sf.toLocaleString()}</td><td style="text-align:right">${s.total_nsf.toLocaleString()}</td>`
           + `<td style="text-align:right">${s.parking_stalls}</td></tr>`).join("");
         out.innerHTML = `<table class="sens-table" style="font-size:12px"><tr><th style="text-align:left">Scheme</th>`
-          + `<th>Units</th><th>Eff.</th><th>Avg SF</th><th>NSF</th><th>Stalls</th></tr>${rows}</table>`
-          + `<div class="meta" style="margin-top:4px">Best by units: <b>${r.best}</b></div>`;
+          + `<th>Units</th><th title="rentable ÷ gross, daylight-limited">Daylight</th><th>Avg SF</th><th>Rent. SF</th><th>Stalls</th></tr>${rows}</table>`
+          + `<div class="meta" style="margin-top:4px">Best by units: <b>${r.best}</b> · daylight efficiency = rentable area within ~9 m of a window ÷ gross</div>`;
       } catch { out.innerHTML = `<div class="meta">test-fit unavailable (API offline)</div>`; }
     };
     host.append(run, opt, out); this.root.appendChild(host);

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -119,11 +119,12 @@ research at [VT Myers-Lawson](https://mlsoc.vt.edu/research.html) (lean construc
 [NYU Schack / PropTech](https://www.sps.nyu.edu/homepage/academics/executive-education/schack-institute-of-real-estate.html),
 and ASU.
 
-- **R1 — Form follows finance (the generative driver).** Willis: skyscraper form is a *financial*
-  product — set by rentable area, daylight, and code, not aesthetics. Make massing **finance-optimal**:
-  a **leasable-depth / daylight constraint** (historically ~25–30 ft from a window to the core),
-  **core-efficiency** (rentable ÷ gross) as an objective, and zoning-envelope + setback-driven form.
-  Wire it into Test Fit's optimize so the highest **rentable-yield** scheme wins (not just max FAR).
+- ✅ **DONE — R1 form follows finance (daylight-limited leasable depth).** `test_fit.layout()` caps
+  leasable depth at a daylight limit (~9 m / 25–30 ft from a window); space deeper earns no rent, so a
+  too-deep plate loses rentable area to a dark core and its **daylight efficiency (rentable ÷ gross)**
+  drops (verified: 40 m plate 43% vs 16 m plate 77%). Surfaced in the Test Fit compare table (Daylight
+  column + ⚠ on deep plates). *Next: make it an optimize objective + sweep plate depth; core-efficiency
+  for the elevator/stair core.*
 - **R2 — Construction as a vertical assembly line.** *Building the Empire State*: fast-track, a
   story-a-day, ~3,500 workers by trade, **just-in-time** steel delivery (no on-site storage),
   finished 45 days early. Model the schedule as a **takt / line-of-balance flow with production

--- a/services/api/src/aec_api/test_fit.py
+++ b/services/api/src/aec_api/test_fit.py
@@ -20,48 +20,52 @@ DEFAULT_MIX = [
 
 
 def layout(plate_w: float, plate_d: float, floors: int = 1, unit_types: list[dict] | None = None,
-           corridor_w: float = 1.8, efficiency_target: float = 0.85) -> dict[str, Any]:
-    """Double-loaded corridor fit on a plate_w × plate_d (m) plate. Returns placed units (metres,
-    centred at plate origin), corridor, and yield metrics (units, NSF/GSF, efficiency, mix)."""
+           corridor_w: float = 1.8, max_lease_depth_m: float = 9.0) -> dict[str, Any]:
+    """Double-loaded corridor fit on a plate_w × plate_d (m) plate. R1 (Willis, *Form Follows
+    Finance*): leasable depth is daylight-limited — space deeper than `max_lease_depth_m` (~25–30 ft)
+    from a window earns no rent, so a too-deep plate loses rentable area to a dark interior core.
+    Returns placed units (metres) + yield metrics incl. **daylight efficiency** (rentable ÷ gross)."""
     types = unit_types or DEFAULT_MIX
     total_pct = sum(t.get("mix_pct", 0) for t in types) or 1.0
-    bay_d = max(2.5, (plate_d - corridor_w) / 2)          # unit depth per side (m)
-    bay_d_sf = bay_d / 1  # depth in m; unit width derived from target area below
+    bay_d = max(2.5, (plate_d - corridor_w) / 2)          # geometric depth per side (m)
+    lease_d = min(bay_d, max_lease_depth_m)               # daylight-limited *leasable* depth (m)
     units: list[dict] = []
     by_type: dict[str, int] = {t["name"]: 0 for t in types}
 
-    # build a repeating sequence of unit *widths* weighted by mix; tile each side along X
+    # unit widths sized so width × leasable-depth ≈ target SF; tile each side along X
     seq: list[tuple[str, float]] = []
     for t in types:
-        w_m = max(2.5, (float(t["target_sf"]) / M2_TO_SF) / bay_d)   # width so width×depth = target SF
-        n = max(1, round((t.get("mix_pct", 0) / total_pct) * 12))    # weight in a 12-slot cycle
+        w_m = max(2.5, (float(t["target_sf"]) / M2_TO_SF) / lease_d)
+        n = max(1, round((t.get("mix_pct", 0) / total_pct) * 12))
         seq += [(t["name"], w_m)] * n
     if not seq:
         seq = [("Unit", 8.0)]
 
-    for side, y_sign in (("N", 1), ("S", -1)):
+    for _side, y_sign in (("N", 1), ("S", -1)):
         x = -plate_w / 2
         i = 0
-        cy = y_sign * (corridor_w / 2 + bay_d / 2)
+        cy = y_sign * (plate_d / 2 - lease_d / 2)          # units pulled to the facade (daylight)
         while True:
             name, w_m = seq[i % len(seq)]
             if x + w_m > plate_w / 2 + 0.01:
                 break
             units.append({"name": name, "cx": round(x + w_m / 2, 2), "cy": round(cy, 2),
-                          "w": round(w_m, 2), "d": round(bay_d, 2)})
+                          "w": round(w_m, 2), "d": round(lease_d, 2)})
             by_type[name] = by_type.get(name, 0) + 1
             x += w_m
             i += 1
 
     units_per_floor = len(units)
     total_units = units_per_floor * max(1, floors)
-    nsf_floor = sum(u["w"] * u["d"] for u in units) * M2_TO_SF
+    nsf_floor = sum(u["w"] * u["d"] for u in units) * M2_TO_SF   # rentable (daylight-aware)
     gsf_floor = plate_w * plate_d * M2_TO_SF
+    core_depth = round(max(0.0, plate_d - 2 * lease_d - corridor_w), 2)   # dark non-rentable strip
     by_type_total = {k: v * max(1, floors) for k, v in by_type.items()}
     return {
         "units": units,                                  # one floor's placed rects (metres)
         "corridor": {"w": corridor_w, "length": round(plate_w, 2)},
-        "bay_depth": round(bay_d, 2),
+        "bay_depth": round(bay_d, 2), "leasable_depth": round(lease_d, 2),
+        "daylight_limited": bay_d > max_lease_depth_m + 0.01, "core_depth_m": core_depth,
         "metrics": {
             "units_per_floor": units_per_floor,
             "total_units": total_units,
@@ -70,6 +74,7 @@ def layout(plate_w: float, plate_d: float, floors: int = 1, unit_types: list[dic
             "total_nsf": round(nsf_floor * max(1, floors)),
             "total_gsf": round(gsf_floor * max(1, floors)),
             "efficiency": round(nsf_floor / gsf_floor, 3) if gsf_floor else 0.0,
+            "daylight_efficiency": round(nsf_floor / gsf_floor, 3) if gsf_floor else 0.0,
             "avg_unit_sf": round(nsf_floor / units_per_floor) if units_per_floor else 0,
             "mix": by_type_total,
         },
@@ -146,6 +151,7 @@ def compare(plate_w: float, plate_d: float, floors: int, schemes: list[dict]) ->
         out.append({
             "name": sc.get("name", "Scheme"),
             "total_units": m["total_units"], "efficiency": m["efficiency"],
+            "daylight_efficiency": m["daylight_efficiency"], "daylight_limited": lay["daylight_limited"],
             "total_nsf": m["total_nsf"], "total_gsf": m["total_gsf"],
             "avg_unit_sf": m["avg_unit_sf"], "mix": m["mix"],
             "parking_stalls": pk["stalls"], "parking_area_sf": pk["area_sf"],

--- a/services/api/test_testfit.py
+++ b/services/api/test_testfit.py
@@ -24,6 +24,16 @@ assert m["total_nsf"] < m["total_gsf"], m
 assert any(u["cy"] > 0 for u in lay["units"]) and any(u["cy"] < 0 for u in lay["units"]), "double-loaded"
 assert sum(m["mix"].values()) == m["total_units"], m["mix"]
 
+# --- R1: form-follows-finance — daylight-limited leasable depth ----------------
+shallow = tf.layout(60, 16, floors=1)          # 16 m deep: bays ~7 m, within daylight reach
+deep = tf.layout(60, 40, floors=1)             # 40 m deep: bays ~19 m, far beyond daylight
+assert not shallow["daylight_limited"], shallow["leasable_depth"]
+assert deep["daylight_limited"] and deep["core_depth_m"] > 0, deep
+# the deep plate wastes a dark interior core → much lower rentable (daylight) efficiency
+assert deep["metrics"]["daylight_efficiency"] < shallow["metrics"]["daylight_efficiency"] - 0.1, \
+    (deep["metrics"]["daylight_efficiency"], shallow["metrics"]["daylight_efficiency"])
+assert deep["leasable_depth"] == 9.0, deep["leasable_depth"]   # capped at the daylight limit
+
 # --- parking: stalls to ratio --------------------------------------------------
 pk = tf.parking(100, ratio=1.25, kind="structured")
 assert pk["stalls"] == 125 and pk["area_sf"] > 0 and pk["cost"] > 0, pk
@@ -70,7 +80,9 @@ with TestClient(app) as c:
     assert pr.status_code == 200 and pr.json()["summary"]["total_taxes"] == 955_533, pr.text
     assert c.get(f"/projects/{pid}/property").json()["summary"]["purchase_price"] == 15_744_700
 
-print(f"TESTFIT OK - corridor layout {m['units_per_floor']} units/floor @ {m['efficiency']*100:.0f}% eff; "
+print(f"TESTFIT OK - R1 daylight: deep-plate eff {deep['metrics']['daylight_efficiency']*100:.0f}% < "
+      f"shallow {shallow['metrics']['daylight_efficiency']*100:.0f}% (core {deep['core_depth_m']}m); "
+      f"corridor layout {m['units_per_floor']} units/floor @ {m['efficiency']*100:.0f}% eff; "
       f"parking {pk['stalls']} stalls; compare ranks studio>2BR ({a['total_units']}>{b['total_units']}); "
       f"optimize swept {opt['considered']} schemes -> best YoC {opt['best']['yield_on_cost']*100:.1f}%; "
       f"property taxes ${ps['total_taxes']:,} -> opex; endpoints ok")


### PR DESCRIPTION
R1: rentable area is daylight-limited (~9m from a window); deep plates lose rentable area to a dark core, lowering daylight efficiency. Surfaced in Test Fit compare. Grounded in Carol Willis, Form Follows Finance. Gate 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)