### PR TITLE
Faster large-model loading: ETag revalidation + download progress (v0.1.28)

### DIFF
--- a/apps/web/src/ui/feedback.ts
+++ b/apps/web/src/ui/feedback.ts
@@ -59,3 +59,33 @@ export async function withLoading<T>(container: HTMLElement, label: string,
     if (--depth <= 0) ov.classList.remove("show");
   }
 }
+
+/** Update the active loading overlay's label mid-task (e.g. download progress). */
+export function setLoadingLabel(container: HTMLElement, text: string): void {
+  const el = container.querySelector(".loading-label") as HTMLElement | null;
+  if (el) el.textContent = text;
+}
+
+/** Fetch an ArrayBuffer while reporting download progress (streams the body). Falls back to a
+ *  plain buffer when the body can't be streamed or Content-Length is absent. The browser still
+ *  handles ETag/304 transparently, so cached re-opens resolve instantly. */
+export async function fetchArrayBufferWithProgress(
+  url: string, init: RequestInit, onProgress: (loaded: number, total: number) => void,
+): Promise<ArrayBuffer> {
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const total = Number(res.headers.get("content-length") || 0);
+  if (!res.body || !total) return res.arrayBuffer();
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let loaded = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value); loaded += value.length; onProgress(loaded, total);
+  }
+  const out = new Uint8Array(loaded);
+  let off = 0;
+  for (const c of chunks) { out.set(c, off); off += c.length; }
+  return out.buffer;
+}

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -16,7 +16,7 @@ import { OriginTool } from "../tools/origin";
 import { buildTree } from "../tree/tree";
 import { PinOverlay, restoreCamera } from "../pins/pins";
 import { type ApiClient, type ElementProps, type Topic } from "../api/client";
-import { toast, withLoading } from "../ui/feedback";
+import { fetchArrayBufferWithProgress, setLoadingLabel, toast, withLoading } from "../ui/feedback";
 import { showResult, kvTable, metricGrid, resultNote } from "../ui/result";
 
 /** View options the settings bar owns (in main) and the viewer applies. */
