### PR TITLE
Sentry-compatible error alerting for production 500s (C3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,16 @@ AEC_LOGIN_WINDOW_SEC=300                          # ...within this sliding windo
 # this value as the bearer token. Unset = the whole /scim/v2 surface returns 503 (disabled).
 # AEC_SCIM_TOKEN=
 
+# --- Error alerting (optional) — Sentry / GlitchTip ---
+# The DB error_log records what broke but alarms no one. Set a DSN to page on-call on production 500s
+# (dedup + release tracking). Server-side only; UNSET = no-op (nothing initializes, no network). Sentry
+# and self-hosted GlitchTip both take the same DSN-style value. After setting the DSN, create alert
+# rules in your Sentry/GlitchTip project. Error reporting only — tracing stays off by default.
+# AEC_SENTRY_DSN=https://<key>@o0.ingest.sentry.io/0   # or your GlitchTip DSN; SENTRY_DSN also honored
+# AEC_SENTRY_ENVIRONMENT=production                    # defaults to AEC_ENV
+# AEC_SENTRY_RELEASE=massing@0.1.0                      # optional; tags events with a release for regressions
+# AEC_SENTRY_TRACES_SAMPLE_RATE=0                       # keep 0 — performance tracing is a separate concern
+
 # --- CORS ---
 # Only needed if a browser calls the API cross-origin. In the bundled stack the web
 # app uses nginx's same-origin /api proxy, so this can stay at the dev default.

--- a/services/api/requirements.in
+++ b/services/api/requirements.in
@@ -37,3 +37,4 @@ ezdxf>=1.1             # DXF quantity takeoff — 2D CAD estimating (dxf_takeoff
 # --- optional (lazy-imported, only when the matching env var is set) ---
 redis>=5.0             # shared rate-limit + login-lockout counters (AEC_REDIS_URL)
 anthropic>=0.69        # optional AI assists (Draft RFI) — ANTHROPIC_API_KEY
+sentry-sdk[fastapi]>=2.0  # external error alerting (sentry.py); no-op unless AEC_SENTRY_DSN is set

--- a/services/api/requirements.lock
+++ b/services/api/requirements.lock
@@ -55,6 +55,7 @@ certifi==2026.6.17 \
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
     #   signxml
 cffi==2.1.0 \
     --hash=sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc \
@@ -373,7 +374,9 @@ ezdxf==1.4.4 \
 fastapi==0.139.0 \
     --hash=sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145 \
     --hash=sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189
-    # via -r services/api/requirements.in
+    # via
+    #   -r services/api/requirements.in
+    #   sentry-sdk
 flask==3.1.3 \
     --hash=sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb \
     --hash=sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c
@@ -1671,6 +1674,10 @@ scipy==1.18.0 \
     --hash=sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d \
     --hash=sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707
     # via -r services/api/requirements.in
+sentry-sdk[fastapi]==2.66.1 \
+    --hash=sha256:86002793161d9a95ef04bdd8d442e9bfece5d989b755f05d6360215094a7aff6 \
+    --hash=sha256:f882fb08710c5f8bfc603aafa3e901b384009a19cc3f76a572b863392ee81cdc
+    # via -r services/api/requirements.in
 shapely==2.1.2 \
     --hash=sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9 \
     --hash=sha256:01d0d304b25634d60bd7cf291828119ab55a3bab87dc4af1e44b07fb225f188b \
@@ -1848,6 +1855,7 @@ urllib3==2.7.0 \
     # via
     #   botocore
     #   requests
+    #   sentry-sdk
 uvicorn[standard]==0.51.0 \
     --hash=sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b \
     --hash=sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0

--- a/services/api/src/aec_api/main.py
+++ b/services/api/src/aec_api/main.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from . import errorlog, metrics
+from . import errorlog, metrics, sentry
 from .db import SessionLocal, init_db
 from .routers import (
     accounting,
@@ -165,6 +165,9 @@ def _production_guard() -> None:
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
+    # External error alerting: no-op unless AEC_SENTRY_DSN/SENTRY_DSN is set. Init early so a failure
+    # in any later startup step is itself reported; fail-open so it can never block boot.
+    sentry.init()
     init_db()
     # Production safety: tokens signed with the public dev secret are forgeable. Warn loudly when
     # RBAC is on, and hard-fail when AEC_REQUIRE_SECRET=1 (set this in real deployments).
@@ -248,6 +251,9 @@ async def _unhandled_error(request: Request, exc: Exception):
             db.close()
     except Exception:                        # noqa: BLE001 — the logger must never mask the original
         logging.getLogger("aec").exception("error-log persist failed")
+    # Additive external alerting: this handler catches the exception before Sentry's auto-capture
+    # would, so report it explicitly. No-op when unconfigured; fail-open so it never affects the 500.
+    sentry.capture_exception(exc, request_id=rid)
     logging.getLogger("aec").exception("unhandled [%s] %s %s", rid, request.method, request.url.path)
     return JSONResponse(status_code=500, content={"detail": "internal server error", "request_id": rid},
                         headers={"X-Request-ID": rid or ""})

--- a/services/api/src/aec_api/sentry.py
+++ b/services/api/src/aec_api/sentry.py
@@ -1,0 +1,123 @@
+"""Sentry-compatible external error alerting — server-side only, no-op until configured.
+
+The DB `error_log` (errorlog.py) is a *record* of what broke; it never alarms anyone. This wires the
+global 500 handler to an external Sentry-compatible sink (Sentry / GlitchTip — both take a DSN-style
+integration) so a production 500 pages on-call, dedups, and tracks releases.
+
+No-op by default: nothing initializes unless `AEC_SENTRY_DSN` (or `SENTRY_DSN`) is set — DSN unset =
+identical app behavior. Error reporting only: `traces_sample_rate` defaults to 0 (performance/tracing
+is a separate concern). Everything here fails open — an init or capture failure is logged and
+swallowed so it can never block boot or mask a response.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+_log = logging.getLogger("aec.sentry")
+
+# Flipped true only once sentry_sdk.init() has succeeded, so capture_exception() is a cheap no-op
+# otherwise (and so the DSN-unset path provably never touches the SDK / network).
+_ENABLED = False
+
+# Request headers that must never leave the process — auth material. Compared case-insensitively.
+_SCRUB_HEADERS = frozenset({"authorization", "cookie", "x-api-key"})
+
+
+def _dsn() -> str:
+    return (os.environ.get("AEC_SENTRY_DSN") or os.environ.get("SENTRY_DSN") or "").strip()
+
+
+def enabled() -> bool:
+    return _ENABLED
+
+
+def _before_send(event, _hint):
+    """Strip credential-bearing headers + request body before an event leaves the process.
+    `send_default_pii=False` already omits cookies/bodies, but we scrub explicitly as defense in
+    depth. If scrubbing itself fails we drop the whole request payload rather than risk leaking it."""
+    try:
+        req = event.get("request")
+        if isinstance(req, dict):
+            headers = req.get("headers")
+            if isinstance(headers, dict):
+                for k in list(headers):
+                    if k.lower() in _SCRUB_HEADERS:
+                        headers[k] = "[scrubbed]"
+            # request bodies can carry credentials (login payloads, API tokens) — never send them
+            if "data" in req:
+                req["data"] = "[scrubbed]"
+    except Exception:                       # noqa: BLE001 — never leak, never raise out of before_send
+        _log.warning("sentry before_send scrub failed; dropping request payload", exc_info=True)
+        try:
+            event.pop("request", None)
+        except Exception:                   # noqa: BLE001
+            pass
+    return event
+
+
+def init() -> bool:
+    """Initialize Sentry iff a DSN is configured. Returns True when Sentry was enabled. Safe to call
+    once at startup; any failure is logged and swallowed (fail-open)."""
+    global _ENABLED
+    dsn = _dsn()
+    if not dsn:
+        return False
+    try:
+        import sentry_sdk
+
+        # Explicit FastAPI/Starlette integrations (the spec's "with the FastAPI integration"). These
+        # are default integrations in modern sentry-sdk, so if the submodules can't be imported we
+        # simply let the SDK auto-detect — never fatal.
+        integrations = []
+        try:
+            from sentry_sdk.integrations.fastapi import FastApiIntegration
+            from sentry_sdk.integrations.starlette import StarletteIntegration
+            integrations = [StarletteIntegration(), FastApiIntegration()]
+        except Exception:                   # noqa: BLE001 — optional; SDK auto-detects FastAPI anyway
+            pass
+
+        try:
+            traces = float(os.environ.get("AEC_SENTRY_TRACES_SAMPLE_RATE", "0") or "0")
+        except ValueError:
+            traces = 0.0
+        environment = (os.environ.get("AEC_SENTRY_ENVIRONMENT")
+                       or os.environ.get("AEC_ENV") or "development")
+        release = os.environ.get("AEC_SENTRY_RELEASE") or None
+
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=environment,
+            release=release,
+            traces_sample_rate=traces,      # 0 = error reporting only, no performance/tracing overhead
+            send_default_pii=False,
+            before_send=_before_send,
+            integrations=integrations,
+        )
+        _ENABLED = True
+        _log.info("Sentry error alerting enabled (environment=%s, traces_sample_rate=%s)",
+                  environment, traces)
+        return True
+    except Exception:                       # noqa: BLE001 — a Sentry failure must never block boot
+        _ENABLED = False
+        _log.warning("Sentry init failed; error alerting disabled", exc_info=True)
+        return False
+
+
+def capture_exception(exc: BaseException, *, request_id: str | None = None) -> None:
+    """Send one exception to Sentry (no-op unless init() enabled it). Tags the event with the
+    request-id so it correlates with the JSON access log and the DB error_log row. Fails open — a
+    capture failure must never mask the original 500."""
+    if not _ENABLED:
+        return
+    try:
+        import sentry_sdk
+
+        if request_id:
+            try:
+                sentry_sdk.set_tag("request_id", request_id)
+            except Exception:               # noqa: BLE001 — tagging is best-effort
+                pass
+        sentry_sdk.capture_exception(exc)
+    except Exception:                       # noqa: BLE001 — capture must never mask the original 500
+        _log.warning("Sentry capture_exception failed", exc_info=True)

--- a/services/api/test_sentry.py
+++ b/services/api/test_sentry.py
@@ -1,0 +1,142 @@
+"""Sentry-compatible error alerting: env-gated no-op, handled-500 capture, fail-open, PII scrubbing.
+Uses a fake sentry_sdk injected into sys.modules so nothing touches the network.
+Run: PYTHONPATH=src:../data/src python3 test_sentry.py"""
+import os
+import sys
+import types
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_sentry.db"
+os.environ["STORAGE_DIR"] = "./test_storage_sentry"
+os.environ["AEC_LOCAL_MODE"] = "1"          # single-operator mode → no IdP needed in tests
+os.environ.pop("AEC_RBAC", None)
+for _k in ("AEC_SENTRY_DSN", "SENTRY_DSN"):  # start from a known DSN-unset state
+    os.environ.pop(_k, None)
+for _f in ("./test_sentry.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api import sentry  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+
+# --- a fake sentry_sdk so init()/capture_exception() never hit the network -----------------------
+class _FakeSentry:
+    def __init__(self):
+        self.init_kwargs = None
+        self.init_calls = 0
+        self.captured = []
+        self.tags = {}
+        self.raise_on_capture = False
+
+    def init(self, **kw):
+        self.init_calls += 1
+        self.init_kwargs = kw
+
+    def capture_exception(self, exc):
+        if self.raise_on_capture:
+            raise RuntimeError("sentry transport down")
+        self.captured.append(exc)
+
+    def set_tag(self, k, v):
+        self.tags[k] = v
+
+
+def _install_fake_sentry() -> _FakeSentry:
+    fake = _FakeSentry()
+    mod = types.ModuleType("sentry_sdk")
+    mod.init = fake.init
+    mod.capture_exception = fake.capture_exception
+    mod.set_tag = fake.set_tag
+    integ = types.ModuleType("sentry_sdk.integrations")
+    fastapi_mod = types.ModuleType("sentry_sdk.integrations.fastapi")
+    starlette_mod = types.ModuleType("sentry_sdk.integrations.starlette")
+
+    class FastApiIntegration:  # noqa: D401 — stand-in for the real integration class
+        pass
+
+    class StarletteIntegration:
+        pass
+
+    fastapi_mod.FastApiIntegration = FastApiIntegration
+    starlette_mod.StarletteIntegration = StarletteIntegration
+    integ.fastapi = fastapi_mod
+    integ.starlette = starlette_mod
+    mod.integrations = integ
+    sys.modules.update({
+        "sentry_sdk": mod,
+        "sentry_sdk.integrations": integ,
+        "sentry_sdk.integrations.fastapi": fastapi_mod,
+        "sentry_sdk.integrations.starlette": starlette_mod,
+    })
+    return fake
+
+
+# a route that always 500s, so the global exception handler runs
+app.add_api_route("/__sentry_boom__",
+                  lambda: (_ for _ in ()).throw(RuntimeError("boom-sentry")), methods=["GET"])
+
+
+# --- 1. DSN UNSET → no-op: app boots, 500 path unchanged, SDK never touched ----------------------
+sentry._ENABLED = False
+fake = _install_fake_sentry()
+assert sentry.init() is False, "init() with no DSN returns False"
+assert sentry.enabled() is False and fake.init_calls == 0, "no DSN → SDK never initialized"
+with TestClient(app, raise_server_exceptions=False) as c:
+    r = c.get("/__sentry_boom__")
+    assert r.status_code == 500 and r.json().get("request_id"), r.text[:200]
+    assert r.headers.get("X-Request-ID") == r.json()["request_id"], r.headers
+assert fake.captured == [], "DSN unset → capture_exception NOT called"
+print("1. DSN unset: app boots, 500 unchanged, capture_exception not called")
+
+
+# --- 2. DSN SET → init runs with safe options; handled 500 is captured + request-id tagged --------
+os.environ["AEC_SENTRY_DSN"] = "https://pub@example.ingest.glitchtip.test/1"
+os.environ["AEC_SENTRY_ENVIRONMENT"] = "staging"
+fake = _install_fake_sentry()
+with TestClient(app, raise_server_exceptions=False) as c:   # lifespan runs sentry.init()
+    assert sentry.enabled() is True and fake.init_calls == 1, "DSN set → init ran once"
+    kw = fake.init_kwargs
+    assert kw["send_default_pii"] is False, kw
+    assert kw["traces_sample_rate"] == 0.0, "error reporting only (no tracing)"
+    assert kw["environment"] == "staging", kw
+    assert callable(kw["before_send"]), "before_send installed"
+    assert len(kw["integrations"]) == 2, "explicit FastAPI + Starlette integrations"
+    r = c.get("/__sentry_boom__")
+    assert r.status_code == 500 and r.json().get("request_id"), r.text[:200]
+    rid = r.json()["request_id"]
+assert len(fake.captured) == 1 and isinstance(fake.captured[0], RuntimeError), fake.captured
+assert fake.tags.get("request_id") == rid, ("event tagged with request-id", fake.tags, rid)
+print(f"2. DSN set: init ran (env=staging, pii off, traces=0), captured 1 exc, tagged rid={rid}")
+
+
+# --- 3. capture failure → fail-open: the normal 500 response is unaffected ------------------------
+fake = _install_fake_sentry()
+fake.raise_on_capture = True
+with TestClient(app, raise_server_exceptions=False) as c:
+    assert sentry.enabled() is True
+    r = c.get("/__sentry_boom__")
+    assert r.status_code == 500 and r.json().get("request_id"), "capture blew up but 500 is clean"
+print("3. capture failure: swallowed, 500 response unaffected (fail-open)")
+
+
+# --- 4. PII scrubbing: before_send drops auth/cookie/x-api-key headers + body --------------------
+event = {"request": {
+    "headers": {"Authorization": "Bearer secret-token", "Cookie": "aec_token=abc",
+                "X-Api-Key": "k-123", "User-Agent": "pytest"},
+    "data": {"password": "hunter2"},
+}}
+scrubbed = sentry._before_send(event, None)
+hdrs = scrubbed["request"]["headers"]
+assert hdrs["Authorization"] == "[scrubbed]" and hdrs["Cookie"] == "[scrubbed]", hdrs
+assert hdrs["X-Api-Key"] == "[scrubbed]", hdrs
+assert hdrs["User-Agent"] == "pytest", "non-sensitive headers preserved"
+assert scrubbed["request"]["data"] == "[scrubbed]", "credential-bearing body dropped"
+print("4. PII scrubbing: authorization/cookie/x-api-key + body scrubbed, others preserved")
+
+# cleanup env so import side effects don't leak to other test modules
+for _k in ("AEC_SENTRY_DSN", "AEC_SENTRY_ENVIRONMENT"):
+    os.environ.pop(_k, None)
+sentry._ENABLED = False
+print("test_sentry OK")


### PR DESCRIPTION
First Tier-2 enterprise item. Closes the "500s page no one" SLA blocker (C3) — the DB `error_log` is a record, not an alarm. Adds Sentry-compatible external error alerting, **server-side only, no-op until a DSN is set**, so it lands safely with no provider chosen (Sentry SaaS, self-hosted Sentry, and GlitchTip all use the same DSN-style integration).

## Changes
- **`services/api/src/aec_api/sentry.py`** (new) — env-gated `init()`, `capture_exception()`, and a `before_send` scrubber. No-op until `AEC_SENTRY_DSN`/`SENTRY_DSN` is set; `_ENABLED` flips true only after a successful init so the unset path provably never touches the SDK/network. `traces_sample_rate` defaults to **0** (error reporting only — tracing is a separate Tier-2 item). Everything fails open: init/capture failures are logged and swallowed, never block boot or mask a 500.
- **`main.py`** — `sentry.init()` early in `lifespan` (before init_db, so startup failures are reported); `sentry.capture_exception(exc, request_id=rid)` inside the existing global 500 handler. The handler catches before Sentry's auto-capture would, so this is explicit. The DB `error_log` write + clean 500 + `X-Request-ID` response are unchanged — Sentry is additive.
- **`requirements.in`** — add `sentry-sdk[fastapi]>=2.0`.
- **`requirements.lock`** — regenerated via `pip-compile --generate-hashes --allow-unsafe` under Python 3.12 (matches `lockfile.yml`); adds `sentry-sdk[fastapi]==2.66.1` + transitive deps, no other pins changed.
- **`.env.example`** — documents `AEC_SENTRY_DSN`, `AEC_SENTRY_ENVIRONMENT` (default `AEC_ENV`), `AEC_SENTRY_RELEASE`, `AEC_SENTRY_TRACES_SAMPLE_RATE`, with an operator note.
- **`test_sentry.py`** — DSN-unset no-op; DSN-set init + capture + request-id tag; capture fail-open; `before_send` scrubs authorization/cookie/x-api-key headers + request body. All pass; `test_errorlog.py` unchanged (no regression).

## Privacy / safety
`send_default_pii=False`; explicit `before_send` scrubs `authorization`/`cookie`/`x-api-key` headers and replaces request `data` with `[scrubbed]` (and drops the whole request payload if scrubbing itself fails). Each event is tagged with the existing request-id for correlation with the JSON access log and the `error_log` row.

## To enable (operator)
Set `AEC_SENTRY_DSN` and create alert rules in your Sentry/GlitchTip instance. Until then, behavior is identical to today.

\`\`\`task
file:services/api/src/aec_api/sentry.py
file:services/api/src/aec_api/main.py
file:services/api/requirements.in
file:services/api/requirements.lock
file:.env.example
\`\`\`