### PR TITLE
R23-JURISDICTION-PACKS — data requirements that belong to an authority

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -27,6 +27,8 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_contracts", "test_reports", "test_esign", "test_publish_status", "test_schedule_alerts",
          "test_schedule_optimize",
          "test_bundle", "test_desktop", "test_localmode", "test_project_budget", "test_rvt_bridge",
+         # R23-JURISDICTION-PACKS — authority-attributed data requirements:
+         "test_jurisdiction_packs", "test_jurisdiction_route",
          "test_bcf", "test_engines", "test_edge_cases", "test_opendata", "test_financials", "test_money", "test_leasemgmt", "test_changeorders",
          "test_migrate", "test_alembic_migrations", "test_appraisal", "test_marketing", "test_workflow_gate", "test_due_feed", "test_directory",
          # R22-CLASSIFY-AI — classification coverage + code proposals:

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -28,7 +28,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_schedule_optimize",
          "test_bundle", "test_desktop", "test_localmode", "test_project_budget", "test_rvt_bridge",
          # R23-JURISDICTION-PACKS — authority-attributed data requirements:
-         "test_jurisdiction_packs", "test_jurisdiction_route",
+         "test_jurisdiction_packs", "test_jurisdiction_route", "test_jurisdiction_authz",
          "test_bcf", "test_engines", "test_edge_cases", "test_opendata", "test_financials", "test_money", "test_leasemgmt", "test_changeorders",
          "test_migrate", "test_alembic_migrations", "test_appraisal", "test_marketing", "test_workflow_gate", "test_due_feed", "test_directory",
          # R22-CLASSIFY-AI — classification coverage + code proposals:

--- a/services/api/src/aec_api/jurisdiction_packs.py
+++ b/services/api/src/aec_api/jurisdiction_packs.py
@@ -48,6 +48,18 @@ _KEY = "jurisdiction_packs.json"
 MAX_PACKS = 100
 MAX_REQUIREMENTS = 200
 
+#: Per-FIELD size caps. `MAX_PACKS`/`MAX_REQUIREMENTS` bound the COUNT, and a bound on the count is
+#: not a bound on the size — the same mistake as capping each parameter value in `recipe_log` while
+#: nothing capped the entry. Stored packs are evaluated by a cheap GET
+#: (`/projects/{pid}/jurisdiction/check`), so oversized selectors persisted once amplify work on
+#: every subsequent read. Selectors reuse `rule_library`'s existing limit rather than inventing a
+#: second one: this module stores rule_library-shaped rules, so a selector it accepts and one
+#: `rule_library` accepts must be the same selector.
+MAX_SELECTOR_LEN = rule_library.MAX_SELECTOR_LEN
+MAX_ID_LEN = rule_library.MAX_ID_LEN
+MAX_TEXT_LEN = 200
+MAX_SOURCE_LEN = 500
+
 #: Fields a pack must carry to be storable. `authority`/`edition`/`source` are required because a
 #: requirement nobody can trace is indistinguishable from one somebody made up.
 REQUIRED = ("id", "jurisdiction", "authority", "name", "edition", "source")
@@ -58,11 +70,14 @@ _ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 #: It PARSES (as a bare-field existence test), resolves to `e.get("Pset_Foo.Bar")`, and matches
 #: nothing, so the requirement reads as satisfied on every model. Parse-validation cannot catch this,
 #: which is the point: the grammar is fine and the meaning is wrong.
-_DOTTED_PSET = re.compile(r"\b(Pset_|Qto_)[A-Za-z0-9_]*\.[A-Za-z0-9_]+")
+#: Quantifiers are BOUNDED (`{0,n}`, not `*`/`+`) and the input is truncated before the search.
+#: Both are required by this repo's ReDoS hardening rule, and a selector arrives straight off
+#: `POST /jurisdiction/packs`.
+_DOTTED_PSET = re.compile(r"\b(Pset_|Qto_)[A-Za-z0-9_]{0,64}\.[A-Za-z0-9_]{1,64}")
 
 
 def _looks_like_dotted_pset(selector: str) -> str | None:
-    m = _DOTTED_PSET.search(selector or "")
+    m = _DOTTED_PSET.search(str(selector or "")[:MAX_SELECTOR_LEN])
     return m.group(0) if m else None
 
 
@@ -98,7 +113,9 @@ EXAMPLE_PACK: dict[str, Any] = {
 def _norm_jurisdiction(j: Any) -> str:
     """Upper-cased and trimmed. Jurisdiction codes are compared, not parsed — `tx`, `TX ` and `Tx`
     are the same place, and treating them as three is how a project silently adopts nothing."""
-    return re.sub(r"\s+", " ", str(j or "")).strip().upper()
+    # Truncate BEFORE the regex. `\s+` is unbounded, and a jurisdiction string reaches this from a
+    # query parameter and from a project field — both user-controlled.
+    return re.sub(r"\s{1,64}", " ", str(j or "")[:MAX_TEXT_LEN]).strip().upper()
 
 
 def validate(pack: dict[str, Any]) -> dict[str, Any]:
@@ -116,6 +133,15 @@ def validate(pack: dict[str, Any]) -> dict[str, Any]:
             f"a pack must carry {', '.join(missing)} — a data requirement with no authority, edition "
             "or source is a house rule wearing a regulator's name, and the submitting party has no "
             "way to look up why their model failed")
+    # Size caps FIRST — before `_ID_RE`, before the selector parse, before the dotted-pset search.
+    # Every one of those applies a regex, and bounding the pattern is only half the rule; the input
+    # has to be bounded too, or a long enough string still buys CPU.
+    for field, cap in (("id", MAX_ID_LEN), ("jurisdiction", MAX_TEXT_LEN),
+                       ("authority", MAX_TEXT_LEN), ("name", MAX_TEXT_LEN),
+                       ("edition", MAX_TEXT_LEN), ("source", MAX_SOURCE_LEN)):
+        if len(str(pack.get(field) or "")) > cap:
+            raise PackError(f"{field} is too long (max {cap} characters)")
+
     pid = str(pack["id"]).strip().lower()
     if not _ID_RE.match(pid):
         raise PackError(f"pack id {pack['id']!r} must be lower-case alphanumeric with . _ - (max 64)")
@@ -134,6 +160,15 @@ def validate(pack: dict[str, Any]) -> dict[str, Any]:
         for field in ("scope", "require"):
             if not str(r.get(field) or "").strip():
                 raise PackError(f"requirement {i} is missing {field!r}")
+            # Same limit `rule_library` enforces — these ARE rule_library rules, and a selector this
+            # module accepts that `rule_library` would reject is a pack that stores and cannot run.
+            if len(str(r[field])) > MAX_SELECTOR_LEN:
+                raise PackError(f"requirement {i}'s {field} is too long "
+                                f"(max {MAX_SELECTOR_LEN} characters)")
+        if len(str(r.get("id") or "")) > MAX_ID_LEN:
+            raise PackError(f"requirement {i}'s id is too long (max {MAX_ID_LEN} characters)")
+        if len(str(r.get("name") or "")) > MAX_TEXT_LEN:
+            raise PackError(f"requirement {i}'s name is too long (max {MAX_TEXT_LEN} characters)")
         # Validated with the SAME parser that will evaluate it. A selector that stores fine and then
         # never matches is a silent pass — the rule looks enforced and enforces nothing.
         for field in ("scope", "require"):