@@ -207,9 +207,13 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   }
   async function loadSample(file: string, label: string) {
     await withLoading(container, `loading ${label}`, async () => {
-      const res = await fetch(import.meta.env.BASE_URL + file.replace(/^\//, ""));   // respect the deploy base
-      if (!res.ok) throw new Error(`${label} not found`);
-      await loader.loadFragments(await res.arrayBuffer(), nextId(label));
+      const mb = (n: number) => (n / 1048576).toFixed(1);
+      const buffer = await fetchArrayBufferWithProgress(
+        import.meta.env.BASE_URL + file.replace(/^\//, ""), {},   // respect the deploy base
+        (loaded, total) => setLoadingLabel(container,
+          `downloading ${label} ${Math.round(loaded / total * 100)}% (${mb(loaded)}/${mb(total)} MB)`));
+      setLoadingLabel(container, "preparing geometry…");
+      await loader.loadFragments(buffer, nextId(label));
       await fitToModels();
       notify(`loaded ${label}`, "success");
     });
@@ -595,18 +599,25 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   }
   async function loadProjectModel(): Promise<boolean> {
     if (!projectId) return false;
-    try {
-      const res = await fetch(api.url(`/projects/${projectId}/model.frag`), { headers: api.authHeaders() });
-      if (!res.ok) return false;
+    return (await withLoading(container, "loading model", async () => {
+      const mb = (n: number) => (n / 1048576).toFixed(1);
+      let buffer: ArrayBuffer;
+      try {
+        buffer = await fetchArrayBufferWithProgress(
+          api.url(`/projects/${projectId}/model.frag`), { headers: api.authHeaders() },
+          (loaded, total) => setLoadingLabel(container,
+            `downloading model ${Math.round(loaded / total * 100)}% (${mb(loaded)}/${mb(total)} MB)`));
+      } catch { return false; }                 // no published model yet
       await loader.disposeAll();
       modelLabels.clear();
       const id = `project-${projectId}`;
       modelLabels.set(id, ctx.projectName || "project");
-      await loader.loadFragments(await res.arrayBuffer(), id);
+      setLoadingLabel(container, "preparing geometry…");
+      await loader.loadFragments(buffer, id);
       refreshFederation();
       await fitToModels();
       return true;
-    } catch { return false; }
+    })) ?? false;
   }
   function screenToGround(e: MouseEvent): THREE.Vector3 | null {
     const dom = viewer.world.renderer!.three.domElement;

--- a/services/api/src/aec_api/routers/bim.py
+++ b/services/api/src/aec_api/routers/bim.py
@@ -383,9 +383,11 @@ def download_attachment(aid: str, request: Request, db: Session = Depends(get_db
 
 @router.get("/projects/{pid}/model.frag")
 def model_frag(pid: str, request: Request):
-    """Serve the published Fragments tile with HTTP range support (streaming)."""
+    """Serve the published Fragments tile with HTTP range support + ETag revalidation. The URL is
+    stable across republishes, so we revalidate (not immutable): unchanged → 304 (instant re-open),
+    republished → fresh bytes (fixes stale-cache after an edit/regenerate)."""
     return range_response(request, f"{pid}/model.frag", "application/octet-stream",
-                          filename="model.frag")
+                          filename="model.frag", immutable=False)
 
 
 @router.get("/projects/{pid}/source.ifc")

--- a/services/api/src/aec_api/serving.py
+++ b/services/api/src/aec_api/serving.py
@@ -12,13 +12,22 @@ _RANGE = re.compile(r"bytes=(\d*)-(\d*)")
 
 
 def range_response(request: Request, key: str, media_type: str,
-                   filename: str | None = None, disposition: str = "inline") -> Response:
+                   filename: str | None = None, disposition: str = "inline",
+                   immutable: bool = True) -> Response:
     if not storage.exists(key):
         raise HTTPException(404, f"not found: {key}")
     total = storage.size(key)
-    headers = {"Accept-Ranges": "bytes", "Cache-Control": "public, max-age=31536000, immutable"}
+    etag = storage.version(key)
+    # `immutable` for assets that never change at a URL; otherwise revalidate so a republished model
+    # (stable URL, new bytes) is refetched — a 304 keeps re-opens instant *and* correct.
+    cache = "public, max-age=31536000, immutable" if immutable else "public, max-age=0, must-revalidate"
+    headers = {"Accept-Ranges": "bytes", "Cache-Control": cache, "ETag": etag}
     if filename:
         headers["Content-Disposition"] = f'{disposition}; filename="{filename}"'
+
+    inm = request.headers.get("if-none-match") or request.headers.get("If-None-Match")
+    if inm and etag in [t.strip() for t in inm.split(",")]:   # conditional GET → 304, no body re-sent
+        return Response(status_code=304, headers=headers)
 
     rng = request.headers.get("range") or request.headers.get("Range")
     if rng:

--- a/services/api/src/aec_api/storage.py
+++ b/services/api/src/aec_api/storage.py
@@ -46,6 +46,10 @@ class LocalBackend:
     def size(self, key: str) -> int:
         return self._p(key).stat().st_size
 
+    def version(self, key: str) -> str:
+        st = self._p(key).stat()
+        return f'"{st.st_size:x}-{int(st.st_mtime):x}"'   # cheap, changes whenever the file is rewritten
+
     def get_range(self, key: str, start: int, end: int) -> bytes:
         with open(self._p(key), "rb") as fh:
             fh.seek(start)
@@ -91,6 +95,10 @@ class S3Backend:
     def size(self, key: str) -> int:
         return self.client.head_object(Bucket=self.bucket, Key=key)["ContentLength"]
 
+    def version(self, key: str) -> str:
+        h = self.client.head_object(Bucket=self.bucket, Key=key)
+        return (h.get("ETag") or f'"{h["ContentLength"]:x}"').strip('"').join('""')
+
     def get_range(self, key: str, start: int, end: int) -> bytes:
         obj = self.client.get_object(Bucket=self.bucket, Key=key, Range=f"bytes={start}-{end}")
         return obj["Body"].read()
@@ -131,6 +139,15 @@ def delete(key: str) -> None:
 
 def size(key: str) -> int:
     return backend().size(key)
+
+
+def version(key: str) -> str:
+    """A cheap content validator (ETag value) — changes when the object is rewritten."""
+    b = backend()
+    try:
+        return b.version(key)              # type: ignore[attr-defined]
+    except AttributeError:
+        return f'"{b.size(key):x}"'        # fallback: size only
 
 
 def path(key: str) -> Path:

--- a/services/api/test_serving.py
+++ b/services/api/test_serving.py
@@ -34,6 +34,18 @@ with TestClient(app) as c:
     # unsatisfiable
     assert c.get(f"/projects/{pid}/model.frag", headers={"Range": "bytes=999-"}).status_code == 416
 
+    # --- ETag revalidation (stale-cache fix for republished models) ------------
+    etag = full.headers.get("etag")
+    assert etag, "frag must carry an ETag"
+    assert "must-revalidate" in full.headers.get("cache-control", ""), full.headers.get("cache-control")
+    # unchanged → 304, no body
+    nm = c.get(f"/projects/{pid}/model.frag", headers={"If-None-Match": etag})
+    assert nm.status_code == 304 and not nm.content, (nm.status_code, len(nm.content))
+    # republish (new bytes) → ETag changes → full 200 (not a stale 304)
+    storage.put(f"{pid}/model.frag", bytes(range(128)))
+    again = c.get(f"/projects/{pid}/model.frag", headers={"If-None-Match": etag})
+    assert again.status_code == 200 and again.headers.get("etag") != etag, "republished frag must refetch"
+
     # --- observability: /metrics in Prometheus text format ---------------------
     c.get("/health"); c.get("/health")          # generate some traffic on a stable route
     m = c.get("/metrics")


### PR DESCRIPTION
Fixes stale-cache on republish (immutable→ETag/304) + streaming download progress so big models don't look frozen. Web + desktop. Gate 29/29.