### PR TITLE
feat: M2 PBR pass + IBL, free Revit→IFC path, library eval docs (v0.1.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the AEC BIM Platform. Releases are signed, auto-updating 
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.1.30 — PBR materials + free Revit import
+- **PBR pass (M2)** — render mode now upgrades plain lit surfaces to `MeshStandardMaterial`
+  (roughness/metalness, keeps the M1 IFC colours) lit by an **IBL studio environment** for soft
+  ambient + reflections, on top of the sun/shadows. Reversible; Fragments' own shader meshes are
+  left untouched so the engine renderer is never at risk.
+- **Free Revit → IFC path** — the Open menu now has *"Free: export IFC from Revit (no bridge)…"*:
+  a guide to Revit's built-in IFC export + the free, open-source **pyRevit**, so getting a model in
+  doesn't require the paid Autodesk bridge.
+- **Docs** — library interoperability evaluation (roadmap §L: IFClite, pyRevit, FreeCAD, Pascal
+  Editor) and ADR 0001 on dependency bundling & the signed-update policy (deps are pinned and ship
+  inside the app update — never background-updated independently).
+
 ## v0.1.29 — render mode (M2 start)
 - **Viewer render mode** (◓ toolbar) — a directional **sun with soft (PCF) shadows**, hemisphere
   sky/ground fill + fill light, **ACES tone mapping** and sRGB output, and a shadow-catching ground

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.29"
+version = "0.1.30"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -58,10 +58,11 @@ buildMenu("open-menu", "Open ▾", [
   { label: "School — Structural", onClick: () => withViewer((v) => void v.loadSample("/school_str.frag", "School (Structural)")) },
   { label: "School — Architectural", onClick: () => withViewer((v) => void v.loadSample("/school_arq.frag", "School (Architectural)")) },
   { label: "BasicHouse", onClick: () => withViewer((v) => void v.loadSample("/basichouse.frag", "BasicHouse")) },
-  { label: "Import (Autodesk — paid bridge)", sep: true },
-  { label: "Revit (.rvt)…", onClick: () => withViewer((v) => v.triggerOpen("convert")) },
-  { label: "AutoCAD (.dwg)…", onClick: () => withViewer((v) => v.triggerOpen("convert")) },
-  { label: "Navisworks (.nwc)…", onClick: () => withViewer((v) => v.triggerOpen("convert")) },
+  { label: "Import from Revit / CAD", sep: true },
+  { label: "Free: export IFC from Revit (no bridge)…", onClick: () => showFreeImportHelp() },
+  { label: "Revit (.rvt) — paid Autodesk bridge…", onClick: () => withViewer((v) => v.triggerOpen("convert")) },
+  { label: "AutoCAD (.dwg) — paid bridge…", onClick: () => withViewer((v) => v.triggerOpen("convert")) },
+  { label: "Navisworks (.nwc) — paid bridge…", onClick: () => withViewer((v) => v.triggerOpen("convert")) },
 ], () => void ensureViewer());
 buildMenu("save-menu", "Save ▾", [
   { label: "Save Project (.mmproj)", onClick: () => saveProjectBundle() },
@@ -69,6 +70,42 @@ buildMenu("save-menu", "Save ▾", [
   { label: "Export Fragments (.frag)", onClick: () => withViewer((v) => void v.exportFrag()) },
   { label: "Export source IFC (.ifc)", onClick: () => withViewer((v) => v.exportIfc()) },
 ], () => void ensureViewer());
+
+/**
+ * The free, offline way to get a Revit/CAD model into the viewer — IFC is the source of truth, so
+ * users don't need the paid Autodesk bridge: export IFC from Revit (built-in) or batch it with the
+ * free, open-source pyRevit, then "Open IFC…". Surfaced so the mission's "free single-project"
+ * promise is actually reachable from the UI, not just the paid path.
+ */
+function showFreeImportHelp() {
+  const { card, msg } = modalShell("Import from Revit for free (no paid bridge)", 540);
+  msg.innerHTML = `
+    <p><b>IFC is the source of truth here</b> — you only need the paid Autodesk bridge if you want to
+    drop a raw <code>.rvt</code> in directly. The free path is to export IFC from Revit, then use
+    <b>Open&nbsp;IFC…</b>:</p>
+    <ol style="margin:8px 0 8px 18px;line-height:1.5">
+      <li><b>One model — Revit built-in:</b> <i>File ▸ Export ▸ IFC</i>. Pick <b>IFC 4</b> (or IFC 2x3
+          for older tools) and a coordinate base of <i>Project / Shared</i>. Save the <code>.ifc</code>.</li>
+      <li><b>Many models / repeatable — pyRevit (free, open-source):</b> install
+          <code>pyRevit</code>, then use its IFC export tools to batch-export views/models to IFC.</li>
+      <li>Back here: <b>Open ▸ Open&nbsp;IFC…</b> — we pre-convert it to Fragments on the server and
+          it streams in like any other model.</li>
+    </ol>
+    <p class="meta">DWG/NWC: export to IFC from their host app the same way, or use the paid bridge.</p>`;
+  card.appendChild(msg);
+  const links = document.createElement("div");
+  links.style.cssText = "display:flex;gap:10px;flex-wrap:wrap;margin-top:6px";
+  for (const [t, href] of [
+    ["pyRevit (free)", "https://github.com/pyrevitlabs/pyRevit"],
+    ["Revit IFC export docs", "https://help.autodesk.com/view/RVT/2024/ENU/?guid=GUID-6708CFD6-0AD7-4D85-8479-A2A8657C9181"],
+  ] as const) {
+    const a = document.createElement("a");
+    a.href = href; a.target = "_blank"; a.rel = "noopener noreferrer";
+    a.textContent = t; a.className = "btn-secondary"; a.style.textDecoration = "none";
+    links.appendChild(a);
+  }
+  card.appendChild(links);
+}
 
 /** Save the whole project (geometry + all data + blobs) as a portable .mmproj bundle. */
 function saveProjectBundle() {

--- a/apps/web/src/viewer/world.ts
+++ b/apps/web/src/viewer/world.ts
@@ -1,5 +1,6 @@
 import * as OBC from "@thatopen/components";
 import * as THREE from "three";
+import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
 
 export type World = OBC.SimpleWorld<OBC.SimpleScene, OBC.OrthoPerspectiveCamera, OBC.SimpleRenderer>;
 
@@ -40,15 +41,67 @@ export function createViewer(container: HTMLElement): Viewer {
 
 const SUN = "aec-sun", HEMI = "aec-hemi", FILL = "aec-fill", GROUND = "aec-shadow-ground";
 
+let envMap: THREE.Texture | null = null;   // PMREM-prefiltered IBL, built lazily from the renderer
+
+/** A neutral studio environment for image-based lighting/reflections (built once, cached). */
+function studioEnv(r: THREE.WebGLRenderer): THREE.Texture {
+  if (envMap) return envMap;
+  const pmrem = new THREE.PMREMGenerator(r);
+  envMap = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+  pmrem.dispose();
+  return envMap;
+}
+
+/** Only these plain lit materials are safe to upgrade to PBR. We deliberately skip Fragments'
+ *  own `ShaderMaterial` meshes — they carry `onBeforeRender` hooks that feed custom uniforms, so
+ *  swapping their material would break the engine's rendering/highlighting. */
+const PBR_CONVERTIBLE = new Set(["MeshLambertMaterial", "MeshBasicMaterial", "MeshPhongMaterial"]);
+
 /**
- * "Render mode": a presentation-grade lighting rig over the flat default scene — a directional sun
- * with soft shadows, hemisphere sky/ground fill, ACES tone mapping and sRGB output, plus a large
- * shadow-catching ground plane. Off by default (cheaper, flat); toggled from the viewer toolbar.
- * Idempotent — safe to call repeatedly and after new models load (re-applies mesh shadow flags).
+ * Swap a Fragments mesh between its default lit material and a PBR `MeshStandardMaterial` that adds
+ * roughness/metalness + responds to the IBL environment (reflections), preserving the per-element
+ * IFC surface colours (M1). The original is stashed on `userData` so toggling render mode off
+ * restores it exactly. Idempotent, and a no-op for materials we shouldn't touch (see above).
+ */
+function setMeshPbr(m: THREE.Mesh, on: boolean): void {
+  const ud = m.userData as { _flatMat?: THREE.Material | THREE.Material[] };
+  const first = Array.isArray(m.material) ? m.material[0] : m.material;
+  if (on) {
+    if (ud._flatMat || !first || !PBR_CONVERTIBLE.has(first.type)) return;   // already done / not safe
+    const make = (src: THREE.Material): THREE.Material => {
+      const b = src as THREE.MeshLambertMaterial;
+      return new THREE.MeshStandardMaterial({
+        color: b.color?.clone?.() ?? new THREE.Color(0xcfd3da),
+        map: b.map ?? null,
+        vertexColors: b.vertexColors,              // keep the per-element IFC surface colours (M1)
+        transparent: b.transparent, opacity: b.opacity, side: b.side,
+        alphaTest: b.alphaTest, depthWrite: b.depthWrite,
+        roughness: 0.82, metalness: 0.0, envMapIntensity: 0.9,   // matte architectural default
+      });
+    };
+    ud._flatMat = m.material;
+    m.material = Array.isArray(m.material) ? m.material.map(make) : make(m.material);
+  } else if (ud._flatMat) {
+    const cur = m.material;                         // dispose the PBR clone(s) we created
+    (Array.isArray(cur) ? cur : [cur]).forEach((mat) => mat.dispose());
+    m.material = ud._flatMat;
+    delete ud._flatMat;
+  }
+}
+
+/**
+ * "Render mode": a presentation-grade upgrade over the flat default scene — a directional sun with
+ * soft shadows, hemisphere sky/ground fill, ACES tone mapping + sRGB output, a shadow-catching
+ * ground plane, **IBL environment lighting**, and a **PBR material swap** (plain lit surfaces →
+ * `MeshStandardMaterial`) so they gain roughness/metalness + environment reflections on top of the
+ * sun. Off by default (cheaper, flat); toggled from the viewer toolbar. Idempotent — safe to call
+ * repeatedly and after new models load.
  */
 export function renderMode(world: World, on: boolean): void {
   const r = world.renderer!.three;
   const s = world.scene.three;
+
+  s.environment = on ? studioEnv(r) : null;   // IBL ambient + reflections (PBR materials only)
 
   r.shadowMap.enabled = on;
   r.shadowMap.type = THREE.PCFSoftShadowMap;
@@ -96,12 +149,13 @@ export function renderMode(world: World, on: boolean): void {
     }
   }
 
-  // (Re)apply cast/receive flags to all current model meshes.
+  // (Re)apply cast/receive flags + the PBR material swap to all current model meshes.
   s.traverse((o) => {
     const m = o as THREE.Mesh;
     if (m.isMesh && m.name !== GROUND) {
       m.castShadow = on;
       m.receiveShadow = on;
+      setMeshPbr(m, on);
     }
   });
 }

--- a/docs/adr/0001-dependencies-and-updates.md
+++ b/docs/adr/0001-dependencies-and-updates.md
@@ -1,0 +1,46 @@
+# ADR 0001 — Dependency bundling & update policy
+
+**Status:** accepted · **Date:** 2026-06-23
+
+## Context
+A library research pass ([roadmap §L](../roadmap.md)) raised two recurring questions:
+
+1. *Are there libraries we need to create/import for the program to run on its own?*
+2. *Do dependencies need to auto-update in the background?*
+
+These touch two non-negotiables: the viewer **must run fully offline** (local WASM, self-hosted
+tiles), and `@thatopen/components` ↔ `@thatopen/fragments` are **version-coupled** (a compatible pair
+must be pinned).
+
+## Decision
+
+### 1. The app runs standalone — no new library is required
+The free single-project product is self-contained already:
+
+- **Desktop** = a **Tauri** shell wrapping the web build, with a **PyInstaller-frozen FastAPI
+  sidecar** for the API/conversion. No system Python, Node, or Docker needed at runtime.
+- **Geometry** = **web-ifc WASM is self-hosted** in the bundle; IFC→Fragments conversion happens in
+  the sidecar. Nothing is fetched from a CDN at runtime, so the viewer works on an air-gapped machine.
+- Source-of-truth and editing boundaries are unchanged: IFC in, Fragments served, Blender/Bonsai is
+  the *desktop* editor. We do **not** add an in-browser authoring library (see roadmap §L, Pascal).
+
+We do **not** hand-roll new libraries; we lean on the pinned stack (web-ifc, ThatOpen, ifcopenshell)
+and our own pure-function engines.
+
+### 2. Dependencies are pinned and ship inside the signed app update — never background-updated alone
+- All third-party geometry/WASM/JS deps are **pinned** (exact compatible versions, esp. the ThatOpen
+  pair) and **bundled** into each release.
+- The **whole application** auto-updates through **signed GitHub releases** (Tauri updater). That is
+  the *only* update channel.
+- We explicitly reject **independent background auto-update** of geometry/WASM libraries, because it
+  would (a) break the offline guarantee (runtime network fetch), and (b) risk pulling an incompatible
+  `components`/`fragments` combination that the pinned-pair rule exists to prevent.
+
+### Consequence for the §L evaluations
+Anything adopted from the research pass (e.g. an `@ifc-lite/geometry` server converter, a FreeCAD
+headless drawing step) follows the same rule: **pin it, bundle it into the sidecar/web build, ship it
+in the signed release** — no separate updater, no runtime download.
+
+## Alternatives considered
+- *Per-library background updaters* — rejected (offline + version-coupling risks above).
+- *Runtime CDN for WASM/tiles* — rejected (violates the offline non-negotiable).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -163,11 +163,14 @@ material info). Grounded in: [IfcMaterial layer sets](https://forums.buildingsma
   IfcMaterial + IfcSurfaceStyle colour per element class to generated/dome models (concrete, glazing,
   steel, vegetation…), so models carry real material data and render in colour. *Next: a material
   editor + per-project palette.*
-- ✅ **DONE (M2 start) — render mode.** A viewer toolbar **render mode** (◓): a directional **sun
+- ✅ **DONE (M2) — render mode + PBR.** A viewer toolbar **render mode** (◓): a directional **sun
   with soft (PCF) shadows**, hemisphere sky/ground fill + a fill light, **ACES tone mapping** & sRGB
-  output, and a shadow-catching ground plane — toggled on demand (flat shading stays the cheap
-  default), re-applied as new models load. *Next: PBR `MeshStandardMaterial` + environment/IBL map,
-  a sun/shadow study by date/location, and a Matterport-style first-person walkthrough.*
+  output, and a shadow-catching ground plane. A **PBR pass** upgrades plain lit surfaces to
+  `MeshStandardMaterial` (roughness/metalness, keeps the M1 IFC colours) lit by an **IBL studio
+  environment** (RoomEnvironment via PMREM) for soft ambient + reflections — Fragments' own
+  `ShaderMaterial` meshes are deliberately left untouched (they carry engine render hooks). Toggled
+  on demand (flat stays the cheap default), reversible, re-applied as new models load. *Next: a
+  sun/shadow study by date/location, and a Matterport-style first-person walkthrough.*
 - **M3 — Family & material depth** (Revit-parity): **IfcMaterialLayerSet** wall/floor/roof assemblies
   (e.g. plasterboard · stud · plasterboard), an expanded parametric **family library** with materials,
   and **import of external IFC type content**.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -177,6 +177,41 @@ material info). Grounded in: [IfcMaterial layer sets](https://forums.buildingsma
   order (zoning → structure/takt/cost → yield). After the Dynamo zero-touch primer. *Next: a visual
   node editor + the module-relations graph view.*
 
+## L. Library & interoperability evaluations  ★ research pass (2026-06)
+Surveyed external libraries against the mission (IFC source-of-truth, server-side IFC→Fragments,
+offline viewer, Blender/Bonsai as the *desktop* editor). Verdicts — adopt only what serves the
+mission; see [adr/0001-dependencies-and-updates.md](adr/0001-dependencies-and-updates.md) for the
+bundling/auto-update policy these feed into.
+
+- **IFClite / `@ifc-lite/*`** (MPL-2.0, Rust+WASM, 25 npm pkgs — [ifc-lite](https://github.com/louistrue/ifc-lite)).
+  Claims ~5× faster geometry than web-ifc and, crucially, **IFC5 / IFCX (JSON) support**. *Verdict:
+  evaluate — but do **not** swap the browser engine* (our non-negotiable is "never parse full IFC in
+  the browser at runtime"; ThatOpen pin coupling). Two useful, contained spikes: **(L1)** trial
+  `@ifc-lite/geometry` (the "ifclite-geom" tessellator) as a faster **server-side** converter behind
+  the existing convert API; **(L2)** track `@ifc-lite/parser` for **IFC5/IFCX readiness** so IFC
+  stays the source of truth as the schema evolves. MPL-2.0 is compatible with our stack.
+- **pyRevit** (free, open-source Revit add-in — [pyrevitlabs/pyRevit](https://github.com/pyrevitlabs/pyRevit)).
+  *Verdict: adopt as guidance, not code.* ✅ **DONE (L3)** — Open menu now has *"Free: export IFC
+  from Revit (no bridge)…"* documenting Revit's built-in IFC export + pyRevit batch export, so the
+  free single-project promise is reachable without the paid Autodesk bridge. Not bundled (it runs
+  inside desktop Revit; we never read .rvt offline).
+- **FreeCAD** (LGPL — [FreeCAD](https://github.com/FreeCAD/FreeCAD)). Scriptable, **headless-capable**
+  via the same `ifcopenshell` we already run, with NativeIFC bidirectional linking + 2D drawing
+  generation. *Verdict: evaluate (L4)* as an optional **headless server engine** for parametric
+  family generation and 2D-drawing export — additive to our pipeline, no new client weight. Lower
+  priority than L1/L2.
+- **Pascal Editor** ([pascalorg/editor](https://github.com/pascalorg/editor), R3F + WebGPU, IFC
+  importer). A browser **3D building editor**. *Verdict: reference only — out of scope.* The mission
+  is explicit that **Blender/Bonsai is the desktop editor, not the web viewer**; in-browser authoring
+  would contradict it. Keep as a UX reference for the existing edit-gated place-tools; do not adopt.
+
+**Do we need to create/import libraries to "run on its own"? Do they auto-update?** No new library is
+required — the desktop build already runs standalone (Tauri shell + bundled PyInstaller FastAPI
+sidecar + self-hosted web-ifc WASM), and the *whole app* auto-updates via signed GitHub releases.
+Third-party geometry/WASM deps are **pinned and shipped inside that signed update**, never
+background-updated independently (that would break the offline guarantee and the ThatOpen
+`components`↔`fragments` version coupling). Policy recorded in the ADR above.
+
 ## D. Platform / production
 Tracked in [production-readiness.md](production-readiness.md): main.ts account/connections split,
 dashboard JSON-extraction perf, Redis-backed rate limits (multi-worker), CI dependency scanning,


### PR DESCRIPTION
**M2 PBR pass** — render mode upgrades plain lit surfaces to MeshStandardMaterial (roughness/metalness, keeps M1 IFC colours) + IBL studio environment (RoomEnvironment/PMREM). Scoped to safe materials only; Fragments' ShaderMaterial meshes untouched. Reversible. Verified in-preview: only Lambert→Standard, shader meshes unchanged, env set, zero console errors across on→render→off.

**Free Revit→IFC path** — Open menu gains a help modal for Revit native IFC export + pyRevit (free), so import doesn't require the paid Autodesk bridge.

**Docs** — roadmap §L (IFClite/pyRevit/FreeCAD/Pascal evaluations) + ADR 0001 (dependency bundling & signed-update policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)