--- a/services/api/src/aec_api/jurisdiction_packs.py
+++ b/services/api/src/aec_api/jurisdiction_packs.py
@@ -1,0 +1,272 @@
+"""R23-JURISDICTION-PACKS — data requirements that belong to an authority, not to a project.
+
+The ring entry: *"jurisdiction-scoped data-requirement rule packs (a regulator defines a pset spec a
+submitted model must satisfy). `query_dsl` + `rule_library` + IDS already carry this shape; turnover
+data requirements are the same problem."*
+
+Checked before building, and the shape is there while the scoping is not:
+
+* `rule_library` rules are **per project** (`{pid}/rule_library.json`) and hand-authored. Two projects
+  in the same city write the same rules twice and drift apart.
+* `ids_authoring` builds an IDS from a **use case**, not from a place.
+* `Project.jurisdiction` exists and already resolves the IBC edition for code-checking — so the field
+  is there and nothing reads it for *data* requirements.
+
+So this adds one thing: a pack is a **named, versioned, attributed** set of requirements keyed to a
+jurisdiction, adopted by a project rather than retyped into it. Each requirement is
+`rule_library`-shaped (`scope` + `require` selectors) and is evaluated by `rule_library.evaluate()` —
+the same evaluator, not a second one. A rule that means something different depending on which engine
+ran it is worse than no rule.
+
+**This module ships no regulatory claims, and that is deliberate.** A table asserting "Texas requires
+X" would be an invention wearing a citation unless someone had actually read the ordinance, and a
+fabricated requirement is worse than a missing one: it fails a model for a rule nobody imposed, and
+the person it fails has no way to check. So the built-in library contains exactly one pack, `example`,
+labelled as an example and attributed to nobody. Real packs are **imported** — from an authority, by
+someone who can point at the document.
+
+That is enforced rather than documented. `validate()` refuses a pack without an `authority`, an
+`edition` and a `source` — because a data requirement with no citation is a house rule wearing a
+regulator's name, and the whole value of the pack is that a submitting party can look up why.
+
+**Adoption is explicit.** `resolve()` returns the packs whose jurisdiction matches, and a project with
+no jurisdiction set gets an empty list and a reason — never a default pack. Same argument as the
+contract family in `notice_clock`: a requirement set from the wrong authority is not a conservative
+approximation of the right one, it is a different answer that looks exactly like it.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from . import rule_library, storage
+
+#: One global document rather than a per-project sidecar — the point of a pack is that it is shared.
+_KEY = "jurisdiction_packs.json"
+
+MAX_PACKS = 100
+MAX_REQUIREMENTS = 200
+
+#: Fields a pack must carry to be storable. `authority`/`edition`/`source` are required because a
+#: requirement nobody can trace is indistinguishable from one somebody made up.
+REQUIRED = ("id", "jurisdiction", "authority", "name", "edition", "source")
+
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+#: `Pset_Foo.Bar` — a property path written with a dot instead of the `::` the resolver uses.
+#: It PARSES (as a bare-field existence test), resolves to `e.get("Pset_Foo.Bar")`, and matches
+#: nothing, so the requirement reads as satisfied on every model. Parse-validation cannot catch this,
+#: which is the point: the grammar is fine and the meaning is wrong.
+_DOTTED_PSET = re.compile(r"\b(Pset_|Qto_)[A-Za-z0-9_]*\.[A-Za-z0-9_]+")
+
+
+def _looks_like_dotted_pset(selector: str) -> str | None:
+    m = _DOTTED_PSET.search(selector or "")
+    return m.group(0) if m else None
+
+
+class PackError(ValueError):
+    """A pack cannot be stored or applied as given."""
+
+
+#: The only built-in. Attributed to nobody on purpose: it demonstrates the shape and asserts nothing
+#: about any real jurisdiction. Real packs arrive through `import_pack`.
+EXAMPLE_PACK: dict[str, Any] = {
+    "id": "example",
+    "jurisdiction": "EXAMPLE",
+    "authority": "(example — not a real authority)",
+    "name": "Example data requirements",
+    "edition": "0",
+    "source": "built-in demonstration pack; replace with a pack from your authority",
+    "is_example": True,
+    "requirements": [
+        # `Pset::Prop`, with TWO colons. `Pset_WallCommon.FireRating` parses cleanly as a bare-field
+        # existence test, resolves to `e.get("Pset_WallCommon.FireRating")`, and therefore never
+        # matches anything — a requirement that looks enforced and enforces nothing. This pack
+        # shipped with exactly that mistake until a test caught it; see `_looks_like_dotted_pset`.
+        {"id": "walls-fire-rating", "name": "Walls declare a fire rating",
+         "scope": "IfcWall", "require": "Pset_WallCommon::FireRating", "severity": "high"},
+        {"id": "doors-fire-rating", "name": "Doors declare a fire rating",
+         "scope": "IfcDoor", "require": "Pset_DoorCommon::FireRating", "severity": "high"},
+        {"id": "spaces-named", "name": "Spaces are named", "scope": "IfcSpace",
+         "require": "name", "severity": "medium"},
+    ],
+}
+
+
+def _norm_jurisdiction(j: Any) -> str:
+    """Upper-cased and trimmed. Jurisdiction codes are compared, not parsed — `tx`, `TX ` and `Tx`
+    are the same place, and treating them as three is how a project silently adopts nothing."""
+    return re.sub(r"\s+", " ", str(j or "")).strip().upper()
+
+
+def validate(pack: dict[str, Any]) -> dict[str, Any]:
+    """A normalised pack, or `PackError` naming what is missing.
+
+    The citation fields are not bureaucracy: this module's whole claim is that a requirement belongs
+    to an authority. A pack that cannot say whose requirement it is has no standing to fail anyone's
+    model, and the person it fails cannot go and read the rule.
+    """
+    if not isinstance(pack, dict):
+        raise PackError("a pack must be an object")
+    missing = [f for f in REQUIRED if not str(pack.get(f) or "").strip()]
+    if missing:
+        raise PackError(
+            f"a pack must carry {', '.join(missing)} — a data requirement with no authority, edition "
+            "or source is a house rule wearing a regulator's name, and the submitting party has no "
+            "way to look up why their model failed")
+    pid = str(pack["id"]).strip().lower()
+    if not _ID_RE.match(pid):
+        raise PackError(f"pack id {pack['id']!r} must be lower-case alphanumeric with . _ - (max 64)")
+
+    reqs = pack.get("requirements")
+    if not isinstance(reqs, list) or not reqs:
+        raise PackError("a pack must carry at least one requirement")
+    if len(reqs) > MAX_REQUIREMENTS:
+        raise PackError(f"a pack may carry at most {MAX_REQUIREMENTS} requirements, got {len(reqs)}")
+
+    seen: set[str] = set()
+    norm_reqs = []
+    for i, r in enumerate(reqs):
+        if not isinstance(r, dict):
+            raise PackError(f"requirement {i} must be an object")
+        for field in ("scope", "require"):
+            if not str(r.get(field) or "").strip():
+                raise PackError(f"requirement {i} is missing {field!r}")
+        # Validated with the SAME parser that will evaluate it. A selector that stores fine and then
+        # never matches is a silent pass — the rule looks enforced and enforces nothing.
+        for field in ("scope", "require"):
+            try:
+                rule_library.query_dsl.parse(r[field])
+            except rule_library.query_dsl.QueryError as e:
+                raise PackError(f"requirement {i} has an unparseable {field}: {e}") from e
+            # Parsing is necessary and not sufficient. `Pset_WallCommon.FireRating` is valid grammar
+            # — a bare-field existence test — and resolves to a key no element has, so the
+            # requirement passes on every model forever. A rule that cannot fail is worse than a
+            # missing one: the authority believes it is enforced.
+            dotted = _looks_like_dotted_pset(r[field])
+            if dotted:
+                raise PackError(
+                    f"requirement {i}'s {field} contains {dotted!r} — property paths use TWO colons "
+                    f"({dotted.replace('.', '::')}). Written with a dot it parses as a bare field "
+                    "name, matches nothing, and the requirement silently passes on every model.")
+        rid = str(r.get("id") or f"r{i}").strip().lower()
+        if rid in seen:
+            raise PackError(f"duplicate requirement id {rid!r} — results are keyed on it")
+        seen.add(rid)
+        sev = str(r.get("severity") or "medium").lower()
+        if sev not in rule_library.SEVERITIES:
+            raise PackError(f"requirement {rid!r} has unknown severity {sev!r}; "
+                            f"known: {', '.join(rule_library.SEVERITIES)}")
+        norm_reqs.append({"id": rid, "name": str(r.get("name") or rid), "scope": str(r["scope"]),
+                          "require": str(r["require"]), "severity": sev})
+
+    return {
+        "id": pid,
+        "jurisdiction": _norm_jurisdiction(pack["jurisdiction"]),
+        "authority": str(pack["authority"]).strip(),
+        "name": str(pack["name"]).strip(),
+        "edition": str(pack["edition"]).strip(),
+        "source": str(pack["source"]).strip(),
+        "is_example": bool(pack.get("is_example")),
+        "requirements": norm_reqs,
+    }
+
+
+def _load() -> list[dict[str, Any]]:
+    try:
+        raw = storage.get(_KEY)
+    except Exception:  # noqa: BLE001 — nothing imported yet
+        return []
+    try:
+        d = json.loads(raw.decode("utf-8"))
+    except Exception as e:  # noqa: BLE001
+        # Same reasoning as recipe_log: an unreadable store is NOT an empty one, and treating it as
+        # empty means the next import overwrites every pack anyone has imported.
+        raise PackError(f"the jurisdiction-pack store exists but could not be read ({e}). "
+                        "It has NOT been overwritten.") from e
+    packs = d.get("packs") if isinstance(d, dict) else None
+    if not isinstance(packs, list):
+        raise PackError("the jurisdiction-pack store is not a pack document. It has NOT been overwritten.")
+    return packs
+
+
+def library() -> list[dict[str, Any]]:
+    """Every pack available — the built-in example plus anything imported."""
+    return [EXAMPLE_PACK, *_load()]
+
+
+def import_pack(pack: dict[str, Any]) -> dict[str, Any]:
+    """Validate and store a pack, replacing any pack with the same id."""
+    norm = validate(pack)
+    if norm["id"] == EXAMPLE_PACK["id"]:
+        raise PackError(f"{EXAMPLE_PACK['id']!r} is the built-in example pack id; choose another")
+    stored = [p for p in _load() if p.get("id") != norm["id"]]
+    if len(stored) >= MAX_PACKS:
+        raise PackError(f"at most {MAX_PACKS} imported packs")
+    stored.append(norm)
+    storage.put(_KEY, json.dumps({"packs": stored}).encode("utf-8"))
+    return norm
+
+
+def delete_pack(pack_id: str) -> bool:
+    stored = _load()
+    keep = [p for p in stored if p.get("id") != str(pack_id).strip().lower()]
+    if len(keep) == len(stored):
+        return False
+    storage.put(_KEY, json.dumps({"packs": keep}).encode("utf-8"))
+    return True
+
+
+def resolve(jurisdiction: str | None) -> dict[str, Any]:
+    """The packs that apply to a jurisdiction.
+
+    No jurisdiction → no packs, with a reason. Never a default: a requirement set from the wrong
+    authority is not a conservative approximation of the right one, it is a different answer that
+    looks exactly like it — and it would fail a model against rules nobody imposed.
+    """
+    j = _norm_jurisdiction(jurisdiction)
+    if not j:
+        return {"jurisdiction": None, "packs": [], "adopted": False,
+                "why": "this project has no jurisdiction set, and data requirements belong to a "
+                       "jurisdiction — set Project.jurisdiction, or apply a pack explicitly by id"}
+    packs = [p for p in library() if p.get("jurisdiction") == j]
+    return {"jurisdiction": j, "packs": packs, "adopted": bool(packs),
+            "why": None if packs else f"no pack has been imported for {j}"}
+
+
+def check(idx: dict[str, dict] | None, packs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Evaluate the packs' requirements against the model index.
+
+    Delegates every requirement to `rule_library.evaluate()`. Reusing the evaluator rather than
+    writing a second one is the point: a requirement expressed in the same selector language must
+    mean the same thing whether a project author wrote it or a regulator published it.
+    """
+    if idx is None:
+        return {"model_scored": False, "packs": [], "total_requirements": 0,
+                "note": "no model index loaded — a data-requirement check needs a model to check"}
+    out = []
+    total = failing = violations = 0
+    for p in packs:
+        res = rule_library.run(idx, p.get("requirements") or [])
+        total += res.get("total_rules", 0)
+        failing += res.get("failing_rules", 0)
+        violations += res.get("total_violations", 0)
+        out.append({
+            "id": p.get("id"), "name": p.get("name"), "authority": p.get("authority"),
+            "edition": p.get("edition"), "source": p.get("source"),
+            "is_example": bool(p.get("is_example")),
+            **res,
+        })
+    return {
+        "model_scored": True, "packs": out,
+        "total_requirements": total, "failing_requirements": failing,
+        "total_violations": violations,
+        "satisfied": failing == 0 and total > 0,
+        # Every result carries its authority and edition. A compliance figure detached from whose
+        # rules it measured is the kind of number that gets quoted at somebody.
+        "attribution": [{"pack": p.get("id"), "authority": p.get("authority"),
+                         "edition": p.get("edition"), "is_example": bool(p.get("is_example"))}
+                        for p in packs],
+    }

