### PR TITLE
Operational hardening: opt-in /metrics auth + configurable compose limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ AEC_HSTS=1                                        # emit Strict-Transport-Securi
 AEC_COOKIE_SECURE=1                               # force Secure flag on the auth cookie (auto-on over HTTPS)
 AEC_CSP=1                                         # 1 = strict resource Content-Security-Policy (or supply a full policy)
 AEC_SIGNED_URL_TTL=3600                           # lifetime (s) of signed model.frag / attachment download URLs
+# AEC_METRICS_AUTH=1                               # require the AEC_API_KEY bearer on /metrics — set this when the
+#                                                  # Prometheus scrape endpoint is reachable from an untrusted network.
+#                                                  # Default OFF = /metrics stays open (unchanged for existing scrapers).
 
 # --- Abuse limits ---
 AEC_MAX_UPLOAD_MB=1024                            # reject request bodies larger than this (-> 413)

--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,22 @@ AEC_LOGIN_MAX_FAILS=8                             # lock a username out after th
 AEC_LOGIN_WINDOW_SEC=300                          # ...within this sliding window (-> 429)
 # AEC_TRUST_XUSER stays UNSET in prod — the X-User header is a dev-only impersonation shim.
 
+# --- Container resource limits (opt-in) — feed the commented-out `deploy.resources.limits` blocks in
+# docker-compose.yml / docker-compose.prod.yml. OFF by default: a hard memory cap that is too low will
+# OOM-kill a legitimate large-IFC conversion mid-run. Uncomment the matching compose block AND set a
+# value here that is sized for YOUR host, then leave generous headroom.
+#   - Converter is the memory-hungry one: IFC→Fragments holds the whole model in RAM, so size it well
+#     above your largest model. If you run conversions in parallel, multiply by AEC_PUBLISH_WORKERS
+#     (PR #70) — each concurrent job holds its own model.
+#   - The API also does in-process reconverts and runs UVICORN_WORKERS (default 4); keep it generous.
+# AEC_API_MEM_LIMIT=4g          # api container memory cap
+# AEC_API_CPUS=2                # api container CPU cap (cores)
+# AEC_CONVERTER_MEM_LIMIT=8g    # converter cap — >= largest model * concurrent jobs (AEC_PUBLISH_WORKERS)
+# AEC_CONVERTER_CPUS=4          # converter CPU cap (cores)
+# AEC_PG_MEM_LIMIT=2g           # postgres cap
+# AEC_MINIO_MEM_LIMIT=1g        # minio cap
+# AEC_WEB_MEM_LIMIT=256m        # web (nginx static) cap
+
 # --- Redis (optional, for multi-worker) — shares rate-limit + login-lockout counters across workers ---
 # AEC_REDIS_URL=redis://redis:6379/0
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,16 +58,32 @@ services:
       # back to the dev defaults (the base compose uses `${…:-bim}` / `${…:-minioadmin}` for local dev).
       DATABASE_URL: "postgresql+psycopg://${POSTGRES_USER:-bim}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env for production}@postgres:5432/${POSTGRES_DB:-bim}"
       S3_SECRET_KEY: "${S3_SECRET_KEY:?set S3_SECRET_KEY in .env for production}"
+    # Resource limits (opt-in): same env vars as the base compose (see .env.example). Kept OFF by
+    # default so a too-low cap can't OOM-kill a legitimate large-IFC reconvert. Uncomment + size
+    # for the production host.
+    # deploy:
+    #   resources:
+    #     limits:
+    #       memory: "${AEC_API_MEM_LIMIT:-4g}"
+    #       cpus: "${AEC_API_CPUS:-2}"
 
   postgres:
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env for production}"
+    # deploy:                              # opt-in cap — uncomment + size for your host
+    #   resources:
+    #     limits:
+    #       memory: "${AEC_PG_MEM_LIMIT:-2g}"
 
   minio:
     restart: unless-stopped
     environment:
       MINIO_ROOT_PASSWORD: "${S3_SECRET_KEY:?set S3_SECRET_KEY in .env for production}"
