### PR TITLE
R22-ENTITLE-RISK — a refused entitlement is not a bad IRR

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -22,6 +22,8 @@ HERE = Path(__file__).resolve().parent
 TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_collab", "test_serving", "test_api",
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
+         # R22-ENTITLE-RISK — approval odds + entitlement duration in the Monte Carlo:
+         "test_entitlement_risk", "test_entitlement_route",
          "test_contracts", "test_reports", "test_esign", "test_publish_status", "test_schedule_alerts",
          "test_schedule_optimize",
          "test_bundle", "test_desktop", "test_localmode", "test_project_budget", "test_rvt_bridge",

--- a/services/api/src/aec_api/proforma/entitlement_risk.py
+++ b/services/api/src/aec_api/proforma/entitlement_risk.py
@@ -1,0 +1,301 @@
+"""R22-ENTITLE-RISK — approval probability and entitlement duration in the Monte Carlo.
+
+The ring calls this *"the largest unmodelled uncertainty in any acquisition proforma"*, and in this
+codebase it is unmodelled twice over:
+
+* **`Timing` has no pre-construction period at all.** `construction_months`, `leaseup_months`,
+  `hold_years` — the deal begins the day the shovel goes in. Nothing represents the 6–30 months
+  between buying a site and being allowed to build on it, so nothing charges for them.
+* **`monte_carlo` can only sample continuous drivers** — normal, uniform, triangular, each set onto
+  a dotted path. Approval is not a number on a path. It is a coin, and the two faces are different
+  projects.
+
+**The decision that shapes this whole module: a denied entitlement is not a bad IRR.** The tempting
+implementation is to make denial a very poor draw and let it flow through `solve()` with everything
+else. It cannot, for a reason that is arithmetic rather than stylistic: if the entitlement is
+refused, the building is never built, there is no NOI, no exit, no equity multiple. Pushing that
+scenario through a solver that assumes construction proceeds produces a *number*, and that number
+then sits inside the P5–P95 of a distribution describing a project that does not exist.
+
+So denial is a **terminal branch with its own economics** — pursuit costs sunk, carry spent to the
+date of refusal, land recovered at whatever it fetches — and denied draws are reported as their own
+population. The approved distribution is reported too, labelled as conditional on approval, because
+that is a real and useful number as long as nobody mistakes it for the deal.
+
+**Probability of clearing a hurdle counts denied draws in the denominator.** A 15% IRR target is not
+cleared by an entitlement that was refused. This mirrors the choice already made in
+`monte_carlo._summary` for undefined metrics, and for the same reason: dividing by the draws that
+happened to work out answers "P[good | it worked]", which flatters a deal exactly when it is at its
+riskiest.
+
+**A duration that costs nothing is refused rather than accepted.** Sampling entitlement months and
+then charging nothing for them changes no output at all — the run completes, the report shows a
+duration distribution, and every metric is identical to the run without it. That is worse than an
+error, because it looks modelled. `carry_cost_monthly` is therefore required whenever
+`duration_months` is given.
+
+**Known limitation, stated because it moves the answer in a knowable direction.** The model has no
+pre-construction period to schedule into, so entitlement carry is capitalised as a month-0 soft cost
+rather than time-phased ahead of construction. Real entitlement spend leaves the account earlier than
+that, so its interest carry is **understated** — this makes the entitled deal look slightly better
+than it is, never worse. Fixing it properly means giving `Timing` a pre-construction period, which is
+a schema change and a separate piece of work.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import numpy as np
+
+from .monte_carlo import _sample, _summary
+from .sensitivity import _get_metric, _set_path
+from .solve import solve
+
+DEFAULT_METRICS = ["returns.equity_irr", "returns.equity_multiple",
+                   "returns.project_irr", "returns.npv"]
+
+
+class EntitlementError(ValueError):
+    """The entitlement inputs cannot produce an honest answer."""
+
+
+def _f(d: dict, key: str, default: float | None = None) -> float:
+    v = d.get(key, default)
+    if v is None:
+        raise EntitlementError(f"entitlement.{key} is required")
+    try:
+        return float(v)
+    except (TypeError, ValueError) as e:
+        raise EntitlementError(f"entitlement.{key} must be a number, got {v!r}") from e
+
+
+def _validate(ent: dict) -> None:
+    p = _f(ent, "approval_probability")
+    if not 0.0 <= p <= 1.0:
+        raise EntitlementError(f"approval_probability must be between 0 and 1, got {p}")
+    if "duration_months" in ent and ent["duration_months"] is not None:
+        if ent.get("carry_cost_monthly") is None:
+            raise EntitlementError(
+                "duration_months was given without carry_cost_monthly. Sampling a duration that "
+                "costs nothing changes no output — every metric would be identical to a run without "
+                "it, while the report showed a duration distribution. That is worse than an error, "
+                "because it looks modelled.")
+        if _f(ent, "carry_cost_monthly") < 0:
+            raise EntitlementError("carry_cost_monthly cannot be negative")
+    lr = ent.get("land_recovery_pct")
+    if lr is not None and not 0.0 <= float(lr) <= 1.0:
+        raise EntitlementError(f"land_recovery_pct must be between 0 and 1, got {lr}")
+
+
+def denial_outcome(ent: dict, months: float) -> dict[str, Any]:
+    """What a refusal actually costs, at the month it is refused.
+
+    Not an IRR. A refused entitlement has no holding period to annualise over in any way a reader
+    would trust — the loss is realised whenever the authority says no, and dressing that up as a rate
+    of return invites it to be compared with the approved IRRs, which is precisely the comparison
+    this module exists to prevent.
+    """
+    pursuit = float(ent.get("pursuit_cost", 0) or 0)
+    carry = float(ent.get("carry_cost_monthly", 0) or 0) * max(0.0, months)
+    land = float(ent.get("land_basis", 0) or 0)
+    recovery_pct = float(ent.get("land_recovery_pct", 1.0) if ent.get("land_recovery_pct") is not None
+                         else 1.0)
+    land_recovered = land * recovery_pct
+    spent = pursuit + carry + land
+    return {
+        "months_to_refusal": round(months, 2),
+        "pursuit_cost": round(pursuit, 2),
+        "carry_cost": round(carry, 2),
+        "land_basis": round(land, 2),
+        "land_recovered": round(land_recovered, 2),
+        "capital_deployed": round(spent, 2),
+        # Negative = money lost. Signed so it sums with approved-case equity without a convention
+        # anyone has to remember.
+        "net_loss": round(land_recovered - spent, 2),
+    }
+
+
+def _with_entitlement_carry(assumptions: dict, months: float, monthly: float) -> dict:
+    """A copy of the assumptions with entitlement carry added as a month-0 soft cost.
+
+    See the module docstring's limitation note: month 0 because there is nowhere earlier to put it,
+    and the resulting understatement of interest carry favours the deal.
+    """
+    a = copy.deepcopy(assumptions)
+    amount = round(months * monthly, 2)
+    if amount:
+        a.setdefault("cost_lines", []).append({
+            "category": "soft", "name": "Entitlement carry",
+            "amount": amount, "start_month": 0, "end_month": 0,
+        })
+    return a
+
+
+def simulate(assumptions: dict, entitlement: dict, *, variables: list[dict] | None = None,
+             iterations: int = 1000, seed: int = 42, metrics: list[str] | None = None,
+             targets: dict[str, float] | None = None) -> dict[str, Any]:
+    """Monte Carlo over the approval coin, the entitlement duration, and any other drivers.
+
+    Each iteration: draw approval. If approved, draw a duration, charge its carry, and solve. If
+    refused, do not solve — record the denial's own economics instead.
+    """
+    _validate(entitlement)
+    metrics = list(metrics or DEFAULT_METRICS)
+    targets = targets or {}
+    variables = list(variables or [])
+    n = max(1, int(iterations))
+    rng = np.random.default_rng(seed)
+
+    p_approve = _f(entitlement, "approval_probability")
+    approved_draws = rng.random(n) < p_approve
+
+    dist = entitlement.get("duration_months")
+    monthly = float(entitlement.get("carry_cost_monthly", 0) or 0)
+    if dist:
+        months = _sample(rng, dist, n)
+        months = np.clip(months, 0.0, None)     # a negative entitlement period is not a thing
+    else:
+        months = np.zeros(n)
+
+    other = {v["path"]: _sample(rng, v["dist"], n) for v in variables}
+
+    collected: dict[str, list[float]] = {m: [] for m in metrics}
+    denials: list[dict[str, Any]] = []
+    failures = 0
+
+    for i in range(n):
+        if not approved_draws[i]:
+            denials.append(denial_outcome(entitlement, float(months[i])))
+            continue
+        a = _with_entitlement_carry(assumptions, float(months[i]), monthly)
+        for path, arr in other.items():
+            _set_path(a, path, float(arr[i]))
+        try:
+            res = solve(a)
+        except Exception:  # noqa: BLE001 — an unsolvable draw is a failure, counted not hidden
+            failures += 1
+            continue
+        for m in metrics:
+            val = _get_metric(res, m)
+            collected[m].append(float(val) if val is not None else float("nan"))
+
+    n_denied = len(denials)
+    n_approved = n - n_denied
+    solved = n_approved - failures
+
+    out: dict[str, Any] = {
+        "iterations": n,
+        "seed": seed,
+        "approval_probability": p_approve,
+        "approved": n_approved,
+        "denied": n_denied,
+        "denied_share": round(n_denied / n, 4),
+        "solve_failures": failures,
+        "solved": solved,
+        "entitlement_months": _months_summary(months, approved_draws),
+        "variables": [{"path": v["path"], "dist": v["dist"]} for v in variables],
+        # Conditional on approval, and labelled as such at the point of use — this is the number most
+        # likely to be quoted without its condition.
+        "metrics_given_approval": {
+            m: _summary(np.array(vals, dtype=float), targets.get(m))
+            for m, vals in collected.items()},
+        "metrics_are_conditional": (
+            f"the distributions above describe the {solved} solved draw(s) in which the entitlement "
+            f"was GRANTED. They say nothing about the {n_denied} draw(s) in which it was refused, "
+            "which are reported separately — a refused entitlement has no IRR because there is no "
+            "project"),
+        "denial": _denial_summary(denials),
+    }
+    out["probability_of_clearing"] = {
+        m: _unconditional_target(collected[m], t, n) for m, t in targets.items() if m in collected
+    }
+    out["expected_value"] = _expected_value(collected, denials, n, metrics)
+    return out
+
+
+def _months_summary(months: np.ndarray, approved: np.ndarray) -> dict[str, Any]:
+    """Duration stats. Reported for the APPROVED draws, because that is the period actually spent
+    reaching an approval; the refused draws carry their own months into the denial economics."""
+    vals = months[approved]
+    if vals.size == 0:
+        return {"n": 0, "note": "no draw was approved"}
+    return {
+        "n": int(vals.size),
+        "mean": round(float(vals.mean()), 2),
+        "p10": round(float(np.percentile(vals, 10)), 2),
+        "p50": round(float(np.percentile(vals, 50)), 2),
+        "p90": round(float(np.percentile(vals, 90)), 2),
+        "max": round(float(vals.max()), 2),
+    }
+
+
+def _unconditional_target(vals: list[float], target: float, n_total: int) -> dict[str, Any]:
+    """P[metric ≥ target] over EVERY iteration, denied ones included.
+
+    A refused entitlement does not clear an IRR hurdle. Dividing by the approved draws instead
+    answers "P[clears | it was approved]", which is a different and much friendlier question.
+    """
+    arr = np.array(vals, dtype=float)
+    defined = arr[~np.isnan(arr)]
+    hits = int((defined >= target).sum()) if defined.size else 0
+    return {
+        "target": target,
+        "probability": round(hits / n_total, 4),
+        "hits": hits,
+        "of_iterations": n_total,
+        "probability_given_approval": (round(hits / arr.size, 4) if arr.size else None),
+        "note": "the headline probability counts every iteration; a refused entitlement cannot clear "
+                "a return hurdle. The conditional figure is shown beside it, not instead of it",
+    }
+
+
+def _denial_summary(denials: list[dict[str, Any]]) -> dict[str, Any]:
+    if not denials:
+        return {"n": 0, "note": "no draw was refused"}
+    losses = np.array([d["net_loss"] for d in denials], dtype=float)
+    return {
+        "n": len(denials),
+        "mean_net_loss": round(float(losses.mean()), 2),
+        "worst_net_loss": round(float(losses.min()), 2),
+        "best_net_loss": round(float(losses.max()), 2),
+        "mean_capital_deployed": round(float(np.mean([d["capital_deployed"] for d in denials])), 2),
+        "note": "net_loss is signed — negative is money lost. No IRR is reported: a refused "
+                "entitlement has no holding period a reader would trust, and quoting a rate would "
+                "invite comparison with the approved returns",
+    }
+
+
+def _expected_value(collected: dict[str, list[float]], denials: list[dict[str, Any]],
+                    n_total: int, metrics: list[str]) -> dict[str, Any]:
+    """Probability-weighted NPV across both branches — the one number that spans them.
+
+    Only NPV is blended, and only NPV can be: it is a value in currency, so a denial's loss and an
+    approval's gain are the same unit and adding them means something. IRR and equity multiple are
+    ratios over a project that, in the denied branch, does not exist — there is nothing to average
+    them against, and an "expected IRR" built by treating a refusal as a 0% return would be a
+    fabrication with a plausible shape.
+    """
+    npvs = np.array(collected.get("returns.npv", []), dtype=float)
+    defined = npvs[~np.isnan(npvs)] if npvs.size else npvs
+    if not n_total:
+        return {"available": False, "reason": "no iterations"}
+    if defined.size == 0 and not denials:
+        return {"available": False, "reason": "no solved draws and no denials"}
+    approved_total = float(defined.sum()) if defined.size else 0.0
+    denied_total = float(sum(d["net_loss"] for d in denials))
+    ev = (approved_total + denied_total) / n_total
+    return {
+        "available": True,
+        "metric": "returns.npv",
+        "expected_npv": round(ev, 2),
+        "approved_mean_npv": round(float(defined.mean()), 2) if defined.size else None,
+        "denied_mean_loss": round(denied_total / len(denials), 2) if denials else None,
+        "blended": "npv only",
+        "why_only_npv": (
+            "NPV is a currency amount, so an approval's gain and a refusal's loss are the same unit "
+            "and adding them means something. IRR and equity multiple are ratios over a project that "
+            "does not exist in the denied branch; an 'expected IRR' that treated a refusal as a 0% "
+            "return would be a fabrication with a plausible shape"),
+        "excluded_metrics": [m for m in metrics if m != "returns.npv"],
+    }

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -15,6 +15,7 @@ from .. import modules as me
 from .. import rbac
 from ..db import get_db
 from ..models import Scenario
+from ..proforma import entitlement_risk
 from ..proforma.draws import reforecast
 from ..proforma.monte_carlo import monte_carlo
 from ..proforma.sensitivity import sensitivity
@@ -595,6 +596,56 @@ class MonteCarloIn(BaseModel):
     seed: int = 42
     metrics: list[str] | None = None       # default: equity/project IRR, multiple, NPV
     targets: dict[str, float] | None = None  # metric → threshold for P[metric ≥ threshold]
+
+
+class EntitlementIn(BaseModel):
+    """Approval odds and what a refusal costs. `duration_months` reuses the Monte Carlo's own
+    Distribution, so an entitlement period is specified exactly like any other sampled driver."""
+    approval_probability: float = Field(ge=0.0, le=1.0)
+    duration_months: Distribution | None = None
+    carry_cost_monthly: float | None = Field(default=None, ge=0)
+    pursuit_cost: float = Field(default=0.0, ge=0)
+    land_basis: float = Field(default=0.0, ge=0)
+    land_recovery_pct: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class EntitlementRiskIn(BaseModel):
+    assumptions: Assumptions
+    entitlement: EntitlementIn
+    variables: list[MonteCarloVar] = []      # optional: other drivers, sampled alongside
+    iterations: int = Field(default=1000, ge=100, le=5000)
+    seed: int = 42
+    metrics: list[str] | None = None
+    targets: dict[str, float] | None = None
+
+
+@router.post("/proforma/entitlement-risk")
+def run_entitlement_risk(body: EntitlementRiskIn):
+    """R22-ENTITLE-RISK — Monte Carlo over the approval coin, the entitlement duration, and any
+    other drivers.
+
+    A denied entitlement is **not** modelled as a bad IRR. If approval is refused the building is
+    never built: there is no NOI, no exit and no multiple, so the draw is not solved at all. It is
+    recorded as a terminal branch with its own economics — pursuit sunk, carry spent to the date of
+    refusal, land recovered at whatever it fetches — and reported as a separate population.
+
+    Consequently the returns here are labelled `metrics_given_approval`, and
+    `probability_of_clearing` counts **every** iteration in its denominator: a refused entitlement
+    does not clear a 15% hurdle. Only NPV is blended into an expected value, because only NPV is a
+    currency amount that can be added across the two branches.
+    """
+    ent = body.entitlement.model_dump(exclude_none=True)
+    if body.entitlement.duration_months is not None:
+        ent["duration_months"] = body.entitlement.duration_months.model_dump(exclude_none=True)
+    try:
+        return entitlement_risk.simulate(
+            body.assumptions.model_dump(), ent,
+            variables=[{"path": v.path, "dist": v.dist.model_dump(exclude_none=True)}
+                       for v in body.variables],
+            iterations=body.iterations, seed=body.seed,
+            metrics=body.metrics, targets=body.targets)
+    except entitlement_risk.EntitlementError as e:
+        raise HTTPException(422, str(e)) from e
 
 
 @router.post("/proforma/monte-carlo")

--- a/services/api/test_entitlement_risk.py
+++ b/services/api/test_entitlement_risk.py
@@ -1,0 +1,230 @@
+"""R22-ENTITLE-RISK — a refused entitlement must not be able to look like a bad IRR.
+
+The finance-math review of this codebase found that `proforma/` tests RANGE-check where they should
+VALUE-check — a `0 <= p <= 1` assertion on a probability cannot fail. So the assertions here are
+arithmetic: with a seeded RNG and a known approval rate, the denied count, the loss and the clearing
+probability are each computed by hand and compared exactly.
+
+The two that matter most:
+
+* a denied draw is **never solved**, so it can never contribute a number to the returns distribution;
+* `probability_of_clearing` divides by **every** iteration, so refusals count against the hurdle.
+
+Both have a tempting wrong version that produces a plausible, friendlier number, which is exactly
+why they are pinned rather than eyeballed.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_entitlement_risk.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+import numpy as np  # noqa: E402
+
+from aec_api.proforma import entitlement_risk as er  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+ASSUMPTIONS = {
+    "timing": {"construction_months": 18, "leaseup_months": 12, "hold_years": 5,
+               "start_date": "2026-01-01"},
+    "cost_lines": [
+        {"category": "land", "name": "Land", "amount": 4_000_000, "curve": "upfront",
+         "start_month": 0, "end_month": 0},
+        {"category": "hard", "name": "Construction", "amount": 20_000_000, "curve": "scurve",
+         "start_month": 1, "end_month": 17},
+        {"category": "soft", "name": "Soft costs", "amount": 3_000_000, "curve": "linear",
+         "start_month": 0, "end_month": 17},
+    ],
+    "debt": {"ltc": 0.65, "rate": 0.085, "points": 0.01, "funding": "equity_first"},
+    "equity": {"lp_pct": 0.9, "gp_pct": 0.1},
+    "operations": {"potential_rent_annual": 3_600_000, "other_income_annual": 120_000,
+                   "opex_annual": 1_300_000, "stabilized_occ": 0.94, "credit_loss_pct": 0.02},
+    "exit": {"exit_cap": 0.055, "selling_cost_pct": 0.02},
+    "waterfall": {"pref_rate": 0.08, "style": "american", "clawback": False,
+                  "tiers": [{"hurdle": 0.12, "lp": 0.8, "gp": 0.2},
+                            {"hurdle": None, "lp": 0.6, "gp": 0.4}]},
+    "discount_rate": 0.10,
+}
+
+# GUARD — the fixture must actually solve, asserted before anything else runs.
+#
+# The first version of this file used invented field names (`max_ltv` for `ltc`, `pref` for
+# `pref_rate`), so EVERY solve raised and `solved` was 0. Three of the assertions below still passed:
+# "n + undefined == solved" is 0 == 0, "solved < iterations" is 0 < 2000, and
+# "solved == approved - failures" is 0 == n - n. A suite that is green on a fixture that never solves
+# is measuring nothing, which is precisely the range-check-instead-of-value-check pattern the
+# finance-math review found across proforma/. Pin the floor first.
+from aec_api.proforma.solve import solve as _solve  # noqa: E402
+
+_probe = _solve(ASSUMPTIONS)
+assert _probe["returns"]["equity_irr"] is not None, "fixture does not produce an equity IRR"
+assert _probe["returns"]["equity_multiple"] > 1.0, _probe["returns"]
+print(f"(fixture solves: equity_irr={_probe['returns']['equity_irr']:.4f})")
+
+ENT = {
+    "approval_probability": 0.7,
+    "duration_months": {"kind": "triangular", "low": 6, "mode": 12, "high": 30},
+    "carry_cost_monthly": 45_000,
+    "pursuit_cost": 850_000,
+    "land_basis": 6_000_000,
+    "land_recovery_pct": 0.9,
+}
+
+# --- 1. validation refuses what cannot produce an honest answer -----------------------------------
+for label, ent, frag in (
+    ("a duration with no carry cost", {**ENT, "carry_cost_monthly": None}, "looks modelled"),
+    ("a probability above 1", {**ENT, "approval_probability": 1.4}, "between 0 and 1"),
+    ("a negative probability", {**ENT, "approval_probability": -0.1}, "between 0 and 1"),
+    ("a land recovery above 1", {**ENT, "land_recovery_pct": 1.5}, "between 0 and 1"),
+    ("a missing probability", {k: v for k, v in ENT.items() if k != "approval_probability"},
+     "required"),
+):
+    try:
+        er.simulate(ASSUMPTIONS, ent, iterations=100)
+        check(f"refuses {label}", False, "no exception")
+    except er.EntitlementError as e:
+        check(f"refuses {label}", frag in str(e), str(e)[:120])
+
+# A duration that costs nothing is the subtle one: the run would COMPLETE, report a duration
+# distribution, and every metric would be identical to a run without it.
+try:
+    er.simulate(ASSUMPTIONS, {**ENT, "carry_cost_monthly": None}, iterations=100)
+    check("  ...and that refusal is about silence, not about a missing field", False)
+except er.EntitlementError as e:
+    check("  ...and that refusal is about silence, not about a missing field",
+          "changes no output" in str(e), str(e)[:150])
+
+# --- 2. the approval coin is exactly as biased as it was told to be --------------------------------
+# Reproduce the engine's own draw: same seed, same generator, same first call.
+rng = np.random.default_rng(42)
+expected_denied = int((rng.random(2000) >= 0.7).sum())
+r = er.simulate(ASSUMPTIONS, ENT, iterations=2000, seed=42)
+check("the denied count matches the seeded Bernoulli draw exactly",
+      r["denied"] == expected_denied, (r["denied"], expected_denied))
+check("  approved + denied == iterations", r["approved"] + r["denied"] == 2000)
+check("  and the denied share is reported", r["denied_share"] == round(expected_denied / 2000, 4))
+check("a 70% approval rate lands near 70%", 0.66 <= (r["approved"] / 2000) <= 0.74,
+      r["approved"] / 2000)
+
+# --- 3. THE assertion: a denied draw is never solved ------------------------------------------------
+n_summary = r["metrics_given_approval"]["returns.equity_irr"]
+# Non-zero FIRST. Every assertion after this is satisfiable at zero, so without this one a fixture
+# that stopped solving would leave the suite green while measuring nothing.
+check("draws actually solved — the floor these assertions rest on",
+      r["solved"] > 0 and n_summary["n"] > 0, (r["solved"], n_summary["n"], r["solve_failures"]))
+check("the returns distribution covers only the SOLVED approved draws",
+      n_summary["n"] + n_summary.get("undefined", 0) == r["solved"],
+      (n_summary["n"], n_summary.get("undefined"), r["solved"]))
+check("  which is strictly fewer than the iterations", 0 < r["solved"] < 2000)
+check("  and the result says the distribution is conditional",
+      "GRANTED" in r["metrics_are_conditional"])
+check("no denied draw contributed a return",
+      r["solved"] == r["approved"] - r["solve_failures"] and r["solve_failures"] == 0,
+      (r["solved"], r["approved"], r["solve_failures"]))
+
+# --- 4. the denial branch has its own arithmetic ----------------------------------------------------
+# Hand-computed: 12 months refusal → 850k pursuit + 12*45k carry + 6M land, recovering 90% of land.
+d = er.denial_outcome(ENT, 12.0)
+check("denial: capital deployed = pursuit + carry + land",
+      d["capital_deployed"] == 850_000 + 12 * 45_000 + 6_000_000, d["capital_deployed"])
+check("denial: land recovered = 90% of basis", d["land_recovered"] == 5_400_000)
+check("denial: net loss = recovered - deployed",
+      d["net_loss"] == 5_400_000 - (850_000 + 540_000 + 6_000_000), d["net_loss"])
+check("  which is negative, i.e. money lost", d["net_loss"] < 0)
+check("denial reports NO irr — a refusal has no holding period to annualise",
+      "irr" not in {k.lower() for k in d})
+check("a longer refusal costs more carry",
+      er.denial_outcome(ENT, 24.0)["net_loss"] < d["net_loss"])
+check("full land recovery still loses the pursuit + carry",
+      er.denial_outcome({**ENT, "land_recovery_pct": 1.0}, 12.0)["net_loss"] == -(850_000 + 540_000))
+
+ds = r["denial"]
+check("the denial summary counts every refused draw", ds["n"] == r["denied"])
+check("  and its mean loss is negative", ds["mean_net_loss"] < 0)
+check("  worst is at least as bad as best", ds["worst_net_loss"] <= ds["best_net_loss"])
+
+# --- 5. clearing a hurdle counts the refusals ---------------------------------------------------------
+r2 = er.simulate(ASSUMPTIONS, ENT, iterations=1000, seed=7,
+                 targets={"returns.equity_irr": 0.15})
+pc = r2["probability_of_clearing"]["returns.equity_irr"]
+check("the hurdle probability divides by EVERY iteration", pc["of_iterations"] == 1000)
+check("  probability == hits / iterations", pc["probability"] == round(pc["hits"] / 1000, 4),
+      (pc["probability"], pc["hits"]))
+check("  the conditional figure is reported beside it, not instead",
+      pc["probability_given_approval"] is not None)
+check("  and the unconditional one is never the larger of the two",
+      pc["probability"] <= pc["probability_given_approval"],
+      (pc["probability"], pc["probability_given_approval"]))
+check("  with the reason stated", "cannot clear a return hurdle" in pc["note"])
+
+# With certain approval the two figures must coincide — the denial branch is empty.
+sure = er.simulate(ASSUMPTIONS, {**ENT, "approval_probability": 1.0}, iterations=400, seed=3,
+                   targets={"returns.equity_irr": 0.15})
+sp = sure["probability_of_clearing"]["returns.equity_irr"]
+check("at 100% approval, conditional and unconditional agree",
+      sp["probability"] == sp["probability_given_approval"], (sp["probability"],
+                                                              sp["probability_given_approval"]))
+check("  and nothing is denied", sure["denied"] == 0 and sure["denial"]["n"] == 0)
+
+never = er.simulate(ASSUMPTIONS, {**ENT, "approval_probability": 0.0}, iterations=200, seed=3,
+                    targets={"returns.equity_irr": 0.15})
+check("at 0% approval nothing is solved", never["solved"] == 0 and never["denied"] == 200)
+check("  the hurdle probability is exactly zero, not undefined",
+      never["probability_of_clearing"]["returns.equity_irr"]["probability"] == 0.0)
+check("  and the duration summary says no draw was approved",
+      never["entitlement_months"]["n"] == 0)
+
+# --- 6. duration actually costs money ------------------------------------------------------------------
+# The whole point: a longer entitlement must show up in the returns. Same seed, same coin, only the
+# duration distribution differs.
+short = er.simulate(ASSUMPTIONS, {**ENT, "duration_months": {"kind": "uniform", "low": 6, "high": 6}},
+                    iterations=300, seed=11)
+long = er.simulate(ASSUMPTIONS, {**ENT, "duration_months": {"kind": "uniform", "low": 36, "high": 36}},
+                   iterations=300, seed=11)
+check("the same seed approves the same draws either way", short["approved"] == long["approved"])
+sm = short["metrics_given_approval"]["returns.equity_irr"]["mean"]
+lm = long["metrics_given_approval"]["returns.equity_irr"]["mean"]
+check("a 36-month entitlement returns LESS than a 6-month one", lm < sm, (sm, lm))
+check("  and the duration summary reflects the input",
+      short["entitlement_months"]["p50"] == 6.0 and long["entitlement_months"]["p50"] == 36.0)
+check("a longer refusal also costs more", long["denial"]["mean_net_loss"] < short["denial"]["mean_net_loss"])
+
+# --- 7. expected value blends only what can be blended ---------------------------------------------------
+ev = r["expected_value"]
+check("an expected value is available", ev["available"] is True)
+check("  it blends NPV only", ev["blended"] == "npv only" and ev["metric"] == "returns.npv")
+check("  IRR and multiple are explicitly excluded",
+      "returns.equity_irr" in ev["excluded_metrics"]
+      and "returns.equity_multiple" in ev["excluded_metrics"], ev["excluded_metrics"])
+check("  with the reason: a ratio over a project that does not exist",
+      "fabrication" in ev["why_only_npv"])
+check("  and the denied mean loss is carried into it", ev["denied_mean_loss"] < 0)
+
+# --- 8. determinism ------------------------------------------------------------------------------------
+again = er.simulate(ASSUMPTIONS, ENT, iterations=500, seed=99)
+once = er.simulate(ASSUMPTIONS, ENT, iterations=500, seed=99)
+check("the same seed gives the same denied count", again["denied"] == once["denied"])
+check("  and the same returns", again["metrics_given_approval"] == once["metrics_given_approval"])
+diff_seed = er.simulate(ASSUMPTIONS, ENT, iterations=500, seed=100)
+check("a different seed gives a different draw", diff_seed["denied"] != again["denied"]
+      or diff_seed["metrics_given_approval"] != again["metrics_given_approval"])
+
+# --- 9. the assumptions are not mutated -------------------------------------------------------------------
+before = len(ASSUMPTIONS["cost_lines"])
+er.simulate(ASSUMPTIONS, ENT, iterations=120, seed=5)
+check("the caller's assumptions are untouched — carry is added to a COPY",
+      len(ASSUMPTIONS["cost_lines"]) == before, len(ASSUMPTIONS["cost_lines"]))
+
+print()
+if FAILED:
+    print(f"entitlement_risk: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("entitlement_risk: all checks passed")

--- a/services/api/test_entitlement_route.py
+++ b/services/api/test_entitlement_route.py
@@ -1,0 +1,155 @@
+"""R22-ENTITLE-RISK over HTTP — the endpoint answers, and it refuses what the engine refuses.
+
+The arithmetic is pinned in `test_entitlement_risk.py`. This asserts the route exists, that the
+pydantic layer does not quietly accept what the engine would reject (a schema that validates a
+duration with no carry cost would let the "looks modelled but changes nothing" case through before
+the engine ever sees it), and that the conditional labelling survives serialization — the labels are
+the whole reason `metrics_given_approval` is safe to publish.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_entitlement_route.py
+"""
+import os
+import sys
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_entitle_route.db"
+os.environ["STORAGE_DIR"] = "./test_storage_entitle_route"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_entitle_route.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+DEAL = {
+    "timing": {"construction_months": 18, "leaseup_months": 12, "hold_years": 5,
+               "start_date": "2026-01-01"},
+    "cost_lines": [
+        {"category": "land", "name": "Land", "amount": 4_000_000, "curve": "upfront",
+         "start_month": 0, "end_month": 0},
+        {"category": "hard", "name": "Construction", "amount": 20_000_000, "curve": "scurve",
+         "start_month": 1, "end_month": 17},
+        {"category": "soft", "name": "Soft costs", "amount": 3_000_000, "curve": "linear",
+         "start_month": 0, "end_month": 17},
+    ],
+    "debt": {"ltc": 0.65, "rate": 0.085, "points": 0.01, "funding": "equity_first"},
+    "equity": {"lp_pct": 0.9, "gp_pct": 0.1},
+    "operations": {"potential_rent_annual": 3_600_000, "other_income_annual": 120_000,
+                   "opex_annual": 1_300_000, "stabilized_occ": 0.94, "credit_loss_pct": 0.02},
+    "exit": {"exit_cap": 0.055, "selling_cost_pct": 0.02},
+    "waterfall": {"pref_rate": 0.08, "style": "american", "clawback": False,
+                  "tiers": [{"hurdle": 0.12, "lp": 0.8, "gp": 0.2},
+                            {"hurdle": None, "lp": 0.6, "gp": 0.4}]},
+    "discount_rate": 0.10,
+}
+
+ENT = {
+    "approval_probability": 0.7,
+    "duration_months": {"kind": "triangular", "low": 6, "mode": 12, "high": 30},
+    "carry_cost_monthly": 45_000,
+    "pursuit_cost": 850_000,
+    "land_basis": 4_000_000,
+    "land_recovery_pct": 0.9,
+}
+
+with TestClient(app) as c:
+    c.headers.update({"X-User": "ent@test"})
+
+    r = c.post("/proforma/entitlement-risk",
+               json={"assumptions": DEAL, "entitlement": ENT, "iterations": 400,
+                     "seed": 42, "targets": {"returns.equity_irr": 0.15}})
+    check("POST /proforma/entitlement-risk answers 200", r.status_code == 200, r.text[:300])
+    J = r.json()
+
+    # The floor, first: everything below is satisfiable at zero.
+    check("draws actually solved", J["solved"] > 0 and J["solve_failures"] == 0,
+          (J["solved"], J["solve_failures"]))
+    check("  approved + denied == iterations", J["approved"] + J["denied"] == 400)
+    check("  and some were denied at p=0.7", 0 < J["denied"] < 400, J["denied"])
+
+    check("returns are labelled as conditional on approval", "metrics_given_approval" in J)
+    check("  with the condition spelled out in the payload",
+          "GRANTED" in J["metrics_are_conditional"])
+    check("  and the label survived JSON", isinstance(J["metrics_are_conditional"], str))
+    check("the denial branch is reported separately", J["denial"]["n"] == J["denied"])
+    check("  with a negative mean loss", J["denial"]["mean_net_loss"] < 0)
+    check("  and no IRR anywhere in it",
+          not any("irr" in k.lower() for k in J["denial"]), sorted(J["denial"]))
+
+    pc = J["probability_of_clearing"]["returns.equity_irr"]
+    check("the hurdle probability counts every iteration", pc["of_iterations"] == 400)
+    check("  and is not larger than the conditional figure",
+          pc["probability"] <= pc["probability_given_approval"],
+          (pc["probability"], pc["probability_given_approval"]))
+
+    ev = J["expected_value"]
+    check("expected value blends NPV only", ev["blended"] == "npv only")
+    check("  and names what it excluded", "returns.equity_irr" in ev["excluded_metrics"])
+
+    check("the entitlement duration is summarized", J["entitlement_months"]["n"] == J["approved"])
+
+    # --- the schema must not accept what the engine refuses ---------------------------------------
+    no_carry = c.post("/proforma/entitlement-risk",
+                      json={"assumptions": DEAL,
+                            "entitlement": {k: v for k, v in ENT.items()
+                                            if k != "carry_cost_monthly"},
+                            "iterations": 200})
+    check("a duration with no carry cost is a 422, not a run that changes nothing",
+          no_carry.status_code == 422, no_carry.status_code)
+    check("  with the reason, not a bare validation error",
+          "changes no output" in no_carry.text or "looks modelled" in no_carry.text,
+          no_carry.text[:200])
+
+    for label, ent in (("probability above 1", {**ENT, "approval_probability": 1.4}),
+                       ("negative probability", {**ENT, "approval_probability": -0.2}),
+                       ("land recovery above 1", {**ENT, "land_recovery_pct": 1.4}),
+                       ("negative carry", {**ENT, "carry_cost_monthly": -5})):
+        resp = c.post("/proforma/entitlement-risk",
+                      json={"assumptions": DEAL, "entitlement": ent, "iterations": 200})
+        check(f"a {label} is rejected", resp.status_code == 422, resp.status_code)
+
+    # --- the degenerate ends, over the wire --------------------------------------------------------
+    sure = c.post("/proforma/entitlement-risk",
+                  json={"assumptions": DEAL, "entitlement": {**ENT, "approval_probability": 1.0},
+                        "iterations": 200, "seed": 3}).json()
+    check("at 100% approval nothing is denied",
+          sure["denied"] == 0 and sure["denial"]["n"] == 0)
+    never = c.post("/proforma/entitlement-risk",
+                   json={"assumptions": DEAL, "entitlement": {**ENT, "approval_probability": 0.0},
+                         "iterations": 200, "seed": 3,
+                         "targets": {"returns.equity_irr": 0.15}}).json()
+    check("at 0% approval nothing is solved", never["solved"] == 0 and never["denied"] == 200)
+    check("  and the hurdle probability is 0.0, not null",
+          never["probability_of_clearing"]["returns.equity_irr"]["probability"] == 0.0)
+
+    # --- determinism over the wire -----------------------------------------------------------------
+    body = {"assumptions": DEAL, "entitlement": ENT, "iterations": 300, "seed": 77}
+    a = c.post("/proforma/entitlement-risk", json=body).json()
+    b = c.post("/proforma/entitlement-risk", json=body).json()
+    check("the same seed gives the same answer over HTTP",
+          a["denied"] == b["denied"] and a["metrics_given_approval"] == b["metrics_given_approval"])
+
+    # --- entitlement-free behaviour is unchanged ----------------------------------------------------
+    mc = c.post("/proforma/monte-carlo", json={
+        "assumptions": DEAL,
+        "variables": [{"path": "exit.exit_cap", "dist": {"kind": "uniform", "low": 0.05, "high": 0.06}}],
+        "iterations": 200, "seed": 42})
+    check("the existing /proforma/monte-carlo endpoint still works", mc.status_code == 200,
+          mc.text[:200])
+    check("  and is untouched by this change", mc.json()["solved"] > 0)
+
+print()
+if FAILED:
+    print(f"entitlement_route: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("entitlement_route: all checks passed")


### PR DESCRIPTION
Ring item **R22-ENTITLE-RISK** (competitive gap ring, Tier 3): *"approval probability + entitlement duration into the existing Monte Carlo. The largest unmodelled uncertainty in any acquisition proforma."*

Backend only — no `apps/web` files touched. Additive: `/proforma/monte-carlo` is untouched and asserted still working.

## It is unmodelled twice over

- **`Timing` has no pre-construction period at all** — `construction_months`, `leaseup_months`, `hold_years`. The deal begins the day the shovel goes in, so nothing represents the 6–30 months between buying a site and being allowed to build on it, and nothing charges for them.
- **`monte_carlo` samples only continuous drivers** onto dotted paths. Approval is not a number on a path. It is a coin, and the two faces are different projects.

## The decision that shapes the module

**A denied entitlement is not a bad IRR.** The tempting implementation makes denial a very poor draw and lets it flow through `solve()` with everything else. It cannot, for a reason that is arithmetic rather than stylistic: if the entitlement is refused the building is never built — no NOI, no exit, no multiple. Pushing that scenario through a solver that *assumes construction proceeds* produces a **number**, and that number then sits inside the P5–P95 of a distribution describing a project that does not exist.

So denial is a **terminal branch with its own economics** — pursuit sunk, carry spent to the date of refusal, land recovered at whatever it fetches — reported as its own population. Four consequences:

1. Returns are named **`metrics_given_approval`** and carry their condition in the payload, because that is the number most likely to be quoted without it.
2. **`probability_of_clearing` divides by every iteration.** A refused entitlement does not clear a 15% hurdle. This is the same choice `monte_carlo._summary` already makes for undefined metrics, for the same reason: dividing by the draws that worked out answers *"P[good | it worked]"*, which flatters a deal exactly when it is at its riskiest. The conditional figure is reported beside it, never instead.
3. **Only NPV is blended** into an expected value — it is a currency amount, so a denial's loss and an approval's gain are the same unit and adding them means something. IRR and equity multiple are ratios over a project that does not exist in the denied branch; an "expected IRR" that treated a refusal as a 0% return would be a fabrication with a plausible shape.
4. **A duration with no `carry_cost_monthly` is refused.** Sampling months that cost nothing changes no output — the run completes, the report shows a duration distribution, and every metric is identical to a run without it. That is worse than an error, because it *looks* modelled.

## Stated limitation

With no pre-construction period to schedule into, entitlement carry is capitalised as a month-0 soft cost. Real entitlement spend leaves the account earlier, so its interest carry is **understated** — this makes the entitled deal look slightly *better* than it is, never worse. Fixing it properly means giving `Timing` a pre-construction period, which is a schema change and separate work.

## The mistake my own first draft made — worth reading

The finance-math review of this repo found that `proforma/` tests **range-check where they should value-check**. My first fixture used invented field names (`max_ltv` for `ltc`, `pref` for `pref_rate`), so **every solve raised and `solved` was 0** — and three assertions still passed:

- `n + undefined == solved` → `0 == 0`
- `solved < iterations` → `0 < 2000`
- `solved == approved - failures` → `0 == n - n`

A suite green on a fixture that never solves is measuring nothing. There is now a probe that solves the fixture before anything else runs, and an explicit non-zero floor asserted *ahead of* the assertions that rest on it.

## Verification

- **46 engine checks + 27 HTTP checks**, value-checked: the denied count is reproduced from the seeded Bernoulli draw *exactly*, the denial loss is hand-computed, the clearing probability is asserted as `hits / iterations`
- Degenerate ends pinned: at p=1.0 conditional and unconditional agree and nothing is denied; at p=0.0 nothing solves and the hurdle probability is `0.0`, not `null`
- A 36-month entitlement provably returns less than a 6-month one on the same seed
- `ruff check src/ ../data/src/` clean (including the isort rule CI enforces)
- `proforma`, `route_authz`, `reachable`, `route_order` pass

## Route

```
POST /proforma/entitlement-risk
```

## Not included, deliberately

Version bump, CHANGELOG and roadmap entries — the files that conflict with concurrent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)