--- a/services/api/src/aec_api/main.py
+++ b/services/api/src/aec_api/main.py
@@ -47,6 +47,7 @@ from .routers import (
     exports,
     generate,
     ids,
+    jurisdiction,
     market,
     modules,
     notices,
@@ -444,6 +445,7 @@ app.include_router(assistant.router, tags=["assistant"])
 app.include_router(construction.router, tags=["construction"])
 app.include_router(operations.router, tags=["operations"])
 app.include_router(standards.router, tags=["standards"])
+app.include_router(jurisdiction.router, tags=["jurisdiction"])
 app.include_router(observability.router, tags=["observability"])
 
 

--- a/services/api/src/aec_api/routers/jurisdiction.py
+++ b/services/api/src/aec_api/routers/jurisdiction.py
@@ -1,0 +1,116 @@
+"""R23-JURISDICTION-PACKS — the pack library, and a project's check against the packs for its place.
+
+The library is global (a pack is meant to be shared); the check is project-scoped, because it needs
+that project's model and that project's jurisdiction.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from .. import jurisdiction_packs as jp
+from .. import model_index
+from ..db import get_db
+from ..deps import get_project
+from ..rbac import current_user, require_role
+
+router = APIRouter()
+
+
+@router.get("/jurisdiction/packs")
+def list_packs(jurisdiction: str | None = Query(None), _: str = Depends(current_user)):
+    """Every data-requirement pack available, optionally filtered to one jurisdiction.
+
+    The built-in `example` pack asserts nothing about any real place — it is there to show the shape.
+    Real packs are imported by someone who can point at the document they came from, which is why
+    `authority`, `edition` and `source` are required to store one."""
+    try:
+        packs = jp.library()
+    except jp.PackError as e:
+        raise HTTPException(409, str(e)) from e
+    if jurisdiction:
+        j = jurisdiction.strip().upper()
+        packs = [p for p in packs if p.get("jurisdiction") == j]
+    return {"packs": packs, "count": len(packs),
+            "note": "a pack states whose requirement it is; the built-in `example` pack states that "
+                    "it is an example and is attributed to nobody"}
+
+
+@router.post("/jurisdiction/packs", status_code=201)
+def import_pack(pack: dict = Body(...), _: str = Depends(current_user)):
+    """Import a data-requirement pack from an authority.
+
+    Refused without `authority`, `edition` and `source`. That is not bureaucracy: a requirement
+    nobody can trace is indistinguishable from one somebody made up, and this pack will be used to
+    fail other people's models. Selectors are validated with the same parser that will evaluate
+    them, so a requirement cannot store cleanly and then silently never match — which reads as a
+    pass."""
+    try:
+        return jp.import_pack(pack)
+    except jp.PackError as e:
+        raise HTTPException(422, str(e)) from e
+
+
+@router.delete("/jurisdiction/packs/{pack_id}")
+def delete_pack(pack_id: str, _: str = Depends(current_user)):
+    try:
+        removed = jp.delete_pack(pack_id)
+    except jp.PackError as e:
+        raise HTTPException(409, str(e)) from e
+    if not removed:
+        raise HTTPException(404, "no imported pack with that id (the built-in example cannot be deleted)")
+    return {"deleted": pack_id}
+
+
+@router.get("/projects/{pid}/jurisdiction/requirements")
+def project_requirements(pid: str, pack: str | None = Query(None),
+                         db: Session = Depends(get_db), _: str = Depends(require_role("viewer"))):
+    """The data requirements that apply to this project, resolved from its jurisdiction.
+
+    A project with no jurisdiction set gets an empty list and the reason — never a default pack. A
+    requirement set from the wrong authority is not a conservative approximation of the right one;
+    it is a different answer that looks exactly like it, and it would fail a model against rules
+    nobody imposed. Pass `?pack=` to apply one explicitly instead."""
+    project = get_project(db, pid)
+    try:
+        if pack:
+            chosen = [p for p in jp.library() if p.get("id") == pack.strip().lower()]
+            if not chosen:
+                raise HTTPException(404, f"no pack with id {pack!r}")
+            return {"jurisdiction": getattr(project, "jurisdiction", None), "packs": chosen,
+                    "adopted": True, "explicit": True,
+                    "note": "applied by id, not resolved from the project's jurisdiction"}
+        return jp.resolve(getattr(project, "jurisdiction", None))
+    except jp.PackError as e:
+        raise HTTPException(409, str(e)) from e
+
+
+@router.get("/projects/{pid}/jurisdiction/check")
+def project_check(pid: str, pack: str | None = Query(None),
+                  db: Session = Depends(get_db), _: str = Depends(require_role("viewer"))):
+    """Check the project's model against the data requirements for its jurisdiction.
+
+    Every result carries the pack's authority and edition. A compliance figure detached from whose
+    rules it measured is the kind of number that gets quoted at somebody, and `is_example` rides
+    along so a run against the demonstration pack can never be mistaken for a real one."""
+    project = get_project(db, pid)
+    try:
+        if pack:
+            packs = [p for p in jp.library() if p.get("id") == pack.strip().lower()]
+            if not packs:
+                raise HTTPException(404, f"no pack with id {pack!r}")
+            resolved = {"jurisdiction": getattr(project, "jurisdiction", None), "explicit": True}
+        else:
+            r = jp.resolve(getattr(project, "jurisdiction", None))
+            packs, resolved = r["packs"], {k: r[k] for k in ("jurisdiction", "adopted", "why")}
+        if not packs:
+            return {**resolved, "model_scored": False, "packs": [],
+                    "note": resolved.get("why") or "no pack applies to this project"}
+        try:
+            model_index.ensure_loaded(pid)
+            idx = model_index.get_index(pid)
+        except Exception:  # noqa: BLE001 — no model uploaded is an answer, not a failure
+            idx = None
+        return {**resolved, **jp.check(idx, packs)}
+    except jp.PackError as e:
+        raise HTTPException(409, str(e)) from e

--- a/services/api/src/aec_api/routers/jurisdiction.py
+++ b/services/api/src/aec_api/routers/jurisdiction.py
@@ -13,12 +13,30 @@ from .. import model_index
 from ..db import get_db
 from ..deps import get_project
 from ..rbac import current_user, require_role
+from .auth import require_admin_user
 
 router = APIRouter()
 
 
+def require_identified(user: str = Depends(current_user)) -> str:
+    """A caller who actually authenticated.
+
+    `current_user` IDENTIFIES; it does not AUTHORISE. With RBAC on and no bearer token, cookie or
+    trusted header it returns the literal string `"anonymous"` — so `Depends(current_user)` on its
+    own is not a gate, it is a name. These routes shipped with exactly that mistake and a live probe
+    returned 200 / **201** / 200 with no credentials at all while `GET /admin/errors` correctly
+    returned 403 in the same run.
+
+    This is the platform-global sibling of the `/projects/{pid}` rule in `route-authz-guard`: a route
+    that LOOKS guarded because a dependency is present, when the dependency only identifies.
+    """
+    if user in ("anonymous", None, ""):
+        raise HTTPException(403, "authentication required")
+    return user
+
+
 @router.get("/jurisdiction/packs")
-def list_packs(jurisdiction: str | None = Query(None), _: str = Depends(current_user)):
+def list_packs(jurisdiction: str | None = Query(None), _: str = Depends(require_identified)):
     """Every data-requirement pack available, optionally filtered to one jurisdiction.
 
     The built-in `example` pack asserts nothing about any real place — it is there to show the shape.
@@ -37,7 +55,7 @@ def list_packs(jurisdiction: str | None = Query(None), _: str = Depends(current_
 
 
 @router.post("/jurisdiction/packs", status_code=201)
-def import_pack(pack: dict = Body(...), _: str = Depends(current_user)):
+def import_pack(pack: dict = Body(...), _admin=Depends(require_admin_user)):
     """Import a data-requirement pack from an authority.
 
     Refused without `authority`, `edition` and `source`. That is not bureaucracy: a requirement
@@ -52,7 +70,7 @@ def import_pack(pack: dict = Body(...), _: str = Depends(current_user)):
 
 
 @router.delete("/jurisdiction/packs/{pack_id}")
-def delete_pack(pack_id: str, _: str = Depends(current_user)):
+def delete_pack(pack_id: str, _admin=Depends(require_admin_user)):
     try:
         removed = jp.delete_pack(pack_id)
     except jp.PackError as e:

--- a/services/api/test_jurisdiction_authz.py
+++ b/services/api/test_jurisdiction_authz.py
@@ -1,0 +1,88 @@
+"""R23-JURISDICTION-PACKS — the GLOBAL pack routes must refuse an unauthenticated caller.
+
+Its own test file, and RBAC-ON, because that is the only configuration in which the bug exists. The
+other two jurisdiction suites run with `AEC_RBAC` popped (the repo's convention), so they could never
+have caught this: with RBAC off `current_user` returns the X-User header and everything is
+authenticated by construction.
+
+THE BUG THIS PINS. `Depends(current_user)` IDENTIFIES; it does not AUTHORISE. With RBAC on and no
+bearer token, cookie or trusted header it returns the literal string `"anonymous"` — so a route
+guarded only by it is not guarded. Measured on the shipped branch before the fix:
+
+    GET    /jurisdiction/packs        -> 200
+    POST   /jurisdiction/packs        -> 201      <-- unauthenticated write to GLOBAL state
+    DELETE /jurisdiction/packs/{id}   -> 200
+    control: GET /admin/errors        -> 403      (so the harness was authenticating correctly)
+
+Packs are global and feed `/projects/{pid}/jurisdiction/check`, so anyone could have added, replaced
+or deleted rule packs that change compliance results across EVERY project in a matching jurisdiction.
+
+This is the platform-global sibling of `test_route_authz`, which only walks `/projects/{pid}` routes —
+a route with no `{pid}` is outside its remit entirely, which is why nothing caught this.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_jurisdiction_authz.py
+"""
+import os
+import sys
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_juris_authz.db"
+os.environ["STORAGE_DIR"] = "./test_storage_juris_authz"
+os.environ["AEC_RBAC"] = "1"                 # the whole point — RBAC ON
+os.environ.pop("AEC_TRUST_XUSER", None)      # ...and the dev header NOT trusted
+os.environ["AEC_AUTH_SECRET"] = "test-secret-that-is-long-enough-to-be-accepted"
+for _f in ("./test_juris_authz.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+PACK = {"id": "authz-probe", "jurisdiction": "TX", "authority": "a", "name": "n",
+        "edition": "1", "source": "s",
+        "requirements": [{"id": "r", "scope": "IfcWall", "require": "name", "severity": "high"}]}
+
+with TestClient(app) as c:
+    # The control first. If this is not 403 the harness is not actually running with RBAC on, and
+    # every assertion below would pass for the wrong reason.
+    ctl = c.get("/admin/errors")
+    check("CONTROL: a known-protected route refuses an anonymous caller",
+          ctl.status_code == 403, ctl.status_code)
+
+    check("anonymous cannot LIST packs", c.get("/jurisdiction/packs").status_code == 403,
+          c.get("/jurisdiction/packs").status_code)
+    imp = c.post("/jurisdiction/packs", json=PACK)
+    check("anonymous cannot IMPORT a pack — global state, every project's compliance",
+          imp.status_code == 403, imp.status_code)
+    dele = c.delete("/jurisdiction/packs/authz-probe")
+    check("anonymous cannot DELETE a pack", dele.status_code == 403, dele.status_code)
+
+    # A bare X-User header must not be enough either — that is the dev path, and it is exactly what
+    # `TRUST_XUSER` gates. If this passes, the header is being trusted in a production posture.
+    c2 = TestClient(app)
+    c2.headers.update({"X-User": "someone@example.com"})
+    with c2:
+        check("an untrusted X-User header does not grant access",
+              c2.post("/jurisdiction/packs", json=PACK).status_code == 403,
+              c2.post("/jurisdiction/packs", json=PACK).status_code)
+
+    # The project-scoped routes were always gated by require_role; assert it rather than assume.
+    check("the project-scoped requirements route is gated too",
+          c.get("/projects/nonexistent/jurisdiction/requirements").status_code in (401, 403, 404))
+    check("the project-scoped check route is gated too",
+          c.get("/projects/nonexistent/jurisdiction/check").status_code in (401, 403, 404))
+
+print()
+if FAILED:
+    print(f"jurisdiction_authz: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("jurisdiction_authz: all checks passed")

--- a/services/api/test_jurisdiction_packs.py
+++ b/services/api/test_jurisdiction_packs.py
@@ -1,0 +1,229 @@
+"""R23-JURISDICTION-PACKS — a requirement nobody can trace has no standing to fail anyone's model.
+
+This module's whole claim is that a data requirement belongs to an AUTHORITY. So most of what is
+asserted here is refusal: a pack without a citation, a selector that would store cleanly and never
+match, a project with no jurisdiction quietly adopting somebody else's rules.
+
+The one that matters most is the last. The tempting behaviour is a sensible default pack, and it is
+the same error as defaulting a contract family in `notice_clock`: a requirement set from the wrong
+authority is not a conservative approximation of the right one — it fails a model against rules
+nobody imposed, and the person it fails cannot look up why.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_jurisdiction_packs.py
+"""
+import os
+import shutil
+import sys
+
+os.environ.setdefault("STORAGE_DIR", "./test_storage_juris")
+sys.path.insert(0, "src")
+
+from aec_api import jurisdiction_packs as jp  # noqa: E402
+from aec_api import rule_library  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+shutil.rmtree(os.environ["STORAGE_DIR"], ignore_errors=True)
+
+GOOD = {
+    "id": "tx-example-city",
+    "jurisdiction": "tx",
+    "authority": "Example City Building Department",
+    "name": "Model submission data requirements",
+    "edition": "2026",
+    "source": "https://example.gov/bim-submission-standard-2026.pdf",
+    "requirements": [
+        {"id": "walls-rated", "name": "Walls declare a fire rating", "scope": "IfcWall",
+         "require": "Pset_WallCommon::FireRating", "severity": "high"},
+        {"id": "spaces-named", "name": "Spaces are named", "scope": "IfcSpace",
+         "require": "name", "severity": "medium"},
+    ],
+}
+
+# --- 1. the citation is not optional ---------------------------------------------------------------
+for field in ("authority", "edition", "source"):
+    try:
+        jp.validate({**GOOD, field: ""})
+        check(f"a pack with no {field} is refused", False, "no exception")
+    except jp.PackError as e:
+        check(f"a pack with no {field} is refused", field in str(e), str(e)[:90])
+try:
+    jp.validate({**GOOD, "authority": "", "edition": ""})
+    check("the refusal names EVERY missing field, not the first", False, "no exception")
+except jp.PackError as e:
+    check("the refusal names EVERY missing field, not the first",
+          "authority" in str(e) and "edition" in str(e), str(e)[:110])
+    check("  and says why a citation is required at all",
+          "house rule" in str(e) or "look up why" in str(e), str(e)[:140])
+
+# --- 2. a selector that would never match is refused at import, not at run time ---------------------
+# A requirement that stores cleanly and then silently never matches reads as a PASS. That is the
+# worst outcome available here: the authority believes it is enforced and nothing is checked.
+for bad, why in ((("scope", "&&&"), "unparseable scope"),
+                 (("require", "&&&"), "unparseable require")):
+    (field, value), label = bad, why
+    try:
+        jp.validate({**GOOD, "requirements": [{**GOOD["requirements"][0], field: value}]})
+        check(f"an {label} is refused", False, "no exception")
+    except jp.PackError as e:
+        check(f"an {label} is refused", field in str(e), str(e)[:90])
+check("selectors are validated with the SAME parser that evaluates them",
+      rule_library.query_dsl.parse is not None)
+
+# Parsing is necessary and NOT sufficient, and this is the case that proves it. `Pset_X.Prop` is
+# valid grammar — a bare-field existence test — resolving to a key no element has. So it matches
+# nothing and the requirement passes on every model, forever. A rule that cannot fail is worse than
+# a missing one: the authority believes it is enforced.
+#
+# The built-in example pack shipped with exactly this mistake until this test caught it.
+for probe in ("Pset_WallCommon.FireRating", "IfcWall & Qto_WallBaseQuantities.NetArea"):
+    parses = True
+    try:
+        rule_library.query_dsl.parse(probe)
+    except rule_library.query_dsl.QueryError:
+        parses = False
+    check(f"{probe!r} PARSES cleanly (which is why parse-validation cannot catch it)", parses)
+    try:
+        jp.validate({**GOOD, "requirements": [{**GOOD["requirements"][0], "require": probe}]})
+        check("  ...but the pack is refused anyway", False, "no exception")
+    except jp.PackError as e:
+        check("  ...but the pack is refused anyway", "TWO colons" in str(e), str(e)[:110])
+        check("  and the message shows the corrected form", "::" in str(e))
+
+check("the built-in example pack is itself valid", jp.validate(jp.EXAMPLE_PACK)["id"] == "example")
+check("  and uses the two-colon property syntax",
+      all("::" in r["require"] or "." not in r["require"]
+          for r in jp.EXAMPLE_PACK["requirements"]),
+      [r["require"] for r in jp.EXAMPLE_PACK["requirements"]])
+
+for label, req in (("a requirement with no scope", {"id": "x", "require": "name"}),
+                   ("a requirement with no require", {"id": "x", "scope": "IfcWall"}),
+                   ("an unknown severity", {**GOOD["requirements"][0], "severity": "critical"})):
+    try:
+        jp.validate({**GOOD, "requirements": [req]})
+        check(f"{label} is refused", False, "no exception")
+    except jp.PackError:
+        check(f"{label} is refused", True)
+try:
+    jp.validate({**GOOD, "requirements": [GOOD["requirements"][0], GOOD["requirements"][0]]})
+    check("duplicate requirement ids are refused", False, "no exception")
+except jp.PackError as e:
+    check("duplicate requirement ids are refused", "duplicate" in str(e))
+try:
+    jp.validate({**GOOD, "requirements": []})
+    check("a pack with no requirements is refused", False, "no exception")
+except jp.PackError:
+    check("a pack with no requirements is refused", True)
+
+# --- 3. normalisation ------------------------------------------------------------------------------
+norm = jp.validate(GOOD)
+check("the jurisdiction is upper-cased so tx/TX/'Tx ' are one place", norm["jurisdiction"] == "TX")
+check("  ...and whitespace-normalised",
+      jp.validate({**GOOD, "jurisdiction": "  tx  "})["jurisdiction"] == "TX")
+check("requirement ids are lower-cased and kept", [r["id"] for r in norm["requirements"]]
+      == ["walls-rated", "spaces-named"])
+check("a pack is not marked as an example unless it says so", norm["is_example"] is False)
+
+# --- 4. the built-in asserts nothing about any real place -------------------------------------------
+ex = jp.EXAMPLE_PACK
+check("the only built-in pack is flagged as an example", ex["is_example"] is True)
+check("  it is attributed to nobody real", "example" in ex["authority"].lower())
+check("  and its jurisdiction is not a real code", ex["jurisdiction"] == "EXAMPLE")
+check("the library ships exactly one built-in", len(jp.library()) == 1)
+try:
+    jp.import_pack({**GOOD, "id": "example"})
+    check("the example id cannot be overwritten by an import", False, "no exception")
+except jp.PackError:
+    check("the example id cannot be overwritten by an import", True)
+
+# --- 5. THE refusal that matters: no jurisdiction, no pack -------------------------------------------
+for empty in (None, "", "   "):
+    r = jp.resolve(empty)
+    check(f"a project with jurisdiction={empty!r} adopts NOTHING",
+          r["packs"] == [] and r["adopted"] is False)
+check("  and it says why, rather than defaulting",
+      "belong to a jurisdiction" in jp.resolve(None)["why"])
+unknown = jp.resolve("ZZ")
+check("an unknown jurisdiction adopts nothing and names it",
+      unknown["packs"] == [] and "ZZ" in unknown["why"])
+
+# --- 6. import / resolve round trip -------------------------------------------------------------------
+saved = jp.import_pack(GOOD)
+check("a valid pack imports", saved["id"] == "tx-example-city")
+res = jp.resolve("TX")
+check("it resolves for its jurisdiction", [p["id"] for p in res["packs"]] == ["tx-example-city"])
+check("  and lower-case resolves the same", [p["id"] for p in jp.resolve("tx")["packs"]]
+      == ["tx-example-city"])
+check("  the resolved pack carries its authority and edition",
+      res["packs"][0]["authority"] and res["packs"][0]["edition"])
+check("re-importing the same id replaces rather than duplicates",
+      len([p for p in jp.library() if p["id"] == "tx-example-city"]) == 1
+      and jp.import_pack({**GOOD, "name": "v2"}) is not None
+      and len([p for p in jp.library() if p["id"] == "tx-example-city"]) == 1)
+check("delete removes it", jp.delete_pack("tx-example-city") is True)
+check("  deleting a pack that is not there reports so", jp.delete_pack("tx-example-city") is False)
+jp.import_pack(GOOD)
+
+# --- 7. the check delegates to rule_library, and carries attribution ----------------------------------
+IDX = {
+    # `psets` is NESTED — the resolver reads e["psets"]["Pset_X"]["Prop"], not a flat dotted key.
+    # The first version of this fixture invented the flat shape, both requirements failed, and the
+    # "2 violations" assertion passed anyway because 2 happened to be the wrong-but-equal number.
+    "w1": {"ifc_class": "IfcWall", "name": "W1",
+           "psets": {"Pset_WallCommon": {"FireRating": "1HR"}}},
+    "w2": {"ifc_class": "IfcWall", "name": "W2", "psets": {}},          # no fire rating -> fails
+    "s1": {"ifc_class": "IfcSpace", "name": "Office 1"},
+    "s2": {"ifc_class": "IfcSpace"},                                     # unnamed -> fails
+}
+out = jp.check(IDX, jp.resolve("TX")["packs"])
+check("the check scores the model", out["model_scored"] is True)
+check("  every requirement is evaluated", out["total_requirements"] == 2)
+check("  both requirements fail on this model", out["failing_requirements"] == 2, out)
+check("  and the violations are counted", out["total_violations"] == 2, out["total_violations"])
+check("  satisfied is False while anything fails", out["satisfied"] is False)
+byid = {r["id"]: r for r in out["packs"][0]["rules"]}
+check("  the failing wall is named", byid["walls-rated"]["fail_guids"] == ["w2"], byid["walls-rated"])
+check("  the unnamed space is named", byid["spaces-named"]["fail_guids"] == ["s2"])
+check("every result carries WHOSE requirement it is",
+      out["attribution"][0]["authority"] == GOOD["authority"]
+      and out["attribution"][0]["edition"] == "2026", out["attribution"])
+check("  and whether it was the example pack", out["attribution"][0]["is_example"] is False)
+
+clean = jp.check({"w1": IDX["w1"], "s1": IDX["s1"]}, jp.resolve("TX")["packs"])
+check("a conforming model satisfies the pack",
+      clean["satisfied"] is True and clean["failing_requirements"] == 0, clean)
+
+check("with no model there is no score, and it says so",
+      jp.check(None, jp.resolve("TX")["packs"])["model_scored"] is False)
+
+# --- 8. an unreadable store is not an empty one ---------------------------------------------------------
+from aec_api import storage  # noqa: E402
+
+storage.put(jp._KEY, b"{ not json")
+try:
+    jp.library()
+    check("an unreadable pack store raises rather than reading as empty", False, "no exception")
+except jp.PackError as e:
+    check("an unreadable pack store raises rather than reading as empty", True)
+    check("  and says it was not overwritten", "NOT been overwritten" in str(e), str(e)[:110])
+storage.put(jp._KEY, b'{"packs": "not a list"}')
+try:
+    jp.library()
+    check("a store that parses but is not a pack document is refused", False, "no exception")
+except jp.PackError:
+    check("a store that parses but is not a pack document is refused", True)
+
+shutil.rmtree(os.environ["STORAGE_DIR"], ignore_errors=True)
+
+print()
+if FAILED:
+    print(f"jurisdiction_packs: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("jurisdiction_packs: all checks passed")

--- a/services/api/test_jurisdiction_packs.py
+++ b/services/api/test_jurisdiction_packs.py
@@ -97,6 +97,40 @@ for probe in ("Pset_WallCommon.FireRating", "IfcWall & Qto_WallBaseQuantities.Ne
         check("  ...but the pack is refused anyway", "TWO colons" in str(e), str(e)[:110])
         check("  and the message shows the corrected form", "::" in str(e))
 
+# --- size caps: a bound on the COUNT is not a bound on the SIZE -------------------------------------
+# Found by the Strix/qodo review on the PR. MAX_PACKS and MAX_REQUIREMENTS cap how MANY, and nothing
+# capped how BIG — and stored packs are evaluated by a cheap GET, so one oversized selector persisted
+# once amplifies work on every later read. Exactly the recipe_log per-value-vs-per-entry mistake,
+# repeated in a second module on the same day.
+for field, cap in (("authority", jp.MAX_TEXT_LEN), ("name", jp.MAX_TEXT_LEN),
+                   ("edition", jp.MAX_TEXT_LEN), ("source", jp.MAX_SOURCE_LEN),
+                   ("jurisdiction", jp.MAX_TEXT_LEN)):
+    try:
+        jp.validate({**GOOD, field: "x" * (cap + 1)})
+        check(f"an oversized {field} is refused", False, "no exception")
+    except jp.PackError as e:
+        check(f"an oversized {field} is refused", "too long" in str(e), str(e)[:80])
+for field in ("scope", "require"):
+    try:
+        jp.validate({**GOOD, "requirements": [
+            {**GOOD["requirements"][0], field: "IfcWall & " + "a" * jp.MAX_SELECTOR_LEN}]})
+        check(f"an oversized {field} selector is refused", False, "no exception")
+    except jp.PackError as e:
+        check(f"an oversized {field} selector is refused", "too long" in str(e), str(e)[:80])
+check("selector cap is rule_library's, not a second opinion",
+      jp.MAX_SELECTOR_LEN == rule_library.MAX_SELECTOR_LEN)
+
+# The regexes are bounded AND the input is truncated before they run — both halves of the rule.
+# A 200k-char selector must return promptly rather than buying CPU.
+import time as _time  # noqa: E402
+
+_t = _time.perf_counter()
+jp._looks_like_dotted_pset("Pset_" + "a" * 200_000 + ".Prop")
+jp._norm_jurisdiction(" " * 200_000 + "tx")
+_elapsed = _time.perf_counter() - _t
+check("a 200k-char input through both regexes returns in <100ms",
+      _elapsed < 0.1, f"{_elapsed * 1000:.1f}ms")
+
 check("the built-in example pack is itself valid", jp.validate(jp.EXAMPLE_PACK)["id"] == "example")
 check("  and uses the two-colon property syntax",
       all("::" in r["require"] or "." not in r["require"]

--- a/services/api/test_jurisdiction_route.py
+++ b/services/api/test_jurisdiction_route.py
@@ -1,0 +1,131 @@
+"""R23-JURISDICTION-PACKS over HTTP — the pack library, and a project's check against its place.
+
+The engine is tested in `test_jurisdiction_packs.py`. What only a live app shows is the resolution
+from `Project.jurisdiction` — the field already existed and drove code editions, and nothing read it
+for data requirements. The assertion that matters: a project with no jurisdiction gets nothing and a
+reason, never a default pack.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_jurisdiction_route.py
+"""
+import os
+import sys
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_juris_route.db"
+os.environ["STORAGE_DIR"] = "./test_storage_juris_route"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_juris_route.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api import model_index  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+PACK = {
+    "id": "tx-example-city", "jurisdiction": "TX",
+    "authority": "Example City Building Department",
+    "name": "Model submission data requirements", "edition": "2026",
+    "source": "https://example.gov/bim-submission-standard-2026.pdf",
+    "requirements": [
+        {"id": "walls-rated", "name": "Walls declare a fire rating", "scope": "IfcWall",
+         "require": "Pset_WallCommon::FireRating", "severity": "high"},
+    ],
+}
+
+ELEMENTS = [
+    {"guid": "w1", "ifc_class": "IfcWall", "name": "W1",
+     "psets": {"Pset_WallCommon": {"FireRating": "1HR"}}, "qtos": {}},
+    {"guid": "w2", "ifc_class": "IfcWall", "name": "W2", "psets": {}, "qtos": {}},
+]
+
+with TestClient(app) as c:
+    c.headers.update({"X-User": "juris@test"})
+
+    lib = c.get("/jurisdiction/packs")
+    check("GET /jurisdiction/packs answers 200", lib.status_code == 200, lib.text[:200])
+    L = lib.json()
+    check("  it ships exactly one built-in", L["count"] == 1, L["count"])
+    check("  flagged as an example, attributed to nobody real",
+          L["packs"][0]["is_example"] is True and "example" in L["packs"][0]["authority"].lower())
+
+    bad = c.post("/jurisdiction/packs", json={**PACK, "authority": ""})
+    check("a pack with no authority is a 422", bad.status_code == 422, bad.status_code)
+    check("  and the response says why a citation is required",
+          "house rule" in bad.text or "look up why" in bad.text, bad.text[:160])
+    dotted = c.post("/jurisdiction/packs", json={
+        **PACK, "requirements": [{**PACK["requirements"][0], "require": "Pset_WallCommon.FireRating"}]})
+    check("a dot-form property path is a 422 — it parses and never matches",
+          dotted.status_code == 422 and "TWO colons" in dotted.text, dotted.text[:160])
+
+    imp = c.post("/jurisdiction/packs", json=PACK)
+    check("a cited pack imports", imp.status_code == 201, imp.text[:200])
+    check("  and appears in the library",
+          len(c.get("/jurisdiction/packs?jurisdiction=TX").json()["packs"]) == 1)
+
+    # --- the resolution that is the point of the feature ---------------------------------------
+    pid = c.post("/projects", json={"name": "No Place"}).json()["id"]
+    none = c.get(f"/projects/{pid}/jurisdiction/requirements").json()
+    check("a project with NO jurisdiction adopts nothing",
+          none["packs"] == [] and none["adopted"] is False)
+    check("  and says why rather than defaulting", "belong to a jurisdiction" in none["why"])
+    chk = c.get(f"/projects/{pid}/jurisdiction/check").json()
+    check("  its check scores nothing and says so", chk["model_scored"] is False)
+
+    tx = c.post("/projects", json={"name": "Texas Tower", "jurisdiction": "TX"}).json()
+    tid = tx["id"]
+    if tx.get("jurisdiction") != "TX":                       # set it explicitly if create ignored it
+        c.patch(f"/projects/{tid}", json={"jurisdiction": "TX"})
+    req = c.get(f"/projects/{tid}/jurisdiction/requirements").json()
+    check("a TX project resolves the TX pack",
+          [p["id"] for p in req["packs"]] == ["tx-example-city"], req)
+    check("  reported as adopted", req["adopted"] is True)
+
+    # --- the check, with attribution --------------------------------------------------------------
+    model_index.load(tid, {"schema": "IFC4", "elements": ELEMENTS,
+                           "counts": {"elements": len(ELEMENTS)}})
+    r = c.get(f"/projects/{tid}/jurisdiction/check")
+    check("GET /jurisdiction/check answers 200", r.status_code == 200, r.text[:200])
+    J = r.json()
+    check("  the model is scored", J["model_scored"] is True)
+    check("  the unrated wall fails the requirement",
+          J["failing_requirements"] == 1 and J["total_violations"] == 1, J)
+    check("  and it is named", J["packs"][0]["rules"][0]["fail_guids"] == ["w2"])
+    check("  the result carries WHOSE requirement it is",
+          J["attribution"][0]["authority"] == PACK["authority"]
+          and J["attribution"][0]["edition"] == "2026", J["attribution"])
+    check("  and that it was not the example pack", J["attribution"][0]["is_example"] is False)
+    check("  satisfied is False while anything fails", J["satisfied"] is False)
+
+    model_index.load(tid, {"schema": "IFC4", "elements": [ELEMENTS[0]], "counts": {"elements": 1}})
+    ok = c.get(f"/projects/{tid}/jurisdiction/check").json()
+    check("a conforming model satisfies the pack", ok["satisfied"] is True, ok)
+
+    # --- explicit application, and the 404s -------------------------------------------------------
+    ex = c.get(f"/projects/{pid}/jurisdiction/check?pack=example").json()
+    check("a pack can be applied explicitly to a project with no jurisdiction",
+          [p["id"] for p in ex.get("packs", [])] == ["example"] or ex.get("model_scored") is False,
+          ex)
+    check("an unknown pack id is a 404",
+          c.get(f"/projects/{tid}/jurisdiction/check?pack=nope").status_code == 404)
+    check("an unknown pack id on requirements is a 404",
+          c.get(f"/projects/{tid}/jurisdiction/requirements?pack=nope").status_code == 404)
+    check("deleting the imported pack works",
+          c.delete("/jurisdiction/packs/tx-example-city").status_code == 200)
+    check("  deleting the built-in example is a 404",
+          c.delete("/jurisdiction/packs/example").status_code == 404)
+
+print()
+if FAILED:
+    print(f"jurisdiction_route: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("jurisdiction_route: all checks passed")

--- a/services/api/test_jurisdiction_route.py
+++ b/services/api/test_jurisdiction_route.py
@@ -13,6 +13,11 @@ import sys
 os.environ["DATABASE_URL"] = "sqlite:///./test_juris_route.db"
 os.environ["STORAGE_DIR"] = "./test_storage_juris_route"
 os.environ.pop("AEC_RBAC", None)
+# Importing/deleting a pack is now platform-admin only — the routes are GLOBAL, and a pack changes
+# compliance results across every project in a matching jurisdiction. `require_admin_user` resolves
+# admins from AEC_ADMIN_EMAILS, so the harness declares its caller one rather than reaching past the
+# gate. (The gate itself is proved by test_jurisdiction_authz, which runs with RBAC ON.)
+os.environ["AEC_ADMIN_EMAILS"] = "juris@test"
 for _f in ("./test_juris_route.db",):
     if os.path.exists(_f):
         os.remove(_f)
@@ -50,6 +55,13 @@ ELEMENTS = [
 
 with TestClient(app) as c:
     c.headers.update({"X-User": "juris@test"})
+    # require_admin_user looks the caller up in the users table, so the row has to exist.
+    from aec_api.db import SessionLocal
+    from aec_api.models import User
+    with SessionLocal() as _db:
+        if not _db.get(User, "juris@test"):
+            _db.add(User(username="juris@test", password_hash="", role="admin", active=True))
+            _db.commit()
 
     lib = c.get("/jurisdiction/packs")
     check("GET /jurisdiction/packs answers 200", lib.status_code == 200, lib.text[:200])


### PR DESCRIPTION
Ring item **R23-JURISDICTION-PACKS**: *"jurisdiction-scoped data-requirement rule packs (a regulator defines a pset spec a submitted model must satisfy). `query_dsl` + `rule_library` + IDS already carry this shape."*

Backend only. Merges clean against current main.

## The shape was there; the scoping was not

- `rule_library` rules are **per project** and hand-authored — two projects in the same city write the same rules twice and drift apart.
- `ids_authoring` builds an IDS from a **use case**, not a place.
- `Project.jurisdiction` already existed and already resolved the IBC edition for code-checking — and **nothing read it for data requirements**.

So this adds one thing: a named, versioned, **attributed** set of requirements keyed to a jurisdiction, *adopted* rather than retyped. Every requirement is `rule_library`-shaped and evaluated by `rule_library.evaluate()` — the same evaluator, not a second one. A rule that means something different depending on which engine ran it is worse than no rule.

## It ships no regulatory claims, deliberately

A table asserting *"Texas requires X"* would be an invention wearing a citation unless someone had actually read the ordinance — and a fabricated requirement is worse than a missing one: it fails a model against a rule nobody imposed, and the person it fails cannot check.

The built-in library is exactly one pack, `example`, attributed to nobody. Real packs are **imported**, by someone who can point at the document.

That's enforced rather than documented: `authority`, `edition` and `source` are required to store a pack. A requirement nobody can trace is indistinguishable from one somebody made up, and this pack will be used to fail other people's models.

**A project with no jurisdiction adopts nothing** and is told why — same argument as the contract family in #95: a requirement set from the wrong authority is not a conservative approximation of the right one.

## Two defects my own tests found — the same one twice

**The example pack shipped broken.** It used `Pset_WallCommon.FireRating`; the resolver uses `Pset::Prop` with **two colons**. Written with a dot it *parses* — as a bare-field existence test — resolves to a key no element has, matches nothing, and **the requirement passes on every model forever**. A rule that cannot fail is worse than a missing one, because the authority believes it's enforced.

Parse-validation cannot catch this: the grammar is fine and the meaning is wrong. Now refused at import with the corrected form in the message, and the built-in is asserted valid against its own validator.

**My test fixture invented the index shape** — flat `{"Pset_X.Prop": v}` when the real one nests under `psets`. Both requirements then failed, and the "2 violations" assertion passed anyway because 2 was the wrong-but-equal number.

Both are the same pattern that has run through this whole batch: *the measurement matched my model, not the thing.*

## Routes

```
GET    /jurisdiction/packs?jurisdiction=
POST   /jurisdiction/packs
DELETE /jurisdiction/packs/{id}
GET    /projects/{pid}/jurisdiction/requirements?pack=
GET    /projects/{pid}/jurisdiction/check?pack=
```

Every check result carries the pack's `authority`, `edition` and `is_example`. A compliance figure detached from whose rules it measured is the kind of number that gets quoted at somebody.

## Verification

- **41 engine checks + 26 HTTP checks** green
- `ruff check src/ ../data/src/` clean
- `route_authz` (695 routes), `reachable`, `route_order`, `rule_library` pass
- No new module and no new table, so no Alembic revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)