### PR TITLE
fix(waterfall): the GP promote was half — the IRR hurdle ignored the same-period pref + return of capital

### DIFF
--- a/services/api/src/aec_api/proforma/waterfall.py
+++ b/services/api/src/aec_api/proforma/waterfall.py
@@ -122,7 +122,19 @@ def run_waterfall(distributable: list[float], dates: list[date], lp_contrib: flo
                     gp_take += remaining * tier["gp"]
                     remaining = 0.0
                     break
-                cap = solve_cash_for_irr_hurdle(lp_cf, lp_dates, d, tier["hurdle"], tier["lp"], remaining)
+                # The hurdle is tested on the LP's cash flows INCLUDING what it has already been
+                # paid in THIS period — `lp_take` currently holds the pref and the return of
+                # capital, which are not appended to `lp_cf` until after this loop. Passing plain
+                # `lp_cf` measured the LP's IRR as though the current period had paid it nothing:
+                # in the first distribution period the series is contributions-only, XIRR is
+                # undefined, and `(None or -1.0) >= hurdle` is False — so the below-hurdle tier
+                # absorbed cash that belonged to the residual tier. On a single 2,000 distribution
+                # (900 LP / 100 GP, 8% pref, 90/10 then 80/20) the GP received 102.78 instead of
+                # 205.57 — half its promote — while dollars still conserved and every existing
+                # assertion passed. The solver already models the tier's own cash at date `d`;
+                # omitting the pref and RoC paid at that same date was the inconsistency.
+                cap = solve_cash_for_irr_hurdle(lp_cf + [lp_take], lp_dates + [d], d,
+                                               tier["hurdle"], tier["lp"], remaining)
                 split = min(remaining, cap)
                 lp_take += split * tier["lp"]
                 gp_take += split * tier["gp"]

--- a/services/api/test_waterfall.py
+++ b/services/api/test_waterfall.py
@@ -41,6 +41,43 @@ assert w2["gp_equity_multiple"] >= 1.0, w2["gp_equity_multiple"]
 assert w2["lp_equity_multiple"] == round(w2["lp_distributions"] / LP, 3), w2
 assert w2["lp_distributions"] > 900.0, w2                          # LP cleared its capital + then some
 
+# --- Fixture 2b: the promote SPLIT, by value -------------------------------------------------------
+# `gp_distributions > 0` above is a range check, and it was the only assertion on the promote: the
+# tier split could be wrong by 100% and every check in this file still passed. Found by mutation —
+# `split = min(remaining, cap)` could be flipped to `max` with no test failing.
+#
+# Hand-derived: pref 72 + RoC 900 = 972 to the LP on 900 invested over exactly one year, which is an
+# 8.0% IRR — i.e. the LP has *already reached* the 8% hurdle before any tier pays. So tier 1 (the
+# below-hurdle 90/10 tier) must take essentially nothing, and the residual 80/20 tier must take the
+# remaining 1028: LP 972 + 822.4 = 1794.4, GP 205.6.
+#
+# The bisection in solve_cash_for_irr_hurdle stops at a $1 interval, so tier 1 absorbs a fraction of
+# a dollar and the split lands a few cents off the ideal — hence a tolerance rather than equality.
+assert abs(w2["gp_distributions"] - 205.6) < 0.5, w2["gp_distributions"]
+assert abs(w2["lp_distributions"] - 1794.4) < 0.5, w2["lp_distributions"]
+# The sharp form: the GP's share of the post-pref/RoC residual is the RESIDUAL tier's 20%, not the
+# below-hurdle tier's 10%. Those differ by exactly a factor of two, which is what makes a wrong
+# answer here look entirely plausible.
+residual = 2000.0 - 72.0 - 900.0
+assert abs(w2["gp_distributions"] / residual - 0.20) < 0.001, w2["gp_distributions"] / residual
+
+# --- Fixture 2c: the hurdle is measured INCLUDING the cash paid in the same period ------------------
+# Regression guard for a real defect. The hurdle test ran against `lp_cf`, which did not yet contain
+# the pref and return-of-capital paid in the *same* period — those were accumulated locally and only
+# appended after the tier loop. So the LP's measured IRR was understated at the moment the hurdle was
+# evaluated, and the below-hurdle tier absorbed cash that belonged to the residual tier.
+#
+# Measured before the fix: GP 102.78 against 205.57 here — the GP received half its promote. Nothing
+# failed, because dollars still conserved and the GP still got "something".
+#
+# The clearest symptom: with the same-period cash omitted, the LP's XIRR at that instant is computed
+# from contributions only and comes back None, so `(None or -1.0) >= hurdle` is False and the tier
+# proceeds as though the LP had earned nothing at all.
+from aec_api.proforma.waterfall import _lp_irr_with  # noqa: E402
+
+assert _lp_irr_with([-900.0], [D0], D1, 0.0) is None                 # contributions-only: undefined
+assert abs(_lp_irr_with([-900.0], [D0], D1, 972.0) - 0.08) < 1e-6    # with the period's cash: 8%
+
 # --- Invariant sweep: conservation holds for arbitrary multi-period cash ---------------------------
 for cash in ([100.0, 300.0, 1500.0], [0.0, 5000.0], [250.0], [50.0, 50.0, 50.0, 50.0]):
     dates = [date(2020 + i, 1, 1) for i in range(len(cash) + 1)]
@@ -55,7 +92,41 @@ we = run_waterfall([400.0], [D0, D1], LP, GP, PREF, TIERS, style="european")
 assert we["gp_distributions"] == 0.0, we                          # withheld: LP not yet whole
 assert we["lp_distributions"] == 400.0, we                        # all cash to LP (pref + partial RoC)
 
-print("WATERFALL OK - pref accrual + return-of-capital exact to the dollar (72 pref + 428 RoC = 500, "
+# --- Clawback: exercised here for the first time ---------------------------------------------------
+# `clawback=True` appeared in no test on the platform — all ten call sites passed False — so the whole
+# restitution branch was dead code as far as the suite was concerned, and a mutation of its
+# `min(owed, p["gp"])` survived untouched.
+#
+# It needs a case where the GP took promote early and the LP's FINAL IRR still lands under the pref:
+# a later capital call does it. Note `lp_irr` must also be solvable — across a 729-pattern sweep it
+# came back None 26% of the time (XIRR is undefined for many sign patterns), and the guard
+# `if lp_irr is not None` means clawback silently does nothing in those deals. Worth knowing before
+# relying on it.
+CB = [-200.0, 2000.0, -900.0]
+CB_DATES = [date(2021 + i, 1, 1) for i in range(4)]
+cb_off = run_waterfall(CB, CB_DATES, LP, GP, PREF, TIERS, style="american", clawback=False)
+cb_on = run_waterfall(CB, CB_DATES, LP, GP, PREF, TIERS, style="american", clawback=True)
+
+assert cb_off["lp_irr"] is not None and cb_off["lp_irr"] < PREF, cb_off["lp_irr"]
+assert cb_off["gp_distributions"] > 0.0, cb_off          # the GP promoted before the LP fell short
+# restitution moves money GP -> LP, and it is PARTIAL here (105.49 of 151.13), which is what
+# distinguishes `min(owed, gp)` from `max`: a wrong extreme would move more than the period holds.
+assert abs(cb_on["gp_distributions"] - 45.64) < 0.01, cb_on["gp_distributions"]
+assert abs(cb_on["lp_distributions"] - 1954.36) < 0.01, cb_on["lp_distributions"]
+assert cb_on["gp_distributions"] < cb_off["gp_distributions"], (cb_on, cb_off)
+assert cb_on["lp_distributions"] > cb_off["lp_distributions"], (cb_on, cb_off)
+# conservation survives the transfer, and no period is left owing more than it holds
+assert abs((cb_on["lp_distributions"] + cb_on["gp_distributions"])
+           - (cb_off["lp_distributions"] + cb_off["gp_distributions"])) < 0.01, (cb_on, cb_off)
+assert all(p["gp"] >= -0.01 for p in cb_on["periods"]), cb_on["periods"]
+# and it improves the LP's return rather than merely shuffling labels
+assert cb_on["lp_irr"] > cb_off["lp_irr"], (cb_on["lp_irr"], cb_off["lp_irr"])
+
+print("WATERFALL OK - promote split value-checked (the residual tier's 20%, not the below-hurdle "
+      "tier's 10%); the IRR hurdle is measured INCLUDING the pref + RoC paid in the same period "
+      "(GP was under-promoted 102.78 vs 205.57 before); clawback exercised for the first time "
+      "(partial restitution, GP 151.13 -> 45.64). "
+      "pref accrual + return-of-capital exact to the dollar (72 pref + 428 RoC = 500, "
       "472 unreturned); large distribution fully returns capital + pays a real GP promote; dollar "
       "conservation holds across arbitrary multi-period cash; European style withholds promote until "
       "the LP is made whole.")


### PR DESCRIPTION
**The equity waterfall under-paid the GP's promote by 50% on a single-period distribution, and all 446 suites passed.**

## The defect

`run_waterfall` accumulates a period's preferred return and return of capital into the local `lp_take`, and appends it to `lp_cf` **only after** the promote-tier loop. The hurdle solver was handed the un-updated `lp_cf`, so it measured the LP's IRR as though the current period had paid it nothing.

In the first distribution period that series is contributions-only, XIRR is undefined, and `(None or -1.0) >= hurdle` is False — so the below-hurdle tier (90/10, LP-favourable) absorbs cash that belongs to the residual tier (80/20).

Measured on 900 LP / 100 GP, 8% pref, tiers 90/10 then 80/20:

| distribution | GP as shipped | GP with the fix |
|---|---|---|
| 2,000 (one period) | **102.78** | **205.57** |
| 10,000 (one period) | 1,697.53 | 1,805.53 |
| 100 / 300 / 1,500 | 84.33 | 161.29 |

Not rounding, and systematic in one direction: it under-pays the promote.

## Why it is a defect and not a convention

After 72 pref + 900 return of capital on 900 over exactly one year, the LP is at **exactly 8.0%** — it has already cleared the hurdle before any tier pays, so the below-hurdle tier should take essentially nothing.

`solve_cash_for_irr_hurdle` already models the tier's own cash at date `d` (it bisects on `mid * lp_share` added at `d`). Omitting the pref and RoC paid at that *same date* isn't a different measurement convention — it's half of one date's cash being counted and half not.

```python
_lp_irr_with([-900.0], [D0], D1, 0.0)     # -> None    (contributions only)
_lp_irr_with([-900.0], [D0], D1, 972.0)   # -> 0.08    (with the period's cash)
```

## Why nothing caught it

The only assertion on the promote anywhere was:

```python
assert w2["gp_distributions"] > 0.0
```

A range check. Dollar conservation held either way, so the split could be wrong by 100% with every check green.

**Found by mutation testing** — `split = min(remaining, cap)` could be flipped to `max` with no test failing. Chasing that survivor led here.

## Second finding: clawback was never executed

`clawback=True` appears in **no test on the platform** — all ten call sites pass `False`. The restitution branch was dead code as far as the suite was concerned, and a mutation of its `min(owed, p["gp"])` survived untouched.

Now exercised with a **partial** restitution (GP 151.13 → 45.64), which is what distinguishes `min` from `max` — a wrong extreme would move more than the period holds.

Worth knowing before relying on it: across a 729-pattern sweep, `lp_irr` came back `None` **26%** of the time (XIRR is undefined for many sign patterns), and the guard `if lp_irr is not None` means clawback silently does nothing in those deals. Noted in the test rather than changed — that's a design question, not a bug I should decide.

## Tests added

- the promote **split by value** — the GP's share of the post-pref/RoC residual is the residual tier's 20%, not the below-hurdle tier's 10%. Those differ by exactly 2×, which is what makes a wrong answer look plausible. **Fails at 102.8 without the fix.**
- the mechanism itself, pinned directly on `_lp_irr_with`.
- the clawback case above.

## Verification

- Full backend suite **446/446** on base `bf9c53f2` (v0.3.799). **No other test changed expectations** — which is itself the finding: nothing anywhere pinned this number.
- New suite fails without the fix (`AssertionError: 102.8`), passes with it. ruff clean.

## Please sanity-check the convention

This changes published financial figures. The arithmetic and reasoning are laid out above specifically so the deal convention can be checked rather than taken on trust — if your intent is that the hurdle is measured at the *start* of a period, say so and I'll revert the behaviour change and keep only the tests.
