### PR TITLE
feat(viewer): sun & shadow study by date/time/location (M2, v0.1.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the AEC BIM Platform. Releases are signed, auto-updating 
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.1.31 — sun & shadow study (M2)
+- **Sun / shadow study** (☀ toolbar) — drive the render-mode sun by **date, time-of-day and
+  latitude/longitude** with a live panel; shadows track the real solar arc (NOAA solar-position
+  math), with warm low-angle light and a below-horizon night state. Opening it auto-enables render
+  mode. Pure solar math is unit-tested.
+
 ## v0.1.30 — PBR materials + free Revit import
 - **PBR pass (M2)** — render mode now upgrades plain lit surfaces to `MeshStandardMaterial`
   (roughness/metalness, keeps the M1 IFC colours) lit by an **IBL studio environment** for soft

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.30"
+version = "0.1.31"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -3,7 +3,8 @@
 // Construction (GC portal) or Finance (proforma) workspaces.
 import * as THREE from "three";
 import CameraControls from "camera-controls";
-import { createViewer, renderMode } from "./world";
+import { createViewer, renderMode, positionSun } from "./world";
+import { sunAltAz, sunSceneDir } from "./solar";
 import { ModelLoader } from "./loader";
 import { type ModelIdMap } from "./modelIds";
 import { SelectionSets } from "./selectionSets";
@@ -389,6 +390,60 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     b.classList.toggle("on", renderOn);
     setStatus(renderOn ? "render mode on — sun + soft shadows" : "render mode off (flat shading)");
     void loader.fragments.core.update(true);
+  });
+
+  // sun / shadow study: drive the render-mode sun by date · time · location (live shadows)
+  let sunPanel: HTMLElement | null = null;
+  function applySun(lat: number, lon: number, date: Date) {
+    const pos = sunAltAz(date, lat, lon);
+    const up = positionSun(viewer.world, sunSceneDir(pos));
+    void loader.fragments.core.update(true);
+    const compass = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"][Math.round(pos.azimuth / 45) % 8];
+    const out = document.getElementById("sun-readout");
+    if (out) out.textContent = up
+      ? `altitude ${pos.altitude.toFixed(0)}° · azimuth ${pos.azimuth.toFixed(0)}° (${compass})`
+      : `sun below horizon — night (alt ${pos.altitude.toFixed(0)}°)`;
+  }
+  toolBtn("☀", "Sun & shadow study (date · time · location)", (b) => {
+    if (sunPanel) { sunPanel.remove(); sunPanel = null; b.classList.remove("on"); return; }
+    if (!renderOn) {   // the study drives the render-mode sun, so make sure it's on
+      renderOn = true; renderMode(viewer.world, true);
+      [...viewerTools.children].forEach((c) => { if ((c as HTMLElement).title?.startsWith("Render mode")) (c as HTMLElement).classList.add("on"); });
+    }
+    b.classList.add("on");
+    const p = document.createElement("div");
+    p.id = "sun-study-panel"; p.className = "floating-panel";
+    p.style.cssText = "position:absolute;right:12px;top:64px;z-index:30;background:var(--panel);border:1px solid var(--line);"
+      + "border-radius:10px;padding:12px;width:230px;display:flex;flex-direction:column;gap:8px;font-size:12px;box-shadow:0 6px 24px #0007";
+    const today = new Date();
+    p.innerHTML = `
+      <div style="display:flex;justify-content:space-between;align-items:center">
+        <strong>☀ Sun &amp; shadow study</strong>
+        <button id="sun-close" class="icon-btn" title="Close" style="width:22px;height:22px">✕</button>
+      </div>
+      <label style="display:flex;justify-content:space-between;gap:6px">Lat
+        <input id="sun-lat" type="number" step="0.1" value="40.7" style="width:80px"></label>
+      <label style="display:flex;justify-content:space-between;gap:6px">Lon
+        <input id="sun-lon" type="number" step="0.1" value="-74.0" style="width:80px"></label>
+      <label style="display:flex;justify-content:space-between;gap:6px">Date
+        <input id="sun-date" type="date" value="${today.toISOString().slice(0, 10)}" style="width:130px"></label>
+      <label>Time of day <span id="sun-time" style="float:right">12:00</span>
+        <input id="sun-hour" type="range" min="0" max="1439" step="5" value="720" style="width:100%"></label>
+      <div id="sun-readout" class="meta" style="min-height:16px"></div>`;
+    (viewer.container.parentElement || viewer.container).appendChild(p);
+    sunPanel = p;
+    const $$ = <T extends HTMLElement>(id: string) => p.querySelector(`#${id}`) as T;
+    const recompute = () => {
+      const lat = +$$<HTMLInputElement>("sun-lat").value, lon = +$$<HTMLInputElement>("sun-lon").value;
+      const mins = +$$<HTMLInputElement>("sun-hour").value;
+      const d = new Date($$<HTMLInputElement>("sun-date").value || today.toISOString().slice(0, 10));
+      d.setHours(Math.floor(mins / 60), mins % 60, 0, 0);
+      $$("sun-time").textContent = `${String(Math.floor(mins / 60)).padStart(2, "0")}:${String(mins % 60).padStart(2, "0")}`;
+      applySun(lat, lon, d);
+    };
+    p.querySelectorAll("input").forEach((el) => el.addEventListener("input", recompute));
+    $$("sun-close").addEventListener("click", () => { p.remove(); sunPanel = null; b.classList.remove("on"); });
+    recompute();
   });
 
   // levels overlay: a horizontal grid + label at each storey elevation (from the API)