+    # deploy:                              # opt-in cap — uncomment + size for your host
+    #   resources:
+    #     limits:
+    #       memory: "${AEC_MINIO_MEM_LIMIT:-1g}"
 
 volumes:
   caddy-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,11 @@
 # Self-host / prod stack. Boot the core with:  docker compose --profile full up --build
 # Convert a model (job):       docker compose run --rm converter /data/model.ifc /data/model.frag
+#
+# Resource limits (opt-in): every service below has a commented-out `deploy.resources.limits`
+# block keyed off env vars (AEC_*_MEM_LIMIT / AEC_*_CPUS — see .env.example for sizing guidance).
+# They are OFF by default on purpose: a hard memory cap that is too low will OOM-kill a legitimate
+# large-IFC conversion mid-run. Uncomment and set values sized for YOUR host before enabling.
+# `deploy.resources.limits` is honored by `docker compose up` (v2); no Swarm required.
 services:
   postgres:
     image: postgres:16
@@ -14,6 +20,10 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    # deploy:                              # opt-in cap — uncomment + size for your host
+    #   resources:
+    #     limits:
+    #       memory: "${AEC_PG_MEM_LIMIT:-2g}"
 
   minio:
     image: minio/minio
@@ -28,6 +38,10 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    # deploy:                              # opt-in cap — uncomment + size for your host
+    #   resources:
+    #     limits:
+    #       memory: "${AEC_MINIO_MEM_LIMIT:-1g}"
 
   api:
     image: massing-api
@@ -58,6 +72,11 @@ services:
       timeout: 3s
       retries: 20
     profiles: ["full"]
+    # deploy:                              # opt-in cap — uncomment + size for your host
+    #   resources:                         # keep generous: UVICORN_WORKERS=4 + an in-process reconvert
+    #     limits:
+    #       memory: "${AEC_API_MEM_LIMIT:-4g}"
+    #       cpus: "${AEC_API_CPUS:-2}"
 
   # one-shot demo seeder (api must be enabled, so pass both profiles):
   #   docker compose --profile full --profile seed run --rm seed
@@ -78,6 +97,10 @@ services:
       api: { condition: service_started }
     ports: ["${WEB_PORT:-8080}:80"]
     profiles: ["full"]
+    # deploy:                              # opt-in cap — uncomment + size for your host
+    #   resources:                         # nginx serving static assets — modest footprint
+    #     limits:
+    #       memory: "${AEC_WEB_MEM_LIMIT:-256m}"
 
   converter:
     build:
@@ -85,6 +108,11 @@ services:
       dockerfile: services/converter/Dockerfile
     volumes: ["./data:/data"]            # drop IFCs here; .frag written here
     profiles: ["tools"]                  # job-style: `docker compose run --rm converter ...`
+    # deploy:                              # opt-in cap — uncomment + size for your host
+    #   resources:                         # IFC→Fragments is memory-hungry: size well above your
+    #     limits:                          # largest model and against AEC_PUBLISH_WORKERS (PR #70),
+    #       memory: "${AEC_CONVERTER_MEM_LIMIT:-8g}"   # since parallel jobs each hold a model in RAM.
+    #       cpus: "${AEC_CONVERTER_CPUS:-4}"
 
 volumes:
   postgres-data:

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -27,7 +27,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_bundle", "test_desktop", "test_localmode", "test_project_budget", "test_rvt_bridge",
          "test_bcf", "test_engines", "test_edge_cases", "test_opendata", "test_financials", "test_money", "test_leasemgmt", "test_changeorders",
          "test_migrate", "test_appraisal", "test_marketing", "test_workflow_gate", "test_due_feed", "test_directory",
-         "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
+         "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
          "test_module_config", "test_module_schema", "test_throttle", "test_route_order",

