### PR TITLE
feat(data): IfcMaterialLayerSet assemblies (M3, v0.1.33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the AEC BIM Platform. Releases are signed, auto-updating 
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.1.33 — material layer sets (M3)
+- **Layered construction assemblies** (M3) — generated models now carry real **IfcMaterialLayerSet**
+  data on walls, slabs and roofs (e.g. exterior wall = brick · cavity · insulation · CMU · gypsum),
+  the way Revit's compound structures work — attached via IfcMaterialLayerSetUsage and chosen from
+  `IsExternal` / slab type. Feeds take-off, U-value and schedules.
+
 ## v0.1.32 — first-person walkthrough (M2 complete)
 - **Walkthrough mode** (🚶 toolbar) — Matterport-style first-person navigation: drops to eye height
   (1.6 m), **W/A/S/D** to walk (locked horizontal so you stay on the floor) and drag to look around.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src-tauri/Cargo.toml
+++ b/apps/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aec-bim"
-version = "0.1.32"
+version = "0.1.33"
 description = "AEC BIM Platform desktop shell"
 edition = "2021"
 rust-version = "1.77.2"

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AEC BIM Platform",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -176,9 +176,13 @@ material info). Grounded in: [IfcMaterial layer sets](https://forums.buildingsma
   height (1.6 m) with **W/A/S/D** to walk (horizontal-locked, feet on the floor) and drag-to-look;
   toggling off restores the prior camera. **M2 is complete** — next rendering depth lives under a
   future theme (real-time GI / baked AO, exterior HDRI skies).
-- **M3 — Family & material depth** (Revit-parity): **IfcMaterialLayerSet** wall/floor/roof assemblies
-  (e.g. plasterboard · stud · plasterboard), an expanded parametric **family library** with materials,
-  and **import of external IFC type content**.
+- **M3 — Family & material depth** (Revit-parity). ✅ **DONE (layer sets)** — `material_layers.py`
+  attaches real **IfcMaterialLayerSet** assemblies (exterior wall = brick · cavity · insulation · CMU ·
+  gypsum; interior partition; floor slab; flat roof) to every wall/slab/roof via an
+  IfcMaterialLayerSetUsage, chosen from `Pset_WallCommon.IsExternal` and slab `PredefinedType`. Runs in
+  the generation pipeline after the M1 palette; carries genuine compound-structure data for take-off,
+  U-value and schedules. *Next: an expanded parametric **family library** with materials, and **import
+  of external IFC type content**.*
 - ✅ **DONE (M4 start) — computational graph** (Dynamo/Hypar-style, zero-touch). `compute_graph.py`
   exposes the pure engines as **nodes** (params→input ports, dict return→output ports) + an executor:
   `GET /compute/nodes` (palette) and `POST /compute/graph` run a {nodes, edges} graph in dependency

--- a/services/data/src/aec_data/massing.py
+++ b/services/data/src/aec_data/massing.py
@@ -309,8 +309,9 @@ def generate_ifc(metrics: dict, out_path: str, name: str = "Massing Study",
                     0.5, 0.5, f2f, name="Supply riser")
             add_box("IfcPipeSegment", storey, elev, ccx + half_w - 0.4, ccy + half_d - 0.4,
                     0.3, 0.3, f2f, name="Plumbing riser")
-    from . import materials
+    from . import material_layers, materials
     materials.apply_palette(model)               # real IFC materials + surface colours (M1)
+    material_layers.apply_layer_sets(model)      # Revit-style layered assemblies on walls/slabs/roofs (M3)
     model.write(out_path)
     return out_path
 
@@ -404,7 +405,8 @@ def generate_dome_ifc(out_path: str, name: str = "Earth Dome House", radius: flo
     qto = ifcopenshell.api.run("pset.add_qto", model, product=space, name="Qto_SpaceBaseQuantities")
     ifcopenshell.api.run("pset.edit_qto", model, qto=qto,
                          properties={"NetFloorArea": area, "GrossFloorArea": area})
-    from . import materials
+    from . import material_layers, materials
     materials.apply_palette(model)               # real IFC materials + surface colours (M1)
+    material_layers.apply_layer_sets(model)      # Revit-style layered assemblies on walls/slabs/roofs (M3)
     model.write(out_path)
     return out_path

--- a/services/data/src/aec_data/material_layers.py
+++ b/services/data/src/aec_data/material_layers.py
@@ -1,0 +1,103 @@
+"""Material layer sets (M3) — Revit-style layered construction assemblies.
+
+Where M1 ([materials.py]) gives each element class a single material + colour, this attaches a real
+**IfcMaterialLayerSet** to walls / floors / roofs (e.g. brick · cavity · insulation · CMU · gypsum)
+via an IfcMaterialLayerSetUsage, so the model carries genuine assembly data the way Revit's compound
+structures do — usable for take-off, thermal (U-value), and schedules.
+
+Pure-ish over an open ifcopenshell model; run as a post-process before writing. Thicknesses are in
+metres (project METRE convention). Wall assembly is chosen from Pset_WallCommon.IsExternal; slab vs
+roof from the slab PredefinedType.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# An assembly = ordered list of (layer name, material name, material category, thickness m).
+# Order is exterior/top face → interior/bottom face.
+ASSEMBLIES: dict[str, list[tuple[str, str, str, float]]] = {
+    "exterior_wall": [
+        ("Brick veneer", "Brick", "masonry", 0.090),
+        ("Air cavity", "Air", "air", 0.025),
+        ("Rigid insulation", "XPS insulation", "insulation", 0.050),
+        ("CMU backup", "Concrete masonry", "masonry", 0.190),
+        ("Gypsum board", "Gypsum", "gypsum", 0.016),
+    ],
+    "interior_partition": [
+        ("Gypsum board", "Gypsum", "gypsum", 0.016),
+        ("Stud cavity", "Mineral wool", "insulation", 0.092),
+        ("Gypsum board", "Gypsum", "gypsum", 0.016),
+    ],
+    "floor_slab": [
+        ("Floor finish", "Vinyl", "finish", 0.010),
+        ("Screed", "Cement screed", "screed", 0.050),
+        ("Structural slab", "Concrete", "concrete", 0.200),
+    ],
+    "flat_roof": [
+        ("Roofing membrane", "Bituminous membrane", "roofing", 0.005),
+        ("Rigid insulation", "PIR insulation", "insulation", 0.120),
+        ("Vapour barrier", "Polyethylene", "membrane", 0.002),
+        ("Structural deck", "Concrete", "concrete", 0.150),
+    ],
+}
+
+
+def _pset_bool(el, pset: str, prop: str) -> bool | None:
+    import ifcopenshell.util.element
+    val = ifcopenshell.util.element.get_psets(el).get(pset, {}).get(prop)
+    return bool(val) if isinstance(val, bool) else None
+
+
+def _assembly_for(el) -> str:
+    """Pick the assembly key for an element from its class / Pset / predefined type."""
+    cls = el.is_a()
+    if cls in ("IfcWall", "IfcWallStandardCase"):
+        ext = _pset_bool(el, "Pset_WallCommon", "IsExternal")
+        return "exterior_wall" if ext or ext is None else "interior_partition"
+    if cls == "IfcRoof":
+        return "flat_roof"
+    if cls == "IfcSlab":
+        return "flat_roof" if str(getattr(el, "PredefinedType", "") or "").upper() == "ROOF" else "floor_slab"
+    return "floor_slab"
+
+
+def apply_layer_sets(model, assemblies: dict | None = None) -> dict[str, Any]:
+    """Attach an IfcMaterialLayerSet (built once per assembly + reused) to every wall / slab / roof
+    via an IfcMaterialLayerSetUsage. Returns counts. Idempotent enough for a one-shot post-process."""
+    import ifcopenshell.api
+
+    lib = assemblies or ASSEMBLIES
+    mat_cache: dict[str, Any] = {}
+    set_cache: dict[str, Any] = {}
+
+    def material(name: str, category: str):
+        if name not in mat_cache:
+            mat_cache[name] = ifcopenshell.api.run("material.add_material", model, name=name, category=category)
+        return mat_cache[name]
+
+    def layer_set(key: str):
+        if key not in set_cache:
+            ls = ifcopenshell.api.run("material.add_material_set", model,
+                                      name=key.replace("_", " ").title(), set_type="IfcMaterialLayerSet")
+            for lname, mname, cat, thick in lib[key]:
+                layer = ifcopenshell.api.run("material.add_layer", model, layer_set=ls, material=material(mname, cat))
+                ifcopenshell.api.run("material.edit_layer", model, layer=layer,
+                                     attributes={"Name": lname, "LayerThickness": float(thick)})
+            set_cache[key] = ls
+        return set_cache[key]
+
+    assigned = 0
+    by_key: dict[str, int] = {}
+    targets = model.by_type("IfcWall") + model.by_type("IfcSlab") + model.by_type("IfcRoof")
+    for el in targets:
+        key = _assembly_for(el)
+        try:
+            ifcopenshell.api.run("material.assign_material", model, products=[el],
+                                 type="IfcMaterialLayerSetUsage", material=layer_set(key))
+            assigned += 1
+            by_key[key] = by_key.get(key, 0) + 1
+        except Exception:                       # noqa: BLE001 — element may not accept a usage
+            pass
+
+    return {"assigned": assigned, "layer_sets": len(set_cache), "by_assembly": by_key,
+            "total_thickness_m": {k: round(sum(t for *_, t in lib[k]), 3) for k in set_cache}}

--- a/services/data/test_massing.py
+++ b/services/data/test_massing.py
@@ -129,8 +129,15 @@ if _have_ifc:
             e = energy.analyze_file(epath)
             assert e["areas_m2"]["window"] > 0 and e["areas_m2"]["exterior_wall_net"] > 0, e["areas_m2"]
             assert e["ua_w_per_k"]["total"] > 0, e["ua_w_per_k"]
+            # M3: Revit-style layered assemblies on walls + slabs (IfcMaterialLayerSet + usage)
+            lsets = em.by_type("IfcMaterialLayerSet")
+            usages = em.by_type("IfcMaterialLayerSetUsage")
+            assert len(lsets) >= 2 and len(em.by_type("IfcMaterialLayer")) >= 6, (len(lsets),)
+            # every wall + slab carries a layer-set usage (4 walls/floor + 1 slab/floor)
+            assert len(usages) == (4 + 1) * m["floors"], (len(usages), m["floors"])
             print(f"ENVELOPE OK - {len(em.by_type('IfcWall'))} walls + {len(em.by_type('IfcWindow'))} windows; "
-                  f"energy WWR {e['areas_m2']['window_wall_ratio']}, UA {e['ua_w_per_k']['total']} W/K")
+                  f"energy WWR {e['areas_m2']['window_wall_ratio']}, UA {e['ua_w_per_k']['total']} W/K; "
+                  f"M3: {len(lsets)} layer sets, {len(usages)} usages")
         finally:
             os.remove(epath)
 


### PR DESCRIPTION
M3 — generated models carry real **IfcMaterialLayerSet** assemblies (exterior wall = brick·cavity·insulation·CMU·gypsum; interior partition; floor slab; flat roof) via IfcMaterialLayerSetUsage, chosen from `IsExternal`/slab type. Feeds take-off, U-value, schedules.

Data gate green: envelope model asserts 2 layer sets + 25 usages (20 walls + 5 slabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)