### PR TITLE
fix(qto): derive length for linear elements so they price non-zero; v0.3.328

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.329 — QTO: derive length for linear elements so they price non-zero
+
+Fixes a $0 in the model estimate. Linear elements (`IfcPipeSegment` / `IfcDuctSegment` /
+`IfcCableCarrierSegment` / `IfcRailing`) are modelled as swept solids with **no Qto length**, so the
+geometry takeoff returned `length = 0` and the per-metre MEP/railing rates (added v0.3.326) totalled them
+at **$0**. `aec_data.qto` now derives a `length` in its geometry fallback as the **longest bounding-box
+dimension** of the meshed solid — robust whether the run is the extrusion depth (vertical pipe/cable riser)
+or lies in the profile plane (a railing extruded to rail height). On `quay_tower.ifc` the 36 pipe segments
+now take off 1,153 m ($207,540), the cable riser 100.5 m ($22,110), and railings 112 m ($13,440) — all
+previously $0. `test_massing.py` extended (cored-model pipe/duct risers assert metre-scale, non-zero length).
+
 ## v0.3.328 — UX-2: element-aware tags
 
 New `add_tag` recipe places an **element-aware tag** — an `IfcAnnotation` (ObjectType "tag") whose label

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.3.328",
+  "version": "0.3.329",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.328",
+  "version": "0.3.329",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/services/data/src/aec_data/qto.py
+++ b/services/data/src/aec_data/qto.py
@@ -16,6 +16,7 @@ import ifcopenshell.util.element as ue
 from .ifc_loader import open_model, physical_elements, storey_name
 
 try:
+    import numpy as _np
     import ifcopenshell.geom as _geom
     import ifcopenshell.util.shape as _shape
     _GEOM_OK = True
@@ -55,17 +56,43 @@ def _quantities(el) -> dict[str, float]:
     return out
 
 
+def _bbox_longest(geo) -> float | None:
+    """Longest bounding-box dimension of a meshed geometry — a robust length proxy for
+    linear elements (a swept solid's run is its dominant extent). Works whether the run is
+    the extrusion depth (vertical pipe/cable riser) or lies in the profile plane (a railing
+    extruded to its rail height). Returns None if the mesh has no vertices.
+
+    NOTE: `geo.verts` is only valid while the owning shape is alive, so callers must keep the
+    shape referenced until this returns (see `_geom_quantities`)."""
+    try:
+        verts = _np.asarray(geo.verts, dtype=float).reshape(-1, 3)
+        if verts.size == 0:
+            return None
+        extents = verts.max(axis=0) - verts.min(axis=0)
+        return float(extents.max())
+    except Exception:
+        return None
+
+
 def _geom_quantities(element, settings) -> dict[str, float]:
-    """Geometry-derived fallback when IfcElementQuantity is missing (guide §8)."""
+    """Geometry-derived fallback when IfcElementQuantity is missing (guide §8).
+
+    Also derives a `length` from the meshed solid's longest bounding-box dimension. Linear
+    elements (IfcPipeSegment / IfcDuctSegment / IfcCableCarrierSegment / IfcRailing) are modelled
+    as swept solids with no Qto length, so without this they price at $0 on a per-length rate."""
     if not _GEOM_OK:
         return {}
     try:
         shape = _geom.create_shape(settings, element)
-        geo = shape.geometry
-        return {
+        geo = shape.geometry  # keep `shape` alive: geo.verts is a view into it
+        out = {
             "volume": float(_shape.get_volume(geo)),
             "area": float(_shape.get_area(geo)),
         }
+        length = _bbox_longest(geo)
+        if length is not None:
+            out["length"] = length
+        return out
     except Exception:
         return {}
 

--- a/services/data/test_massing.py
+++ b/services/data/test_massing.py
@@ -294,6 +294,21 @@ if _have_ifc:
             assert len(cm.by_type("IfcPipeSegment")) == 2 * m["floors"], "plumbing riser + water main per floor"
             assert len(cm.by_type("IfcWall")) == 4 * m["floors"], "core walls"
             print(f"CORE OK - elevator + 2 egress stairs (code-separated) + duct/pipe risers+mains + core walls across {m['floors']} floors")
+
+            # QTO length: MEP risers/mains are swept solids with no Qto length, so geometry
+            # must derive one (longest bbox dimension) — else they price at $0 on a per-length rate.
+            from aec_data import qto as _qto
+            _qto._TAKEOFF_CACHE.clear()
+            _lens: dict[str, list[float]] = {}
+            for r in _qto.takeoff_file(cpath, force_geometry=True):
+                if r["ifc_class"] in ("IfcPipeSegment", "IfcDuctSegment"):
+                    _lens.setdefault(r["ifc_class"], []).append(r.get("length") or 0.0)
+            assert set(_lens) == {"IfcPipeSegment", "IfcDuctSegment"}, _lens
+            for _c, _ls in _lens.items():
+                assert all(l > 0 for l in _ls), f"{_c} length not derived from geometry: {_ls}"
+                assert max(_ls) > 2.0, f"{_c} riser length not metre-scale: {max(_ls)}"
+            print(f"QTO LENGTH OK - pipe/duct segments carry non-zero geometry length "
+                  f"(pipe max {max(_lens['IfcPipeSegment']):.1f} m, duct max {max(_lens['IfcDuctSegment']):.1f} m)")
         finally:
             os.remove(cpath)
 


### PR DESCRIPTION
## Problem
Linear elements — `IfcPipeSegment`, `IfcDuctSegment`, `IfcCableCarrierSegment`, `IfcRailing` — are modelled as swept solids with **no Qto length**. `aec_data.qto` derived area/volume from geometry but never length, so the takeoff returned `length = 0`. The per-metre MEP/railing rates (added in v0.3.326, on this branch) therefore totalled these at **$0**.

## Fix
`_geom_quantities` now also derives a `length` as the **longest bounding-box dimension** of the meshed solid. This is robust across both geometry patterns in the models:
- vertical pipe/cable risers, where the run is the extrusion depth, and
- railings extruded to rail height, where the run lies in the profile plane.

## Verification (`quay_tower.ifc`)
| Class | Qty | Amount (was) |
|---|---|---|
| IfcPipeSegment | 1,153 m | $207,540 ($0) |
| IfcCableCarrierSegment | 100.5 m | $22,110 ($0) |
| IfcRailing | 112 m | $13,440 ($0) |

`test_massing.py` extended — the cored model's pipe/duct risers now assert metre-scale, non-zero geometry length. `test_massing`, `test_estimate`, `test_discipline` all pass.

## Base
Stacked on `fix/ifc-loader-stale-cache` (the v0.3.325–327 train) because the fix depends on the v0.3.326 MEP rates. Single commit; bumps to **v0.3.328**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)