--- a/services/api/src/aec_api/main.py
+++ b/services/api/src/aec_api/main.py
@@ -10,7 +10,7 @@ import time
 import uuid
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request, Response
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -520,9 +520,30 @@ app.add_api_route("/healthz", health, methods=["GET"], include_in_schema=False)
 app.add_api_route("/readyz", ready, methods=["GET"], include_in_schema=False)
 
 
+def _metrics_auth_enabled() -> bool:
+    """Read per-request so operators can flip the gate without a code change / restart-only rebuild."""
+    return os.environ.get("AEC_METRICS_AUTH", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _guard_metrics(request: Request) -> None:
+    """Optional bearer gate for /metrics. OFF by default → open exactly as before (existing scrapers
+    keep working, no breaking change). Set AEC_METRICS_AUTH=1 to require the AEC_API_KEY bearer when
+    the scrape endpoint is reachable from an untrusted network. Reuses the same API-key credential as
+    the other protected paths."""
+    if not _metrics_auth_enabled():
+        return
+    from . import rbac as _rbac
+    key = _rbac.API_KEY or os.environ.get("AEC_API_KEY")
+    authz = request.headers.get("authorization", "")
+    tok = authz[len("Bearer "):] if authz.startswith("Bearer ") else ""
+    if not (key and tok == key):
+        raise HTTPException(status_code=401, detail="metrics authentication required")
+
+
 @app.get("/metrics")
-def prometheus_metrics() -> Response:
-    """Prometheus text exposition (request counts, latencies, in-flight, uptime)."""
+def prometheus_metrics(_: None = Depends(_guard_metrics)) -> Response:
+    """Prometheus text exposition (request counts, latencies, in-flight, uptime). Open by default;
+    gate behind the AEC_API_KEY bearer by setting AEC_METRICS_AUTH=1."""
     return Response(metrics.render(), media_type="text/plain; version=0.0.4; charset=utf-8")
 
 

--- a/services/api/src/aec_api/main.py
+++ b/services/api/src/aec_api/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import hmac
 import json
 import logging
 import os
@@ -536,7 +537,7 @@ def _guard_metrics(request: Request) -> None:
     key = _rbac.API_KEY or os.environ.get("AEC_API_KEY")
     authz = request.headers.get("authorization", "")
     tok = authz[len("Bearer "):] if authz.startswith("Bearer ") else ""
-    if not (key and tok == key):
+    if not (key and hmac.compare_digest(tok, key)):
         raise HTTPException(status_code=401, detail="metrics authentication required")
 
 

--- a/services/api/test_metrics_auth.py
+++ b/services/api/test_metrics_auth.py
@@ -32,6 +32,8 @@ with TestClient(app) as c:
     assert c.get("/metrics").status_code == 401, "expected 401 without bearer when gate on"
     # wrong bearer → 401
     assert c.get("/metrics", headers=BEARER("nope")).status_code == 401, "expected 401 with wrong bearer"
+    # wrong bearer of the SAME length → 401 (exercises the constant-time hmac.compare_digest path)
+    assert c.get("/metrics", headers=BEARER("xcrape-secret")).status_code == 401, "expected 401 with same-length wrong bearer"
     # correct bearer → 200 and still Prometheus text
     ok = c.get("/metrics", headers=BEARER("scrape-secret"))
     assert ok.status_code == 200, ok.status_code

--- a/services/api/test_metrics_auth.py
+++ b/services/api/test_metrics_auth.py
@@ -1,0 +1,45 @@
+"""Opt-in /metrics authentication (SEC F2): /metrics is open by default (existing scrapers unaffected),
+but when AEC_METRICS_AUTH=1 it requires the AEC_API_KEY bearer. The flag is read per-request, so this
+one process exercises both modes by toggling os.environ.
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_metrics_auth.py"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_metrics_auth.db"
+os.environ["STORAGE_DIR"] = "./test_storage_metrics_auth"
+os.environ.pop("AEC_RBAC", None)
+os.environ.pop("AEC_METRICS_AUTH", None)      # default posture: open
+os.environ["AEC_API_KEY"] = "scrape-secret"   # the bearer that will be required when the gate is on
+for _f in ("./test_metrics_auth.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient   # noqa: E402
+from aec_api.main import app                # noqa: E402
+
+BEARER = lambda t: {"Authorization": f"Bearer {t}"}  # noqa: E731
+
+with TestClient(app) as c:
+    # --- default (flag unset): /metrics is open, no bearer needed -------------------------------
+    os.environ.pop("AEC_METRICS_AUTH", None)
+    r = c.get("/metrics")
+    assert r.status_code == 200, r.status_code
+    assert "text/plain" in r.headers.get("content-type", ""), r.headers.get("content-type")
+    assert "process_uptime_seconds" in r.text, r.text[:200]
+
+    # --- opt-in (AEC_METRICS_AUTH=1): the bearer is required ------------------------------------
+    os.environ["AEC_METRICS_AUTH"] = "1"
+    # no bearer → 401
+    assert c.get("/metrics").status_code == 401, "expected 401 without bearer when gate on"
+    # wrong bearer → 401
+    assert c.get("/metrics", headers=BEARER("nope")).status_code == 401, "expected 401 with wrong bearer"
+    # correct bearer → 200 and still Prometheus text
+    ok = c.get("/metrics", headers=BEARER("scrape-secret"))
+    assert ok.status_code == 200, ok.status_code
+    assert "process_uptime_seconds" in ok.text, ok.text[:200]
+
+    # --- toggling back off restores open access (no restart) ------------------------------------
+    os.environ.pop("AEC_METRICS_AUTH", None)
+    assert c.get("/metrics").status_code == 200, "expected open again after clearing the flag"
+
+print("METRICS AUTH OK - /metrics open by default; AEC_METRICS_AUTH=1 requires AEC_API_KEY bearer "
+      "(401 without/wrong, 200 with); toggle is live per-request")


### PR DESCRIPTION
Tier-1 follow-up to the production/enterprise audit (PR #70 shipped the safe source-local items). Two operational hardening changes, both OFF by default so no current deployment breaks.

## 1. Opt-in bearer auth for /metrics (SEC F2)
- File: \`services/api/src/aec_api/main.py\`
- \`/metrics\` was unauthenticated and rate-limit-exempt (Prometheus exposition → internal route inventory / traffic shape to any caller reaching the API port).
- New \`_guard_metrics\` dependency: OFF by default (route stays open — existing scrapers unaffected). Set \`AEC_METRICS_AUTH=1\` to require the \`AEC_API_KEY\` bearer (401 without/wrong, 200 with). Reuses the same API-key credential as other protected paths. Flag read per-request (no restart to flip).
- New \`test_metrics_auth.py\` covers open-default, 401 no/wrong bearer, 200 correct, and live toggle. Documented in \`.env.example\`.

## 2. .env-configurable compose resource limits (PERF D1)
- Files: \`docker-compose.yml\`, \`docker-compose.prod.yml\`, \`.env.example\`
- Commented-out \`deploy.resources.limits\` blocks keyed off env vars (\`AEC_API_MEM_LIMIT/CPUS\`, \`AEC_CONVERTER_MEM_LIMIT/CPUS\`, \`AEC_PG_MEM_LIMIT\`, \`AEC_MINIO_MEM_LIMIT\`, \`AEC_WEB_MEM_LIMIT\`) on every service. OFF by default — hard caps would OOM legitimate large IFC conversions; operators opt in and size for their host. \`.env.example\` gives sizing guidance (converter pool vs PR #70's \`AEC_PUBLISH_WORKERS\`).

No dependency/lockfile or Dockerfile changes. Both compose files validated as parseable YAML. Tests: \`test_metrics_auth\` (new) + \`test_metrics\`/\`test_security\`/\`test_prod_hardening\` all pass.

\`\`\`task
file:services/api/src/aec_api/main.py
file:docker-compose.yml
file:docker-compose.prod.yml
file:.env.example
\`\`\`