### PR TITLE
sec(prefab): no response text derives from a caught exception (CodeQL #108)

### DIFF
--- a/services/api/src/aec_api/prefab_kit.py
+++ b/services/api/src/aec_api/prefab_kit.py
@@ -21,10 +21,24 @@ That is the same discipline as an issued drawing. The revision cloud is the poin
 """
 from __future__ import annotations
 
+import logging
 from datetime import date, datetime
 from typing import Any
 
 from . import query_dsl
+
+log = logging.getLogger("aec")
+
+#: Refusals that reach a response, exported as CONSTANTS. The rule they exist for: no text in an HTTP
+#: response may derive from a caught exception, because CodeQL's py/stack-trace-exposure taints a
+#: caught exception regardless of its class — typing it does not help, only changing the shape does.
+#: A router answers with these directly rather than stringifying whatever was raised.
+BAD_SELECTOR = ("the selector could not be evaluated — check its syntax against the QUERY-DSL "
+                "(the parse error is in the server log)")
+FREEZE_NO_MATCH = "the selector matches no elements — there is nothing to release"
+FREEZE_TRUNCATED = ("the selector matched more elements than the query limit returns; a frozen scope "
+                    "must be the whole set, not the first page of it")
+FREEZE_FAILED = "the kit's scope could not be frozen"
 
 #: A kit is only as good as the moment it was frozen, so the states that mean "the shop is working"
 #: are named. Before `released` a kit is a proposal and the live selector IS its scope; from
@@ -117,8 +131,16 @@ def resolve(idx: dict[str, dict] | None, selector: str, limit: int = 5000) -> di
         return {"selector": selector or "", "guids": [], "matched": 0, "error": "no selector set"}
     try:
         r = query_dsl.select(idx, selector, limit=limit)
-    except query_dsl.QueryError as e:
-        return {"selector": selector, "guids": [], "matched": 0, "error": f"bad selector: {e}"}
+    except query_dsl.QueryError:
+        # The exception's text does NOT go into the payload. `resolve()` feeds three response paths
+        # (the register, the kit detail, and freeze), so putting a caught exception's message in
+        # `error` puts it in three responses — which is what CodeQL alert #108
+        # (py/stack-trace-exposure) fired on, at the GET detail route rather than at freeze.
+        # Typing the exception does not clear it; a caught exception is tainted whatever its class.
+        # The shape has to change: a constant out, the detail to the log where an operator can find
+        # it. See memory `codeql-stack-trace-exposure` and the option_score.EMPTY_OPTIONS precedent.
+        log.info("prefab kit selector %r did not parse", selector, exc_info=True)
+        return {"selector": selector, "guids": [], "matched": 0, "error": BAD_SELECTOR}
     return {"selector": selector, "guids": list(r["guids"]), "matched": r["matched"],
             "truncated": bool(r.get("truncated")),
             "note": r.get("note")}
@@ -336,6 +358,23 @@ def register(kits: list[dict[str, Any]], idx: dict[str, dict] | None, *,
     }
 
 
+def freeze_blocker(kit: dict[str, Any], idx: dict[str, dict] | None) -> str | None:
+    """Why this kit cannot be frozen — one of the exported constants — or None if it can.
+
+    Split out from `freeze()` so a router can ask the question and answer with a constant, instead of
+    calling `freeze()` and stringifying whatever it raised. That is the difference between a response
+    whose text is a fixed literal and one derived from a caught exception, which is what
+    py/stack-trace-exposure is about."""
+    live = resolve(idx, (kit.get("data") or kit).get("selector") or "")
+    if live.get("error"):
+        return live["error"]                    # already a constant — see `resolve`
+    if not live["guids"]:
+        return FREEZE_NO_MATCH
+    if live.get("truncated"):
+        return FREEZE_TRUNCATED
+    return None
+
+
 def freeze(kit: dict[str, Any], idx: dict[str, dict] | None) -> dict[str, Any]:
     """The GUID list to write onto a kit when it is released.
 
@@ -343,13 +382,9 @@ def freeze(kit: dict[str, Any], idx: dict[str, dict] | None) -> dict[str, Any]:
     than a side effect. Refuses an empty or erroring selector — freezing nothing and calling it a
     released kit is the failure this whole module is built around.
     """
+    blocker = freeze_blocker(kit, idx)
+    if blocker:
+        raise ValueError(blocker)
     live = resolve(idx, (kit.get("data") or kit).get("selector") or "")
-    if live.get("error"):
-        raise ValueError(live["error"])
-    if not live["guids"]:
-        raise ValueError("the selector matches no elements — there is nothing to release")
-    if live.get("truncated"):
-        raise ValueError("the selector matched more elements than the query limit returns; a frozen "
-                         "scope must be the whole set, not the first page of it")
     return {"guids": live["guids"], "frozen_guids": "\n".join(live["guids"]),
             "selector": live["selector"], "matched": live["matched"]}

--- a/services/api/src/aec_api/routers/prefab.py
+++ b/services/api/src/aec_api/routers/prefab.py
@@ -81,10 +81,17 @@ def prefab_freeze(pid: str, rid: str, db: Session = Depends(get_db),
     precisely the failure this whole mechanism exists to prevent, and it would be indistinguishable
     from a correctly released one on every screen."""
     kit = me.get_record(db, "prefab_kit", pid, rid)
+    idx = _index(pid)
+    # Ask WHY it cannot be frozen and answer with that constant, rather than calling `freeze()` and
+    # stringifying whatever it raised. `str(e)` on a caught exception is the py/stack-trace-exposure
+    # sink; every string that can reach the response below is a module-level literal.
+    blocker = pk.freeze_blocker(kit, idx)
+    if blocker:
+        raise HTTPException(422, blocker)
     try:
-        frozen = pk.freeze(kit, _index(pid))
-    except ValueError as e:
-        raise HTTPException(422, str(e)) from e
+        frozen = pk.freeze(kit, idx)
+    except ValueError:                       # deliberately unbound — a fixed literal, never `e`
+        raise HTTPException(422, pk.FREEZE_FAILED) from None
     me.update_record(db, "prefab_kit", pid, rid,
                      {"frozen_guids": frozen["frozen_guids"]}, actor,
                      rbac.party_role_for(db, pid, actor))

--- a/services/api/test_prefab_kit.py
+++ b/services/api/test_prefab_kit.py
@@ -51,7 +51,25 @@ check("a selector resolves to the matching GUIDs", sorted(r["guids"]) == ["g1", 
 bad = pk.resolve(IDX, "&&&")
 check("a bad selector returns an error rather than raising",
       bad.get("error") and bad["guids"] == [], bad)
-check("  because one broken kit must not fail a register of twelve", "bad selector" in bad["error"])
+check("  because one broken kit must not fail a register of twelve", bad["error"] == pk.BAD_SELECTOR)
+
+# CodeQL #108 (py/stack-trace-exposure, medium) fired on this, at the GET kit-detail route — not at
+# freeze, which is where I would have looked. `resolve()` feeds THREE response paths (register,
+# detail, freeze), so `f"bad selector: {e}"` put a caught exception's text in three responses.
+#
+# Typing the exception does not clear it — a caught exception is tainted whatever its class. Only the
+# shape helps: a constant out, the detail to the log. These assertions pin that, because the natural
+# "improvement" is to put the parse error back in for friendlier diagnostics.
+import re as _re  # noqa: E402
+
+for probe in ("&&&", "storey", "!!!"):
+    err = pk.resolve(IDX, probe).get("error")
+    if err:
+        check(f"the error for {probe!r} carries NO exception text", err in
+              (pk.BAD_SELECTOR, "no selector set"), err)
+check("the constant does not embed a formatted exception",
+      not _re.search(r"Error|Exception|Traceback|line \d+", pk.BAD_SELECTOR), pk.BAD_SELECTOR)
+check("  and it tells the reader where the detail went", "server log" in pk.BAD_SELECTOR)
 check("an empty selector is an error too", pk.resolve(IDX, "  ").get("error") == "no selector set")
 check("with no model loaded nothing matches, and it says so",
       pk.resolve(None, "IfcDuctSegment")["matched"] == 0)
@@ -201,6 +219,22 @@ check("the register says whether a model was loaded at all", reg["model_loaded"]
 # --- 8. freeze refuses to write a scope that isn't one ---------------------------------------------
 f = pk.freeze(kit(selector="IfcDuctSegment & storey=L3"), IDX)
 check("freeze returns the resolved list", f["guids"] == ["g1", "g2"] or sorted(f["guids"]) == ["g1", "g2"])
+
+# The engine's refusal and the router's constant must not drift apart — two names for one string is
+# how a router starts answering with something the engine never says. `freeze_blocker` exists so the
+# router can ASK rather than catch, which is what keeps `str(e)` out of the response.
+check("freeze_blocker returns the exported constant for an empty match",
+      pk.freeze_blocker(kit(selector="IfcWall & storey=L9"), IDX) == pk.FREEZE_NO_MATCH)
+check("freeze_blocker returns the exported constant for a bad selector",
+      pk.freeze_blocker(kit(selector="&&&"), IDX) == pk.BAD_SELECTOR)
+check("freeze_blocker returns None when the kit CAN be frozen",
+      pk.freeze_blocker(kit(selector="IfcDuctSegment & storey=L3"), IDX) is None)
+try:
+    pk.freeze(kit(selector="IfcWall & storey=L9"), IDX)
+    check("freeze raises exactly what freeze_blocker reports", False, "no exception")
+except ValueError as _e:
+    check("freeze raises exactly what freeze_blocker reports",
+          str(_e) == pk.FREEZE_NO_MATCH, str(_e))
 check("  as newline-separated text for the record", f["frozen_guids"].count("\n") == 1)
 for label, sel, idx_ in (("an empty selector", "", IDX),
                          ("a selector matching nothing", "IfcWall & storey=L9", IDX),


### PR DESCRIPTION
Live **medium** CodeQL alert on `main` — `py/stack-trace-exposure` at `routers/prefab.py:64-67`, opened two minutes after #96 merged. Flagged by the security-audit session.

## Two things I had wrong, both worth recording

### 1. My alert query was unsound — which is why I kept reporting "CodeQL 0 open alerts"

```bash
gh api .../code-scanning/alerts --paginate -q '<filter>' | head -1
```

`--paginate` applies the filter **per page** and prints one result per page. `head -1` took the first page's count and I called it the total. Once an alert existed it emitted `1\n0`.

The sound form — one line per alert across all pages, then count lines:

```bash
gh api ".../code-scanning/alerts?state=open&per_page=100" --paginate -q '.[].number' | wc -l
```

This repo already has *"probe a `--jq` filter before looping on it"* in its notes. I had it and did it anyway.

### 2. The sink was not where it was reported to be

The finding arrived pointing at the **freeze** route. The alert's own location is lines **64-67** — `return pk.assess(...)` in the **GET kit-detail** route.

Checking that changed the fix. The root cause is `resolve()` returning `f\"bad selector: {e}\"`, and **`resolve()` feeds three response paths** — register, detail, and freeze. Fixing only freeze would have left two tainted and the alert open.

## The fix

Fixed at the source: `resolve()` returns the exported constant `BAD_SELECTOR` and logs the parse error server-side, so the detail an operator needs still exists and none of it reaches a response.

Per this repo's own precedent (`option_score.EMPTY_OPTIONS` → `routers/conceptual.py`, v0.3.671): **typing the exception does not clear this** — a caught exception is tainted whatever its class. Only changing the shape does.

`freeze_blocker()` is split out so the router **asks** why a kit cannot be frozen and answers with the constant, rather than calling `freeze()` and stringifying whatever it raised. The remaining `except ValueError` is deliberately unbound and answers with a fixed literal.

## Tests pin the property, not the message

- the error for three malformed selectors is one of the two constants
- the constant contains no `Error` / `Exception` / `Traceback` / `line N`
- `freeze()` raises **exactly** what `freeze_blocker()` reports, so the engine's refusal and the router's constant cannot drift into two names for one string

The natural future "improvement" here is to put the parse detail back for friendlier diagnostics — which is what these assertions exist to catch.

`prefab_kit` 52 checks + `prefab_route` 31 checks green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)