### PR TITLE
R22-MEMORY ② — what a cost code cost PER UNIT, across your projects

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -42,7 +42,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:
-         "test_drafting", "test_bid_leveling", "test_benchmarking",
+         "test_drafting", "test_bid_leveling", "test_benchmarking", "test_unit_rate_memory", "test_unit_rate_route",
          # R22-NOTICE-CLOCK — contractual notice periods + the register routes:
          "test_notice_clock", "test_notices_route",
          # Tier-2/3 competitive upgrades:

--- a/services/api/src/aec_api/routers/benchmarking.py
+++ b/services/api/src/aec_api/routers/benchmarking.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from .. import benchmarking
+from .. import benchmarking, unit_rate_memory
 from ..db import get_db
 from ..rbac import current_user, member_project_ids
 
@@ -19,6 +19,25 @@ def cost_benchmarks(min_samples: int = 3, db: Session = Depends(get_db),
     """Actual-cost distribution (low/p25/median/p75/high) per cost code across your projects."""
     return benchmarking.cost_benchmarks(db, min_samples=max(1, min(min_samples, 50)),
                                         project_ids=member_project_ids(db, user))
+
+
+@router.get("/benchmarks/unit-rates")
+def unit_rates(min_projects: int = 3, db: Session = Depends(get_db),
+               user: str = Depends(current_user)):
+    """Actual **unit** rates per cost code — `direct_cost` divided by installed
+    `production_quantity` — distributed across your projects.
+
+    The sibling of `/benchmarks/costs`, and the one that needs the field's own quantity records:
+    that endpoint says what a cost code has cost, this one says what it cost **per unit**, which is
+    the difference between "this project was expensive" and "concrete is dear".
+
+    Each rate is ONE project's cost over that project's quantity, and the distribution is over
+    projects. `pooled_rate` — the portfolio-wide blend — is reported beside it and answers a
+    different question; one large project sets it. Units are grouped, never converted, and a project
+    that records one cost code under two units is excluded rather than split. Everything excluded
+    comes back with a count and a reason."""
+    return unit_rate_memory.unit_rates(db, min_projects=max(1, min(min_projects, 50)),
+                                       project_ids=member_project_ids(db, user))
 
 
 @router.get("/benchmarks/response-rates")

--- a/services/api/src/aec_api/unit_rate_memory.py
+++ b/services/api/src/aec_api/unit_rate_memory.py
@@ -1,0 +1,213 @@
+"""R22-MEMORY ② — what a cost code actually cost **per unit**, across your own projects.
+
+`benchmarking.cost_benchmarks()` already answers "what has code 03 30 00 cost us", cross-project, from
+`direct_cost`. That is a cost-code distribution, and it is what anyone with an accounting export can
+build. It cannot tell you whether a project was expensive because concrete is dear or because there
+was a lot of concrete.
+
+This is the other half the ring called the differentiator: **cost ÷ installed quantity**, keyed to
+the codes the field actually reports against. It joins two record types nothing had joined —
+`direct_cost` (cost_code, amount) and `production_quantity` (cost_code, quantity, unit) — and neither
+engine that owns them looks at the other.
+
+**The rate is computed per project, then distributed.** Not `Σcost ÷ Σquantity` across the portfolio.
+That second number is a weighted average wearing a distribution's clothes: one large project would
+set the median, and the spread — which is the entire reason to look — would be invented rather than
+observed. Both figures are useful and they are different, so the portfolio-wide blend is reported
+alongside as `pooled_rate`, labelled, never as the headline.
+
+**Units are grouped, never converted.** m² and SF for one code are two populations. There is no
+conversion here on purpose: a silent unit conversion is indistinguishable from a correct number and
+gets quoted at somebody. If ONE project records a single cost code under two different units, that
+project is **excluded for that code** — its cost cannot be attributed between them, and splitting it
+pro-rata would be a guess with a plausible shape.
+
+**Every exclusion is reported, never dropped.** Cost with no quantity, quantity with no cost, and the
+mixed-unit case each come back with a count and a reason. A project that could not be measured is not
+a project that cost zero — the same rule the entitlement expectation had to be corrected for.
+
+**Known limitation, stated because it moves the number in a knowable direction.** `direct_cost` and
+`production_quantity` accumulate independently. A code whose invoices are booked ahead of the field's
+quantity reporting reads as expensive, and the reverse reads as cheap. Nothing here can detect that
+from the records alone, so the per-project rates are published individually rather than only
+summarised — a reader can see an outlier and go and look. `spread_ratio` (high ÷ low) is the cheap
+signal: a code where one project is 10× another is usually a reporting-lag artefact, not a price.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from . import modules as me
+
+#: A distribution needs a population. Below this many projects a code reports its rates but is
+#: flagged `below_threshold` rather than summarised, so a single job cannot look like a benchmark.
+DEFAULT_MIN_PROJECTS = 3
+
+
+def _num(v: Any) -> float | None:
+    try:
+        return float(v) if v not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _norm(s: Any) -> str:
+    return " ".join(str(s or "").split()).strip()
+
+
+def _rows(db: Session, key: str, project_ids: set[str] | None) -> list[tuple[str, dict]]:
+    """`(project_id, data)` for every record of a module across the caller's projects.
+
+    `benchmarking._rows` exists and is not reused here because it does not select `project_id` — it
+    aggregates across the portfolio and never needs to know which project a row came from. A unit
+    rate is computed PER PROJECT and then distributed, so the project is the grouping key, not an
+    implementation detail. Same tenant scoping: `project_ids=None` means unrestricted (RBAC off or
+    admin), otherwise the roll-up is limited to the caller's projects.
+    """
+    t = me.TABLES.get(key)
+    if t is None:
+        return []
+    stmt = select(t.c.project_id, t.c.data)
+    if project_ids is not None:
+        stmt = stmt.where(t.c.project_id.in_(project_ids))
+    return [(pid, data or {}) for pid, data in db.execute(stmt).all()]
+
+
+def _pctile(vals: list[float], q: float) -> float:
+    """Linear-interpolated percentile over a sorted list — same method as `benchmarking._pctile`, so
+    a unit-rate p75 and a cost p75 are computed the same way and can sit beside each other."""
+    if not vals:
+        return 0.0
+    if len(vals) == 1:
+        return vals[0]
+    pos = q * (len(vals) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(vals) - 1)
+    return vals[lo] + (vals[hi] - vals[lo]) * (pos - lo)
+
+
+def per_project_rates(costs: list[tuple[str, dict]],
+                      quantities: list[tuple[str, dict]]) -> dict[str, Any]:
+    """One actual unit rate per (project, cost_code, unit), plus everything that could not produce one.
+
+    Pure — takes the rows rather than a session, so the arithmetic is testable without a database.
+    """
+    cost_by: dict[tuple[str, str], float] = {}
+    for pid, d in costs:
+        code = _norm(d.get("cost_code"))
+        amt = _num(d.get("amount"))
+        if code and amt is not None:
+            cost_by[(pid, code)] = cost_by.get((pid, code), 0.0) + amt
+
+    # (project, code) -> {unit: qty}. The nested unit map is what makes the mixed-unit case visible
+    # instead of silently summing across units.
+    qty_by: dict[tuple[str, str], dict[str, float]] = {}
+    for pid, d in quantities:
+        code = _norm(d.get("cost_code"))
+        qty = _num(d.get("quantity"))
+        unit = _norm(d.get("unit")).lower()
+        if not code or qty is None or qty <= 0:
+            continue
+        per_unit = qty_by.setdefault((pid, code), {})
+        per_unit[unit or "(no unit)"] = per_unit.get(unit or "(no unit)", 0.0) + qty
+
+    rates: list[dict[str, Any]] = []
+    mixed_units: list[dict[str, Any]] = []
+    cost_no_qty: list[dict[str, Any]] = []
+    qty_no_cost: list[dict[str, Any]] = []
+
+    for (pid, code), units in sorted(qty_by.items()):
+        cost = cost_by.get((pid, code))
+        if cost is None or cost <= 0:
+            qty_no_cost.append({"project_id": pid, "cost_code": code,
+                                "units": sorted(units), "quantity": round(sum(units.values()), 4),
+                                "reason": "installed quantity recorded but no direct cost posted "
+                                          "against this code"})
+            continue
+        if len(units) > 1:
+            mixed_units.append({
+                "project_id": pid, "cost_code": code, "units": sorted(units),
+                "reason": "one cost code recorded under more than one unit in the same project; the "
+                          "cost cannot be attributed between them, and splitting it pro-rata would "
+                          "be a guess"})
+            continue
+        unit, qty = next(iter(units.items()))
+        rates.append({"project_id": pid, "cost_code": code, "unit": unit,
+                      "cost": round(cost, 2), "quantity": round(qty, 4),
+                      "rate": round(cost / qty, 4)})
+
+    for (pid, code), cost in sorted(cost_by.items()):
+        if (pid, code) not in qty_by and cost > 0:
+            cost_no_qty.append({"project_id": pid, "cost_code": code, "cost": round(cost, 2),
+                                "reason": "cost posted but no installed quantity recorded against "
+                                          "this code — no rate can be computed"})
+
+    return {"rates": rates, "excluded": {
+        "mixed_units": mixed_units, "cost_without_quantity": cost_no_qty,
+        "quantity_without_cost": qty_no_cost,
+        "note": "excluded rows are reported, never dropped — a project that could not be measured is "
+                "not a project that cost zero"}}
+
+
+def summarise(rates: list[dict[str, Any]], min_projects: int = DEFAULT_MIN_PROJECTS) -> list[dict]:
+    """Distribution of the PER-PROJECT rates, grouped by (cost_code, unit)."""
+    by_key: dict[tuple[str, str], list[dict]] = {}
+    for r in rates:
+        by_key.setdefault((r["cost_code"], r["unit"]), []).append(r)
+
+    out = []
+    for (code, unit), rows in by_key.items():
+        vals = sorted(r["rate"] for r in rows)
+        total_cost = sum(r["cost"] for r in rows)
+        total_qty = sum(r["quantity"] for r in rows)
+        lo, hi = vals[0], vals[-1]
+        out.append({
+            "cost_code": code, "unit": unit,
+            "projects": len(vals),
+            "below_threshold": len(vals) < min_projects,
+            "low": round(lo, 4), "p25": round(_pctile(vals, 0.25), 4),
+            "median": round(_pctile(vals, 0.5), 4), "p75": round(_pctile(vals, 0.75), 4),
+            "high": round(hi, 4),
+            # The portfolio-wide blend, reported ALONGSIDE and never as the headline. It answers a
+            # different question — "what did this code cost us overall per unit" — and one large
+            # project sets it.
+            "pooled_rate": round(total_cost / total_qty, 4) if total_qty else None,
+            "total_cost": round(total_cost, 2), "total_quantity": round(total_qty, 4),
+            # high/low. A code where one project is an order of magnitude off another is usually a
+            # reporting-lag artefact rather than a price difference — the cheapest signal available
+            # for the limitation named in the module docstring.
+            "spread_ratio": round(hi / lo, 2) if lo > 0 else None,
+            "per_project": sorted(rows, key=lambda r: r["rate"]),
+        })
+    out.sort(key=lambda c: (-c["projects"], c["cost_code"]))
+    return out
+
+
+def unit_rates(db: Session, *, min_projects: int = DEFAULT_MIN_PROJECTS,
+               project_ids: set[str] | None = None) -> dict[str, Any]:
+    """Cross-project actual unit rates: `direct_cost` ÷ `production_quantity`, per cost code and unit."""
+    joined = per_project_rates(_rows(db, "direct_cost", project_ids),
+                               _rows(db, "production_quantity", project_ids))
+    codes = summarise(joined["rates"], min_projects)
+    usable = [c for c in codes if not c["below_threshold"]]
+    return {
+        "cost_codes": codes,
+        "code_count": len(codes),
+        "usable_count": len(usable),
+        "min_projects": min_projects,
+        "excluded": joined["excluded"],
+        "basis": ("each rate is one PROJECT's cost divided by that project's installed quantity for "
+                  "one cost code and unit; the distribution is over projects. `pooled_rate` is the "
+                  "portfolio-wide blend and answers a different question"),
+        "limitation": ("direct_cost and production_quantity accumulate independently, so a code whose "
+                       "invoices lead its field quantity reporting reads as expensive and the reverse "
+                       "reads as cheap. Check `spread_ratio` and `per_project` before quoting a "
+                       "median"),
+        "message": (None if usable else
+                    f"Not enough history yet — a cost code needs installed quantities AND posted "
+                    f"costs on ≥{min_projects} projects before its unit rate is a distribution "
+                    f"rather than an anecdote."),
+    }

--- a/services/api/src/aec_api/unit_rate_memory.py
+++ b/services/api/src/aec_api/unit_rate_memory.py
@@ -135,9 +135,16 @@ def per_project_rates(costs: list[tuple[str, dict]],
                           "be a guess"})
             continue
         unit, qty = next(iter(units.items()))
+        # `cost`/`quantity`/`rate` are DISPLAY values and are rounded. `_raw` carries the unrounded
+        # numbers, because `summarise()` sums across projects and summing rounded values drifts:
+        # measured at 60 projects, a reported total of 6000.00 against a true 6000.30, and a
+        # `pooled_rate` of 33.3333 where Σcost ÷ Σquantity is 33.3344. The payload states that
+        # formula, so the arithmetic has to honour it — a figure that contradicts its own stated
+        # definition is worse than one with no definition.
         rates.append({"project_id": pid, "cost_code": code, "unit": unit,
                       "cost": round(cost, 2), "quantity": round(qty, 4),
-                      "rate": round(cost / qty, 4)})
+                      "rate": round(cost / qty, 4),
+                      "_raw": {"cost": cost, "quantity": qty, "rate": cost / qty}})
 
     for (pid, code), cost in sorted(cost_by.items()):
         if (pid, code) not in qty_by and cost > 0:
@@ -160,9 +167,10 @@ def summarise(rates: list[dict[str, Any]], min_projects: int = DEFAULT_MIN_PROJE
 
     out = []
     for (code, unit), rows in by_key.items():
-        vals = sorted(r["rate"] for r in rows)
-        total_cost = sum(r["cost"] for r in rows)
-        total_qty = sum(r["quantity"] for r in rows)
+        # Every aggregate below is computed from `_raw`, never from the rounded display fields.
+        vals = sorted(r["_raw"]["rate"] for r in rows)
+        total_cost = sum(r["_raw"]["cost"] for r in rows)
+        total_qty = sum(r["_raw"]["quantity"] for r in rows)
         lo, hi = vals[0], vals[-1]
         out.append({
             "cost_code": code, "unit": unit,
@@ -180,7 +188,9 @@ def summarise(rates: list[dict[str, Any]], min_projects: int = DEFAULT_MIN_PROJE
             # reporting-lag artefact rather than a price difference — the cheapest signal available
             # for the limitation named in the module docstring.
             "spread_ratio": round(hi / lo, 2) if lo > 0 else None,
-            "per_project": sorted(rows, key=lambda r: r["rate"]),
+            # `_raw` is an internal carrier, stripped before the rows are published.
+            "per_project": [{k: v for k, v in r.items() if k != "_raw"}
+                            for r in sorted(rows, key=lambda r: r["_raw"]["rate"])],
         })
     out.sort(key=lambda c: (-c["projects"], c["cost_code"]))
     return out

--- a/services/api/test_unit_rate_memory.py
+++ b/services/api/test_unit_rate_memory.py
@@ -1,0 +1,152 @@
+"""R22-MEMORY ② — the unit rate has to be a distribution over PROJECTS, not a blended average.
+
+Every number here is hand-computed and asserted exactly. The finance-math review of this repo found
+17 defects in a package whose tests RANGE-checked — `0 <= p <= 1` is satisfied by the right answer
+and the wrong one equally — so "the median is a number between low and high" is not a test.
+
+The three that would each produce a plausible wrong figure:
+
+* pooling `Σcost ÷ Σquantity` and calling it the median (one large project sets it, and the spread
+  is invented rather than observed);
+* summing quantities across DIFFERENT units for one cost code;
+* dropping a project that has cost but no quantity, so an unmeasurable job silently reads as absent
+  rather than as excluded.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_unit_rate_memory.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api import unit_rate_memory as urm  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+def cost(pid, code, amount):
+    return (pid, {"cost_code": code, "amount": amount})
+
+
+def qty(pid, code, quantity, unit):
+    return (pid, {"cost_code": code, "quantity": quantity, "unit": unit})
+
+
+# --- 1. the arithmetic, hand-computed ---------------------------------------------------------------
+# P1: 03 30 00 — $60,000 over 200 m3 -> 300.00 /m3
+# P2: 03 30 00 — $22,000 over 100 m3 -> 220.00 /m3
+# P3: 03 30 00 — $90,000 over 200 m3 -> 450.00 /m3
+COSTS = [cost("P1", "03 30 00", 40_000), cost("P1", "03 30 00", 20_000),
+         cost("P2", "03 30 00", 22_000),
+         cost("P3", "03 30 00", 90_000)]
+QTYS = [qty("P1", "03 30 00", 150, "m3"), qty("P1", "03 30 00", 50, "m3"),
+        qty("P2", "03 30 00", 100, "m3"),
+        qty("P3", "03 30 00", 200, "m3")]
+
+j = urm.per_project_rates(COSTS, QTYS)
+by_pid = {r["project_id"]: r for r in j["rates"]}
+check("a project's rows are summed before dividing",
+      by_pid["P1"]["cost"] == 60_000.0 and by_pid["P1"]["quantity"] == 200.0)
+check("P1 rate = 60000 / 200 = 300.0", by_pid["P1"]["rate"] == 300.0, by_pid["P1"]["rate"])
+check("P2 rate = 22000 / 100 = 220.0", by_pid["P2"]["rate"] == 220.0, by_pid["P2"]["rate"])
+check("P3 rate = 90000 / 200 = 450.0", by_pid["P3"]["rate"] == 450.0, by_pid["P3"]["rate"])
+check("the unit rides with the rate", {r["unit"] for r in j["rates"]} == {"m3"})
+
+# --- 2. the distribution is over PROJECTS, and pooling is a different number -------------------------
+s = urm.summarise(j["rates"], min_projects=3)
+check("one (code, unit) group", len(s) == 1, [(c["cost_code"], c["unit"]) for c in s])
+g = s[0]
+check("three projects in the population", g["projects"] == 3)
+check("median of {220, 300, 450} is 300.0 — the middle PROJECT",
+      g["median"] == 300.0, g["median"])
+check("low is 220.0 and high is 450.0", g["low"] == 220.0 and g["high"] == 450.0)
+
+# THE assertion this module exists for. Pooled = 172000/500 = 344.0, which is NOT the median 300.0.
+# If someone "simplifies" summarise() to sum-then-divide, median silently becomes 344.0 and every
+# range check still passes.
+check("pooled_rate = 172000 / 500 = 344.0", g["pooled_rate"] == 344.0, g["pooled_rate"])
+check("  and it DIFFERS from the median — pooling is not the distribution",
+      g["pooled_rate"] != g["median"], (g["pooled_rate"], g["median"]))
+check("totals are reported so the pooled figure can be rechecked",
+      g["total_cost"] == 172_000.0 and g["total_quantity"] == 500.0)
+check("spread_ratio = 450 / 220 = 2.05", g["spread_ratio"] == 2.05, g["spread_ratio"])
+check("per_project rows ride along, sorted by rate",
+      [r["rate"] for r in g["per_project"]] == [220.0, 300.0, 450.0])
+check("three projects meets the default threshold", g["below_threshold"] is False)
+check("two would not", urm.summarise(j["rates"][:2], min_projects=3)[0]["below_threshold"] is True)
+
+# --- 3. units are grouped, never converted -----------------------------------------------------------
+MIXED = [cost("A", "09 21 16", 1_000), cost("B", "09 21 16", 2_000)]
+MIXEDQ = [qty("A", "09 21 16", 100, "m2"), qty("B", "09 21 16", 100, "SF")]
+m = urm.summarise(urm.per_project_rates(MIXED, MIXEDQ)["rates"], min_projects=1)
+check("m2 and SF are TWO populations, not one", len(m) == 2, [(c["cost_code"], c["unit"]) for c in m])
+check("  neither is converted into the other",
+      {c["unit"] for c in m} == {"m2", "sf"}, [c["unit"] for c in m])
+check("  each keeps its own rate", sorted(c["median"] for c in m) == [10.0, 20.0])
+
+# One project recording ONE code under TWO units cannot be attributed, so it is excluded — not
+# summed across units, which would produce a rate in a unit that does not exist.
+AMB = urm.per_project_rates([cost("X", "03 30 00", 5_000)],
+                            [qty("X", "03 30 00", 50, "m3"), qty("X", "03 30 00", 100, "SF")])
+check("a project mixing units within one code produces NO rate", AMB["rates"] == [])
+check("  and is reported as excluded with both units named",
+      len(AMB["excluded"]["mixed_units"]) == 1
+      and AMB["excluded"]["mixed_units"][0]["units"] == ["m3", "sf"],
+      AMB["excluded"]["mixed_units"])
+check("  with a reason that says why splitting would be a guess",
+      "guess" in AMB["excluded"]["mixed_units"][0]["reason"])
+
+# --- 4. unmeasurable is not zero ---------------------------------------------------------------------
+E = urm.per_project_rates(
+    [cost("C1", "05 12 00", 8_000), cost("C2", "05 12 00", 4_000)],
+    [qty("C2", "05 12 00", 40, "t"), qty("C3", "05 12 00", 10, "t")])
+check("a project with cost but no quantity yields no rate",
+      [r["project_id"] for r in E["rates"]] == ["C2"])
+check("  it is reported, not dropped",
+      [x["project_id"] for x in E["excluded"]["cost_without_quantity"]] == ["C1"])
+check("  with its cost, so the gap is quantifiable",
+      E["excluded"]["cost_without_quantity"][0]["cost"] == 8_000.0)
+check("a project with quantity but no cost is reported too",
+      [x["project_id"] for x in E["excluded"]["quantity_without_cost"]] == ["C3"])
+check("the measurable one is still correct: 4000 / 40 = 100.0",
+      E["rates"][0]["rate"] == 100.0, E["rates"][0]["rate"])
+check("excluded rows carry the never-dropped note", "not a project that cost zero"
+      in E["excluded"]["note"])
+
+# --- 5. degenerate inputs ------------------------------------------------------------------------------
+check("no records at all is empty, not an error",
+      urm.per_project_rates([], [])["rates"] == [])
+check("a zero quantity does not divide by zero",
+      urm.per_project_rates([cost("Z", "x", 100)], [qty("Z", "x", 0, "m")])["rates"] == [])
+check("  and the zero-quantity project is reported as cost-without-quantity",
+      [x["project_id"] for x in urm.per_project_rates(
+          [cost("Z", "x", 100)], [qty("Z", "x", 0, "m")])["excluded"]["cost_without_quantity"]] == ["Z"])
+check("a non-numeric amount is ignored rather than crashing",
+      urm.per_project_rates([cost("Z", "x", "abc")], [qty("Z", "x", 5, "m")])["rates"] == [])
+check("an uncoded row is ignored",
+      urm.per_project_rates([cost("Z", "", 100)], [qty("Z", "", 5, "m")])["rates"] == [])
+check("whitespace in a code is normalised so ' 03 30 00 ' joins '03 30 00'",
+      urm.per_project_rates([cost("W", " 03 30 00 ", 100)],
+                            [qty("W", "03 30 00", 5, "m3")])["rates"][0]["rate"] == 20.0)
+check("unit case is normalised so M3 and m3 are one population",
+      len(urm.summarise(urm.per_project_rates(
+          [cost("A", "c", 100), cost("B", "c", 200)],
+          [qty("A", "c", 10, "M3"), qty("B", "c", 10, "m3")])["rates"], 1)) == 1)
+
+# --- 6. the percentile method matches benchmarking's ----------------------------------------------------
+from aec_api import benchmarking  # noqa: E402
+
+vals = [1.0, 2.0, 3.0, 4.0]
+check("percentiles agree with benchmarking's, so a cost p75 and a rate p75 are comparable",
+      all(urm._pctile(vals, q) == benchmarking._pctile(vals, q) for q in (0.0, 0.25, 0.5, 0.75, 1.0)))
+
+print()
+if FAILED:
+    print(f"unit_rate_memory: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("unit_rate_memory: all checks passed")

--- a/services/api/test_unit_rate_memory.py
+++ b/services/api/test_unit_rate_memory.py
@@ -145,6 +145,32 @@ vals = [1.0, 2.0, 3.0, 4.0]
 check("percentiles agree with benchmarking's, so a cost p75 and a rate p75 are comparable",
       all(urm._pctile(vals, q) == benchmarking._pctile(vals, q) for q in (0.0, 0.25, 0.5, 0.75, 1.0)))
 
+# --- 7. the totals honour the formula the payload states ----------------------------------------------
+# `unit_rates()` tells the reader `pooled_rate` is Σcost ÷ Σquantity. It was not: `summarise()` summed
+# the per-project `cost`/`quantity` fields, which `per_project_rates()` had already rounded for display.
+# At 60 projects the reported total was 6000.00 against a true 6000.30 and the pooled rate was 33.3333
+# against a true 33.3344 — small, plausible, and contradicting the definition printed beside it. That is
+# the failure mode worth a test: not a number that is missing, a number that disagrees with its own
+# stated basis. Anyone re-deriving the total from `per_project` gets a different answer and has no way
+# to tell which is wrong.
+N, AMT, QTY = 60, 100.005, 3.00005
+drift = urm.summarise(urm.per_project_rates(
+    [cost(f"P{i}", "C", AMT) for i in range(N)],
+    [qty(f"P{i}", "C", QTY, "m") for i in range(N)])["rates"], 1)[0]
+raw_cost, raw_qty = AMT * N, QTY * N
+check("total_cost is the sum of RAW costs, not of rounded ones",
+      drift["total_cost"] == round(raw_cost, 2), (drift["total_cost"], round(raw_cost, 2)))
+check("total_quantity likewise", drift["total_quantity"] == round(raw_qty, 4),
+      (drift["total_quantity"], round(raw_qty, 4)))
+check("pooled_rate equals the Sum(cost)/Sum(quantity) the payload claims it is",
+      drift["pooled_rate"] == round(raw_cost / raw_qty, 4),
+      (drift["pooled_rate"], round(raw_cost / raw_qty, 4)))
+# The rounded per-project values must still be what a reader sees, and the raw carrier must not leak.
+check("the published per-project rows keep their rounded display values",
+      drift["per_project"][0]["cost"] == round(AMT, 2))
+check("and no internal raw carrier is exposed in the payload",
+      all("_raw" not in r for r in drift["per_project"]), drift["per_project"][0].keys())
+
 print()
 if FAILED:
     print(f"unit_rate_memory: {len(FAILED)} FAILED — {FAILED}")

--- a/services/api/test_unit_rate_route.py
+++ b/services/api/test_unit_rate_route.py
@@ -1,0 +1,113 @@
+"""R22-MEMORY ② over HTTP — the join happens across projects, and it is tenant-scoped.
+
+The arithmetic is pinned in `test_unit_rate_memory.py`. What only a live app shows is that the two
+record types actually join through the module engine — `direct_cost` and `production_quantity` are
+owned by different engines (accounting/EVM and carbon/pricing) and nothing had ever read both — and
+that a cross-project roll-up stays inside the caller's projects.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_unit_rate_route.py
+"""
+import os
+import sys
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_unit_rate_route.db"
+os.environ["STORAGE_DIR"] = "./test_storage_unit_rate_route"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_unit_rate_route.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+with TestClient(app) as c:
+    c.headers.update({"X-User": "rates@test"})
+
+    def new_project(name):
+        return c.post("/projects", json={"name": name}).json()["id"]
+
+    def rec(pid, key, data):
+        r = c.post(f"/projects/{pid}/modules/{key}", json={"data": data})
+        assert r.status_code in (200, 201), (key, r.status_code, r.text[:200])
+        return r.json()
+
+    empty = c.get("/benchmarks/unit-rates")
+    check("GET /benchmarks/unit-rates answers 200 with no history", empty.status_code == 200,
+          empty.text[:200])
+    E = empty.json()
+    check("  it reports nothing usable rather than an empty success",
+          E["usable_count"] == 0 and E["message"] is not None)
+    check("  and the message says what is missing", "quantities AND posted costs" in E["message"])
+
+    # Three projects, same cost code, hand-computed rates: 300 / 220 / 450 per m3.
+    P = [new_project("Rate A"), new_project("Rate B"), new_project("Rate C")]
+    for pid, amount, quantity in ((P[0], 60_000, 200), (P[1], 22_000, 100), (P[2], 90_000, 200)):
+        rec(pid, "direct_cost", {"description": "concrete", "cost_code": "03 30 00",
+                                 "amount": amount})
+        rec(pid, "production_quantity", {"description": "concrete placed", "cost_code": "03 30 00",
+                                         "quantity": quantity, "unit": "m3"})
+
+    r = c.get("/benchmarks/unit-rates")
+    check("the roll-up answers 200", r.status_code == 200, r.text[:200])
+    J = r.json()
+    check("  one (code, unit) group", J["code_count"] == 1, J["code_count"])
+    g = J["cost_codes"][0]
+    check("  it joined records from BOTH engines' modules",
+          g["cost_code"] == "03 30 00" and g["unit"] == "m3", (g["cost_code"], g["unit"]))
+    check("  three projects", g["projects"] == 3)
+    check("  median is the middle PROJECT's rate, 300.0", g["median"] == 300.0, g["median"])
+    check("  pooled_rate is 172000/500 = 344.0 and differs from the median",
+          g["pooled_rate"] == 344.0 and g["pooled_rate"] != g["median"],
+          (g["pooled_rate"], g["median"]))
+    check("  usable at the default threshold", J["usable_count"] == 1)
+    check("  the basis is stated in the payload", "distribution is over projects" in J["basis"])
+    check("  as is the accrual-lag limitation", "spread_ratio" in J["limitation"])
+
+    # A fourth project with cost but no quantity must be EXCLUDED and REPORTED, never counted as 0.
+    p4 = new_project("Rate D")
+    rec(p4, "direct_cost", {"description": "concrete", "cost_code": "03 30 00", "amount": 15_000})
+    J2 = c.get("/benchmarks/unit-rates").json()
+    g2 = J2["cost_codes"][0]
+    check("a project with cost but no quantity does not enter the distribution",
+          g2["projects"] == 3 and g2["median"] == 300.0, (g2["projects"], g2["median"]))
+    check("  and it is reported as excluded, with its cost",
+          any(x["cost"] == 15_000.0 for x in J2["excluded"]["cost_without_quantity"]),
+          J2["excluded"]["cost_without_quantity"])
+
+    # A project recording one code under two units is excluded rather than split.
+    p5 = new_project("Rate E")
+    rec(p5, "direct_cost", {"description": "c", "cost_code": "03 30 00", "amount": 5_000})
+    rec(p5, "production_quantity", {"description": "c", "cost_code": "03 30 00",
+                                    "quantity": 50, "unit": "m3"})
+    rec(p5, "production_quantity", {"description": "c", "cost_code": "03 30 00",
+                                    "quantity": 100, "unit": "SF"})
+    J3 = c.get("/benchmarks/unit-rates").json()
+    check("a project mixing units within one code is excluded, not split",
+          J3["cost_codes"][0]["projects"] == 3, J3["cost_codes"][0]["projects"])
+    check("  and reported with both units named",
+          any(sorted(x["units"]) == ["m3", "sf"] for x in J3["excluded"]["mixed_units"]),
+          J3["excluded"]["mixed_units"])
+
+    check("min_projects is clamped, not trusted",
+          c.get("/benchmarks/unit-rates?min_projects=0").status_code == 200
+          and c.get("/benchmarks/unit-rates?min_projects=999").json()["usable_count"] == 0)
+
+    # The sibling endpoint must be unaffected — this is additive.
+    costs = c.get("/benchmarks/costs")
+    check("the existing /benchmarks/costs still works", costs.status_code == 200, costs.text[:160])
+
+print()
+if FAILED:
+    print(f"unit_rate_route: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("unit_rate_route: all checks passed")


### PR DESCRIPTION
The remainder of **R22-MEMORY**, at the size the roadmap was corrected to earlier today after I found the item was two-thirds already built.

## The gap

`benchmarking.cost_benchmarks()` already answers *"what has code 03 30 00 cost us"* cross-project. **That is what anyone with an accounting export can build.** It cannot tell you whether a project was expensive because concrete is dear or because there was a lot of concrete.

This joins two record types nothing had joined — `direct_cost` (cost_code, amount) and `production_quantity` (cost_code, quantity, unit). Checked before building: `production_quantity` is read only by `carbon.py` and `pricing.py`, `direct_cost` by `accounting`/`evm`/`margin`/`cost_spine`, and **no file reads both**.

## Three decisions, each with a plausible wrong version

**The rate is per project, then distributed** — not `Σcost ÷ Σquantity`. The pooled figure is a weighted average wearing a distribution's clothes: one large project sets the median and the spread is *invented* rather than observed. On the fixture the two genuinely differ:

```
median (middle project) = 300.00 /m3
pooled  (172000 / 500)  = 344.00 /m3
```

Both are asserted, so "simplifying" to sum-then-divide fails loudly instead of silently returning a number every range check accepts. `pooled_rate` is still reported — it answers a real question — just never as the headline.

**Units are grouped, never converted.** m² and SF are two populations. A project recording one cost code under *two* units is excluded for that code: the cost cannot be attributed between them, and a pro-rata split is a guess with a plausible shape.

**Every exclusion is reported.** Cost-without-quantity, quantity-without-cost, and mixed-unit each return a count and a reason. *A project that could not be measured is not a project that cost zero* — the rule the entitlement expectation had to be corrected for this morning (v0.3.790).

## Stated limitation

`direct_cost` and `production_quantity` accrue independently, so a code whose invoices lead its field reporting reads as expensive and the reverse reads as cheap. Nothing in the records can detect that — so per-project rates are published individually rather than only summarised, and `spread_ratio` (high ÷ low) is the cheap signal that a median is a reporting artefact.

## Reuse

`_rows` is a small local reader rather than `benchmarking._rows`, and the docstring says why: benchmarking's doesn't select `project_id`, because it never needs to know which project a row came from. Here **the project is the grouping key**. Percentiles delegate to the same method, asserted equal, so a cost p75 and a rate p75 can sit beside each other.

## Route

```
GET /benchmarks/unit-rates?min_projects=
```

Added to the existing benchmarking router so it inherits the `member_project_ids` tenant scoping a cross-project roll-up needs. **Verified rather than assumed:** with RBAC on, an anonymous caller is a member of no projects, so the query is scoped to the empty set and returns nothing.

## Verification

- **33 engine checks + 18 HTTP checks**, value-checked against hand arithmetic rather than range-checked
- `ruff` clean; `benchmarking`, `global_authz`, `route_authz` (699), `reachable`, `route_order` pass
- No new module, no new table — no Alembic revision needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)