### PR TITLE
R22-CLASSIFY-AI — a coverage number that counts only what the model says

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -27,6 +27,8 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_bundle", "test_desktop", "test_localmode", "test_project_budget", "test_rvt_bridge",
          "test_bcf", "test_engines", "test_edge_cases", "test_opendata", "test_financials", "test_money", "test_leasemgmt", "test_changeorders",
          "test_migrate", "test_alembic_migrations", "test_appraisal", "test_marketing", "test_workflow_gate", "test_due_feed", "test_directory",
+         # R22-CLASSIFY-AI — classification coverage + code proposals:
+         "test_classify_assist", "test_classify_route",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",

--- a/services/api/src/aec_api/classify_assist.py
+++ b/services/api/src/aec_api/classify_assist.py
@@ -1,0 +1,344 @@
+"""R22-CLASSIFY-AI — cost/discipline classification for a model somebody else authored.
+
+**The finding this is built around.** `classification.classify(ifc_class, system)` returns a
+`(code, title)` tuple for any input. When the class is not in the system's map it returns the
+system's **default bucket** — MasterFormat `01 00 00 General Requirements`, NRM1 `0 Facilitating
+works` — and the return type cannot express the difference. A model we authored is full of classes
+that *are* in the map, so this never shows. An imported model is full of `IfcBuildingElementProxy`,
+and every one of those elements prices as General Requirements while the estimate reports a complete
+takeoff. Nothing is missing, nothing errors, and the number is wrong.
+
+That is the same shape as the `get_area` defect: a fault that only fires on a particular provenance
+of model, so the everyday path never catches it. Here the provenance is *imported*, which is nearly
+every real client model.
+
+**So the first job is a coverage number that can be believed.** `coverage()` counts only what the
+model actually **declares** — an `IfcRelAssociatesClassification` on the element. A code we derived
+is a proposal, and proposals never inflate coverage. A 4% figure on a client model is the true
+starting point of a cost exercise, and it is more useful than the 100% the current path implies.
+
+**The second job is proposals with their evidence.** Four bases, ranked, and each says what kind of
+claim it is:
+
+* `declared` — the model asserts it. Not a proposal at all.
+* `keyword` — the element's own name or type name determines the code ("CMU partition" → unit
+  masonry). Specific to this element.
+* `class_map` — the element's IFC class is in the system's published map. True of the class, and
+  therefore identical for every element of that class in the model — including the ones it is wrong
+  for. NRM1 maps `IfcWall` to *external walls*; an interior wall exported as plain `IfcWall` gets
+  the external code, and nothing about the derivation knows that.
+* `unmapped` — the class is not in the map. **This is the one the current code hides**, and it is
+  reported as a gap rather than filled with the default bucket.
+
+**Nothing is ever written by reading it.** `propose()` computes; `apply_plan()` turns an explicit
+list of accepted GUIDs into `set_classification` recipe steps. A classification that appeared on
+elements because somebody opened a report is indistinguishable, a week later, from one a quantity
+surveyor decided.
+
+**Uniclass and OmniClass are refused outright.** The standing rule in this codebase is that a
+Uniclass code is never guessed; the tables here are the published IFC-class maps for MasterFormat,
+DIN 276 and NRM 1, which is a different thing from inventing a Uniclass reference from a keyword. A
+request to propose one is an error with that reason, not an empty result — an empty result reads as
+"nothing to classify".
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from . import classification as cls
+
+#: Bases, most to least authoritative. `unmapped` is not a basis for a code; it is the absence of one.
+BASES = ("declared", "keyword", "class_map", "unmapped")
+
+#: Systems this module will propose codes for — those with a published IFC-class map in
+#: `classification.CLASSIFICATIONS`.
+def systems() -> list[str]:
+    return sorted(cls.CLASSIFICATIONS)
+
+
+#: Systems this module refuses to propose for, and why. Kept as data so the refusal carries a reason
+#: rather than being a missing branch.
+REFUSED: dict[str, str] = {
+    "uniclass": "a Uniclass code is never guessed in this codebase — the tables here are published "
+                "IFC-class maps, which is not the same thing as inferring a Uniclass reference from "
+                "an element name. Import a Uniclass mapping or set the codes explicitly.",
+    "omniclass": "no published IFC-class map for OmniClass is carried here; proposing one would be "
+                 "invention rather than derivation.",
+}
+
+
+class ClassifyError(ValueError):
+    """The request cannot be answered honestly — an unknown or refused classification system."""
+
+
+# Keyword refinements, per system. Each rule is (pattern, applies-to-classes, code, title).
+# These exist because the class alone genuinely does not determine the code, and the element's own
+# name does: a wall is masonry or gypsum, and "IfcWall" says nothing about which. `applies_to` is an
+# empty tuple when the rule stands on the keyword alone.
+#
+# Deliberately small. Every rule here is one where the keyword IS the answer; a longer list of
+# plausible-sounding rules would raise the proposal rate and lower the proportion a reviewer accepts,
+# which is the wrong trade for a surface whose whole purpose is that a human confirms each line.
+_KEYWORDS: dict[str, list[tuple[str, tuple[str, ...], str, str]]] = {
+    "masterformat": [
+        (r"\bcmu\b|concrete masonry|\bmasonry\b|\bbrick\b", ("IfcWall", "IfcWallStandardCase"),
+         "04 20 00", "Unit Masonry"),
+        (r"\bgyp\b|gypsum|drywall|\bstud\b|partition", ("IfcWall", "IfcWallStandardCase"),
+         "09 20 00", "Plaster & Gypsum Board"),
+        (r"cast[- ]?in[- ]?place|\bcip\b|\bconcrete\b", ("IfcWall", "IfcWallStandardCase", "IfcColumn",
+                                                         "IfcSlab", "IfcBeam"),
+         "03 30 00", "Cast-in-Place Concrete"),
+        (r"\bsteel\b|\bhss\b|\bw\d+x\d+", ("IfcColumn", "IfcBeam", "IfcMember", "IfcPlate"),
+         "05 12 00", "Structural Steel Framing"),
+        (r"acoustic(al)? (ceiling|tile)|\bact\b|suspended ceiling", (),
+         "09 50 00", "Ceilings"),
+        (r"\bcarpet\b|resilient floor|\bvct\b|\blvt\b", (),
+         "09 60 00", "Flooring"),
+    ],
+    "nrm1": [
+        (r"\bexternal\b|\bexterior\b|\bfacade\b|\bfaçade\b", ("IfcWall", "IfcWallStandardCase"),
+         "2.6", "External walls"),
+        (r"\binternal\b|\binterior\b|partition", ("IfcWall", "IfcWallStandardCase"),
+         "2.7", "Internal walls & partitions"),
+        (r"\bexternal\b|\bexterior\b", ("IfcDoor",), "2.6", "External walls"),
+    ],
+    "din276": [
+        (r"\baußen\b|\baussen\b|\bexternal\b|\bexterior\b", ("IfcWall", "IfcWallStandardCase"),
+         "331", "Tragende Außenwände"),
+        (r"\binnen\b|\binternal\b|\binterior\b|partition", ("IfcWall", "IfcWallStandardCase"),
+         "341", "Tragende Innenwände"),
+    ],
+}
+
+
+def _system(system: str) -> str:
+    key = (system or "").strip().lower()
+    if key in REFUSED:
+        raise ClassifyError(f"{system!r}: {REFUSED[key]}")
+    if key not in cls.CLASSIFICATIONS:
+        raise ClassifyError(f"unknown classification system {system!r}; "
+                            f"known: {', '.join(systems())}")
+    return key
+
+
+def read_declared(model: Any) -> dict[str, list[dict[str, Any]]]:
+    """`{guid: [{system, code, title}]}` from each element's `IfcRelAssociatesClassification`.
+
+    Walks `ReferencedSource` up to the owning `IfcClassification`, because a reference may point at
+    another reference (a facet of a code) rather than straight at the source — reading only one level
+    reports the system as None for every correctly-authored hierarchical code.
+    """
+    out: dict[str, list[dict[str, Any]]] = {}
+    for rel in (model.by_type("IfcRelAssociatesClassification") or []):
+        ref = getattr(rel, "RelatingClassification", None)
+        if ref is None:
+            continue
+        src = getattr(ref, "ReferencedSource", None)
+        seen = 0
+        while src is not None and getattr(src, "is_a", None) and src.is_a("IfcClassificationReference"):
+            src = getattr(src, "ReferencedSource", None)
+            seen += 1
+            if seen > 16:                    # a malformed self-referencing chain must not hang a scan
+                src = None
+                break
+        entry = {"system": getattr(src, "Name", None) if src is not None else None,
+                 "code": getattr(ref, "Identification", None),
+                 "title": getattr(ref, "Name", None)}
+        for obj in (getattr(rel, "RelatedObjects", None) or []):
+            guid = getattr(obj, "GlobalId", None)
+            if guid:
+                out.setdefault(guid, []).append(dict(entry))
+    return out
+
+
+#: The names a model authored elsewhere actually writes into `IfcClassification.Name`. An explicit
+#: list rather than fuzzy matching: the first version of this matched substrings in both directions,
+#: which meant the display name "CSI MasterFormat (US/CA)" contributed the fragment "us" and a model
+#: declaring "AusSpec" matched MasterFormat. A wrong system match is worse than no match — it reports
+#: an element as classified under a standard it was never classified under.
+_ALIASES: dict[str, frozenset[str]] = {
+    "masterformat": frozenset({"masterformat", "master format", "csi masterformat",
+                               "csi master format", "csi masterformat (us/ca)", "csi"}),
+    "din276": frozenset({"din276", "din 276", "din-276", "din 276 (dach)"}),
+    "nrm1": frozenset({"nrm1", "nrm 1", "nrm-1", "rics nrm 1", "rics nrm1", "rics nrm 1 (uk)"}),
+}
+
+
+def _norm(s: Any) -> str:
+    """Lowercase, collapse internal whitespace, strip. Nothing else — no substring games."""
+    return re.sub(r"\s+", " ", str(s or "")).strip().lower()
+
+
+def _declared_for(entries: list[dict[str, Any]] | None, system: str) -> dict[str, Any] | None:
+    """The declared code for `system`, matched on the classification source's name.
+
+    Exact match against a known alias, after normalising case and whitespace. An entry whose source
+    name we do not recognise is deliberately NOT counted as this system: it may be a different
+    standard, and counting it would inflate the coverage figure with codes that are not comparable.
+    """
+    if not entries:
+        return None
+    label = _norm(cls.CLASSIFICATIONS[system]["name"])
+    wanted = set(_ALIASES.get(system, frozenset())) | {system, _norm(system), label}
+    for e in entries:
+        if not e.get("code"):
+            continue                        # a reference with no Identification classifies nothing
+        if _norm(e.get("system")) in wanted:
+            return e
+    return None
+
+
+def _keyword_hit(text: str, ifc_class: str, system: str) -> tuple[str, str, str] | None:
+    low = (text or "").lower()
+    for pattern, applies, code, title in _KEYWORDS.get(system, []):
+        if applies and ifc_class not in applies:
+            continue
+        if re.search(pattern, low):
+            return code, title, pattern
+    return None
+
+
+def propose(elements: list[dict[str, Any]], system: str,
+            declared: dict[str, list[dict[str, Any]]] | None = None) -> dict[str, Any]:
+    """One row per element: what it is classified as, or what it could be and on what evidence.
+
+    `elements` are index records — `{guid, ifc_class, name, type_name}`. `declared` is the output of
+    `read_declared`; without it every element is treated as undeclared, which is honest for a caller
+    that only has the property index (the index does not carry classification associations) but makes
+    the coverage figure a lower bound. That is stated in the result rather than left to be inferred.
+    """
+    key = _system(system)
+    sysdef = cls.CLASSIFICATIONS[key]
+    cmap = sysdef["map"]
+    rows: list[dict[str, Any]] = []
+
+    for e in elements:
+        guid = e.get("guid")
+        ifc_class = e.get("ifc_class") or e.get("class") or ""
+        name = e.get("name") or ""
+        type_name = e.get("type_name") or e.get("type") or ""
+        row: dict[str, Any] = {"guid": guid, "ifc_class": ifc_class or None,
+                               "name": name or None, "type_name": type_name or None}
+
+        found = _declared_for((declared or {}).get(guid or ""), key)
+        if found:
+            rows.append({**row, "basis": "declared", "code": found["code"],
+                         "title": found.get("title"), "confidence": None,
+                         "evidence": "the model carries this classification on the element"})
+            continue
+
+        hit = _keyword_hit(f"{name} {type_name}", ifc_class, key)
+        if hit:
+            code, title, pattern = hit
+            rows.append({**row, "basis": "keyword", "code": code, "title": title,
+                         "confidence": "medium",
+                         "evidence": f"the element's own name/type matches /{pattern}/"})
+            continue
+
+        if ifc_class in cmap:
+            code, title = cmap[ifc_class]
+            rows.append({**row, "basis": "class_map", "code": code, "title": title,
+                         "confidence": "low",
+                         "evidence": f"{key} maps {ifc_class} to this code — true of the CLASS, so "
+                                     f"every {ifc_class} in the model gets it, including the ones it "
+                                     f"is wrong for"})
+            continue
+
+        rows.append({**row, "basis": "unmapped", "code": None, "title": None, "confidence": None,
+                     "evidence": (f"{key} has no entry for {ifc_class or '(no class)'}. "
+                                  f"`classification.classify` would return the default bucket "
+                                  f"{sysdef['default'][0]} {sysdef['default'][1]!r} here, which is "
+                                  "not a classification of this element")
+                     if ifc_class else "the element carries no IFC class"})
+
+    rows.sort(key=lambda r: (BASES.index(r["basis"]), r["ifc_class"] or "", r["name"] or ""))
+    return {
+        "system": key, "system_name": sysdef["name"],
+        "default_bucket": {"code": sysdef["default"][0], "title": sysdef["default"][1]},
+        "rows": rows,
+        "declared_supplied": declared is not None,
+        **coverage(rows, key),
+    }
+
+
+def coverage(rows: list[dict[str, Any]], system: str) -> dict[str, Any]:
+    """The headline number, and what it is made of.
+
+    `classified_pct` counts **declared only**. A derived code is a proposal; letting proposals count
+    would make the figure describe how good our guessing is rather than how classified the model is,
+    and the whole reason to look at it is to decide whether a cost exercise can start.
+    """
+    total = len(rows)
+    by_basis: dict[str, int] = dict.fromkeys(BASES, 0)
+    for r in rows:
+        by_basis[r["basis"]] = by_basis.get(r["basis"], 0) + 1
+    declared = by_basis["declared"]
+    proposable = by_basis["keyword"] + by_basis["class_map"]
+    unmapped = by_basis["unmapped"]
+
+    if not total:
+        headline = "no elements to classify"
+    elif declared == total:
+        headline = "fully classified in the model"
+    else:
+        headline = (f"{round(100 * declared / total, 1)}% of {total} element(s) carry a "
+                    f"{system} code in the model")
+    return {
+        "total": total,
+        "declared": declared,
+        "classified_pct": round(100 * declared / total, 1) if total else None,
+        "proposable": proposable,
+        "unmapped": unmapped,
+        "by_basis": by_basis,
+        "headline": headline,
+        "counts_only_declared": (
+            "classified_pct counts only codes the MODEL declares. Derived codes are proposals and do "
+            "not raise it — a coverage figure that included our own guesses would measure the "
+            "guessing, not the model"),
+        "unmapped_warning": (
+            f"{unmapped} element(s) have no entry in the {system} class map. An estimate built "
+            f"without classifying them prices them in the default bucket and reports a complete "
+            f"takeoff") if unmapped else None,
+    }
+
+
+def apply_plan(rows: list[dict[str, Any]], accept: list[str], system: str,
+               *, edition: str | None = None) -> dict[str, Any]:
+    """`set_classification` recipe steps for an explicit list of accepted GUIDs.
+
+    Accepting is a separate, deliberate act — nothing here is applied as a side effect of computing
+    a proposal. Anything asked for that cannot be applied is returned in `skipped` **with a reason**
+    rather than dropped: a plan that silently covers 40 of the 60 elements somebody ticked is worse
+    than one that refuses, because the 20 look done.
+    """
+    key = _system(system)
+    wanted = list(dict.fromkeys(accept or []))          # dedupe, keep the caller's order
+    by_guid = {r["guid"]: r for r in rows if r.get("guid")}
+    steps: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+
+    for guid in wanted:
+        row = by_guid.get(guid)
+        if row is None:
+            skipped.append({"guid": guid, "reason": "not in the proposal set"})
+            continue
+        if row["basis"] == "declared":
+            skipped.append({"guid": guid, "reason": "already declared in the model; applying would "
+                                                    "add a second reference for the same system"})
+            continue
+        if not row.get("code"):
+            skipped.append({"guid": guid, "reason": row.get("evidence") or "no code to apply"})
+            continue
+        params = {"guid": guid, "system": cls.CLASSIFICATIONS[key]["name"],
+                  "code": row["code"], "name": row.get("title")}
+        if edition:
+            params["edition"] = edition
+        steps.append({"recipe": "set_classification", "params": params})
+
+    return {
+        "system": key, "steps": steps, "count": len(steps),
+        "skipped": skipped,
+        "note": "apply with POST /projects/{pid}/edit/batch, or one step at a time via POST "
+                "/projects/{pid}/edit — the steps are ordinary GUID-stable edit recipes",
+    }

--- a/services/api/src/aec_api/main.py
+++ b/services/api/src/aec_api/main.py
@@ -28,6 +28,7 @@ from .routers import (
     bidding,
     bim,
     carbon,
+    classify,
     client_portal,
     closeout,
     codecheck,
@@ -417,6 +418,7 @@ app.include_router(payapp.router, tags=["payapp"])
 app.include_router(accounting.router, tags=["accounting"])
 app.include_router(carbon.router, tags=["carbon"])
 app.include_router(codecheck.router, tags=["codecheck"])
+app.include_router(classify.router, tags=["classify"])
 app.include_router(ids.router, tags=["ids"])
 app.include_router(procurement.router, tags=["procurement"])
 app.include_router(conceptual.router, tags=["conceptual"])

--- a/services/api/src/aec_api/routers/classify.py
+++ b/services/api/src/aec_api/routers/classify.py
@@ -34,6 +34,16 @@ def _elements(model) -> list[dict]:
             if el.id() in seen:
                 continue
             seen.add(el.id())
+            if el.is_a("IfcOpeningElement"):
+                # A void is not a thing to classify or price, and `qto.py` skips openings at both of
+                # its call sites — so counting them here would make this denominator disagree with
+                # the takeoff's. "12% classified" has to mean 12% of what actually gets priced,
+                # otherwise the coverage figure and the estimate describe different models.
+                #
+                # (`ifc_loader.physical_elements` does NOT filter them; the convention lives at the
+                # call sites. Following the convention rather than changing the shared helper, which
+                # would silently move every existing quantity.)
+                continue
             try:
                 t = ue.get_type(el)
             except Exception:               # noqa: BLE001 — a broken type relation is not fatal here

--- a/services/api/src/aec_api/routers/classify.py
+++ b/services/api/src/aec_api/routers/classify.py
@@ -1,0 +1,116 @@
+"""R22-CLASSIFY-AI — classification coverage + code proposals for an imported model (project-scoped).
+
+Reads the project's source IFC for the classifications it actually declares, proposes codes for the
+rest with their evidence, and turns an explicit list of accepted GUIDs into `set_classification` edit
+recipe steps. It never writes: the plan is returned for the caller to apply through the ordinary
+authoring path, so a classification always has an author.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from .. import classify_assist as ca
+from ..db import get_db
+from ..deps import open_source_ifc
+from ..rbac import require_role
+
+router = APIRouter()
+
+
+def _elements(model) -> list[dict]:
+    """Index-shaped records straight off the model, so the engine takes the same shape whether it is
+    fed the property index or a freshly opened file."""
+    import ifcopenshell.util.element as ue
+
+    out = []
+    seen: set[int] = set()
+    for kls in ("IfcBuildingElement", "IfcElement"):
+        try:
+            found = model.by_type(kls)
+        except RuntimeError:                # class absent from this schema
+            continue
+        for el in found:
+            if el.id() in seen:
+                continue
+            seen.add(el.id())
+            try:
+                t = ue.get_type(el)
+            except Exception:               # noqa: BLE001 — a broken type relation is not fatal here
+                t = None
+            out.append({"guid": el.GlobalId, "ifc_class": el.is_a(),
+                        "name": getattr(el, "Name", None),
+                        "type_name": getattr(t, "Name", None) if t is not None else None})
+    return out
+
+
+@router.get("/projects/{pid}/classify/coverage")
+def classify_coverage(pid: str, system: str = Query("masterformat"),
+                      db: Session = Depends(get_db), _: str = Depends(require_role("viewer"))):
+    """How much of the model actually carries a classification code, and what the rest would need.
+
+    **The percentage counts only what the model declares.** Derived codes are proposals and do not
+    raise it. A low figure on a client's model is the true starting point of a cost exercise — the
+    alternative is the implicit 100% you get from a class map that silently returns its default
+    bucket for every unmapped class."""
+    try:
+        ca.systems()
+        model = open_source_ifc(db, pid)
+        rows = ca.propose(_elements(model), system, ca.read_declared(model))
+    except ca.ClassifyError as e:
+        raise HTTPException(422, str(e)) from e
+    return {k: v for k, v in rows.items() if k != "rows"}
+
+
+@router.get("/projects/{pid}/classify/proposals")
+def classify_proposals(pid: str, system: str = Query("masterformat"),
+                       basis: str | None = Query(None, description="declared|keyword|class_map|unmapped"),
+                       limit: int = Query(2000, ge=1, le=20000),
+                       db: Session = Depends(get_db), _: str = Depends(require_role("viewer"))):
+    """One row per element: its code and the evidence for it.
+
+    `basis` says what kind of claim each row is. `class_map` rows are true of the element's CLASS and
+    therefore identical for every element of that class — including the ones they are wrong for — so
+    they are worth reviewing as a group rather than one at a time. `unmapped` rows have no code at
+    all; those are the ones an estimate would silently price in the default bucket."""
+    if basis is not None and basis not in ca.BASES:
+        raise HTTPException(422, f"unknown basis {basis!r}; known: {', '.join(ca.BASES)}")
+    try:
+        model = open_source_ifc(db, pid)
+        result = ca.propose(_elements(model), system, ca.read_declared(model))
+    except ca.ClassifyError as e:
+        raise HTTPException(422, str(e)) from e
+    rows = result["rows"]
+    if basis:
+        rows = [r for r in rows if r["basis"] == basis]
+    truncated = len(rows) > limit
+    return {**{k: v for k, v in result.items() if k != "rows"},
+            "rows": rows[:limit], "returned": min(len(rows), limit),
+            "matching": len(rows), "truncated": truncated,
+            # Say what was cut. A page that stops at the limit and does not mention it reads as the
+            # whole set, and the whole set is exactly what a coverage exercise needs to know.
+            "truncation_note": (f"{len(rows) - limit} further row(s) matched and are not shown; "
+                                "raise ?limit= or filter by ?basis=") if truncated else None}
+
+
+@router.post("/projects/{pid}/classify/plan")
+def classify_plan(pid: str, accept: list[str] = Body(..., embed=True),
+                  system: str = Body("masterformat", embed=True),
+                  edition: str | None = Body(None, embed=True),
+                  db: Session = Depends(get_db), _: str = Depends(require_role("editor"))):
+    """Turn an explicit list of accepted GUIDs into `set_classification` recipe steps.
+
+    Returns a plan; it does not apply it. Accepting a proposal is a deliberate act with an author,
+    and a classification that appeared on elements because somebody opened a report is
+    indistinguishable a week later from one a quantity surveyor decided. Anything that cannot be
+    applied comes back in `skipped` **with a reason** rather than being dropped — a plan that
+    silently covers 40 of the 60 elements somebody ticked is worse than one that refuses, because
+    the other 20 look done."""
+    if not accept:
+        raise HTTPException(422, "accept must list at least one GlobalId")
+    try:
+        model = open_source_ifc(db, pid)
+        result = ca.propose(_elements(model), system, ca.read_declared(model))
+        return ca.apply_plan(result["rows"], accept, system, edition=edition)
+    except ca.ClassifyError as e:
+        raise HTTPException(422, str(e)) from e