--- a/apps/web/src/viewer/solar.test.ts
+++ b/apps/web/src/viewer/solar.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { sunAltAz, sunSceneDir } from "./solar";
+
+describe("solar", () => {
+  it("sun is high near solar noon on the equinox at the equator", () => {
+    // 2024-03-20 equinox, equator, local solar noon (lon 0, tz 0) → sun ~overhead
+    const p = sunAltAz(new Date("2024-03-20T12:00:00"), 0, 0, 0);
+    expect(p.altitude).toBeGreaterThan(80);
+  });
+
+  it("sun is below the horizon at local midnight", () => {
+    const p = sunAltAz(new Date("2024-06-21T00:00:00"), 40.7, -74, -5);
+    expect(p.altitude).toBeLessThan(0);
+  });
+
+  it("morning sun sits in the east, afternoon sun in the west", () => {
+    const am = sunAltAz(new Date("2024-06-21T08:00:00"), 40.7, -74, -5);
+    const pm = sunAltAz(new Date("2024-06-21T16:00:00"), 40.7, -74, -5);
+    expect(am.azimuth).toBeLessThan(180);   // east of south
+    expect(pm.azimuth).toBeGreaterThan(180); // west of south
+  });
+
+  it("scene direction points up when the sun is above the horizon", () => {
+    const noon = sunAltAz(new Date("2024-06-21T13:00:00"), 40.7, -74, -5);
+    const dir = sunSceneDir(noon);
+    expect(dir.y).toBeGreaterThan(0);
+    // unit vector
+    const len = Math.hypot(dir.x, dir.y, dir.z);
+    expect(len).toBeCloseTo(1, 5);
+  });
+
+  it("northern-summer noon sun is to the south (azimuth near 180°)", () => {
+    const p = sunAltAz(new Date("2024-06-21T12:00:00"), 40.7, -74, -5);
+    expect(Math.abs(p.azimuth - 180)).toBeLessThan(35);
+  });
+});

--- a/apps/web/src/viewer/solar.ts
+++ b/apps/web/src/viewer/solar.ts
@@ -1,0 +1,65 @@
+/**
+ * Solar position for the render-mode **sun / shadow study**. A NOAA-based algorithm good enough for
+ * architectural shadow studies (accurate to a fraction of a degree). Given a date/time + latitude /
+ * longitude it returns the sun's altitude & azimuth, and a scene-space direction toward the sun.
+ *
+ * Scene convention (matches the viewer): Y is up, East = +x, North = −z (see app.ts plan coords).
+ */
+
+const RAD = Math.PI / 180;
+
+export interface SunPos {
+  altitude: number;  // degrees above the horizon (negative ⇒ below = night)
+  azimuth: number;   // degrees, clockwise from North
+}
+
+/** Day of year (1–366) for a local date. */
+function dayOfYear(d: Date): number {
+  const start = Date.UTC(d.getFullYear(), 0, 0);
+  const cur = Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
+  return Math.floor((cur - start) / 86400000);
+}
+
+/**
+ * Sun altitude/azimuth for a wall-clock local time at (lat, lon). `tzHours` is the location's UTC
+ * offset; when omitted we estimate it from longitude (round(lon/15)) — fine for a shadow study where
+ * relative sun movement matters more than civil-time exactness.
+ */
+export function sunAltAz(date: Date, latDeg: number, lonDeg: number, tzHours?: number): SunPos {
+  const tz = tzHours ?? Math.round(lonDeg / 15);
+  const hours = date.getHours() + date.getMinutes() / 60 + date.getSeconds() / 3600;
+  const n = dayOfYear(date);
+  // fractional year (radians)
+  const g = (2 * Math.PI / 365) * (n - 1 + (hours - 12) / 24);
+  // solar declination (radians)
+  const decl = 0.006918 - 0.399912 * Math.cos(g) + 0.070257 * Math.sin(g)
+    - 0.006758 * Math.cos(2 * g) + 0.000907 * Math.sin(2 * g)
+    - 0.002697 * Math.cos(3 * g) + 0.00148 * Math.sin(3 * g);
+  // equation of time (minutes)
+  const eqtime = 229.18 * (0.000075 + 0.001868 * Math.cos(g) - 0.032077 * Math.sin(g)
+    - 0.014615 * Math.cos(2 * g) - 0.040849 * Math.sin(2 * g));
+  // true solar time (minutes) → hour angle (degrees)
+  const tst = hours * 60 + eqtime + 4 * lonDeg - 60 * tz;
+  const ha = tst / 4 - 180;
+
+  const lat = latDeg * RAD, haR = ha * RAD;
+  const cosZen = Math.sin(lat) * Math.sin(decl) + Math.cos(lat) * Math.cos(decl) * Math.cos(haR);
+  const zen = Math.acos(Math.min(1, Math.max(-1, cosZen)));
+  const altitude = 90 - zen / RAD;
+
+  // azimuth clockwise from North via atan2 (robust at high sun, no acos-branch degeneracy): the
+  // atan2 term is 0 at solar noon and signed by the hour angle, so +180° puts noon due south.
+  const az = (Math.atan2(Math.sin(haR), Math.cos(haR) * Math.sin(lat) - Math.tan(decl) * Math.cos(lat)) / RAD
+    + 180 + 360) % 360;
+  return { altitude, azimuth: az };
+}
+
+/**
+ * Unit vector *toward* the sun in scene space (Y up, E=+x, N=−z). Use as a DirectionalLight position
+ * (× distance), aimed at the scene centre. Below the horizon the y-component is simply negative.
+ */
+export function sunSceneDir(p: SunPos): { x: number; y: number; z: number } {
+  const alt = p.altitude * RAD, az = p.azimuth * RAD;
+  const ca = Math.cos(alt);
+  return { x: ca * Math.sin(az), y: Math.sin(alt), z: -ca * Math.cos(az) };
+}

