### PR TITLE
feat(viewer): render mode — sun, soft shadows & tone mapping (M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to the AEC BIM Platform. Releases are signed, auto-updating 
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.1.29 — render mode (M2 start)
+- **Viewer render mode** (◓ toolbar) — a directional **sun with soft (PCF) shadows**, hemisphere
+  sky/ground fill + fill light, **ACES tone mapping** and sRGB output, and a shadow-catching ground
+  plane. Off by default (flat shading stays the cheap default); re-applies as new models load.
+  First step toward Revit/Rhino/Matterport-style rendering.
+
+## v0.1.28 — faster large-model loading
+- **Download progress** — large models stream with a live "downloading N% (x/y MB) → preparing
+  geometry" label instead of a generic spinner that looked frozen.
+- **ETag revalidation** — `model.frag` now serves an ETag + `must-revalidate`: unchanged models
+  re-open instantly via **304**, while a republished/edited model is always refetched (fixes a
+  stale-cache bug where an immutable 1-year cache served the old geometry forever).
+
+## v0.1.27 — computational graph (M4 start)
+- **Dynamo-style node graph** over the pure engines: `GET /compute/nodes` (palette) and
+  `POST /compute/graph` run a {nodes, edges} graph in dependency order (zoning → structure / takt /
+  cost → yield-on-cost). Zero-touch: function params become input ports, dict returns become outputs.
+
+## v0.1.26 — IFC materials & surface colours (M1 start)
+- **Materials & surface styles** — generated/dome models get an IfcMaterial + IfcSurfaceStyle colour
+  per element class (concrete, glazing, steel, vegetation…), so models carry real material data.
+
+## v0.1.25 — gamified getting-started
+- **Getting-started checklist** — a floating progress pill guides new users through the 6 core
+  actions (load a model, generate, test-fit, budget, project, memo) with a progress bar + celebration.
+
 ## v0.1.22 — 4D & the vertical assembly line
 - **4D construction sequencing** — map model elements onto a takt plan; **scrub the build sequence
   in the viewer** (a slider isolates what's built to date).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.28"
+version = "0.1.29"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -3,7 +3,7 @@
 // Construction (GC portal) or Finance (proforma) workspaces.
 import * as THREE from "three";
 import CameraControls from "camera-controls";
-import { createViewer } from "./world";
+import { createViewer, renderMode } from "./world";
 import { ModelLoader } from "./loader";
 import { type ModelIdMap } from "./modelIds";
 import { SelectionSets } from "./selectionSets";
@@ -381,6 +381,16 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     setStatus("section box on (toggle to clear)");
   });
 
