### PR TITLE
R23-RECIPE-ARTIFACT — record the inputs, or there is no timeline

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -24,6 +24,8 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
          "test_contracts", "test_reports", "test_esign", "test_publish_status", "test_schedule_alerts",
          "test_schedule_optimize",
+         # R23-RECIPE-ARTIFACT — the edit-recipe log + its routes:
+         "test_recipe_log", "test_recipe_route",
          "test_bundle", "test_desktop", "test_localmode", "test_project_budget", "test_rvt_bridge",
          "test_bcf", "test_engines", "test_edge_cases", "test_opendata", "test_financials", "test_money", "test_leasemgmt", "test_changeorders",
          "test_migrate", "test_alembic_migrations", "test_appraisal", "test_marketing", "test_workflow_gate", "test_due_feed", "test_directory",

--- a/services/api/src/aec_api/main.py
+++ b/services/api/src/aec_api/main.py
@@ -60,6 +60,7 @@ from .routers import (
     proforma,
     properties,
     realestate,
+    recipes,
     reports,
     research,
     responsibility,
@@ -396,6 +397,7 @@ app.include_router(modules.router, tags=["modules"])
 app.include_router(cost.router, tags=["cost"])
 app.include_router(contracts.router, tags=["contracts"])
 app.include_router(reports.router, tags=["reports"])
+app.include_router(recipes.router, tags=["recipes"])
 app.include_router(schedule.router, tags=["schedule"])
 app.include_router(site.router, tags=["site"])
 app.include_router(bidding.router, tags=["bidding"])

--- a/services/api/src/aec_api/recipe_log.py
+++ b/services/api/src/aec_api/recipe_log.py
@@ -1,0 +1,265 @@
+"""R23-RECIPE-ARTIFACT — the edit-recipe log as a first-class, replayable artifact.
+
+**The ring entry's premise needed correcting before this could be built.** It reads: *"make the
+edit-recipe log first-class: versioned, diffable, exportable, replayable against a fresh IFC. It
+already IS a CAD operation timeline; formalising it serves provenance, the as-built audit trail, and
+AI consumption in one move."*
+
+There was no timeline to formalise. What existed was two things, neither of which is one:
+
+* `edit_history.json` — a stack of **file paths** for undo/redo. No recipe, no parameters, no actor,
+  no time. Restoring a prior path is all it has to do, and it does that.
+* the audit log — one row per edit. `/edit` records `detail=result`, which is the recipe's
+  **outputs**; `/edit/batch` records `[s["recipe"] for s in steps]`, the recipe **names**.
+
+So the *inputs* were nowhere. Every capability the item asks for depends on them: you cannot replay
+an operation you did not record the arguments to, cannot diff two edits whose arguments you never
+kept, and cannot export a provenance trail that says only "something called add_wall happened".
+
+This module records the missing half. Each entry is what would have to be true to re-run the edit on
+a different file: the recipe, its parameters, who ran it, when, the source it ran against and the
+source it produced, and the outputs it claimed.
+
+**Parameters are recorded, and parameters can be large.** A mesh recipe carries vertex arrays;
+`map_properties` carries a whole rule set. An unbounded log turns a sidecar JSON into something that
+has to be paged in on every read. So a parameter value over `_MAX_VALUE` bytes is replaced by a
+descriptor — its type, size and a hash — and the entry is marked `params_elided`. A replay of an
+elided entry is **refused**, not attempted with the descriptor: the point of the log is that a replay
+either reproduces the edit or says it cannot.
+
+**Replay is a plan, not an execution.** `replay_plan()` returns the steps in order for the caller to
+apply through the existing `/edit/batch` path. Re-running edits is exactly the kind of thing that
+should have one author and one audit row, and a log that could re-run itself would have neither.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from . import pid_lock, storage
+
+#: Entries kept per project. The undo stack keeps 50; this keeps more because it is a provenance
+#: record rather than a working stack, but it is still bounded — an unbounded sidecar is a slow leak.
+_MAX = 500
+
+#: Serialized size above which a single parameter VALUE is elided. 8 KB comfortably holds a rule set
+#: or a point list, and excludes the mesh arrays that would otherwise dominate the file.
+_MAX_VALUE = 8192
+
+LOG_VERSION = 1
+
+
+def _key(pid: str) -> str:
+    return f"{storage.safe_seg(pid)}/recipe_log.json"
+
+
+def _locked(fn):
+    """Serialize load→mutate→save per project — same rationale as `edit_history._locked`."""
+    import functools
+
+    @functools.wraps(fn)
+    def wrap(pid, *a, **k):
+        with pid_lock.mutating(pid):
+            return fn(pid, *a, **k)
+    return wrap
+
+
+def _load(pid: str) -> dict:
+    try:
+        d = json.loads(storage.get(_key(pid)).decode("utf-8"))
+        return {"version": d.get("version", LOG_VERSION), "entries": list(d.get("entries") or [])}
+    except Exception:  # noqa: BLE001 — no log yet / unreadable → empty, never fatal
+        return {"version": LOG_VERSION, "entries": []}
+
+
+def _save(pid: str, d: dict) -> None:
+    storage.put(_key(pid), json.dumps(d).encode("utf-8"))
+
+
+def _digest(raw: bytes) -> str:
+    return "sha256:" + hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _shrink(params: Any) -> tuple[Any, bool]:
+    """Params with over-large values replaced by descriptors. Returns (params, elided?).
+
+    A descriptor keeps what a reader needs to recognise the value — its type, its length and a hash —
+    without keeping the value. It is deliberately NOT a truncation: half a vertex array looks like a
+    vertex array and would invite somebody to use it.
+    """
+    if not isinstance(params, dict):
+        return params, False
+    out: dict[str, Any] = {}
+    elided = False
+    for k, v in params.items():
+        try:
+            # STRICT dumps, no `default=`. With a fallback encoder this never raises — every value
+            # "serializes" — so a value that cannot round-trip would be stored as-is and then fail in
+            # `_save`, where `append_safe` swallows it and the WHOLE entry is silently lost. Eliding
+            # one parameter is a gap you can see; losing the entry is a gap you cannot.
+            raw = json.dumps(v).encode("utf-8")
+        except (TypeError, ValueError):
+            out[k] = {"__elided__": True, "type": type(v).__name__, "reason": "not JSON-serializable"}
+            elided = True
+            continue
+        if len(raw) > _MAX_VALUE:
+            out[k] = {"__elided__": True, "type": type(v).__name__, "bytes": len(raw),
+                      "length": len(v) if isinstance(v, (list, tuple, str, dict)) else None,
+                      "hash": _digest(raw)}
+            elided = True
+        else:
+            out[k] = v
+    return out, elided
+
+
+def entry(recipe: str, params: dict | None, *, actor: str | None, source_in: str | None,
+          source_out: str | None, outputs: Any = None, batch: str | None = None,
+          at: str | None = None) -> dict[str, Any]:
+    """Build one log entry. Pure — separated from `record` so it can be tested without storage."""
+    shrunk, elided = _shrink(params or {})
+    e: dict[str, Any] = {
+        "recipe": recipe,
+        "params": shrunk,
+        "params_elided": elided,
+        "actor": actor,
+        "at": at or datetime.now(timezone.utc).isoformat(),
+        # Basenames, not full paths: the log is exported and read elsewhere, and a server filesystem
+        # layout is neither useful to the reader nor something to hand out.
+        "source_in": _base(source_in),
+        "source_out": _base(source_out),
+        "outputs": outputs,
+    }
+    if batch:
+        e["batch"] = batch
+    return e
+
+
+def _base(path: str | None) -> str | None:
+    if not path:
+        return None
+    return str(path).replace("\\", "/").rsplit("/", 1)[-1]
+
+
+@_locked
+def record(pid: str, entries: list[dict[str, Any]]) -> int:
+    """Append entries. Returns the number stored.
+
+    Callers wrap this in a try/except: a provenance record that can break an edit is a worse trade
+    than a provenance record with a gap in it. `append_safe` does that wrapping so no call site has
+    to remember."""
+    if not entries:
+        return 0
+    d = _load(pid)
+    d["entries"] = (d["entries"] + list(entries))[-_MAX:]
+    _save(pid, d)
+    return len(entries)
+
+
+def append_safe(pid: str, entries: list[dict[str, Any]]) -> None:
+    """Fail-open `record`. The edit has already happened and been committed by the time this runs;
+    raising here would turn a logging fault into a failed edit that in fact succeeded."""
+    try:
+        record(pid, entries)
+    except Exception:  # noqa: BLE001 — see docstring; a gap in the log beats a false failure
+        import logging
+        logging.getLogger("aec").warning("recipe_log: could not record %d entry(ies) for %s",
+                                         len(entries), pid, exc_info=True)
+
+
+def log(pid: str, *, limit: int = 200, offset: int = 0, recipe: str | None = None) -> dict[str, Any]:
+    """The log, newest first."""
+    d = _load(pid)
+    rows = list(reversed(d["entries"]))
+    if recipe:
+        rows = [r for r in rows if r.get("recipe") == recipe]
+    total = len(rows)
+    page = rows[max(0, offset): max(0, offset) + max(1, limit)]
+    return {
+        "version": d["version"], "total": total, "returned": len(page),
+        "offset": max(0, offset), "entries": page,
+        "recipes": sorted({r.get("recipe") for r in d["entries"] if r.get("recipe")}),
+        "elided": sum(1 for r in d["entries"] if r.get("params_elided")),
+        "bounded_at": _MAX,
+        "note": (f"the log keeps the most recent {_MAX} entries; older edits have been dropped"
+                 if len(d["entries"]) >= _MAX else None),
+    }
+
+
+def diff(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
+    """What changed between two entries — which parameters differ, and how.
+
+    Only meaningful for two runs of the SAME recipe, and that is asserted rather than assumed: the
+    parameter names of `add_wall` and `set_pset` have nothing to say to each other, and a key-by-key
+    comparison across them would report every field as changed and mean nothing.
+    """
+    if a.get("recipe") != b.get("recipe"):
+        return {"comparable": False,
+                "reason": f"different recipes ({a.get('recipe')!r} vs {b.get('recipe')!r}) — their "
+                          "parameters are not the same vocabulary, so a field-level diff would be "
+                          "noise rather than information"}
+    pa, pb = a.get("params") or {}, b.get("params") or {}
+    keys = sorted(set(pa) | set(pb))
+    changed = [{"param": k, "before": pa.get(k), "after": pb.get(k)}
+               for k in keys if pa.get(k) != pb.get(k)]
+    return {
+        "comparable": True, "recipe": a.get("recipe"),
+        "changed": changed, "unchanged": [k for k in keys if pa.get(k) == pb.get(k)],
+        "identical": not changed,
+        "elided": bool(a.get("params_elided") or b.get("params_elided")),
+        "elided_warning": ("one or both entries have elided parameters; a value replaced by a "
+                           "descriptor compares by hash, so an unchanged descriptor means the value "
+                           "was identical but a changed one only means it differed")
+                          if (a.get("params_elided") or b.get("params_elided")) else None,
+    }
+
+
+class ReplayError(ValueError):
+    """The log cannot produce a faithful replay, and will not produce an unfaithful one."""
+
+
+def replay_plan(entries: list[dict[str, Any]], *, indices: list[int] | None = None) -> dict[str, Any]:
+    """Ordered `{recipe, params}` steps for `/edit/batch`.
+
+    Refuses on any entry whose parameters were elided. The alternative — replaying with the
+    descriptor in place of the value — produces a recipe call that looks like the original and is
+    not, which is the one outcome a provenance feature must never produce. Refusing names the
+    entries, so the caller knows which edits cannot be reproduced and why.
+    """
+    picked = entries if indices is None else [entries[i] for i in indices
+                                              if 0 <= i < len(entries)]
+    if indices is not None and len(picked) != len(indices):
+        raise ReplayError("one or more indices are outside the log")
+    if not picked:
+        raise ReplayError("nothing to replay")
+    bad = [i for i, e in enumerate(picked) if e.get("params_elided")]
+    if bad:
+        names = ", ".join(f"#{i} {picked[i].get('recipe')}" for i in bad)
+        raise ReplayError(
+            f"{len(bad)} entry(ies) have elided parameters and cannot be replayed faithfully: {names}. "
+            "Replaying them with the stored descriptor would call the recipe with something that "
+            "resembles the original argument and is not it")
+    return {
+        "steps": [{"recipe": e["recipe"], "params": e.get("params") or {}} for e in picked],
+        "count": len(picked),
+        "note": "apply with POST /projects/{pid}/edit/batch — one version, one audit row, one author. "
+                "This module does not execute; a replay should have an author the same way the "
+                "original edit did",
+    }
+
+
+def export(pid: str) -> dict[str, Any]:
+    """The whole log as a portable document, oldest first — the provenance artifact.
+
+    Oldest-first because this is meant to be read as a sequence of operations, and because that is
+    the order `replay_plan` needs. `log()` is newest-first because that is the order a person reads a
+    history in. The two orders are deliberate and are each stated in the payload."""
+    d = _load(pid)
+    return {
+        "version": d["version"], "project": pid, "order": "oldest_first",
+        "count": len(d["entries"]), "entries": d["entries"],
+        "elided": sum(1 for r in d["entries"] if r.get("params_elided")),
+        "replayable": all(not r.get("params_elided") for r in d["entries"]),
+        "bounded_at": _MAX,
+    }

--- a/services/api/src/aec_api/recipe_log.py
+++ b/services/api/src/aec_api/recipe_log.py
@@ -30,6 +30,16 @@ either reproduces the edit or says it cannot.
 **Replay is a plan, not an execution.** `replay_plan()` returns the steps in order for the caller to
 apply through the existing `/edit/batch` path. Re-running edits is exactly the kind of thing that
 should have one author and one audit row, and a log that could re-run itself would have neither.
+
+**The storage ceiling, stated so it is a decision rather than a surprise.** `_MAX` (500 entries) ×
+`_MAX_ENTRY` (256 KB) = **~131 MB** worst case per project, and `_load()` re-parses the whole file on
+every edit, so that figure is also the ceiling on per-edit cost. It is bounded, which the first
+version was not (an unbounded params dict measured 602 MB), but bounded is not the same as small.
+Reaching it takes an editor posting maximum-size parameters on 500 consecutive edits; a realistic log
+is a few hundred bytes per entry. The cap is kept at 256 KB rather than lowered because a smaller one
+elides legitimate parameters, and every elision is a replay this module can no longer reproduce —
+which is the capability it exists to provide. If that trade ever looks wrong, lower `_MAX_ENTRY`
+first: it costs fidelity on large edits, whereas lowering `_MAX` costs history outright.
 """
 from __future__ import annotations
 
@@ -159,7 +169,12 @@ def _redact_names(value: Any, _depth: int = 0) -> tuple[Any, bool]:
     depth should cost a stub, not a RecursionError inside an edit that has already succeeded.
     """
     if _depth > 12:
-        return value, False
+        # FAIL CLOSED. Returning the sub-tree verbatim here meant a credential nested 13 deep was
+        # stored in the clear — and the deeper it was buried the safer it was from the scrubber,
+        # which is precisely backwards for a guard whose job is to not persist secrets. The stub
+        # also marks the entry elided, so `replay_plan` refuses it like every other elision path.
+        return {"__elided__": True, "type": type(value).__name__,
+                "reason": "beyond the maximum nesting depth the denylist can scan"}, True
     if isinstance(value, dict):
         out: dict[Any, Any] = {}
         hit = False

--- a/services/api/src/aec_api/recipe_log.py
+++ b/services/api/src/aec_api/recipe_log.py
@@ -112,7 +112,14 @@ def _load(pid: str) -> dict:
     except Exception as e:  # noqa: BLE001 — exists() said yes and get() failed: do not assume empty
         raise LogUnreadable(f"the recipe log for {pid} exists but could not be read: {e}") from e
     if not raw:
-        return {"version": LOG_VERSION, "entries": []}
+        # A present-but-EMPTY file is unreadable, not absent. Zero bytes is the single most likely
+        # physical corruption signature — an interrupted write, a disk-full flush, a container killed
+        # mid-put — so treating it as "no log yet" would leave the destructive path open in exactly
+        # the case the rest of this function exists to close. `_save` always writes at least
+        # `{"version":1,"entries":[]}`, so a log that was ever written is never legitimately empty.
+        raise LogUnreadable(
+            f"the recipe log for {pid} exists but is empty (0 bytes) — most likely an interrupted "
+            "write. It has NOT been overwritten; the file is on disk and can be inspected by hand.")
     try:
         d = json.loads(raw.decode("utf-8"))
     except Exception as e:  # noqa: BLE001
@@ -133,6 +140,48 @@ def _digest(raw: bytes) -> str:
     return "sha256:" + hashlib.sha256(raw).hexdigest()[:16]
 
 
+def _credential_stub(v: Any) -> dict[str, Any]:
+    return {"__elided__": True, "type": type(v).__name__,
+            "reason": "parameter name looks like a credential; the log is exportable"}
+
+
+def _redact_names(value: Any, _depth: int = 0) -> tuple[Any, bool]:
+    """Apply the credential-name denylist at EVERY level, not just the top.
+
+    The denylist exists for "the recipe nobody has written yet", and anything structured enough to
+    carry a credential tends to nest — `{"config": {"api_key": ...}}` is a more plausible shape for
+    such a recipe than a flat top-level key. Walking only the top level meant the regex never saw it.
+
+    Size elision stays top-level on purpose: it is about bytes, and a top-level value's serialized
+    length already accounts for its children. This pass is about NAMES.
+
+    Depth-capped rather than trusted: params arrive from a request body, and a pathological nesting
+    depth should cost a stub, not a RecursionError inside an edit that has already succeeded.
+    """
+    if _depth > 12:
+        return value, False
+    if isinstance(value, dict):
+        out: dict[Any, Any] = {}
+        hit = False
+        for k, v in value.items():
+            if _SENSITIVE_KEY.search(str(k)):
+                out[k] = _credential_stub(v)
+                hit = True
+                continue
+            nv, sub = _redact_names(v, _depth + 1)
+            out[k] = nv
+            hit = hit or sub
+        return out, hit
+    if isinstance(value, (list, tuple)):
+        items, hit = [], False
+        for v in value:
+            nv, sub = _redact_names(v, _depth + 1)
+            items.append(nv)
+            hit = hit or sub
+        return items, hit
+    return value, False
+
+
 def _shrink(params: Any) -> tuple[Any, bool]:
     """Params with over-large values replaced by descriptors. Returns (params, elided?).
 
@@ -146,10 +195,12 @@ def _shrink(params: Any) -> tuple[Any, bool]:
     elided = False
     for k, v in params.items():
         if _SENSITIVE_KEY.search(str(k)):
-            out[k] = {"__elided__": True, "type": type(v).__name__,
-                      "reason": "parameter name looks like a credential; the log is exportable"}
+            out[k] = _credential_stub(v)
             elided = True
             continue
+        v, hit = _redact_names(v)
+        if hit:
+            elided = True
         try:
             # STRICT dumps, no `default=`. With a fallback encoder this never raises — every value
             # "serializes" — so a value that cannot round-trip would be stored as-is and then fail in
@@ -206,7 +257,15 @@ def _fit(e: dict[str, Any]) -> dict[str, Any]:
         candidates = [(len(json.dumps(v, default=str)), k) for k, v in params.items()
                       if not (isinstance(v, dict) and v.get("__elided__"))]
         if not candidates:
-            break                       # everything is already a descriptor; this is as small as it gets
+            # Out of values to elide and still over. Elision replaces VALUES, so an entry whose bulk
+            # is in its KEY NAMES (4000 keys of 200 chars is ~1.3 MB of pure keys) can never be
+            # brought under the cap this way. Replace `params` wholesale so the cap is a guarantee
+            # rather than a best effort — `replay_plan` already refuses elided entries, so nothing
+            # downstream is fooled by the substitution.
+            e["params"] = {"__elided__": True, "reason": "entry too large to store",
+                           "keys": len(params), "bytes": _size(e)}
+            e["params_elided"] = True
+            break
         _, worst = max(candidates)
         raw = json.dumps(params[worst], default=str).encode("utf-8")
         params[worst] = {"__elided__": True, "type": type(params[worst]).__name__,

--- a/services/api/src/aec_api/recipe_log.py
+++ b/services/api/src/aec_api/recipe_log.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from datetime import datetime, timezone
 from typing import Any
 
@@ -48,7 +49,32 @@ _MAX = 500
 #: or a point list, and excludes the mesh arrays that would otherwise dominate the file.
 _MAX_VALUE = 8192
 
+#: Serialized size above which the ENTRY is elided further, largest value first.
+#:
+#: `_MAX_VALUE` alone bounds each value and therefore bounds nothing: `params` comes off the request
+#: body, which is capped by `AEC_MAX_UPLOAD_MB` (1 GB by default), so 300 individually-small values
+#: of 4 KB each is a 1.2 MB entry that passes every per-value check with `params_elided=False`. At
+#: `_MAX` entries that is a ~600 MB sidecar, and `_load()` re-parses the whole file on EVERY edit —
+#: so the cost is not disk, it is that each subsequent edit on that project gets slower, permanently.
+_MAX_ENTRY = 262_144
+
+#: Parameter keys always elided regardless of size. No recipe in the registry takes a credential
+#: today; this is insurance against one that does, because `export()` hands the whole log out. Keyed
+#: on the NAME rather than on a recipe allowlist so it covers recipes nobody has written yet.
+_SENSITIVE_KEY = re.compile(r"secret|token|password|passwd|licen[cs]e|api[_-]?key|credential|private[_-]?key",
+                            re.I)
+
 LOG_VERSION = 1
+
+
+class LogUnreadable(RuntimeError):
+    """The log file exists but could not be parsed.
+
+    Distinct from "there is no log yet", and the distinction is the whole point: conflating them
+    meant a corrupt file read as an empty history, the next append wrote that empty history back, and
+    the prior entries were gone — silently, and with `record()` reporting success. For a provenance
+    artifact that is the worst available failure: it does not break, it just quietly becomes a
+    shorter history, and a reader concludes the project is young."""
 
 
 def _key(pid: str) -> str:
@@ -67,11 +93,36 @@ def _locked(fn):
 
 
 def _load(pid: str) -> dict:
+    """The stored log, or an empty one when there is genuinely nothing stored.
+
+    Raises `LogUnreadable` when the key EXISTS but does not parse. Returning an empty log there —
+    which is what a bare `except` did — makes the next `record()` append to nothing and `_save()`
+    overwrite the file, destroying every prior entry while reporting success. `storage.exists()`
+    distinguishes the two cases, so the destructive path is avoidable and therefore not acceptable.
+    """
+    key = _key(pid)
     try:
-        d = json.loads(storage.get(_key(pid)).decode("utf-8"))
-        return {"version": d.get("version", LOG_VERSION), "entries": list(d.get("entries") or [])}
-    except Exception:  # noqa: BLE001 — no log yet / unreadable → empty, never fatal
+        present = storage.exists(key)
+    except Exception:  # noqa: BLE001 — a backend that cannot answer is treated as "unknown", below
+        present = True
+    if not present:
         return {"version": LOG_VERSION, "entries": []}
+    try:
+        raw = storage.get(key)
+    except Exception as e:  # noqa: BLE001 — exists() said yes and get() failed: do not assume empty
+        raise LogUnreadable(f"the recipe log for {pid} exists but could not be read: {e}") from e
+    if not raw:
+        return {"version": LOG_VERSION, "entries": []}
+    try:
+        d = json.loads(raw.decode("utf-8"))
+    except Exception as e:  # noqa: BLE001
+        raise LogUnreadable(
+            f"the recipe log for {pid} exists but is not valid JSON ({e}). It has NOT been "
+            "overwritten — the file is intact on disk and can be recovered by hand.") from e
+    if not isinstance(d, dict) or not isinstance(d.get("entries"), list):
+        raise LogUnreadable(
+            f"the recipe log for {pid} parsed but is not a log document. It has NOT been overwritten.")
+    return {"version": d.get("version", LOG_VERSION), "entries": list(d["entries"])}
 
 
 def _save(pid: str, d: dict) -> None:
@@ -94,6 +145,11 @@ def _shrink(params: Any) -> tuple[Any, bool]:
     out: dict[str, Any] = {}
     elided = False
     for k, v in params.items():
+        if _SENSITIVE_KEY.search(str(k)):
+            out[k] = {"__elided__": True, "type": type(v).__name__,
+                      "reason": "parameter name looks like a credential; the log is exportable"}
+            elided = True
+            continue
         try:
             # STRICT dumps, no `default=`. With a fallback encoder this never raises — every value
             # "serializes" — so a value that cannot round-trip would be stored as-is and then fail in
@@ -133,7 +189,38 @@ def entry(recipe: str, params: dict | None, *, actor: str | None, source_in: str
     }
     if batch:
         e["batch"] = batch
+    return _fit(e)
+
+
+def _fit(e: dict[str, Any]) -> dict[str, Any]:
+    """Elide the largest remaining parameters until the whole entry fits `_MAX_ENTRY`.
+
+    The per-value cap bounds one value; this bounds the record. Largest-first so the smallest number
+    of parameters is lost, and it always terminates: each pass removes the biggest remaining
+    un-elided value, and with none left the entry is a fixed set of small descriptors.
+    """
+    params = e.get("params")
+    if not isinstance(params, dict):
+        return e
+    while _size(e) > _MAX_ENTRY:
+        candidates = [(len(json.dumps(v, default=str)), k) for k, v in params.items()
+                      if not (isinstance(v, dict) and v.get("__elided__"))]
+        if not candidates:
+            break                       # everything is already a descriptor; this is as small as it gets
+        _, worst = max(candidates)
+        raw = json.dumps(params[worst], default=str).encode("utf-8")
+        params[worst] = {"__elided__": True, "type": type(params[worst]).__name__,
+                         "bytes": len(raw), "hash": _digest(raw),
+                         "reason": f"entry exceeded {_MAX_ENTRY} bytes"}
+        e["params_elided"] = True
     return e
+
+
+def _size(e: dict[str, Any]) -> int:
+    try:
+        return len(json.dumps(e, default=str).encode("utf-8"))
+    except (TypeError, ValueError):
+        return 0                        # unserializable cannot be measured; _shrink already handled it
 
 
 def _base(path: str | None) -> str | None:

--- a/services/api/src/aec_api/routers/authoring.py
+++ b/services/api/src/aec_api/routers/authoring.py
@@ -619,8 +619,13 @@ def edit(pid: str, recipe: str = Body(...), params: dict = Body(default={}),
             raise HTTPException(403, str(e)) from e
         except (ValueError, KeyError) as e:            # E8 guard rejection / sandbox reject / missing param
             raise HTTPException(400, str(e)) from e
-        from .. import edit_history  # S4 — record the pre-edit version so this edit can be undone
+        from .. import (
+            edit_history,  # S4 — record the pre-edit version so this edit can be undone
+            recipe_log,  # R23 — record the recipe + PARAMS so this edit can be replayed
+        )
         edit_history.push(pid, p.source_ifc)
+        recipe_log.append_safe(pid, [recipe_log.entry(
+            recipe, params, actor=actor, source_in=p.source_ifc, source_out=out, outputs=result)])
         p.source_ifc = out  # new version becomes the source of truth
         audit.record(db, action="ifc.edit", actor=actor, method="POST",
                      path=f"/projects/{pid}/edit", detail=result)
@@ -701,6 +706,10 @@ def edit_batch(pid: str, steps: list[dict] = Body(...), publish: bool = Body(def
             raise HTTPException(400, str(e)) from e
         from .. import edit_history
         edit_history.push(pid, p.source_ifc)               # ONE undo entry for the whole batch
+        from .. import recipe_log
+        recipe_log.append_safe(pid, [recipe_log.entry(       # ...but one LOG entry per step: the
+            s.get("recipe"), s.get("params"), actor=actor,   # batch is one version, and it is also
+            source_in=p.source_ifc, source_out=out, batch=stamp) for s in steps])  # N operations
         p.source_ifc = out
         audit.record(db, action="ifc.edit_batch", actor=actor, method="POST",
                      path=f"/projects/{pid}/edit/batch",
@@ -793,6 +802,10 @@ def macros_run(pid: str, macro_id: str, args: dict = Body(default={}, embed=True
         except (ValueError, KeyError) as e:
             raise HTTPException(400, str(e)) from e
         edit_history.push(pid, p.source_ifc)                # ONE undo entry for the whole macro
+        from .. import recipe_log
+        recipe_log.append_safe(pid, [recipe_log.entry(
+            s.get("recipe"), s.get("params"), actor=actor, source_in=p.source_ifc,
+            source_out=out, batch=f"macro:{macro_id}") for s in steps])
         p.source_ifc = out
         audit.record(db, action="ifc.macro", actor=actor, method="POST",
                      path=f"/projects/{pid}/macros/{macro_id}/run",
@@ -861,8 +874,11 @@ async def content_import(pid: str, file: UploadFile = File(...), category: str =
         result = ed.apply_recipe(p.source_ifc, "place_content", params, out)
     except (ValueError, KeyError) as ex:
         raise HTTPException(400, str(ex)) from ex
-    from .. import edit_history
+    from .. import edit_history, recipe_log
     edit_history.push(pid, p.source_ifc)
+    recipe_log.append_safe(pid, [recipe_log.entry(
+        "place_content", params, actor=actor, source_in=p.source_ifc, source_out=out,
+        outputs=result)])
     p.source_ifc = out
     audit.record(db, action="content.import", actor=actor, method="POST",
                  path=f"/projects/{pid}/content/import", detail={"category": cat, "faces": len(faces)})

--- a/services/api/src/aec_api/routers/recipes.py
+++ b/services/api/src/aec_api/routers/recipes.py
@@ -16,6 +16,19 @@ from ..rbac import require_role
 router = APIRouter()
 
 
+def _guard(fn, *a, **k):
+    """Map an unreadable log to a 409 rather than a 500 — and say the file is intact.
+
+    The alternative the module used to have was to report an EMPTY log, which is worse than an
+    error: it reads as "this project has no history" and the next edit would have written that
+    emptiness back."""
+    try:
+        return fn(*a, **k)
+    except recipe_log.LogUnreadable as e:
+        raise HTTPException(409, str(e)) from e
+
+
+
 @router.get("/projects/{pid}/recipes/log")
 def recipe_log_read(pid: str, limit: int = Query(200, ge=1, le=2000), offset: int = Query(0, ge=0),
                     recipe: str | None = None,
@@ -26,7 +39,7 @@ def recipe_log_read(pid: str, limit: int = Query(200, ge=1, le=2000), offset: in
     The parameters are the part that did not exist before: the audit log records an edit's *outputs*
     and the undo stack records *file paths*, so nothing kept what an edit was actually asked to do.
     Without the inputs there is no replay, no diff and no provenance trail worth the name."""
-    return recipe_log.log(pid, limit=limit, offset=offset, recipe=recipe)
+    return _guard(recipe_log.log, pid, limit=limit, offset=offset, recipe=recipe)
 
 
 @router.get("/projects/{pid}/recipes/export")
@@ -37,7 +50,7 @@ def recipe_log_export(pid: str, db: Session = Depends(get_db),
     Oldest-first because it is meant to be read as a sequence of operations, and because that is the
     order a replay needs. `/recipes/log` is newest-first because that is the order a person reads a
     history in. Both orders are stated in their payloads rather than left to be discovered."""
-    return recipe_log.export(pid)
+    return _guard(recipe_log.export, pid)
 
 
 @router.get("/projects/{pid}/recipes/diff")
@@ -48,7 +61,7 @@ def recipe_log_diff(pid: str, a: int = Query(..., ge=0), b: int = Query(..., ge=
     Only meaningful for two runs of the same recipe, and that is checked rather than assumed — the
     parameter names of `add_wall` and `set_pset` are not the same vocabulary, and a key-by-key
     comparison across them would report every field as changed and mean nothing."""
-    entries = recipe_log.export(pid)["entries"]
+    entries = _guard(recipe_log.export, pid)["entries"]
     for i in (a, b):
         if i >= len(entries):
             raise HTTPException(404, f"entry {i} is outside the log ({len(entries)} entr(ies))")
@@ -68,7 +81,7 @@ def recipe_replay_plan(pid: str, indices: list[int] | None = Body(None, embed=Tr
     descriptor in place of the value would call the recipe with something that *resembles* the
     original argument and is not it, which is the one outcome a provenance feature must never
     produce. The refusal names the entries so the caller knows which edits cannot be reproduced."""
-    entries = recipe_log.export(pid)["entries"]
+    entries = _guard(recipe_log.export, pid)["entries"]
     try:
         return recipe_log.replay_plan(entries, indices=indices)
     except recipe_log.ReplayError as e:

--- a/services/api/src/aec_api/routers/recipes.py
+++ b/services/api/src/aec_api/routers/recipes.py
@@ -1,0 +1,75 @@
+"""R23-RECIPE-ARTIFACT — the edit-recipe log: read it, diff it, export it, replay it.
+
+Its own router rather than more of `authoring.py`, which is already the app's largest write surface.
+The capture side lives there (four call sites beside the existing `edit_history.push`); everything
+read-only lives here.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from .. import recipe_log
+from ..db import get_db
+from ..rbac import require_role
+
+router = APIRouter()
+
+
+@router.get("/projects/{pid}/recipes/log")
+def recipe_log_read(pid: str, limit: int = Query(200, ge=1, le=2000), offset: int = Query(0, ge=0),
+                    recipe: str | None = None,
+                    db: Session = Depends(get_db), _: str = Depends(require_role("viewer"))):
+    """The edit-recipe log, newest first — recipe, parameters, actor, time, and the source files it
+    ran between.
+
+    The parameters are the part that did not exist before: the audit log records an edit's *outputs*
+    and the undo stack records *file paths*, so nothing kept what an edit was actually asked to do.
+    Without the inputs there is no replay, no diff and no provenance trail worth the name."""
+    return recipe_log.log(pid, limit=limit, offset=offset, recipe=recipe)
+
+
+@router.get("/projects/{pid}/recipes/export")
+def recipe_log_export(pid: str, db: Session = Depends(get_db),
+                      _: str = Depends(require_role("viewer"))):
+    """The whole log as a portable document, **oldest first** — the provenance artifact.
+
+    Oldest-first because it is meant to be read as a sequence of operations, and because that is the
+    order a replay needs. `/recipes/log` is newest-first because that is the order a person reads a
+    history in. Both orders are stated in their payloads rather than left to be discovered."""
+    return recipe_log.export(pid)
+
+
+@router.get("/projects/{pid}/recipes/diff")
+def recipe_log_diff(pid: str, a: int = Query(..., ge=0), b: int = Query(..., ge=0),
+                    db: Session = Depends(get_db), _: str = Depends(require_role("viewer"))):
+    """Compare two log entries by their index in the export (oldest-first) order.
+
+    Only meaningful for two runs of the same recipe, and that is checked rather than assumed — the
+    parameter names of `add_wall` and `set_pset` are not the same vocabulary, and a key-by-key
+    comparison across them would report every field as changed and mean nothing."""
+    entries = recipe_log.export(pid)["entries"]
+    for i in (a, b):
+        if i >= len(entries):
+            raise HTTPException(404, f"entry {i} is outside the log ({len(entries)} entr(ies))")
+    return recipe_log.diff(entries[a], entries[b])
+
+
+@router.post("/projects/{pid}/recipes/replay-plan")
+def recipe_replay_plan(pid: str, indices: list[int] | None = Body(None, embed=True),
+                       db: Session = Depends(get_db), _: str = Depends(require_role("editor"))):
+    """Ordered `{recipe, params}` steps to re-run the logged edits against another model.
+
+    Returns a **plan**, and does not execute it. Re-running a sequence of authoring edits is exactly
+    the kind of thing that should carry one author and one audit row, and a log that could re-run
+    itself would carry neither — apply the steps through `POST /projects/{pid}/edit/batch`.
+
+    Refuses if any selected entry had parameters elided for size. Replaying with the stored
+    descriptor in place of the value would call the recipe with something that *resembles* the
+    original argument and is not it, which is the one outcome a provenance feature must never
+    produce. The refusal names the entries so the caller knows which edits cannot be reproduced."""
+    entries = recipe_log.export(pid)["entries"]
+    try:
+        return recipe_log.replay_plan(entries, indices=indices)
+    except recipe_log.ReplayError as e:
+        raise HTTPException(422, str(e)) from e

--- a/services/api/test_recipe_log.py
+++ b/services/api/test_recipe_log.py
@@ -12,11 +12,16 @@ cannot, never quietly call the recipe with something that resembles the original
 
 Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_recipe_log.py
 """
+import json
+import os
+import shutil
 import sys
 
+os.environ.setdefault("STORAGE_DIR", "./test_storage_recipe_log")
 sys.path.insert(0, "src")
 
 from aec_api import recipe_log as rl  # noqa: E402
+from aec_api import storage  # noqa: E402
 
 FAILED: list[str] = []
 
@@ -120,6 +125,78 @@ check("  and it says why rather than reporting every field as changed",
 edf = rl.diff(be, be)
 check("a diff touching an elided entry warns about what the comparison means",
       edf["elided"] is True and "compares by hash" in edf["elided_warning"])
+
+# --- 5. a corrupt log is NEVER silently replaced ------------------------------------------------------
+# Found by the security-audit session, reproduced here before fixing: `_load` caught bare Exception
+# and returned an empty log, so a file that existed but did not parse read as "no history". The next
+# `record()` then appended to that emptiness and `_save()` overwrote the file — 120 entries gone,
+# with `record` reporting SUCCESS and `append_safe` never firing. For a provenance artifact that is
+# the worst available failure: it does not break, it quietly becomes a shorter history.
+PID = "corrupt-test"
+shutil.rmtree(os.environ["STORAGE_DIR"], ignore_errors=True)
+rl.record(PID, [rl.entry("add_wall", {"i": i}, actor="a", source_in="a", source_out="b")
+                for i in range(120)])
+check("a log with 120 entries loads", len(rl._load(PID)["entries"]) == 120)
+
+storage.put(rl._key(PID), b"{ this is not valid json")
+try:
+    rl._load(PID)
+    check("a corrupt log RAISES rather than reading as empty", False, "no exception")
+except rl.LogUnreadable as e:
+    check("a corrupt log RAISES rather than reading as empty", True)
+    check("  and says the file was not overwritten", "NOT been overwritten" in str(e), str(e)[:120])
+
+# The behaviour that matters: an append must not be able to destroy it.
+rl.append_safe(PID, [rl.entry("add_column", {"p": 1}, actor="a", source_in="a", source_out="b")])
+check("append_safe on a corrupt log does not overwrite it",
+      storage.get(rl._key(PID)) == b"{ this is not valid json")
+check("  the edit still succeeds — append_safe swallows it, as designed", True)
+
+# An absent log is still an empty log, not an error. Absent and unreadable must stay distinguishable.
+shutil.rmtree(os.environ["STORAGE_DIR"], ignore_errors=True)
+check("an ABSENT log is empty, not an error", rl._load("never-written")["entries"] == [])
+
+# A file that parses but is not a log document is also refused.
+rl.record("shape-test", [rl.entry("x", {}, actor="a", source_in="a", source_out="b")])
+storage.put(rl._key("shape-test"), b'{"version": 1, "entries": "not a list"}')
+try:
+    rl._load("shape-test")
+    check("a parseable non-log document is refused", False, "no exception")
+except rl.LogUnreadable:
+    check("a parseable non-log document is refused", True)
+
+# --- 6. the ENTRY is bounded, not just each value ------------------------------------------------------
+# Also from the security audit: `_MAX_VALUE` bounds one value and therefore bounds nothing. `params`
+# comes off the request body (capped at AEC_MAX_UPLOAD_MB, 1 GB by default), so 300 individually
+# small values is a 1.2 MB entry that passes every per-value check — and `_load` re-parses the whole
+# sidecar on every edit, so the cost lands on every subsequent edit, permanently.
+many = {f"k{i}": "x" * 4000 for i in range(300)}       # each value 4 KB, all under _MAX_VALUE
+me = rl.entry("mesh", many, actor="a", source_in="a", source_out="b")
+size = len(json.dumps(me).encode("utf-8"))
+check("an entry of many small values is capped", size <= rl._MAX_ENTRY, f"{size:,} bytes")
+check("  and is marked elided", me["params_elided"] is True)
+check("  largest-first, so the fewest parameters are lost",
+      sum(1 for v in me["params"].values() if isinstance(v, dict) and v.get("__elided__")) < 300)
+check("  survivors are kept verbatim",
+      any(v == "x" * 4000 for v in me["params"].values()))
+check("  and the cap reason is stated on the elided ones",
+      any(isinstance(v, dict) and str(v.get("reason", "")).startswith("entry exceeded")
+          for v in me["params"].values()))
+check("a small entry is untouched by the cap", rl.entry(
+    "add_wall", {"start": [0, 0]}, actor="a", source_in="a", source_out="b")["params_elided"] is False)
+
+# --- 7. credential-looking parameters never reach the exportable log --------------------------------------
+sec = rl.entry("connect", {"api_key": "sk-live-123", "auth_token": "t", "PASSWORD": "p",
+                           "licence_key": "L", "host": "example.com"},
+               actor="a", source_in="a", source_out="b")
+for k in ("api_key", "auth_token", "PASSWORD", "licence_key"):
+    check(f"{k} is elided by name", sec["params"][k].get("__elided__") is True, sec["params"][k])
+check("  with the reason", "credential" in sec["params"]["api_key"]["reason"])
+check("  and the value is nowhere in the serialized entry",
+      "sk-live-123" not in json.dumps(sec))
+check("an ordinary parameter beside them is untouched", sec["params"]["host"] == "example.com")
+
+shutil.rmtree(os.environ["STORAGE_DIR"], ignore_errors=True)
 
 print()
 if FAILED:

--- a/services/api/test_recipe_log.py
+++ b/services/api/test_recipe_log.py
@@ -32,6 +32,14 @@ def check(label, ok, detail=""):
         FAILED.append(label)
 
 
+def _deep_nest(depth):
+    """A dict nested `depth` levels — for the recursion guard in the name denylist."""
+    node = {"leaf": 1}
+    for _ in range(depth):
+        node = {"n": node}
+    return node
+
+
 # --- 1. an entry keeps what a replay would need ---------------------------------------------------
 e = rl.entry("add_wall", {"start": [0, 0], "end": [6, 0], "height": 3.0},
              actor="ana@x", source_in="/srv/ifc/p1/model.ifc",
@@ -195,6 +203,80 @@ check("  with the reason", "credential" in sec["params"]["api_key"]["reason"])
 check("  and the value is nowhere in the serialized entry",
       "sk-live-123" not in json.dumps(sec))
 check("an ordinary parameter beside them is untouched", sec["params"]["host"] == "example.com")
+
+# --- 8. the second-order gaps, all three found by the audit after the first fix ---------------------------
+# 8a. A ZERO-BYTE file is the most likely physical corruption signature — an interrupted write, a
+# disk-full flush, a container killed mid-put. The first fix refused every malformed shape EXCEPT
+# this one, which is the one it was built for.
+shutil.rmtree(os.environ["STORAGE_DIR"], ignore_errors=True)
+rl.record("zero", [rl.entry("w", {"i": i}, actor="a", source_in="a", source_out="b")
+                   for i in range(50)])
+storage.put(rl._key("zero"), b"")
+try:
+    rl._load("zero")
+    check("a ZERO-BYTE log is refused, not read as absent", False, "no exception")
+except rl.LogUnreadable as e:
+    check("a ZERO-BYTE log is refused, not read as absent", True)
+    check("  and names the likely cause", "interrupted write" in str(e), str(e)[:120])
+rl.append_safe("zero", [rl.entry("c", {}, actor="a", source_in="a", source_out="b")])
+check("  an append cannot overwrite it", storage.get(rl._key("zero")) == b"")
+
+# Every malformed shape in the family now refuses. Asserted as a set so a future early-return
+# cannot quietly reopen one of them.
+shapes = {
+    "empty": b"",
+    "not-json": b"{ nope",
+    "json-list": b"[1,2,3]",
+    "json-string": b'"hello"',
+    "no-entries-key": b'{"version": 1}',
+    "entries-not-a-list": b'{"version": 1, "entries": "no"}',
+}
+refused = []
+for name, blob in shapes.items():
+    rl.record(f"s-{name}", [rl.entry("w", {}, actor="a", source_in="a", source_out="b")])
+    storage.put(rl._key(f"s-{name}"), blob)
+    try:
+        rl._load(f"s-{name}")
+    except rl.LogUnreadable:
+        refused.append(name)
+check("every malformed shape refuses, including the empty one",
+      sorted(refused) == sorted(shapes), sorted(set(shapes) - set(refused)))
+
+# 8b. The denylist has to reach NESTED keys. A future recipe carrying a credential is far more
+# likely to take a config blob than a flat top-level api_key.
+nested = rl.entry("connect", {"config": {"api_key": "SUPERSECRET-NESTED",
+                                         "inner": {"auth_token": "DEEPER"}},
+                              "servers": [{"password": "IN-A-LIST"}],
+                              "host": "example.com"},
+                  actor="a", source_in="a", source_out="b")
+blob = json.dumps(nested)
+for secret in ("SUPERSECRET-NESTED", "DEEPER", "IN-A-LIST"):
+    check(f"a nested {secret!r} never reaches the log", secret not in blob)
+check("  the nested key is stubbed, not dropped",
+      nested["params"]["config"]["api_key"].get("__elided__") is True)
+check("  a credential inside a LIST is caught too",
+      nested["params"]["servers"][0]["password"].get("__elided__") is True)
+check("  the entry is marked elided", nested["params_elided"] is True)
+check("  and ordinary nested values survive", nested["params"]["host"] == "example.com")
+check("pathological nesting costs a stub, not a RecursionError",
+      rl.entry("deep", {"a": _deep_nest(60)}, actor="a", source_in="a",
+               source_out="b")["params"] is not None)
+
+# 8c. The cap has to be total. Elision replaces VALUES, so an entry whose bulk is in its KEY NAMES
+# runs the loop out of candidates while still far over.
+keyheavy = rl.entry("x", {("k%04d" % i) + "y" * 200: 1 for i in range(4000)},
+                    actor="a", source_in="a", source_out="b")
+ksize = len(json.dumps(keyheavy).encode("utf-8"))
+check("an entry whose bulk is KEY NAMES is still capped", ksize <= rl._MAX_ENTRY, f"{ksize:,}")
+check("  params replaced wholesale, so the cap is a guarantee",
+      keyheavy["params"].get("__elided__") is True, keyheavy["params"])
+check("  reporting how many keys were dropped", keyheavy["params"]["keys"] == 4000)
+check("  and marked elided, so replay_plan refuses it", keyheavy["params_elided"] is True)
+try:
+    rl.replay_plan([keyheavy])
+    check("  replay refuses the wholesale-elided entry", False, "no exception")
+except rl.ReplayError:
+    check("  replay refuses the wholesale-elided entry", True)
 
 shutil.rmtree(os.environ["STORAGE_DIR"], ignore_errors=True)
 

--- a/services/api/test_recipe_log.py
+++ b/services/api/test_recipe_log.py
@@ -262,6 +262,30 @@ check("pathological nesting costs a stub, not a RecursionError",
       rl.entry("deep", {"a": _deep_nest(60)}, actor="a", source_in="a",
                source_out="b")["params"] is not None)
 
+# The depth cap must FAIL CLOSED. It first returned the sub-tree verbatim past the limit, so a
+# credential nested 13 deep was stored in the clear — and the deeper it was buried the safer it was
+# from the scrubber, which is backwards for a guard whose job is to not persist secrets. The
+# docstring said "should cost a stub"; the code cost the redaction instead.
+def _bury(depth, secret="DEEPSECRET"):
+    node = {"api_key": secret}
+    for _ in range(depth):
+        node = {"n": node}
+    return node
+
+
+for depth in (0, 1, 5, 11, 12, 13, 20, 40):
+    e = rl.entry("x", {"cfg": _bury(depth)}, actor="a", source_in="a", source_out="b")
+    check(f"a credential nested {depth} deep never reaches the log",
+          "DEEPSECRET" not in json.dumps(e))
+deep = rl.entry("x", {"cfg": _bury(20)}, actor="a", source_in="a", source_out="b")
+check("  past the depth cap the sub-tree is stubbed, not passed through",
+      deep["params_elided"] is True)
+try:
+    rl.replay_plan([deep])
+    check("  and replay refuses it, like every other elision path", False, "no exception")
+except rl.ReplayError:
+    check("  and replay refuses it, like every other elision path", True)
+
 # 8c. The cap has to be total. Elision replaces VALUES, so an entry whose bulk is in its KEY NAMES
 # runs the loop out of candidates while still far over.
 keyheavy = rl.entry("x", {("k%04d" % i) + "y" * 200: 1 for i in range(4000)},

--- a/services/api/test_recipe_log.py
+++ b/services/api/test_recipe_log.py
@@ -198,7 +198,12 @@ sec = rl.entry("connect", {"api_key": "sk-live-123", "auth_token": "t", "PASSWOR
                            "licence_key": "L", "host": "example.com"},
                actor="a", source_in="a", source_out="b")
 for k in ("api_key", "auth_token", "PASSWORD", "licence_key"):
-    check(f"{k} is elided by name", sec["params"][k].get("__elided__") is True, sec["params"][k])
+    # The failure detail is a BOOLEAN, never the value. CodeQL flagged the earlier version HIGH
+    # (py/clear-text-logging-sensitive-data at check()'s print): a dict keyed `api_key` is tainted as
+    # sensitive, and passing it as `detail` printed it on failure. A test asserting that secrets
+    # never reach a log must not print them when it fails — which is exactly when it would.
+    check(f"{k} is elided by name", sec["params"][k].get("__elided__") is True,
+          "not elided")
 check("  with the reason", "credential" in sec["params"]["api_key"]["reason"])
 check("  and the value is nowhere in the serialized entry",
       "sk-live-123" not in json.dumps(sec))

--- a/services/api/test_recipe_log.py
+++ b/services/api/test_recipe_log.py
@@ -1,0 +1,128 @@
+"""R23-RECIPE-ARTIFACT — the log has to record the INPUTS, and refuse when it cannot reproduce them.
+
+The ring entry says the edit-recipe log "already IS a CAD operation timeline" and needs formalising.
+It was not one. `edit_history.json` is a stack of file paths for undo; the audit log records an
+edit's *outputs* (`/edit`) or just the recipe *names* (`/edit/batch`). The **parameters were nowhere**,
+and every capability the item asks for — replay, diff, export — depends on them.
+
+So the tests below are about the inputs: that they are kept, that an over-large one is elided rather
+than truncated, and that a replay of an elided entry is **refused** rather than attempted with the
+descriptor. That last one is the whole discipline: a replay must either reproduce the edit or say it
+cannot, never quietly call the recipe with something that resembles the original argument.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_recipe_log.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api import recipe_log as rl  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+# --- 1. an entry keeps what a replay would need ---------------------------------------------------
+e = rl.entry("add_wall", {"start": [0, 0], "end": [6, 0], "height": 3.0},
+             actor="ana@x", source_in="/srv/ifc/p1/model.ifc",
+             source_out="/srv/ifc/p1/model_20260729.ifc", outputs={"guid": "abc"})
+check("the recipe is kept", e["recipe"] == "add_wall")
+check("the PARAMETERS are kept — the half that did not exist before",
+      e["params"] == {"start": [0, 0], "end": [6, 0], "height": 3.0}, e["params"])
+check("the actor is kept", e["actor"] == "ana@x")
+check("the outputs are kept alongside, not instead", e["outputs"] == {"guid": "abc"})
+check("it is timestamped", e["at"].startswith("20"))
+check("paths are reduced to basenames — a server layout is not the reader's business",
+      e["source_in"] == "model.ifc" and e["source_out"] == "model_20260729.ifc", e["source_in"])
+check("nothing is elided for an ordinary recipe", e["params_elided"] is False)
+
+# --- 2. a large value is elided, and the elision is legible ----------------------------------------
+big = {"verts": [float(i) for i in range(5000)], "name": "Mesh"}
+be = rl.entry("add_mesh_representation", big, actor="ana@x", source_in="a.ifc", source_out="b.ifc")
+check("an over-large value is elided", be["params_elided"] is True)
+check("  the small sibling parameter survives", be["params"]["name"] == "Mesh")
+d = be["params"]["verts"]
+check("  the elided value becomes a descriptor", d.get("__elided__") is True, d)
+check("  carrying its type, size and a hash", d["type"] == "list" and d["bytes"] > 8192 and d["hash"])
+check("  and its element count", d["length"] == 5000)
+check("  it is NOT a truncation — half a vertex array looks like a vertex array",
+      not isinstance(d, list))
+
+unserializable = rl.entry("weird", {"obj": object(), "ok": 1}, actor="a", source_in="a", source_out="b")
+check("a non-JSON-serializable value elides rather than raising",
+      unserializable["params"]["obj"].get("__elided__") is True
+      and unserializable["params_elided"] is True, unserializable["params"])
+check("  with the reason stated", unserializable["params"]["obj"]["reason"] == "not JSON-serializable")
+# The invariant that makes the elision worth doing: whatever `entry` returns must survive the trip
+# through storage. If a value slipped past `_shrink`, `_save` would raise, `append_safe` would
+# swallow it, and the WHOLE entry would vanish — a worse failure than eliding one parameter.
+import json as _json  # noqa: E402
+
+for label, ent in (("an ordinary entry", e), ("an elided entry", be),
+                   ("an unserializable-param entry", unserializable)):
+    try:
+        _json.dumps(ent)
+        check(f"{label} is JSON-serializable end to end", True)
+    except (TypeError, ValueError) as ex:
+        check(f"{label} is JSON-serializable end to end", False, ex)
+
+# --- 3. replay refuses what it cannot reproduce -----------------------------------------------------
+good = [rl.entry("add_wall", {"start": [0, 0], "end": [6, 0]}, actor="a", source_in="a", source_out="b"),
+        rl.entry("add_column", {"point": [2, 2]}, actor="a", source_in="b", source_out="c")]
+plan = rl.replay_plan(good)
+check("a clean log replays", plan["count"] == 2)
+check("  as ordered {recipe, params} steps",
+      [s["recipe"] for s in plan["steps"]] == ["add_wall", "add_column"])
+check("  with the original parameters", plan["steps"][0]["params"]["end"] == [6, 0])
+check("  and it is a PLAN, not an execution", "does not execute" in plan["note"])
+
+sel = rl.replay_plan(good, indices=[1])
+check("a subset can be selected", sel["count"] == 1 and sel["steps"][0]["recipe"] == "add_column")
+
+for label, arg, entries in (("an elided entry", None, good + [be]),
+                            ("an out-of-range index", [9], good),
+                            ("an empty selection", [], good)):
+    try:
+        rl.replay_plan(entries, indices=arg)
+        check(f"replay refuses {label}", False, "no exception")
+    except rl.ReplayError as ex:
+        check(f"replay refuses {label}", True)
+        if label == "an elided entry":
+            check("  naming the entry that cannot be reproduced",
+                  "add_mesh_representation" in str(ex), str(ex)[:100])
+            check("  and saying why the descriptor must not be substituted",
+                  "resembles the original" in str(ex), str(ex)[:160])
+
+# --- 4. diff compares like with like ------------------------------------------------------------------
+w1 = rl.entry("add_wall", {"start": [0, 0], "end": [6, 0], "height": 3.0}, actor="a",
+              source_in="a", source_out="b")
+w2 = rl.entry("add_wall", {"start": [0, 0], "end": [8, 0], "height": 3.0}, actor="a",
+              source_in="b", source_out="c")
+df = rl.diff(w1, w2)
+check("two runs of the same recipe are comparable", df["comparable"] is True)
+check("  only the changed parameter is reported",
+      [c["param"] for c in df["changed"]] == ["end"], df["changed"])
+check("  with before and after", df["changed"][0]["before"] == [6, 0]
+      and df["changed"][0]["after"] == [8, 0])
+check("  and the unchanged ones are named too", set(df["unchanged"]) == {"start", "height"})
+check("identical entries diff as identical", rl.diff(w1, w1)["identical"] is True)
+
+cross = rl.diff(w1, rl.entry("set_pset", {"guid": "g"}, actor="a", source_in="a", source_out="b"))
+check("two DIFFERENT recipes are not comparable", cross["comparable"] is False)
+check("  and it says why rather than reporting every field as changed",
+      "not the same vocabulary" in cross["reason"], cross["reason"])
+
+edf = rl.diff(be, be)
+check("a diff touching an elided entry warns about what the comparison means",
+      edf["elided"] is True and "compares by hash" in edf["elided_warning"])
+
+print()
+if FAILED:
+    print(f"recipe_log: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("recipe_log: all checks passed")

--- a/services/api/test_recipe_log.py
+++ b/services/api/test_recipe_log.py
@@ -255,8 +255,13 @@ nested = rl.entry("connect", {"config": {"api_key": "SUPERSECRET-NESTED",
                               "host": "example.com"},
                   actor="a", source_in="a", source_out="b")
 blob = json.dumps(nested)
-for secret in ("SUPERSECRET-NESTED", "DEEPER", "IN-A-LIST"):
-    check(f"a nested {secret!r} never reaches the log", secret not in blob)
+# The LABEL is printed on every run, not just on failure — so a secret interpolated into it is
+# logged unconditionally. This is where the HIGH alert actually lived; fixing only the `detail`
+# argument left it open, because `check()` prints both. Describe the case by position, never by value.
+for where, secret in (("in a nested dict", "SUPERSECRET-NESTED"),
+                      ("two dicts down", "DEEPER"),
+                      ("inside a list", "IN-A-LIST")):
+    check(f"a credential {where} never reaches the log", secret not in blob)
 check("  the nested key is stubbed, not dropped",
       nested["params"]["config"]["api_key"].get("__elided__") is True)
 check("  a credential inside a LIST is caught too",

--- a/services/api/test_recipe_route.py
+++ b/services/api/test_recipe_route.py
@@ -1,0 +1,186 @@
+"""R23-RECIPE-ARTIFACT over HTTP — the capture actually fires, and the replay actually reproduces.
+
+The engine is tested in `test_recipe_log.py`. What only a live app can show is whether the four
+capture hooks in `authoring.py` are on the paths edits really take, and — the assertion the whole
+item is for — whether replaying the logged steps against a *fresh* model produces the same building.
+
+That last one is the difference between a log and a provenance artifact. A log that records
+plausible-looking steps nobody has ever re-run is indistinguishable from one that works.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_recipe_route.py
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_recipe_route.db"
+os.environ["STORAGE_DIR"] = "./test_storage_recipe_route"
+os.environ["IFC_DIR"] = "./test_ifc_recipe_route"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_recipe_route.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "data" / "src"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+from aec_data import massing  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+blank = Path(tempfile.gettempdir()) / "recipe_route.ifc"
+massing.generate_blank_ifc(str(blank), name="Recipe Tower", storeys=2, storey_height=3.5)
+
+
+def new_project(c, name):
+    pid = c.post("/projects", json={"name": name}).json()["id"]
+    r = c.post(f"/projects/{pid}/source-ifc?publish=false",
+               files={"file": ("model.ifc", blank.read_bytes(), "application/octet-stream")})
+    assert r.status_code == 200, r.text[:160]
+    return pid
+
+
+def wall_count(c, pid):
+    r = c.post(f"/projects/{pid}/model/query", json={"query": "IfcWall"})
+    if r.status_code != 200:
+        r = c.get(f"/projects/{pid}/model/query?query=IfcWall")
+    return r
+
+
+with TestClient(app) as c:
+    c.headers.update({"X-User": "ana@test"})
+    pid = new_project(c, "Recipe Tower")
+
+    empty = c.get(f"/projects/{pid}/recipes/log")
+    check("GET /recipes/log answers 200 on a project with no edits", empty.status_code == 200,
+          empty.text[:200])
+    check("  and is empty", empty.json()["total"] == 0)
+
+    # --- a single edit through /edit ---------------------------------------------------------------
+    e1 = c.post(f"/projects/{pid}/edit",
+                json={"recipe": "add_wall",
+                      "params": {"start": [0, 0], "end": [6, 0], "height": 3.0, "storey": "Level 1"},
+                      "publish": False})
+    check("POST /edit succeeds", e1.status_code == 200, e1.text[:250])
+
+    L = c.get(f"/projects/{pid}/recipes/log").json()
+    check("the edit was captured", L["total"] == 1, L)
+    row = L["entries"][0]
+    check("  with its recipe", row["recipe"] == "add_wall")
+    check("  with its PARAMETERS — the half that did not exist before",
+          row["params"]["end"] == [6, 0] and row["params"]["height"] == 3.0, row["params"])
+    check("  with the actor", row["actor"] == "ana@test", row["actor"])
+    check("  and the source it ran between",
+          row["source_in"] and row["source_out"] and row["source_in"] != row["source_out"],
+          (row["source_in"], row["source_out"]))
+    check("  paths are basenames, not server paths", "/" not in (row["source_out"] or ""))
+
+    # --- a batch: one version, N log entries -------------------------------------------------------
+    e2 = c.post(f"/projects/{pid}/edit/batch", json={
+        "steps": [
+            {"recipe": "add_wall", "params": {"start": [0, 0], "end": [0, 4], "height": 3.0,
+                                              "storey": "Level 1"}},
+            {"recipe": "add_column", "params": {"point": [2, 2], "height": 3.0, "storey": "Level 2"}},
+        ], "publish": False})
+    check("POST /edit/batch succeeds", e2.status_code == 200, e2.text[:250])
+
+    L2 = c.get(f"/projects/{pid}/recipes/log").json()
+    check("a 2-step batch logs 2 entries — one version, two operations", L2["total"] == 3, L2["total"])
+    batch = [r for r in L2["entries"] if r.get("batch")]
+    check("  both carry the same batch id", len({r["batch"] for r in batch}) == 1, batch)
+    check("  and their parameters are kept per step",
+          sorted(r["recipe"] for r in batch) == ["add_column", "add_wall"])
+    check("the log is newest-first", L2["entries"][0]["recipe"] in ("add_wall", "add_column")
+          and L2["entries"][-1]["recipe"] == "add_wall")
+    check("the recipes actually used are listed", set(L2["recipes"]) == {"add_wall", "add_column"})
+
+    filt = c.get(f"/projects/{pid}/recipes/log?recipe=add_column").json()
+    check("filtering by recipe works",
+          filt["total"] == 1 and filt["entries"][0]["recipe"] == "add_column", filt["total"])
+
+    # --- export is oldest-first, and says so --------------------------------------------------------
+    ex = c.get(f"/projects/{pid}/recipes/export").json()
+    check("GET /recipes/export returns the whole log", ex["count"] == 3)
+    check("  oldest first, stated in the payload", ex["order"] == "oldest_first")
+    check("  the first entry is the first edit", ex["entries"][0]["params"]["end"] == [6, 0],
+          ex["entries"][0]["params"])
+    check("  and it reports whether the log is replayable", ex["replayable"] is True)
+
+    # --- diff ----------------------------------------------------------------------------------------
+    d = c.get(f"/projects/{pid}/recipes/diff?a=0&b=1").json()
+    check("two add_wall runs are comparable", d["comparable"] is True, d.get("reason"))
+    check("  and only the changed parameter is named",
+          [x["param"] for x in d["changed"]] == ["end"], d["changed"])
+    cross = c.get(f"/projects/{pid}/recipes/diff?a=0&b=2").json()
+    check("add_wall vs add_column is refused as incomparable", cross["comparable"] is False)
+    check("an out-of-range index is a 404",
+          c.get(f"/projects/{pid}/recipes/diff?a=0&b=99").status_code == 404)
+
+    # --- THE assertion: replay onto a fresh model reproduces the building --------------------------
+    plan = c.post(f"/projects/{pid}/recipes/replay-plan", json={})
+    check("POST /recipes/replay-plan answers 200", plan.status_code == 200, plan.text[:250])
+    steps = plan.json()["steps"]
+    check("  the plan has every logged step, in order", len(steps) == 3
+          and [s["recipe"] for s in steps] == ["add_wall", "add_wall", "add_column"],
+          [s["recipe"] for s in steps])
+
+    fresh = new_project(c, "Replayed Tower")
+    applied = c.post(f"/projects/{fresh}/edit/batch", json={"steps": steps, "publish": False})
+    check("the plan applies to a DIFFERENT project's fresh model", applied.status_code == 200,
+          applied.text[:250])
+
+    # What this asserts, stated plainly: the replay ran the SAME recipes with the SAME parameters, in
+    # the same order, against the same starting model, and every step was accepted. That is the
+    # property the log is responsible for.
+    #
+    # It does NOT compare the two models geometrically. There is no endpoint on this build that
+    # returns a comparable whole-model summary, and an assertion written as `if the endpoint exists`
+    # is worse than none: it passes silently when the endpoint 500s, so a green run stops meaning
+    # anything. Element-level equivalence between an original and its replay is exactly what
+    # R23-DIGEST's `diff()` answers, and wiring the two together is the follow-up.
+    rl2 = c.get(f"/projects/{fresh}/recipes/log").json()
+    check("  and the replay is itself captured on the new project, step for step",
+          [r["recipe"] for r in reversed(rl2["entries"])] == [s["recipe"] for s in steps],
+          [r["recipe"] for r in rl2["entries"]])
+    check("  with the same parameters that were logged on the original",
+          [r["params"] for r in reversed(rl2["entries"])] == [s["params"] for s in steps])
+
+    sub = c.post(f"/projects/{pid}/recipes/replay-plan", json={"indices": [2]}).json()
+    check("a subset can be replayed", sub["count"] == 1 and sub["steps"][0]["recipe"] == "add_column")
+    bad = c.post(f"/projects/{pid}/recipes/replay-plan", json={"indices": [99]})
+    check("an out-of-range index is a 422, not a 500", bad.status_code == 422, bad.status_code)
+
+    # --- the log must never be able to break an edit -------------------------------------------------
+    # append_safe swallows storage faults because the edit has already been committed by then; a
+    # logging fault must not turn a successful edit into a reported failure.
+    from aec_api import recipe_log as rl
+
+    orig = rl.record
+    try:
+        rl.record = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("storage down"))
+        still = c.post(f"/projects/{pid}/edit",
+                       json={"recipe": "add_column",
+                             "params": {"point": [4, 4], "height": 3.0, "storey": "Level 2"},
+                             "publish": False})
+        check("an edit still succeeds when the log cannot be written", still.status_code == 200,
+              still.text[:200])
+    finally:
+        rl.record = orig
+    check("  and the failure left a gap rather than a corrupt entry",
+          c.get(f"/projects/{pid}/recipes/log").json()["total"] == 3)
+
+print()
+if FAILED:
+    print(f"recipe_route: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("recipe_route: all checks passed")


### PR DESCRIPTION
Ring item **R23-RECIPE-ARTIFACT** (engineering upgrade ring, Tier 3): *"make the edit-recipe log first-class: versioned, diffable, exportable, replayable against a fresh IFC. It already **is** a CAD operation timeline; formalising it serves provenance, the as-built audit trail, and AI consumption in one move."*

Backend only — no `apps/web` files touched.

## The premise needed correcting first

There was no timeline to formalise. What existed was two things, neither of which is one:

- **`edit_history.json`** — a stack of **file paths** for undo/redo. No recipe, no parameters, no actor, no time. Restoring a prior path is all it has to do, and it does that.
- **the audit log** — one row per edit. `/edit` records `detail=result`, which is the recipe's **outputs**; `/edit/batch` records `[s["recipe"] for s in steps]`, the recipe **names**.

So the **inputs were nowhere**, and every capability the item asks for rests on them. You cannot replay an operation whose arguments you never kept, cannot diff two edits whose arguments you never kept, and cannot export a provenance trail that says only *"something called add_wall happened"*. This PR records the missing half.

## What is captured, and what deliberately isn't

`recipe_log.py` stores what would have to be true to re-run an edit elsewhere: recipe, parameters, actor, time, the source it ran between, and the outputs it claimed. Captured at four sites in `authoring.py`, beside the existing `edit_history.push` — `/edit`, `/edit/batch` (one version, **N** log entries), macro runs, and content import.

Two sites are **not** captured, because neither is a recipe: `/edit/graph` runs a node graph, which `/edit/batch` cannot replay, and model-option activation swaps a whole file. Logging them as recipes would put entries in the log that a replay would have to refuse anyway.

## Three decisions where the easy version would be quietly wrong

- **Large values are elided, not truncated.** A mesh recipe carries vertex arrays. Over 8 KB a value becomes a descriptor — type, size, hash. *Half a vertex array looks exactly like a vertex array* and would invite somebody to use it.
- **A replay of an elided entry is REFUSED**, naming the entries. Substituting the descriptor would call the recipe with something that *resembles* the original argument and is not it — the one outcome a provenance feature must never produce. Either it reproduces the edit or it says it cannot.
- **Replay returns a plan and does not execute.** Re-running authoring edits should carry one author and one audit row; a log that could re-run itself would carry neither. Apply through `/edit/batch`.

## A bug my own test caught while I was writing it

`_shrink` sized values with `json.dumps(v, default=str)` — which **never raises**, because the fallback encoder stringifies anything. A non-serializable parameter would therefore pass through, fail later in `_save`, get swallowed by the fail-open wrapper, and **the whole entry would vanish**. Eliding one parameter is a gap you can see; losing the entry is a gap you cannot. Now a strict `dumps`, with the entry's end-to-end serializability asserted.

The capture is fail-open by design, and that is tested: the edit is already committed by the time the log is written, so a logging fault must never turn a successful edit into a reported failure.

## Routes

Its own router — `authoring.py` is already the app's largest write surface.

```
GET  /projects/{pid}/recipes/log?recipe=&limit=&offset=
GET  /projects/{pid}/recipes/export      (oldest-first; the log is newest-first)
GET  /projects/{pid}/recipes/diff?a=&b=
POST /projects/{pid}/recipes/replay-plan
```

## Verification

- 26 engine checks + 32 HTTP checks green
- The HTTP set drives the real loop: edit a model, then **replay the logged plan onto a different project's fresh model** and assert every step is accepted with the same parameters
- It states plainly **what it does not assert**: the two models are not compared geometrically. No endpoint here returns a comparable whole-model summary, and an `if the endpoint exists` branch passes silently when the endpoint 500s — so a green run would stop meaning anything. That comparison is exactly what R23-DIGEST's `diff()` answers; wiring the two is the natural follow-up (see #94).
- `ruff check src/ ../data/src/` clean; `route_authz` (684 routes), `reachable`, `route_order`, `edit_undo` and `macros` pass
- Merges clean against `main` and against all four sibling PRs (#94–#97), in any order

## Not included, deliberately

Version bump, CHANGELOG and roadmap entries — the files that conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)