--- a/apps/web/src/viewer/world.ts
+++ b/apps/web/src/viewer/world.ts
@@ -159,3 +159,20 @@ export function renderMode(world: World, on: boolean): void {
     }
   });
 }
+
+/**
+ * Aim the render-mode sun from a scene-space direction (unit vector *toward* the sun) — used by the
+ * sun/shadow study. Warms the colour and dims the sun near the horizon (and below it) so dawn/dusk
+ * and night read correctly. No-op if render mode isn't on. Returns true when the sun is up.
+ */
+export function positionSun(world: World, dir: { x: number; y: number; z: number }, distance = 160): boolean {
+  const sun = world.scene.three.getObjectByName(SUN) as THREE.DirectionalLight | null;
+  if (!sun) return false;
+  sun.position.set(dir.x * distance, Math.max(dir.y, -0.2) * distance, dir.z * distance);
+  const up = dir.y > 0;
+  // intensity fades to 0 at/below the horizon; warmer + softer when low in the sky
+  const t = Math.max(0, Math.min(1, dir.y / 0.25));            // 0 at horizon → 1 once well up
+  sun.intensity = up ? 0.6 + 2.0 * Math.min(1, dir.y * 3) : 0;
+  sun.color.setHSL(0.09 + 0.04 * t, 0.55 - 0.25 * t, 0.5 + 0.08 * t); // sunrise orange → midday white
+  return up;
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -169,8 +169,10 @@ material info). Grounded in: [IfcMaterial layer sets](https://forums.buildingsma
   `MeshStandardMaterial` (roughness/metalness, keeps the M1 IFC colours) lit by an **IBL studio
   environment** (RoomEnvironment via PMREM) for soft ambient + reflections — Fragments' own
   `ShaderMaterial` meshes are deliberately left untouched (they carry engine render hooks). Toggled
-  on demand (flat stays the cheap default), reversible, re-applied as new models load. *Next: a
-  sun/shadow study by date/location, and a Matterport-style first-person walkthrough.*
+  on demand (flat stays the cheap default), reversible, re-applied as new models load. A **sun /
+  shadow study** (☀) drives the render-mode sun by **date · time-of-day · latitude/longitude** (NOAA
+  solar position), so shadows track the real sun arc live — including warm low-angle light and a
+  below-horizon night state. *Next: a Matterport-style first-person walkthrough.*
 - **M3 — Family & material depth** (Revit-parity): **IfcMaterialLayerSet** wall/floor/roof assemblies
   (e.g. plasterboard · stud · plasterboard), an expanded parametric **family library** with materials,
   and **import of external IFC type content**.


### PR DESCRIPTION
Adds a ☀ **sun / shadow study** that drives the render-mode sun from date · time-of-day · latitude/longitude (NOAA solar position). Live panel repositions the sun so shadows track the real arc; warm/dim at low angles, below-horizon night state. Opening it auto-enables render mode.

Verified in-preview: sun arcs E(72°)→S(182°,high)→W(289°)→below-horizon(intensity 0); 5 new solar unit tests pass (15 total); typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)