### PR TITLE
Dependency hygiene: pin Dockerfile base images by digest + npm audit fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,16 @@ updates:
     directory: /
     schedule: { interval: weekly }
     open-pull-requests-limit: 3
+  # Container base images: auto-bump the @sha256 digests pinned in each Dockerfile FROM line.
+  - package-ecosystem: docker
+    directory: /services/api
+    schedule: { interval: weekly }
+    open-pull-requests-limit: 3
+  - package-ecosystem: docker
+    directory: /apps/web
+    schedule: { interval: weekly }
+    open-pull-requests-limit: 3
+  - package-ecosystem: docker
+    directory: /services/converter
+    schedule: { interval: weekly }
+    open-pull-requests-limit: 3

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,6 +1,6 @@
 # Build the Vite app, then serve the static bundle with nginx.
 # Build context = repo root (this is an npm workspace: the only lockfile is the root package-lock.json).
-FROM node:20-slim AS build
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS build
 WORKDIR /repo
 # Manifests + lockfile first, so `npm ci` is a reproducible, cache-friendly layer that only re-runs when
 # deps change — not on every source edit. `npm ci` (vs `npm install`) installs EXACTLY the locked tree
@@ -11,7 +11,7 @@ RUN npm ci
 COPY apps/web/ apps/web/
 RUN npm run build --workspace apps/web   # prebuild copies web-ifc WASM into public/wasm/
 
-FROM nginx:alpine
+FROM nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
 COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /repo/apps/web/dist /usr/share/nginx/html
 EXPOSE 80

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.560",
+      "version": "0.3.584",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.1",
@@ -4297,6 +4297,23 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -5629,22 +5646,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ]
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -5,7 +5,7 @@
 # Pin the fragments/web-ifc pair to the SAME versions as the client parser (apps/web/package.json).
 # CI enforces this (scripts/check-fragments-version.mjs) — a mismatch means the server emits .frag the
 # browser can't parse.
-FROM node:20-slim AS converter
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS converter
 WORKDIR /conv
 ARG FRAGMENTS_VERSION=3.4.5
 ARG WEBIFC_VERSION=0.0.77
@@ -15,7 +15,7 @@ RUN npm init -y >/dev/null 2>&1 && npm install --no-audit --no-fund \
 # --- python build stage (B3): a full toolchain compiles any source-only wheel HERE, then we lift only
 # the installed packages into the runtime image below. gcc + headers never ship to production, so the
 # runtime image is smaller and carries no compiler in its attack surface. ---
-FROM python:3.12-slim AS pybuild
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS pybuild
 # build toolchain + the same shared libs, so wheels that need to compile can link during install
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1 libglib2.0-0 build-essential python3-dev \
@@ -29,7 +29,7 @@ COPY services/api/requirements.lock /tmp/req/requirements.lock
 # wholesale into the runtime stage.
 RUN pip install --prefix=/install --require-hashes -r /tmp/req/requirements.lock
 
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1 \

--- a/services/converter/Dockerfile
+++ b/services/converter/Dockerfile
@@ -1,5 +1,5 @@
 # IFC→Fragments converter (Node). Build context = repo root.
-FROM node:20-slim
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0
 WORKDIR /app
 
 # install just what the converter needs; web-ifc ships its own WASM. Pin to the SAME versions as the


### PR DESCRIPTION
Tier-1 follow-up to the production/enterprise audit. Dependency-only (no application source). Extends PR #69's supply-chain work to the Dockerfile `FROM` lines and fixes a dev-only npm advisory.

## 1. Pin Dockerfile base images by digest (SEC F4)
- Files: `services/api/Dockerfile`, `apps/web/Dockerfile`, `services/converter/Dockerfile`, `.github/dependabot.yml`
- All 6 `FROM` lines pinned by `@sha256:` digest instead of mutable tags (node:20-slim, python:3.12-slim, nginx:alpine). Digests resolved via the Docker Hub registry API and verified as multi-platform OCI indexes (docker/buildx unavailable in the sandbox).
- Added 3 `package-ecosystem: docker` Dependabot entries (one per Dockerfile directory) so digests auto-bump weekly. YAML validated.

> **Merge-order note:** these `FROM` lines currently reference `node:20-slim` (current `main`). PR #69 (#69) bumps them to `node:22-slim`. If #69 merges first, this branch's `node:20-slim@sha256:...` pins will conflict and should be rebased onto `node:22-slim` digests (Dependabot will also re-resolve). Recommend merging #69 first, then rebasing this.

## 2. npm audit fix — dev/docs chain (SEC F6)
- File: `apps/web/package.json` + root `package-lock.json`
- **Fixed:** `fast-uri` 3.1.2 → 3.1.4 (GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6, via `vite-plugin-pwa → workbox-build → ajv → fast-uri`). Lock regenerated with `--install-strategy=nested`.
- **Deferred:** nested `js-yaml`/`@redocly/openapi-core` — the fix ships in redocly 2.x, but `openapi-typescript@7.13.0` caps redocly at `<2.0.0` (1.34.17 hard-pins js-yaml 4.2.0). Unfixable without a breaking major; left per the spec.
- `npm audit` 3 high → 2 high (deferred pair, both dev-only). `npm audit --omit=dev` stays **0**.

## Validations
- `npm run typecheck -w apps/web` ✅, `npm run build -w apps/web` (PWA/workbox, `dist/sw.js`) ✅, `openapi-typescript` codegen ✅, 121 tests pass ✅.
- Note: validated under Node 20 (current `main` target; PR #69's Node 22 bump is unmerged).

\`\`\`task
file:services/api/Dockerfile
file:apps/web/Dockerfile
file:services/converter/Dockerfile
file:.github/dependabot.yml
file:apps/web/package.json
file:package-lock.json
\`\`\`