### PR TITLE
Security + performance hardening from production/enterprise audit

### DIFF
--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -14,6 +14,19 @@ server {
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header X-Frame-Options SAMEORIGIN always;
 
+    # compression. The Vite build emits precompressed .gz siblings (see vite.config.ts precompress
+    # plugin), so gzip_static serves those directly for hashed JS/CSS/wasm — including the ~7 MB
+    # thatopen chunk — with zero runtime CPU. gzip on (+ gzip_types) additionally compresses proxied
+    # /api/ JSON, which has no precompressed sibling on disk. NOTE: brotli_static is intentionally NOT
+    # set — the stock nginx:alpine image ships without the ngx_brotli module, so the directive would
+    # fail to load. The .br siblings are still emitted; switch to a brotli-enabled image to serve them.
+    gzip_static on;
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css application/javascript text/javascript application/json application/wasm image/svg+xml application/manifest+json;
+
     # NOTE: do NOT add a `types { ... }` block here — a server/location-level types
     # block REPLACES the whole inherited MIME map, leaving html/js/css as
     # application/octet-stream (the browser then downloads index.html instead of

--- a/services/api/src/aec_api/bcf_io.py
+++ b/services/api/src/aec_api/bcf_io.py
@@ -14,6 +14,7 @@ BIMcollab / ACC no longer silently drops its comments and labels."""
 from __future__ import annotations
 
 import io
+import os
 import xml.etree.ElementTree as ET  # for Element node types only — parsing goes through defusedxml
 import zipfile
 from datetime import datetime, timezone
@@ -23,9 +24,32 @@ from typing import Any
 # XXE / billion-laughs / external-entity attacks (same protection as citygml.py). Returns standard
 # ElementTree nodes, so the rest of the ET-based traversal is unchanged.
 from defusedxml.ElementTree import fromstring as _safe_fromstring
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from .models import Comment, Topic, Viewpoint
+
+# Decompression-bomb guard: the raw upload is capped by AEC_MAX_UPLOAD_MB, but a tiny zip can still
+# expand to gigabytes in RAM. Cap each entry AND the running total of uncompressed bytes.
+_MAX_UNZIP_MB = int(os.environ.get("AEC_MAX_UNZIP_MB", "512"))
+_MAX_UNZIP_BYTES = _MAX_UNZIP_MB * 1024 * 1024
+
+
+def _open_bcfzip(data: bytes) -> zipfile.ZipFile:
+    """Open a .bcfzip, rejecting decompression bombs by checking the declared uncompressed size of
+    each entry and the cumulative total against AEC_MAX_UNZIP_MB (default 512)."""
+    try:
+        z = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile:
+        raise HTTPException(422, "not a valid .bcfzip (bad zip archive)")
+    total = 0
+    for info in z.infolist():
+        total += info.file_size
+        if info.file_size > _MAX_UNZIP_BYTES or total > _MAX_UNZIP_BYTES:
+            z.close()
+            raise HTTPException(413, f"BCF zip exceeds the {_MAX_UNZIP_MB} MB uncompressed limit "
+                                     "(possible decompression bomb)")
+    return z
 
 _BCF_VERSION = "2.1"          # default export version
 _BCF_VERSIONS = ("2.1", "3.0")
@@ -294,7 +318,7 @@ def parse_records_bcfzip(data: bytes) -> list[dict]:
     """Parse a .bcfzip into record dicts {data:{subject,description,priority}, anchor, element_guids}
     suitable for creating module records. Pulls selected components + camera from any viewpoint."""
     out = []
-    with zipfile.ZipFile(io.BytesIO(data)) as z:
+    with _open_bcfzip(data) as z:
         names = z.namelist()
         for name in [n for n in names if n.endswith("markup.bcf")]:
             root = _safe_fromstring(z.read(name))
@@ -325,7 +349,7 @@ def parse_records_bcfzip(data: bytes) -> list[dict]:
 def import_bcfzip(db: Session, project_id: str, data: bytes) -> int:
     """Import topics from a .bcfzip. Returns the count imported."""
     count = 0
-    with zipfile.ZipFile(io.BytesIO(data)) as z:
+    with _open_bcfzip(data) as z:
         names = z.namelist()
         markups = [n for n in names if n.endswith("markup.bcf")]
         for name in markups:

--- a/services/api/src/aec_api/routers/authoring.py
+++ b/services/api/src/aec_api/routers/authoring.py
@@ -4,6 +4,7 @@ clashes survive. This is the server-side / AI-driven path; the desktop path is B
 Bonsai driven over Bonsai-MCP (same ifcopenshell.api operations)."""
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import logging
 import os
@@ -11,7 +12,6 @@ import re
 import subprocess
 import sys
 import tempfile
-import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1275,12 +1275,22 @@ def run_publish(pid: str) -> None:
         _set_pub_status(pid, "error", {"error": str(e)[:300]})
 
 
+# Bounded pool for background publishes: a raw Thread per request lets N concurrent uploads spawn N
+# heavy ifcopenshell converts at once and exhaust CPU/RAM. Cap concurrency (AEC_PUBLISH_WORKERS,
+# default 2); excess publishes queue. All 13 call sites funnel through _publish_bg, so this one pool
+# governs the whole app.
+_PUBLISH_WORKERS = max(1, int(os.environ.get("AEC_PUBLISH_WORKERS", "2")))
+_publish_pool = concurrent.futures.ThreadPoolExecutor(
+    max_workers=_PUBLISH_WORKERS, thread_name_prefix="publish")
+
+
 def _publish_bg(pid: str) -> None:
     """Run run_publish off the request thread. A 50MB IFC convert takes minutes — doing it in-request
-    would tie up a worker; clients poll publish/status. (Swap this for `worker.enqueue(run_publish, pid)`
-    to move it onto a real queue without touching run_publish.)"""
+    would tie up a worker; clients poll publish/status. Submitted to a bounded pool so a burst of
+    uploads can't spawn unbounded converts. (Swap the pool for `worker.enqueue(run_publish, pid)` to
+    move it onto a real queue without touching run_publish.)"""
     _set_pub_status(pid, "running")
-    threading.Thread(target=run_publish, args=(pid,), daemon=True).start()
+    _publish_pool.submit(run_publish, pid)
 
 
 @router.get("/projects/{pid}/publish/status")

--- a/services/api/src/aec_api/routers/bim.py
+++ b/services/api/src/aec_api/routers/bim.py
@@ -8,6 +8,7 @@ import re
 from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
 
 from .. import audit, bcf_io, rbac, signing, storage
 from ..db import get_db
@@ -463,7 +464,8 @@ async def import_bundle(file: UploadFile = File(...), name: str | None = Form(No
                         db: Session = Depends(get_db)):
     """Open a .mmproj bundle as a new project (fresh id) — geometry, data, and blobs restored."""
     from .. import bundle as bundle_io
-    new_pid = bundle_io.import_bundle(db, await file.read(), new_name=name)
+    data = await file.read()
+    new_pid = await run_in_threadpool(bundle_io.import_bundle, db, data, new_name=name)   # zip unpack off-loop
     return _with_kind(_project(db, new_pid))
 
 
@@ -596,7 +598,7 @@ async def add_attachment(pid: str, tid: str, kind: str = Form("file"),
     safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", os.path.basename(file.filename or "file")).lstrip(".") or "file"
     safe_name = safe_name.replace("..", "_")     # belt: no traversal sequences even inside the name
     key = f"{pid}/{tid}/{safe_name}"
-    storage.put(key, data)
+    await run_in_threadpool(storage.put, key, data)   # MinIO put off the event loop (PERF-1 pattern)
     a = Attachment(topic_id=tid, filename=file.filename, content_type=file.content_type,
                    size=len(data), kind=kind, storage_key=key)
     db.add(a)
@@ -714,10 +716,14 @@ def export_subset_ifc(pid: str, query: str = Query(..., min_length=1, max_length
     res = ifcpatch_lib.extract_subset(model, keep)  # the shared open_model() cache other endpoints use
     if not res["available"] or res["kept"] == 0:
         raise HTTPException(422, "selector matched no physical elements to export")
+    from starlette.background import BackgroundTask
+
     fd, out = tempfile.mkstemp(suffix=".ifc", prefix="subset-")  # server-chosen path — no user input in it
     os.close(fd)
     model.write(out)
-    return FileResponse(out, filename=f"subset-{pid}.ifc", media_type="application/octet-stream")
+    # FileResponse streams but never deletes — attach a cleanup task so the throwaway subset doesn't leak in /tmp
+    return FileResponse(out, filename=f"subset-{pid}.ifc", media_type="application/octet-stream",
+                        background=BackgroundTask(os.unlink, out))
 
 
 # --- BCF interoperability ----------------------------------------------------
@@ -735,7 +741,8 @@ def bcf_export(pid: str, version: str = Query("2.1", pattern="^(2\\.1|3\\.0)$"),
 async def bcf_import(pid: str, file: UploadFile = File(...), db: Session = Depends(get_db),
                      _: str = Depends(require_role("editor"))):
     _project(db, pid)
-    count = bcf_io.import_bcfzip(db, pid, await file.read())
+    data = await file.read()
+    count = await run_in_threadpool(bcf_io.import_bcfzip, db, pid, data)   # zip+XML parse off the event loop
     audit.record(db, action="bcf.import", method="POST", path=f"/projects/{pid}/bcf/import",
                  detail={"topics": count})
     db.commit()
@@ -748,7 +755,8 @@ async def coordination_import_xlsx(pid: str, file: UploadFile = File(...), db: S
     """Import a Solibri / Navisworks (or any tabular) clash report XLSX -> one coordination_issue per
     row (GUIDs anchor it on the model; each round-trips to BCF). Sniffs the header + maps aliases."""
     from .. import clash_import
-    res = clash_import.import_clash_xlsx(db, pid, await file.read(), actor)
+    data = await file.read()
+    res = await run_in_threadpool(clash_import.import_clash_xlsx, db, pid, data, actor)   # XLSX parse off-loop
     audit.record(db, action="coordination.import_xlsx", method="POST",
                  path=f"/projects/{pid}/coordination/import-xlsx", detail={"imported": res.get("imported", 0)})
     db.commit()
@@ -762,7 +770,8 @@ async def coordination_import_xml(pid: str, file: UploadFile = File(...), db: Se
     clash (name → subject, its clash test → discipline, type/distance/status → description; GUIDs anchor
     it on the model and each round-trips to BCF). Untrusted XML parsed with defusedxml."""
     from .. import clash_import