+  // render mode: presentation lighting + soft shadows (off by default — flat is cheaper/faster)
+  let renderOn = false;
+  toolBtn("◓", "Render mode — sun, soft shadows & PBR lighting", (b) => {
+    renderOn = !renderOn;
+    renderMode(viewer.world, renderOn);
+    b.classList.toggle("on", renderOn);
+    setStatus(renderOn ? "render mode on — sun + soft shadows" : "render mode off (flat shading)");
+    void loader.fragments.core.update(true);
+  });
+
   // levels overlay: a horizontal grid + label at each storey elevation (from the API)
   const levelObjs: THREE.Object3D[] = [];
   toolBtn("☰", "Toggle storey levels overlay", async (b) => {
@@ -659,6 +669,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     const box = new THREE.Box3();
     viewer.world.scene.three.traverse((o) => { const m = o as THREE.Mesh; if (m.isMesh) box.expandByObject(m); });
     if (box.isEmpty()) return;
+    if (renderOn) renderMode(viewer.world, true);   // newly loaded meshes need cast/receive flags set
     await viewer.world.camera.controls.fitToSphere(box.getBoundingSphere(new THREE.Sphere()), true);
     await loader.fragments.core.update(true);
   }

--- a/apps/web/src/viewer/world.ts
+++ b/apps/web/src/viewer/world.ts
@@ -1,4 +1,5 @@
 import * as OBC from "@thatopen/components";
+import * as THREE from "three";
 
 export type World = OBC.SimpleWorld<OBC.SimpleScene, OBC.OrthoPerspectiveCamera, OBC.SimpleRenderer>;
 
@@ -35,4 +36,72 @@ export function createViewer(container: HTMLElement): Viewer {
   const grid = grids.create(world);
 
   return { components, world, container, grid };
+}
+
+const SUN = "aec-sun", HEMI = "aec-hemi", FILL = "aec-fill", GROUND = "aec-shadow-ground";
+
+/**
+ * "Render mode": a presentation-grade lighting rig over the flat default scene — a directional sun
+ * with soft shadows, hemisphere sky/ground fill, ACES tone mapping and sRGB output, plus a large
+ * shadow-catching ground plane. Off by default (cheaper, flat); toggled from the viewer toolbar.
+ * Idempotent — safe to call repeatedly and after new models load (re-applies mesh shadow flags).
+ */
+export function renderMode(world: World, on: boolean): void {
+  const r = world.renderer!.three;
+  const s = world.scene.three;
+
+  r.shadowMap.enabled = on;
+  r.shadowMap.type = THREE.PCFSoftShadowMap;
+  r.toneMapping = on ? THREE.ACESFilmicToneMapping : THREE.NoToneMapping;
+  r.toneMappingExposure = on ? 1.05 : 1;
+  r.outputColorSpace = THREE.SRGBColorSpace;
+
+  let sun = s.getObjectByName(SUN) as THREE.DirectionalLight | null;
+  if (on && !sun) {
+    sun = new THREE.DirectionalLight(0xfff4e6, 2.4);
+    sun.name = SUN;
+    sun.position.set(45, 90, 35);
+    sun.castShadow = true;
+    sun.shadow.mapSize.set(2048, 2048);
+    sun.shadow.camera.near = 1;
+    sun.shadow.camera.far = 500;
+    const d = 140;
+    Object.assign(sun.shadow.camera, { left: -d, right: d, top: d, bottom: -d });
+    sun.shadow.bias = -0.0004;
+    sun.shadow.normalBias = 0.04;
+    s.add(sun);
+
+    const hemi = new THREE.HemisphereLight(0xbcd4ff, 0x556070, 0.55); // sky / ground bounce
+    hemi.name = HEMI;
+    s.add(hemi);
+
+    const fill = new THREE.DirectionalLight(0x9fb4d0, 0.5);
+    fill.name = FILL;
+    fill.position.set(-40, 30, -25);
+    s.add(fill);
+
+    const ground = new THREE.Mesh(
+      new THREE.PlaneGeometry(2000, 2000),
+      new THREE.ShadowMaterial({ opacity: 0.28 }),
+    );
+    ground.name = GROUND;
+    ground.rotation.x = -Math.PI / 2;
+    ground.position.y = -0.01; // just under the model so it catches shadows without z-fighting
+    ground.receiveShadow = true;
+    s.add(ground);
+  } else if (!on) {
+    for (const name of [SUN, HEMI, FILL, GROUND]) {
+      const o = s.getObjectByName(name);
+      if (o) s.remove(o);
+    }
+  }
+
+  // (Re)apply cast/receive flags to all current model meshes.
+  s.traverse((o) => {
+    const m = o as THREE.Mesh;
+    if (m.isMesh && m.name !== GROUND) {
+      m.castShadow = on;
+      m.receiveShadow = on;
+    }
+  });
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -163,9 +163,11 @@ material info). Grounded in: [IfcMaterial layer sets](https://forums.buildingsma
   IfcMaterial + IfcSurfaceStyle colour per element class to generated/dome models (concrete, glazing,
   steel, vegetation…), so models carry real material data and render in colour. *Next: a material
   editor + per-project palette.*
-- **M2 — Photorealistic rendering** (Revit/Rhino/Matterport): a viewer **render mode** — PBR
-  (MeshStandardMaterial) + environment/IBL lighting, **soft shadows + ambient occlusion**, a
-  **sun/shadow study** by date/location, and a **Matterport-style first-person walkthrough**.
+- ✅ **DONE (M2 start) — render mode.** A viewer toolbar **render mode** (◓): a directional **sun
+  with soft (PCF) shadows**, hemisphere sky/ground fill + a fill light, **ACES tone mapping** & sRGB
+  output, and a shadow-catching ground plane — toggled on demand (flat shading stays the cheap
+  default), re-applied as new models load. *Next: PBR `MeshStandardMaterial` + environment/IBL map,
+  a sun/shadow study by date/location, and a Matterport-style first-person walkthrough.*
 - **M3 — Family & material depth** (Revit-parity): **IfcMaterialLayerSet** wall/floor/roof assemblies
   (e.g. plasterboard · stud · plasterboard), an expanded parametric **family library** with materials,
   and **import of external IFC type content**.


### PR DESCRIPTION
Adds a viewer **render mode** toggle (◓): directional sun + PCF soft shadows, hemisphere sky/ground fill, ACES tone mapping + sRGB, and a shadow-catching ground plane. Off by default; re-applies as new models load. First step on the M2 rendering theme. Backfills CHANGELOG v0.1.25–v0.1.28.

Verified: typecheck + web tests (10) + build clean; preview-tested toggle on/off on a loaded model (soft ground shadow + directional shading visible, zero console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)