--- a/services/api/test_classify_assist.py
+++ b/services/api/test_classify_assist.py
@@ -1,0 +1,211 @@
+"""R22-CLASSIFY-AI — the coverage number has to be believable before the proposals matter.
+
+The defect this module was built around is in `classification.classify()`: it returns a
+`(code, title)` tuple for ANY ifc_class, falling back to the system's default bucket when the class
+is not in the map. The return type cannot express "I did not know". A model we authored is full of
+mapped classes so it never shows; an imported model is full of `IfcBuildingElementProxy`, and every
+one prices as `01 00 00 General Requirements` while the estimate reports a complete takeoff.
+
+That is the `get_area` shape again — a fault that only fires on a particular provenance of model, so
+the everyday path never catches it. The first test below pins the underlying behaviour so nobody
+"fixes" this module by going back through the silent path.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_classify_assist.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api import classification as cls  # noqa: E402
+from aec_api import classify_assist as ca  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+def el(guid, ifc_class, name=None, type_name=None):
+    return {"guid": guid, "ifc_class": ifc_class, "name": name, "type_name": type_name}
+
+
+# --- 0. the behaviour this module exists to make visible -------------------------------------------
+code, title = cls.classify("IfcBuildingElementProxy", "masterformat")
+check("an unmapped class still returns a (code, title) from the class map",
+      (code, title) == cls.CLASSIFICATIONS["masterformat"]["default"], (code, title))
+check("  which is the default bucket, indistinguishable from a real answer",
+      code == "01 00 00")
+
+# --- 1. the systems it will and will not propose for ------------------------------------------------
+check("it proposes for the systems with a published class map",
+      set(ca.systems()) == set(cls.CLASSIFICATIONS), ca.systems())
+for refused in ("uniclass", "Uniclass", "omniclass"):
+    try:
+        ca.propose([], refused)
+        check(f"{refused!r} is refused", False, "no exception")
+    except ca.ClassifyError as e:
+        check(f"{refused!r} is refused", True)
+        if refused == "uniclass":
+            check("  with the standing reason, not a bare 'unknown system'",
+                  "never guessed" in str(e), str(e)[:80])
+try:
+    ca.propose([], "nonsense")
+    check("an unknown system is an error, not an empty result", False, "no exception")
+except ca.ClassifyError:
+    check("an unknown system is an error, not an empty result", True)
+
+# --- 2. the four bases ------------------------------------------------------------------------------
+elements = [
+    el("g1", "IfcWall", "CMU Partition Type A"),           # keyword: masonry
+    el("g2", "IfcWall", "Gyp Bd Partition 3-5/8"),         # keyword: gypsum
+    el("g3", "IfcWall", "Wall-01"),                        # class_map only
+    el("g4", "IfcBuildingElementProxy", "Widget 12"),      # unmapped
+    el("g5", "IfcSlab", "Level 2 Slab"),                   # class_map
+    el("g6", "IfcDoor", "D-101"),                          # class_map, and declared below
+]
+declared = {"g6": [{"system": "CSI MasterFormat", "code": "08 11 13", "title": "Hollow Metal Doors"}]}
+
+p = ca.propose(elements, "masterformat", declared)
+by_guid = {r["guid"]: r for r in p["rows"]}
+check("a declared code wins over everything derivable", by_guid["g6"]["basis"] == "declared")
+check("  and the model's own code is reported, not ours",
+      by_guid["g6"]["code"] == "08 11 13", by_guid["g6"]["code"])
+check("a name keyword beats the class map", by_guid["g1"]["basis"] == "keyword"
+      and by_guid["g1"]["code"] == "04 20 00", by_guid["g1"])
+check("  and a different keyword gives a different code on the SAME class",
+      by_guid["g2"]["code"] == "09 20 00", by_guid["g2"]["code"])
+check("  each keyword row carries the pattern that fired",
+      "matches /" in by_guid["g1"]["evidence"])
+check("a plain wall falls to the class map", by_guid["g3"]["basis"] == "class_map")
+check("  at LOW confidence, because it is a fact about the class",
+      by_guid["g3"]["confidence"] == "low")
+check("  and the evidence says so in words",
+      "true of the CLASS" in by_guid["g3"]["evidence"])
+check("an unmapped class gets NO code", by_guid["g4"]["basis"] == "unmapped"
+      and by_guid["g4"]["code"] is None, by_guid["g4"])
+check("  and its evidence names the bucket it would otherwise have been given",
+      "01 00 00" in by_guid["g4"]["evidence"] and "not a classification" in by_guid["g4"]["evidence"])
+
+# --- 3. coverage counts DECLARED only ----------------------------------------------------------------
+check("coverage counts only what the model declares", p["declared"] == 1 and p["total"] == 6)
+check("  so the percentage is 16.7, not 83.3", p["classified_pct"] == 16.7, p["classified_pct"])
+check("  proposals are counted separately", p["proposable"] == 4, p["proposable"])
+check("  as are the elements nothing can classify", p["unmapped"] == 1)
+check("  and the result says the figure excludes our guesses",
+      "not the model" in p["counts_only_declared"])
+check("  with a warning naming the estimate consequence",
+      "default bucket" in (p["unmapped_warning"] or ""), p["unmapped_warning"])
+check("the basis counts add up to the total", sum(p["by_basis"].values()) == p["total"])
+
+nothing = ca.propose(elements, "masterformat")          # no `declared` supplied at all
+check("with no declared map supplied, coverage is 0% and says the map was absent",
+      nothing["classified_pct"] == 0.0 and nothing["declared_supplied"] is False)
+
+# --- 4. system-name matching is exact, not fuzzy ------------------------------------------------------
+# The first version matched substrings both ways, so the display name "CSI MasterFormat (US/CA)"
+# contributed the fragment "us" and a model declaring "AusSpec" matched MasterFormat. A wrong system
+# match is worse than none: it reports an element as classified under a standard it never was.
+for name, expect in (("MasterFormat", True), ("masterformat", True), ("CSI MasterFormat", True),
+                     ("CSI  MasterFormat ", True), ("AusSpec", False), ("us", False),
+                     ("Uniclass 2015", False), ("NRM 1", False)):
+    got = ca.propose([el("x", "IfcDoor", "D")], "masterformat",
+                     {"x": [{"system": name, "code": "08 11 13", "title": "t"}]})
+    is_declared = got["rows"][0]["basis"] == "declared"
+    check(f"a source named {name!r} {'matches' if expect else 'does NOT match'} masterformat",
+          is_declared is expect, got["rows"][0]["basis"])
+
+noid = ca.propose([el("x", "IfcDoor", "D")], "masterformat",
+                  {"x": [{"system": "MasterFormat", "code": None, "title": "t"}]})
+check("a classification reference with no Identification classifies nothing",
+      noid["rows"][0]["basis"] != "declared")
+
+# --- 5. NRM1 external/internal — where the class map is confidently wrong ------------------------------
+nrm = ca.propose([el("w1", "IfcWall", "External Cavity Wall"),
+                  el("w2", "IfcWall", "Internal Partition"),
+                  el("w3", "IfcWall", "Wall")], "nrm1")
+n = {r["guid"]: r for r in nrm["rows"]}
+check("NRM1: an externally-named wall proposes external walls",
+      n["w1"]["code"] == "2.6" and n["w1"]["basis"] == "keyword")
+check("NRM1: an internally-named wall proposes internal walls",
+      n["w2"]["code"] == "2.7" and n["w2"]["basis"] == "keyword")
+check("NRM1: an unnamed wall takes the class map's guess — which is 'external' for every IfcWall",
+      n["w3"]["code"] == "2.6" and n["w3"]["basis"] == "class_map", n["w3"])
+
+# --- 6. the plan is explicit, and refuses loudly --------------------------------------------------------
+plan = ca.apply_plan(p["rows"], ["g1", "g3"], "masterformat")
+check("a plan is built for the accepted GUIDs only", plan["count"] == 2, plan["count"])
+check("  as ordinary set_classification recipe steps",
+      all(s["recipe"] == "set_classification" for s in plan["steps"]))
+check("  carrying the system's real name, not our key",
+      plan["steps"][0]["params"]["system"] == cls.CLASSIFICATIONS["masterformat"]["name"])
+check("  and the code from the row", plan["steps"][0]["params"]["code"] == "04 20 00")
+
+mixed = ca.apply_plan(p["rows"], ["g1", "g4", "g6", "ghost", "g1"], "masterformat")
+check("only the applicable one becomes a step", mixed["count"] == 1, mixed["count"])
+reasons = {s["guid"]: s["reason"] for s in mixed["skipped"]}
+check("  an unmapped element is skipped WITH a reason", "g4" in reasons)
+check("  an already-declared element is skipped, not double-tagged",
+      "already declared" in reasons.get("g6", ""), reasons.get("g6"))
+check("  a GUID not in the proposal set is skipped by name",
+      "not in the proposal set" in reasons.get("ghost", ""))
+check("  nothing is silently dropped: every rejected GUID is accounted for",
+      set(reasons) == {"g4", "g6", "ghost"}, sorted(reasons))
+check("  a duplicate accept does not produce two steps", mixed["count"] == 1)
+
+ed = ca.apply_plan(p["rows"], ["g1"], "masterformat", edition="2020")
+check("an edition rides through to the recipe", ed["steps"][0]["params"]["edition"] == "2020")
+
+# --- 7. read_declared walks the reference chain ----------------------------------------------------------
+class FakeEnt:
+    def __init__(self, kind, **kw):
+        self._kind = kind
+        self.__dict__.update(kw)
+
+    def is_a(self, other=None):
+        return self._kind if other is None else other == self._kind
+
+
+class FakeModel:
+    def __init__(self, rels):
+        self._rels = rels
+
+    def by_type(self, kind):
+        return self._rels if kind == "IfcRelAssociatesClassification" else []
+
+
+source = FakeEnt("IfcClassification", Name="MasterFormat")
+# A reference pointing at ANOTHER reference (a facet of a code) rather than straight at the source —
+# reading only one level reports system=None for every correctly-authored hierarchical code.
+parent_ref = FakeEnt("IfcClassificationReference", Identification="08", Name="Openings",
+                     ReferencedSource=source)
+leaf = FakeEnt("IfcClassificationReference", Identification="08 11 13", Name="Hollow Metal Doors",
+               ReferencedSource=parent_ref)
+obj = FakeEnt("IfcDoor", GlobalId="d1")
+got = ca.read_declared(FakeModel([FakeEnt("IfcRelAssociatesClassification",
+                                          RelatingClassification=leaf, RelatedObjects=[obj])]))
+check("read_declared walks up a reference chain to the owning IfcClassification",
+      got["d1"][0]["system"] == "MasterFormat", got)
+check("  and keeps the leaf's code", got["d1"][0]["code"] == "08 11 13")
+
+# A self-referencing chain is malformed input, not a reason to hang a whole-model scan.
+loop = FakeEnt("IfcClassificationReference", Identification="X", Name="loop")
+loop.ReferencedSource = loop
+looped = ca.read_declared(FakeModel([FakeEnt("IfcRelAssociatesClassification",
+                                             RelatingClassification=loop,
+                                             RelatedObjects=[FakeEnt("IfcWall", GlobalId="w9")])]))
+check("a self-referencing chain terminates instead of hanging the scan",
+      looped["w9"][0]["code"] == "X")
+
+# --- 8. an empty model ------------------------------------------------------------------------------------
+empty = ca.propose([], "masterformat", {})
+check("no elements is not a crash", empty["total"] == 0 and empty["classified_pct"] is None)
+check("  and the headline says so", "no elements" in empty["headline"])
+
+print()
+if FAILED:
+    print(f"classify_assist: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("classify_assist: all checks passed")

--- a/services/api/test_classify_route.py
+++ b/services/api/test_classify_route.py
@@ -1,0 +1,141 @@
+"""R22-CLASSIFY-AI over HTTP — against a real IFC, including one classified through the edit recipe.
+
+The engine is tested in `test_classify_assist.py` against dicts. What only a live app can show is
+the round trip that matters: propose a code, apply it through the ordinary `set_classification` edit
+recipe, re-read the model, and confirm the element now reads as **declared** — i.e. that what this
+module proposes and what the platform writes are the same thing, read back by a path that did not
+write them.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_classify_route.py
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_classify_route.db"
+os.environ["STORAGE_DIR"] = "./test_storage_classify_route"
+os.environ["IFC_DIR"] = "./test_ifc_classify_route"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_classify_route.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "data" / "src"))
+
+import ifcopenshell  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+from aec_data import edit_struct, massing  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+# A model shaped like an import: named walls that a keyword can read, and a proxy that nothing maps.
+tmp = Path(tempfile.gettempdir()) / "classify_route.ifc"
+massing.generate_blank_ifc(str(tmp), name="Classify Tower", storeys=1, storey_height=3.5)
+m = ifcopenshell.open(str(tmp))
+cmu = edit_struct.add_wall(m, (0.0, 0.0), (6.0, 0.0), height=3.0, storey="Level 1")
+m.by_guid(cmu).Name = "CMU Partition Type A"
+plain = edit_struct.add_wall(m, (0.0, 0.0), (0.0, 4.0), height=3.0, storey="Level 1")
+m.by_guid(plain).Name = "Wall-02"
+proxy = m.create_entity("IfcBuildingElementProxy", GlobalId=ifcopenshell.guid.new(), Name="Widget 12")
+m.write(str(tmp))
+
+with TestClient(app) as c:
+    c.headers.update({"X-User": "classify@test"})
+    pid = c.post("/projects", json={"name": "Classify Tower"}).json()["id"]
+
+    pre = c.get(f"/projects/{pid}/classify/coverage")
+    check("no source IFC → a 4xx, not a 500", 400 <= pre.status_code < 500, pre.status_code)
+
+    up = c.post(f"/projects/{pid}/source-ifc?publish=false",
+                files={"file": ("model.ifc", tmp.read_bytes(), "application/octet-stream")})
+    check("the model uploads", up.status_code == 200, up.text[:160])
+
+    cov = c.get(f"/projects/{pid}/classify/coverage")
+    check("GET /classify/coverage answers 200", cov.status_code == 200, cov.text[:200])
+    C = cov.json()
+    check("  an unclassified import reads as 0% classified", C["classified_pct"] == 0.0, C)
+    check("  which is the honest starting point, not the implicit 100% of a default bucket",
+          C["declared"] == 0 and C["total"] >= 3, C["total"])
+    check("  the proxy is counted as unmapped", C["unmapped"] >= 1, C["by_basis"])
+    check("  with a warning naming the estimate consequence",
+          "default bucket" in (C["unmapped_warning"] or ""))
+    check("  and the coverage response does not carry the full row set",
+          "rows" not in C, sorted(C))
+
+    props = c.get(f"/projects/{pid}/classify/proposals")
+    check("GET /classify/proposals answers 200", props.status_code == 200, props.text[:200])
+    P = props.json()
+    rows = {r["guid"]: r for r in P["rows"]}
+    check("  the CMU-named wall proposes unit masonry on its own name",
+          rows[cmu]["basis"] == "keyword" and rows[cmu]["code"] == "04 20 00", rows.get(cmu))
+    check("  the plainly-named wall falls to the class map at low confidence",
+          rows[plain]["basis"] == "class_map" and rows[plain]["confidence"] == "low",
+          rows.get(plain))
+    check("  the proxy gets no code at all",
+          rows[proxy.GlobalId]["basis"] == "unmapped" and rows[proxy.GlobalId]["code"] is None)
+
+    only = c.get(f"/projects/{pid}/classify/proposals?basis=unmapped").json()
+    check("filtering by basis works", {r["basis"] for r in only["rows"]} == {"unmapped"})
+    check("an unknown basis is a 422",
+          c.get(f"/projects/{pid}/classify/proposals?basis=vibes").status_code == 422)
+    check("an unknown system is a 422",
+          c.get(f"/projects/{pid}/classify/coverage?system=nonsense").status_code == 422)
+    uni = c.get(f"/projects/{pid}/classify/coverage?system=uniclass")
+    check("uniclass is refused with its standing reason", uni.status_code == 422
+          and "never guessed" in uni.text, uni.text[:120])
+
+    # Truncation must announce itself — a page that stops at the limit and says nothing reads as the
+    # whole set, and the whole set is precisely what a coverage exercise needs.
+    one = c.get(f"/projects/{pid}/classify/proposals?limit=1").json()
+    check("a truncated page says how many rows it did not show",
+          one["truncated"] is True and "further row" in one["truncation_note"], one.get("truncation_note"))
+
+    # --- the round trip -----------------------------------------------------------------------------
+    plan = c.post(f"/projects/{pid}/classify/plan",
+                  json={"accept": [cmu, plain, proxy.GlobalId], "system": "masterformat"})
+    check("POST /classify/plan answers 200", plan.status_code == 200, plan.text[:200])
+    PL = plan.json()
+    check("  the two classifiable walls become steps", PL["count"] == 2, PL["count"])
+    check("  and the proxy is skipped with a reason",
+          [s["guid"] for s in PL["skipped"]] == [proxy.GlobalId], PL["skipped"])
+    check("  the steps are ordinary set_classification recipes",
+          {s["recipe"] for s in PL["steps"]} == {"set_classification"})
+    check("an empty accept list is a 422",
+          c.post(f"/projects/{pid}/classify/plan", json={"accept": []}).status_code == 422)
+
+    applied = c.post(f"/projects/{pid}/edit/batch", json={"steps": PL["steps"], "publish": False})
+    check("the plan applies through the ordinary authoring path", applied.status_code == 200,
+          applied.text[:250])
+
+    # Re-read through read_declared — a path that did not write these — and confirm they now count.
+    after = c.get(f"/projects/{pid}/classify/coverage").json()
+    check("the applied codes now read back as DECLARED", after["declared"] == 2, after["by_basis"])
+    check("  so coverage rose, and only because the MODEL now says so",
+          after["classified_pct"] > C["classified_pct"], (C["classified_pct"], after["classified_pct"]))
+    rows2 = {r["guid"]: r for r in c.get(f"/projects/{pid}/classify/proposals").json()["rows"]}
+    check("  the CMU wall reads as declared with the code we proposed",
+          rows2[cmu]["basis"] == "declared" and rows2[cmu]["code"] == "04 20 00", rows2.get(cmu))
+    check("  the proxy is still unmapped — nothing was invented for it",
+          rows2[proxy.GlobalId]["basis"] == "unmapped")
+
+    replan = c.post(f"/projects/{pid}/classify/plan",
+                    json={"accept": [cmu], "system": "masterformat"}).json()
+    check("re-accepting an already-declared element is refused, not double-tagged",
+          replan["count"] == 0 and "already declared" in replan["skipped"][0]["reason"],
+          replan["skipped"])
+
+print()
+if FAILED:
+    print(f"classify_route: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("classify_route: all checks passed")

--- a/services/api/test_classify_route.py
+++ b/services/api/test_classify_route.py
@@ -47,6 +47,10 @@ m.by_guid(cmu).Name = "CMU Partition Type A"
 plain = edit_struct.add_wall(m, (0.0, 0.0), (0.0, 4.0), height=3.0, storey="Level 1")
 m.by_guid(plain).Name = "Wall-02"
 proxy = m.create_entity("IfcBuildingElementProxy", GlobalId=ifcopenshell.guid.new(), Name="Widget 12")
+# An opening is a void — nothing to classify or price. `qto.py` skips openings at both of its call
+# sites, so if this one landed in the coverage denominator the figure would disagree with the
+# takeoff's about what the model contains.
+opening = m.create_entity("IfcOpeningElement", GlobalId=ifcopenshell.guid.new(), Name="Door void")
 m.write(str(tmp))
 
 with TestClient(app) as c:
@@ -67,6 +71,10 @@ with TestClient(app) as c:
     check("  which is the honest starting point, not the implicit 100% of a default bucket",
           C["declared"] == 0 and C["total"] >= 3, C["total"])
     check("  the proxy is counted as unmapped", C["unmapped"] >= 1, C["by_basis"])
+    # Assert the property, not a hand-counted total — the blank model also carries a ground-reference
+    # slab, and hardcoding "3" here just encoded my own miscount of the fixture.
+    check("  the basis counts still add up to the total",
+          sum(C["by_basis"].values()) == C["total"], (C["by_basis"], C["total"]))
     check("  with a warning naming the estimate consequence",
           "default bucket" in (C["unmapped_warning"] or ""))
     check("  and the coverage response does not carry the full row set",
@@ -83,6 +91,10 @@ with TestClient(app) as c:
           rows.get(plain))
     check("  the proxy gets no code at all",
           rows[proxy.GlobalId]["basis"] == "unmapped" and rows[proxy.GlobalId]["code"] is None)
+    check("  the IfcOpeningElement is absent entirely — a void is not classifiable",
+          opening.GlobalId not in rows, sorted(r["ifc_class"] for r in P["rows"]))
+    check("  and no opening appears under any basis",
+          not any(r["ifc_class"] == "IfcOpeningElement" for r in P["rows"]))
 
     only = c.get(f"/projects/{pid}/classify/proposals?basis=unmapped").json()
     check("filtering by basis works", {r["basis"] for r in only["rows"]} == {"unmapped"})


### PR DESCRIPTION
Ring item **R22-CLASSIFY-AI** (competitive gap ring, Tier 2, ⭐): *"assisted classification of imported IFC. We have a canonical discipline tree and a rule that a Uniclass code is never guessed — correct, and it means a client's unclassified model (which is nearly every real model) gets nothing."*

Backend only — no `apps/web` files touched.

## Checking the premise turned up the more interesting half

`classification.classify(ifc_class, system)` returns a `(code, title)` tuple for **any** input. When the class is not in the system's map it returns the **default bucket** — MasterFormat `01 00 00 General Requirements`, NRM1 `0 Facilitating works` — and the return type cannot express the difference.

A model we author is full of classes that *are* in the map, so this never shows. An imported model is full of `IfcBuildingElementProxy`, and every one of those elements prices as General Requirements while the estimate reports a complete takeoff. Nothing is missing, nothing errors, and the number is wrong.

That is the same shape as the `get_area` defect: a fault that only fires on one *provenance* of model, so the everyday path never catches it. There the provenance was models we authored; here it is **imported**, which is nearly every real client model.

## So the first deliverable is a coverage figure that can be believed

`classified_pct` counts **only what the model declares** via `IfcRelAssociatesClassification`. Derived codes are proposals and never raise it — a percentage that included our own guesses would measure the guessing, not the model. **0% on a client import is the true starting point of a cost exercise**, and more useful than the implicit 100% you get today.

## Second: proposals that carry their evidence

Four ranked bases, each saying what kind of claim it is:

| basis | what it means |
|---|---|
| `declared` | the model asserts it. Not a proposal. |
| `keyword` | the element's **own name** determines the code ("CMU Partition" → unit masonry). Specific to this element. |
| `class_map` | the IFC class is in the published map. True of the **class**, so identical for every element of that class — *including the ones it is wrong for*. NRM1 maps `IfcWall` to **external walls**; an interior wall exported as plain `IfcWall` gets the external code, and nothing about the derivation knows that. Low confidence, and the evidence string says so. |
| `unmapped` | no entry. **The case the current code hides** — reported as a gap, with the bucket it would otherwise have been given named in the evidence. |

**Uniclass and OmniClass are refused outright**, with the standing reason. The tables here are published IFC-class maps, which is a different thing from inferring a Uniclass reference from a name. A refusal with a reason, not an empty result — an empty result reads as "nothing to classify".

**Nothing is written by reading it.** `/classify/plan` turns an *explicit* list of accepted GUIDs into ordinary `set_classification` recipe steps for the caller to apply. A classification that appeared on elements because somebody opened a report is indistinguishable, a week later, from one a quantity surveyor decided. Anything unapplicable comes back in `skipped` **with a reason** rather than being dropped.

## A defect in my own first draft, worth recording

The system-name matcher did substring comparison in both directions, so the display name `"CSI MasterFormat (US/CA)"` contributed the fragment `"us"` and a model declaring **"AusSpec" matched MasterFormat**. A wrong system match is worse than no match — it reports an element as classified under a standard it never was. Now an exact match against an explicit alias list, asserted in both directions.

## Routes

```
GET  /projects/{pid}/classify/coverage?system=
GET  /projects/{pid}/classify/proposals?system=&basis=&limit=
POST /projects/{pid}/classify/plan
```

## Verification

- 47 engine checks + 30 HTTP checks green
- The HTTP set drives the full round trip against a real IFC: **propose → apply through `/edit/batch` → re-read → assert the element now reads as `declared`** — i.e. that what this proposes and what the platform writes are the same thing, read back by a path that did not write them. That round trip is also what caught the endpoint being `/edit/batch`, not the `/edit-batch` my first draft cited in its own note.
- `ruff check src/ ../data/src/` clean (the CI invocation)
- `route_authz` (683 routes), `reachable`, `route_order`, `classification`, `engines` pass
- No new module and no new table, so no Alembic revision is needed here

## Not included, deliberately

Version bump, CHANGELOG and roadmap entries — the files that conflict. Left for merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)