-    res = clash_import.import_clash_xml(db, pid, await file.read(), actor)
+    data = await file.read()
+    res = await run_in_threadpool(clash_import.import_clash_xml, db, pid, data, actor)   # XML parse off-loop
     audit.record(db, action="coordination.import_xml", method="POST",
                  path=f"/projects/{pid}/coordination/import-xml", detail={"imported": res.get("imported", 0)})
     db.commit()

--- a/services/api/src/aec_api/routers/convert.py
+++ b/services/api/src/aec_api/routers/convert.py
@@ -8,7 +8,9 @@ error otherwise — it never fakes a conversion. IFC, .frag (and glTF/OBJ/STL, f
 fully offline via the normal Open flow."""
 from __future__ import annotations
 
+import logging
 import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -17,9 +19,12 @@ from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFil
 from starlette.concurrency import run_in_threadpool
 
 from ..rbac import current_user
+from ..serving import content_disposition
 from ..throttle import rate_limited
 
 router = APIRouter()
+
+_log = logging.getLogger("aec.convert")
 
 # Conversions are heavy (subprocess / paid APS cloud translation) — cap per caller.
 _throttle = rate_limited("convert", 12)
@@ -60,7 +65,10 @@ async def convert(file: UploadFile = File(...), _: str = Depends(current_user),
                                      "APS_CLIENT_SECRET and retry — there is no open-source RVT reader.")
         # APS configured: RVT → IFC (Model Derivative) → .frag via the Node converter (cli --rvt).
         with tempfile.TemporaryDirectory() as td:
-            rvt = Path(td) / (file.filename or "model.rvt")
+            # UploadFile.filename is attacker-controlled — sanitize before joining so it can't escape
+            # the temp dir (path traversal). The .frag output path stays server-chosen.
+            safe = re.sub(r"[^A-Za-z0-9._-]", "_", os.path.basename(file.filename or "model.rvt")) or "model.rvt"
+            rvt = Path(td) / safe
             frag = Path(td) / "out.frag"
             rvt.write_bytes(await file.read())
             try:
@@ -69,13 +77,18 @@ async def convert(file: UploadFile = File(...), _: str = Depends(current_user),
                     lambda: subprocess.run(["node", str(_CONVERTER), "--rvt", str(rvt), str(frag)],
                                            check=True, capture_output=True, timeout=1800))
             except subprocess.CalledProcessError as e:
-                raise HTTPException(502, f"APS RVT→IFC translation failed: {(e.stderr or b'').decode()[:300]}")
+                # Log the subprocess stderr server-side for debugging; return a generic error so
+                # internal APS/converter detail never leaks to the caller.
+                _log.error("APS RVT→IFC translation failed (exit %s): %s",
+                           e.returncode, (e.stderr or b"").decode("utf-8", "replace"))
+                raise HTTPException(502, "APS RVT→IFC translation failed. Please retry; "
+                                         "contact an administrator if the problem persists.")
             except FileNotFoundError:
                 raise HTTPException(500, "Node is required for the RVT converter but isn't installed on the server.")
             if not frag.exists():
                 raise HTTPException(502, "APS translation produced no fragments output.")
             return Response(frag.read_bytes(), media_type="application/octet-stream",
-                            headers={"Content-Disposition": 'attachment; filename="model.frag"'})
+                            headers={"Content-Disposition": content_disposition("model.frag")})
     if ext == "e57":
         from .. import e57
         data = await file.read()
@@ -85,9 +98,9 @@ async def convert(file: UploadFile = File(...), _: str = Depends(current_user),
             raise HTTPException(503, str(exc))
         except Exception as exc:  # noqa: BLE001 — bad/corrupt E57
             raise HTTPException(422, f"could not read E57: {exc}")
-        base = (file.filename or "scan.e57").rsplit(".", 1)[0]
+        base = os.path.basename((file.filename or "scan.e57")).rsplit(".", 1)[0] or "scan"
         return Response(xyz, media_type="text/plain",
-                        headers={"Content-Disposition": f'attachment; filename="{base}.xyz"'})
+                        headers={"Content-Disposition": content_disposition(f"{base}.xyz")})
     if ext in ("dwg", "nwc"):
         raise HTTPException(501, f".{ext} is a closed Autodesk format with no open-source "
                                  f"converter. It requires the paid Autodesk APS / ODA SDK bridge. "

--- a/services/api/src/aec_api/routers/convert.py
+++ b/services/api/src/aec_api/routers/convert.py
@@ -98,7 +98,7 @@ async def convert(file: UploadFile = File(...), _: str = Depends(current_user),
             raise HTTPException(503, str(exc))
         except Exception as exc:  # noqa: BLE001 — bad/corrupt E57
             raise HTTPException(422, f"could not read E57: {exc}")
-        base = os.path.basename((file.filename or "scan.e57")).rsplit(".", 1)[0] or "scan"
+        base = os.path.basename(file.filename or "scan.e57").rsplit(".", 1)[0] or "scan"
         return Response(xyz, media_type="text/plain",
                         headers={"Content-Disposition": content_disposition(f"{base}.xyz")})
     if ext in ("dwg", "nwc"):

--- a/services/api/src/aec_api/serving.py
+++ b/services/api/src/aec_api/serving.py
@@ -2,13 +2,29 @@
 the viewer/CDN can request partial content. Works over either storage backend."""
 from __future__ import annotations
 
+import os
 import re
+from urllib.parse import quote
 
 from fastapi import HTTPException, Request, Response
 
 from . import storage
 
 _RANGE = re.compile(r"bytes=(\d*)-(\d*)")
+
+
+def content_disposition(filename: str | None, disposition: str = "attachment",
+                        fallback: str = "download") -> str:
+    """Build a header-injection-safe Content-Disposition value from a (possibly attacker-controlled)
+    filename. Strips any path and CR/LF, quotes an ASCII fallback for `filename="..."`, and adds an
+    RFC 5987 `filename*=UTF-8''...` form so non-ASCII names survive without crashing latin-1 header
+    encoding. Used for attachment/model/export downloads where the name comes from the client."""
+    raw = os.path.basename(filename or "").replace("\r", "").replace("\n", "").strip()
+    raw = raw or fallback
+    # ASCII fallback: drop control chars and anything that could break the quoted-string / header
+    ascii_name = "".join(c for c in raw if 32 <= ord(c) < 127 and c not in '"\\').strip() or fallback
+    encoded = quote(raw, safe="")
+    return f"{disposition}; filename=\"{ascii_name}\"; filename*=UTF-8''{encoded}"
 
 
 def range_response(request: Request, key: str, media_type: str,
@@ -26,7 +42,7 @@ def range_response(request: Request, key: str, media_type: str,
     headers = {"Accept-Ranges": "bytes", "Cache-Control": cache, "ETag": etag,
                "Cross-Origin-Resource-Policy": "cross-origin"}
     if filename:
-        headers["Content-Disposition"] = f'{disposition}; filename="{filename}"'
+        headers["Content-Disposition"] = content_disposition(filename, disposition)
 
     inm = request.headers.get("if-none-match") or request.headers.get("If-None-Match")
     if inm and etag in [t.strip() for t in inm.split(",")]:   # conditional GET → 304, no body re-sent

--- a/services/api/test_bcf.py
+++ b/services/api/test_bcf.py
@@ -169,6 +169,36 @@ with TestClient(app) as c:
         assert topic.labels == ["NC-9"], topic.labels               # grouped <Labels><Label> read
         assert topic.comments and topic.comments[0].text == "please fix", topic.comments  # nested comment read
 
+    # --- SEC F9: decompression-bomb bounds — oversized uncompressed entries are rejected ----------
+    from fastapi import HTTPException as _HTTPExc  # noqa: E402
+
+    # a highly-compressible entry: ~2 MB of zeros -> tiny on disk, but declared file_size is real
+    bomb = io.BytesIO()
+    with zipfile.ZipFile(bomb, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("bcf.version", b'<?xml version="1.0"?><Version VersionId="2.1"/>')
+        z.writestr("big/markup.bcf", b"\x00" * (2 * 1024 * 1024))
+    orig_limit = bcf_io._MAX_UNZIP_BYTES
+    try:
+        bcf_io._MAX_UNZIP_BYTES = 1024                       # 1 KB ceiling for the test
+        threw = False
+        try:
+            bcf_io.import_bcfzip(SessionLocal(), src, bomb.getvalue())
+        except _HTTPExc as e:
+            threw = True
+            assert e.status_code == 413, e.status_code       # Payload Too Large, clear rejection
+        assert threw, "oversized zip entry must be rejected"
+        # parse_records_bcfzip shares the same guard
+        threw2 = False
+        try:
+            bcf_io.parse_records_bcfzip(bomb.getvalue())
+        except _HTTPExc as e:
+            threw2 = True and e.status_code == 413
+        assert threw2, "parse_records must also reject the bomb"
+    finally:
+        bcf_io._MAX_UNZIP_BYTES = orig_limit
+    # under the (restored) real 512 MB limit, a normal small bcfzip still imports fine
+    assert bcf_io.parse_records_bcfzip(blob) is not None, "normal bcfzip still parses under the limit"
+
     # empty project still exports a valid (topic-less) bcfzip — no crash
     empty = c.post("/projects", json={"name": "Empty"}).json()["id"]
     e = c.get(f"/projects/{empty}/bcf/export")

--- a/services/api/test_serving.py
+++ b/services/api/test_serving.py
@@ -57,4 +57,22 @@ with TestClient(app) as c:
     # the matched route TEMPLATE is used, not the raw path (bounded label cardinality)
     assert "/projects/{pid}/model.frag" in body and pid not in body
 
-    print("SERVING OK — 200 full / 206 ranged / 416 unsatisfiable; Accept-Ranges; /metrics exposed")
+    # --- Content-Disposition hardening (SEC F8): header-injection-safe filenames ----------------
+    from aec_api.serving import content_disposition
+    # path components and CR/LF are stripped so a client filename can't traverse or inject headers
+    cd = content_disposition("../../etc/passwd")
+    assert "\r" not in cd and "\n" not in cd, cd
+    assert 'filename="passwd"' in cd, cd                 # basename only, no path
+    inj = content_disposition("evil\r\nSet-Cookie: x=1.frag")
+    assert "\r" not in inj and "\n" not in inj, inj      # CRLF injection neutralized
+    # a double-quote is stripped from the ASCII fallback so it can't break out of the quoted-string
+    assert 'filename="ab.ifc"' in content_disposition('a"b.ifc'), content_disposition('a"b.ifc')
+    # empty/blank falls back to the default
+    assert 'filename="download"' in content_disposition("   "), content_disposition("   ")
+    # non-ASCII gets an RFC 5987 filename* form and a safe ASCII fallback (never crashes latin-1 headers)
+    uni = content_disposition("план-façade.ifc")
+    assert "filename*=UTF-8''" in uni, uni
+    uni.encode("latin-1")                                # must be a legal HTTP header value
+
+    print("SERVING OK — 200 full / 206 ranged / 416 unsatisfiable; Accept-Ranges; /metrics exposed; "
+          "Content-Disposition strips traversal/CRLF and RFC-5987-encodes non-ASCII")

--- a/services/api/test_subset_export.py
+++ b/services/api/test_subset_export.py
@@ -3,8 +3,17 @@ via remove_deep2, spatial skeleton preserved) + the /export/subset.ifc route (ga
 match, valid contained IFC out).
 Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_subset_export.py"""
 import os
+import tempfile as _tempfile
 
 TMP = os.path.join(os.path.dirname(__file__), "_subset_src.ifc")
+
+# PERF-B6 cleanup test: route the subset FileResponse's mkstemp into an isolated dir so we can assert
+# the throwaway .ifc is deleted by the response's BackgroundTask (no /tmp leak).
+_SUBSET_TMPDIR = os.path.join(os.path.dirname(__file__), "_subset_tmp")
+os.makedirs(_SUBSET_TMPDIR, exist_ok=True)
+_tempfile.tempdir = _SUBSET_TMPDIR
+
+import glob as _glob  # noqa: E402
 
 import ifcopenshell  # noqa: E402
 
@@ -98,10 +107,16 @@ with TestClient(app) as c:
     assert r.status_code == 200, (r.status_code, r.text[:200])
     body = r.content.decode("utf-8", "ignore")
     assert "IFCCOLUMN" in body.upper() and "IFCWALL" not in body.upper(), "subset content wrong"
-    assert r.headers["content-disposition"].endswith('subset.ifc"') or "subset" in r.headers.get("content-disposition", "")
+    assert "subset" in r.headers.get("content-disposition", "")
+    # PERF-B6: the FileResponse's BackgroundTask (TestClient runs it after the response) must delete
+    # the server-chosen temp file — no subset-*.ifc left behind in the temp dir.
+    leftovers = _glob.glob(os.path.join(_SUBSET_TMPDIR, "subset-*.ifc"))
+    assert not leftovers, f"subset temp file leaked: {leftovers}"
 
 if os.path.exists(TMP):
     os.remove(TMP)
+import shutil as _shutil  # noqa: E402
+_shutil.rmtree(_SUBSET_TMPDIR, ignore_errors=True)
 
 print("SUBSET-EXPORT OK - the keep-set prune drops the wall and keeps both columns (GUIDs unchanged) with the "
       "spatial skeleton intact; the pruned model round-trips as a valid IFC; empty keep-set prunes all, a bare "

--- a/services/api/test_subset_export.py
+++ b/services/api/test_subset_export.py
@@ -14,6 +14,7 @@ os.makedirs(_SUBSET_TMPDIR, exist_ok=True)
 _tempfile.tempdir = _SUBSET_TMPDIR
 
 import glob as _glob  # noqa: E402
+import shutil as _shutil  # noqa: E402
 
 import ifcopenshell  # noqa: E402
 
@@ -115,7 +116,6 @@ with TestClient(app) as c:
 
 if os.path.exists(TMP):
     os.remove(TMP)
-import shutil as _shutil  # noqa: E402
 _shutil.rmtree(_SUBSET_TMPDIR, ignore_errors=True)
 
 print("SUBSET-EXPORT OK - the keep-set prune drops the wall and keeps both columns (GUIDs unchanged) with the "


### PR DESCRIPTION
Implements the safe, low-risk hardening items from the production/enterprise audit. All changes are source-local; no architectural rewrites. Each item cites `file:line` evidence from the audit.

## Performance
- **nginx precompressed assets + API JSON compression** (\`apps/web/nginx.conf\`): enable \`gzip_static on;\` to serve the Vite-emitted \`.gz\` siblings directly (incl. the ~7 MB \`thatopen\` chunk) with zero runtime CPU, plus \`gzip on;\` so proxied \`/api/\` JSON is compressed. \`brotli_static\` intentionally omitted — stock \`nginx:alpine\` has no \`ngx_brotli\` module; \`.br\` siblings still ship for a future brotli-enabled image.
- **Subset-IFC export temp cleanup** (\`bim.py\`): attach \`BackgroundTask(os.unlink, out)\` to the \`FileResponse\` so throwaway \`subset-*.ifc\` no longer leaks in \`/tmp\`.
- **Blocking IO off the event loop** (\`bim.py\`): wrap \`storage.put\` (add_attachment), \`bundle_io.import_bundle\`, \`bcf_io.import_bcfzip\`, and \`clash_import.import_clash_xlsx/xml\` in \`run_in_threadpool\` (mirrors the existing \`authoring.py\` pattern). Stops MinIO/zip/XML work from stalling uvicorn workers.
- **Bounded background-publish concurrency** (\`authoring.py\`): replace per-request \`threading.Thread\` with a module-level \`ThreadPoolExecutor(max_workers=AEC_PUBLISH_WORKERS)\` (default 2). All 13 publish call sites funnel through \`_publish_bg\`, so one pool governs the whole app; excess publishes queue instead of exhausting CPU/RAM.

## Security
- **RVT upload path traversal** (\`convert.py:63-65\`, MEDIUM): sanitize \`UploadFile.filename\` with \`basename\` + regex before joining into the temp dir. Pre-existing, gated behind auth+APS.
- **Hide APS subprocess stderr** (\`convert.py:72-73\`): log full stderr server-side, return a generic 502 to the caller.
- **Content-Disposition header injection** (\`serving.py\` + \`convert.py\` + \`bim.py\`): new shared \`content_disposition()\` helper strips path + CR/LF, quotes an ASCII fallback, and adds an RFC 5987 \`filename*=UTF-8''\` form for non-ASCII names. Applied to \`.frag\`/\`.xyz\` responses and all \`range_response()\` downloads.
- **BCF decompression-bomb guard** (\`bcf_io.py\`): new \`_open_bcfzip()\` checks each \`ZipInfo.file_size\` and the cumulative total against \`AEC_MAX_UNZIP_MB\` (default 512), raising 413 on oversized archives and 422 on bad zips. \`defusedxml\` parsing untouched.

## Tests
- \`test_serving.py\` — \`content_disposition()\` path traversal / CRLF / non-ASCII / blank cases.
- \`test_bcf.py\` — decompression-bomb rejection (both \`import_bcfzip\` and \`parse_records_bcfzip\`).
- \`test_subset_export.py\` — asserts no \`subset-*.ifc\` remains after the response.
- 16 related backend suites green; \`npm run build -w apps/web\` green with \`.gz\`/\`.br\` siblings confirmed. ruff clean on changed files.

## Deferred (separate PRs)
\`/metrics\` auth (breaks Prometheus scrapers; needs opt-in path), compose CPU/mem limits (OOM risk for legitimate conversion), Dockerfile digest pinning (needs exact platform digests), \`npm audit fix\` dev/docs chain (lockfile churn), and the architectural items (Alembic migrations, OpenTelemetry tracing, Sentry alerting, on-demand rendering, warm converter worker, chunk splitting, point-cloud worker, streaming uploads/downloads, batch portfolio aggregates, and product gaps: clash detection, IFC version-compare, public API, SOC 2).

\`\`\`task
file:apps/web/nginx.conf
file:services/api/src/aec_api/bcf_io.py
file:services/api/src/aec_api/routers/authoring.py
file:services/api/src/aec_api/routers/bim.py
file:services/api/src/aec_api/routers/convert.py
file:services/api/src/aec_api/serving.py
\`\`\`