### PR TITLE
MOD-SWEEP — field-level sweep of all 133 registers

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -213,6 +213,14 @@ export interface ModuleField {
   name: string; label: string; type: string; required?: boolean; options?: string[];
   module?: string;   // for type:"reference" — the target module key
   fieldset?: string; // F1 — labeled form section this field groups under
+  /** MOD-SWEEP — the unit a numeric value is measured in ("ft", "yr", "days", "kWh").
+   *
+   *  The sweep found 170 numeric fields with no unit anywhere in the config, most of them encoding it
+   *  in the field NAME instead — `elevation_ft`, `expected_life_years`, `ld_per_day`. A unit in a name
+   *  is a unit only a human can read: it cannot be shown next to an input, appended in a table cell,
+   *  converted, or checked. Declaring it makes the number self-describing, which is most of the
+   *  difference between a form and a tool. */
+  unit?: string;
 }
 export interface ModuleDef {
   key: string; name: string; section: string; icon: string; pinnable: boolean;

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -20,6 +20,19 @@ import type { RoomDef } from "../api/types";
 // grouped per source file so one dynamic import covers all its exports (Vite dedupes the chunk).
 
 /**
+ * How many records of a referenced module are fetched to build the id→label map for a table.
+ *
+ * A bound is necessary — a reference column must not pull an unbounded register to render one page —
+ * but the bound is also a correctness boundary, so it is named rather than buried as a literal. Past
+ * this many records the tail of the target module is genuinely unresolvable from the client, and
+ * `refCell` is required to SAY so instead of inventing a label. See MOD-SWEEP below.
+ */
+const REF_RESOLVE_LIMIT = 500;
+
+/** A record id is a `uuid.uuid4()` string server-side, so this distinguishes an id from free text. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
  * GC portal UI — one config-driven engine renders every module's list / form / record pages
  * from its module.json (fetched at /modules). No per-module code: the same views drive RFIs,
  * the change-order chain, daily reports, etc. Workflow actions are server-gated by party role.
@@ -1652,17 +1665,23 @@ export class PortalUI {
 
     // Relational cells: resolve each reference column's ids → {ref,title} once (one fetch per
     // referenced module, not per cell), so a reference reads as the linked record and navigates on
-    // click instead of showing a raw id. Bounded fetch; unresolved ids fall back to the short id.
+    // click instead of showing a raw id.
+    //
+    // The fetch is BOUNDED, and that bound is the reason `refCell` exists rather than an inline
+    // fallback: past 500 records of the target module the tail is simply not in the map, and the old
+    // code rendered any unresolved value as a link labelled `String(v).slice(0, 8)`. On a project with
+    // 600 companies, company #550 therefore drew a clickable link showing eight characters of its own
+    // id, opening nothing — a control that looks resolved and is not. See `refCell`.
     const refCols = cols.filter((c) => c.type === "reference" && c.module);
     const refMaps: Record<string, Map<string, { ref: string; title: string | null }>> = {};
     if (refCols.length) {
       await Promise.all(refCols.map(async (c) => {
         try {
-          const recs = await this.host.api.moduleRecordsFiltered(pid, c.module!, { limit: 500 });
+          const recs = await this.host.api.moduleRecordsFiltered(pid, c.module!, { limit: REF_RESOLVE_LIMIT });
           const map = new Map<string, { ref: string; title: string | null }>();
           for (const rr of recs) map.set(rr.id, { ref: rr.ref, title: rr.title });
           refMaps[c.name] = map;
-        } catch { /* leave unresolved — falls back to the short id */ }
+        } catch { /* leave unresolved — refCell states so rather than faking a link */ }
       }));
     }
 
@@ -1684,14 +1703,7 @@ export class PortalUI {
         } else if (editing && EDITABLE.includes(c.type)) {
           tr.appendChild(this.inlineCell(pid, m, r, c));
         } else if (c.type === "reference" && c.module && v) {
-          const td = document.createElement("td");
-          const id = String(v);
-          const info = refMaps[c.name]?.get(id);
-          const a = document.createElement("a"); a.href = "#"; a.className = "ref-link";
-          a.textContent = info ? (info.title ? `${info.ref} · ${info.title}` : info.ref) : id.slice(0, 8);
-          a.title = `Open linked ${c.module.replace(/_/g, " ")}${info ? ` ${info.ref}` : ""}`;
-          a.onclick = (e) => { e.preventDefault(); e.stopPropagation(); this.openByBrief(c.module!, id); };
-          td.appendChild(a); tr.appendChild(td);
+          tr.appendChild(this.refCell(String(v), c, refMaps[c.name]));
         } else {
           cell(this.fmtCell(c, v));
         }
@@ -1757,12 +1769,72 @@ export class PortalUI {
     } catch (e) { toast(`convert failed: ${(e as Error).message}`, "error"); }
   }
 
+  /**
+   * MOD-SWEEP — a reference cell that never pretends to have resolved.
+   *
+   * The old inline version rendered EVERY non-empty reference as a clickable link labelled
+   * `String(v).slice(0, 8)`, falling back to those eight characters whenever the id was not in the
+   * resolved map. Three different values took that path and all three looked identical to a working
+   * link: a record deleted since it was referenced, a record past `REF_RESOLVE_LIMIT` in a large
+   * register, and — the one that matters for the field sweep — a **legacy free-text value** in a field
+   * that used to be `text`. Converting `coi.vendor` from text to reference would have turned
+   * "Acme Electrical Inc" into a link reading `Acme Ele` that opens nothing.
+   *
+   * So the three cases are now distinguished, because they call for different things from the user:
+   *
+   * - **resolved** → the link, labelled `REF-001 · Title`, navigating on click.
+   * - **an id we could not resolve** (UUID-shaped, absent from the map) → the short id, NOT a link,
+   *   marked as unresolved. The record may be deleted or beyond the fetch bound; either way clicking
+   *   is not the answer and offering it is a lie.
+   * - **not an id at all** → the value verbatim, full length, marked as unlinked text. This is what a
+   *   pre-conversion value looks like, and showing it whole is what lets someone re-link it by hand.
+   *
+   * Truncating to 8 characters was the specific harm in every case: it is short enough to look like an
+   * id and long enough to look deliberate.
+   */
+  private refCell(
+    v: string,
+    c: ModuleDef["fields"][number],
+    map: Map<string, { ref: string; title: string | null }> | undefined,
+  ): HTMLElement {
+    const td = document.createElement("td");
+    const info = map?.get(v);
+    const target = String(c.module ?? "record").replace(/_/g, " ");
+    if (info) {
+      const a = document.createElement("a"); a.href = "#"; a.className = "ref-link";
+      a.textContent = info.title ? `${info.ref} · ${info.title}` : info.ref;
+      a.title = `Open linked ${target} ${info.ref}`;
+      a.onclick = (e) => { e.preventDefault(); e.stopPropagation(); this.openByBrief(c.module!, v); };
+      td.appendChild(a);
+      return td;
+    }
+    const span = document.createElement("span");
+    if (UUID_RE.test(v)) {
+      span.className = "ref-unresolved";
+      span.textContent = `${v.slice(0, 8)}…`;
+      span.title = `This ${target} could not be resolved — it may have been deleted, or lie beyond `
+        + `the first ${REF_RESOLVE_LIMIT} records of ${target}. Not a working link.`;
+    } else {
+      span.className = "ref-unlinked";
+      span.textContent = v;                        // in full: it is the only handle for re-linking
+      span.title = `Plain text, not a link to a ${target} record. Edit the field to pick the `
+        + `${target} it refers to.`;
+    }
+    td.appendChild(span);
+    return td;
+  }
+
   /** Format a field value for a compact table cell. */
   private fmtCell(f: ModuleDef["fields"][number], v: unknown): string {
     if (v == null || v === "") return "";
     if (f.type === "currency") return `$${Number(v).toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+    if (f.type === "percent") return `${Number(v).toLocaleString(undefined, { maximumFractionDigits: 2 })}%`;
     if (f.type === "multiselect" && Array.isArray(v)) return (v as string[]).join(", ");
-    if (f.type === "reference") return String(v).slice(0, 8);
+    // Same defect as the old refCell fallback, in the path taken when a reference is NOT a resolved
+    // column: eight characters of a value, indistinguishable from a resolved label. A UUID at least
+    // announces itself as an id; anything else is shown as the text it is.
+    if (f.type === "reference") return UUID_RE.test(String(v)) ? `${String(v).slice(0, 8)}…` : String(v);
+    if (f.unit) return `${String(v)} ${f.unit}`;
     return String(v).slice(0, 40);
   }
 

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -541,6 +541,15 @@ html, body { overflow: hidden; }   /* the app manages its own internal scrolling
 .portal-act { font-size: 11px; color: var(--muted); padding: 2px 0; border-bottom: 1px solid #2b2d31; }
 .ref-link { color: var(--accent); cursor: pointer; text-decoration: none; }
 .ref-link:hover { text-decoration: underline; }
+/* MOD-SWEEP — the two ways a reference can FAIL to resolve, each visibly not a link.
+   Both were previously drawn as `.ref-link` with an 8-character label, so a deleted record, a record
+   past the resolve bound, and a legacy free-text value all looked like working links. The styling is
+   deliberately quiet rather than alarming: neither state is the user's fault, and neither is an error
+   — they just must not read as navigable. No accent colour, no pointer, no underline. */
+.ref-unresolved { color: var(--muted); font-variant-numeric: tabular-nums; cursor: help;
+                  border-bottom: 1px dotted var(--line); }
+.ref-unlinked { color: var(--text, inherit); cursor: help; border-bottom: 1px dashed var(--line);
+                opacity: .92; }
 .chip { display: inline-block; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 0 8px; font-size: 11px; margin: 1px 0; }
 
 /* UX-CHIPS — the shared status/delta chip vocabulary (ui/chips.ts) */

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -33,6 +33,7 @@ here**. Do not cite an archived file as current.
 | `gc-tools-audit.md` | Per-module audit of the 69 GC-portal modules | roadmap + [../gc-portal.md](../gc-portal.md) |
 | `gc-modules-roadmap.md` | Field-vs-office deep dive across the config-driven GC modules | roadmap |
 | `module-room-audit.md` | 133 registers against the seven rooms; sprints 1–2 built, 3–6 proposed | roadmap; the allocation itself is enforced by `test_module_rooms.py` |
+| `module-field-sweep.md` | Field-level sweep of all 133 modules, 2026-07-29 — fields, fieldsets, relationships, CRUD. Compares against a Django app the user built previously, which uses ForeignKeys where these modules used strings. Applied: 54 additive text+reference pairs, 67 units moved out of field names, 20 percent retypes, 41 widened tables, and two live fake-link defects in the reference renderer | Nothing — **current**. Every number in it is a floor in `test_module_fields.py`; §8 lists what is deliberately not done |
 | `ux-findings.md` | App-wide heuristic UX review | Shipped through the R24 interface ring |
 | `ux-ia.md` | Information-architecture plan for ~100 registers | Shipped as the room spine (`apps/web/src/shell/spine.ts`) |
 | `design-audit.md` | External design audit, 2026-07-25 — 18 findings, 5 principles | R24 interface ring |

--- a/docs/internal/module-field-sweep.md
+++ b/docs/internal/module-field-sweep.md
@@ -1,0 +1,159 @@
+# Module field sweep — fields, fieldsets, relationships, CRUD
+
+**Date:** 2026-07-29 · **Against:** v0.3.799 (`bf9c53f2`) · **Scope:** all 133 modules, 1171 fields.
+**Internal.** `docs/` is the Pages web root and gets published wholesale — working notes belong here.
+
+Reference material: **[eManagerNYC/django_emanager](https://github.com/eManagerNYC/django_emanager)**,
+a Django construction-management app the user built previously. 7 apps, 21 models. Its value is not its
+depth — it is an early scaffold — but that it makes **different structural choices** in exactly the
+places this sweep is about.
+
+---
+
+## 0. What was checked
+
+| # | Check | Method | Grade |
+|---|---|---|---|
+| F1 | Field/fieldset/type census | Parsed all 133 `module.json` | **Verified** |
+| F2 | Reference graph | Static parse of `type: reference` | **Verified** |
+| F3 | Missed relationships | Field name matched against module keys + domain aliases | **Verified list, triaged by hand** — the alias table produces candidates, not conclusions; 20 of 74 were rejected on inspection |
+| F4 | Reference render path | Read `portal.ts` | **Verified** — two live defects, below |
+| F5 | Filter/sort capability | Read `moduleRecordsFiltered` signature + `openModule` | **Verified** |
+| F6 | Reference repo comparison | Downloaded and read all 7 `models.py` | **Verified** |
+
+---
+
+## 1. The field vocabulary was eleven words long
+
+Across 1171 fields, the complete set of attributes in use:
+
+```
+name · label · type · fieldset · options · required · module ·
+source_module · source_field · op · help
+```
+
+Every one is structural or presentational. **Nothing said what a number measures.** No `unit`, no
+`default`, no `min`/`max`, no `placeholder`, no `unique`, no `readonly`, no `depends_on`. A field could
+declare that it *is* a number and never what kind.
+
+The tell was units living in field **names**: `elevation_ft`, `expected_life_years`, `ld_per_day`,
+`temp_f`, `distance_mi`. A unit in a name is readable only by a human — it cannot be rendered beside an
+input, appended to a cell, converted, or checked.
+
+## 2. Two live defects in the reference renderer
+
+**F4a — an unresolvable reference rendered as a working link.** `portal.ts` resolved reference columns
+into an id→label map, then fell back to `String(v).slice(0, 8)` **as a clickable link**. Three
+different situations took that path and all three looked identical to a resolved reference:
+
+1. the target record was deleted since it was referenced;
+2. the target lies past the resolve bound (below);
+3. — the one that matters here — the value is **legacy free text** in a field that used to be `text`.
+
+Truncating to 8 characters was the specific harm: short enough to look like an id, long enough to look
+deliberate. Converting `coi.vendor` to a reference would have turned `"Acme Electrical Inc"` into a
+link reading **`Acme Ele`** that opens nothing.
+
+**F4b — reference resolution is capped at 500 records.** One fetch per referenced module, `limit: 500`.
+On a project with 600 companies, company #550's references fall into the same fake-link path. Silent.
+
+Both fixed: `refCell` now distinguishes *resolved* (link) from *unresolved id* (short id, not a link,
+marked) from *not an id at all* (the value in full, marked as unlinked text). The bound is a named
+constant because it is a correctness boundary, not a tuning parameter. The same 8-character truncation
+existed a second time in `fmtCell` and is fixed there too.
+
+## 3. Relationships — 74 strings that name a register
+
+Only **98** reference fields existed across 133 modules; **69** modules had none at all. Meanwhile 74
+text fields named a concept with its own register: `vendor`, `location`, `spec_section`, `system`,
+`inspector`, `bidder`, `tenant`, `carrier`, `responsible`.
+
+**This is precisely where the reference repo differs.** `django_emanager` uses ForeignKeys throughout —
+`rfi.division → divisions`, `submittal.division → divisions`, `ticket.labor_rate → laborrates` (M2M),
+`contracts.company → company`, `budget.project → projects`. Where Massing stores a trade name as text,
+the reference app stores a link.
+
+**They were not converted in place.** The codebase already contained the safe pattern in three places —
+`investor` + `investor_company`, `lease` + `tenant_company`, `subcontract` + `vendor_company` — all
+adding a reference *beside* the text field. That is the precedent this sweep followed rather than
+inventing one: the text keeps rendering so no stored value breaks, the reference carries the link, and a
+backfill can populate it. **54 reference fields added**, each adjacent to its text twin and sharing its
+fieldset (both asserted, because a pair rendered in two different places is a pair nobody recognises).
+
+**20 candidates were rejected**, and the reasons are the useful part:
+
+- `permit.authority`, `entitlement.agency` → an AHJ is not a project company.
+- `asset_register.manufacturer` → a product maker, not a project party.
+- `risk.owner`, `assumption.owner`, `lessons_learned.owner` → a *person* accountable, and whether that
+  is `contact` or `company` genuinely differs per module. Left alone rather than guessed.
+- `photos`, `deficiencies`, `deliveries`, `assumptions`, `spec_sections` → **plural**. These are child
+  lists, not single references. They need the `table` type (still unbuilt) and a reference would be
+  wrong in a way that looks right.
+
+## 4. Ideas worth taking from the reference repo
+
+Beyond the FK habit, four structural ideas Massing lacks:
+
+| `django_emanager` | Massing today |
+|---|---|
+| `ticket` links `labor_rate` (M2M), `material_rate` (M2M), `equipment_rate` (O2O) and totals them into `total_labor` / `total_material` / `total_equipment` / `total_cost` with `work_shifts`, `work_start`, `work_end` | `eticket` has 6 fields and **no link to any rate library**. The rate registers exist and nothing consumes them — the T&M ticket is where they should compose |
+| `requisition` carries `coi` and `lienwaiver` on the record, plus `prev_amount` and `stored_materials` | `owner_invoice` has 5 fields, no lien-waiver or COI link, no stored materials — matches the G702 gap from the room audit |
+| `contracts.contract_file` is a `FileField`; `submittal.submittal_file` too | 3 `file` fields exist system-wide; `prime_contract` and `submittal` have none |
+| `exclusion_assumption` on `changeorder`, `contracts`, `ticket` — exclusions are first-class | only `bid_submission` carries inclusions/exclusions, as prose |
+
+The `ticket` → rate-library composition is the sharpest of these and is now the top item for the next
+pass: it is the same shape as the SOV-from-estimate gap — the data exists, the consumer exists, the
+link does not.
+
+## 5. Field typing
+
+- **20 `*_pct` fields were typed `number`**, so 7.5% and 7.5 rendered identically and formatted with
+  thousands separators. Retyped to `percent` (19 by suffix + `evm_snapshot.percent_complete`, which a
+  suffix-only rule missed — the usual reason to widen a pattern rather than enumerate).
+- **67 units declared**, moved *out of field names* and into the schema. Lossless: a unit was declared
+  only where the name already stated it.
+- **Four inferences were wrong and were caught by reading the output**, not by a test:
+  `capital_plan.planned_year`, `fca_element.recommended_year`,
+  `market_assumption.construction_start_year` are **calendar years, not durations** — the suffix rule
+  labelled all three `yr`. And `prime_contract.ld_per_day` is dollars *per* day, not days. The gate now
+  asserts those three carry no unit, so a future bulk pass cannot re-lose the distinction.
+
+## 6. CRUD and filters
+
+- **`list_columns`: 15 registers had none, 40 had two.** So the table was a title and a status chip — a
+  list you must open every row of is not a register. Widened on **41** registers, **append-only**: the
+  first attempt chose columns by type priority and silently dropped human-chosen ones like
+  `bid_package.trade`, so it was redone to preserve every existing column and append.
+- **A reference appeared in only 2 of 133 registers' columns** while 98 reference fields existed — the
+  tool had the relationship and the table didn't show it. Now **32**.
+- **Filtering is `q` + `state` only.** `moduleRecordsFiltered` accepts `{q, state, limit, offset}` and
+  nothing else. On a 20-field register you cannot filter by discipline, vendor, cost code, or a date
+  range; sorting is client-side over the fetched page only. **This is the largest remaining CRUD gap**
+  and it is not addressed here — it needs a query parameter per filterable field plus a server-side
+  sort, which is an API change, not a config change.
+
+## 7. Result
+
+| | before | after |
+|---|---|---|
+| reference fields | 98 | **152** |
+| modules with no reference at all | 69 | **49** |
+| `percent`-typed fields | 2 | **22** |
+| fields declaring a unit | 0 | **67** |
+| registers with fewer than 3 columns | 55 | **17** |
+| registers surfacing a reference as a column | 2 | **32** |
+
+`test_module_fields.py` holds each of these as a **floor**, not an equality — adding a module never
+requires editing it, undoing the work fails it. It also asserts the pair-adjacency and shared-fieldset
+rules, and the three calendar-year exceptions by name.
+
+## 8. Not done
+
+1. **Per-field filters and server-side sort** (§6) — the biggest remaining CRUD gap.
+2. **The `table` field type** — still the blocker for the 22 list-in-a-textarea fields and for `sov`,
+   `estimate`, `bid_submission` being documents rather than rows.
+3. **Backfilling the 54 new reference fields** from their text twins — needs a matcher and a review
+   step; a wrong auto-link is worse than an empty one.
+4. **`eticket` → rate libraries** (§4), the highest-value relationship still missing.
+5. **`default`, `min`/`max`, `placeholder`, `readonly`** — the rest of the field vocabulary.
+6. **Fieldsets on the remaining 62 modules** with none.

--- a/services/api/modules/action_item/module.json
+++ b/services/api/modules/action_item/module.json
@@ -55,6 +55,12 @@
       "name": "responsible",
       "label": "Responsible",
       "type": "text"
+    },
+    {
+      "name": "responsible_contact",
+      "label": "Responsible (linked)",
+      "type": "reference",
+      "module": "contact"
     }
   ],
   "workflow": {
@@ -76,7 +82,8 @@
   },
   "list_columns": [
     "priority",
-    "due_date"
+    "due_date",
+    "meeting"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/as_built/module.json
+++ b/services/api/modules/as_built/module.json
@@ -96,7 +96,9 @@
   },
   "list_columns": [
     "discipline",
-    "status"
+    "status",
+    "drawing",
+    "format"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/asi/module.json
+++ b/services/api/modules/asi/module.json
@@ -108,7 +108,8 @@
   },
   "list_columns": [
     "cost_time_impact",
-    "issued_date"
+    "issued_date",
+    "rfi"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/asset_register/module.json
+++ b/services/api/modules/asset_register/module.json
@@ -27,6 +27,13 @@
       "fieldset": "Asset"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Asset"
+    },
+    {
       "name": "serial",
       "label": "Serial #",
       "type": "text",
@@ -72,7 +79,8 @@
       "name": "expected_life_years",
       "label": "Expected Life (yrs)",
       "type": "number",
-      "fieldset": "Reserve Study"
+      "fieldset": "Reserve Study",
+      "unit": "yr"
     },
     {
       "name": "replacement_cost",
@@ -130,7 +138,8 @@
       "name": "elevation_ft",
       "label": "Installed Elevation (ft)",
       "type": "number",
-      "fieldset": "Resilience"
+      "fieldset": "Resilience",
+      "unit": "ft"
     },
     {
       "name": "warranty_count",

--- a/services/api/modules/bid_package/module.json
+++ b/services/api/modules/bid_package/module.json
@@ -122,7 +122,9 @@
   },
   "list_columns": [
     "trade",
-    "due_date"
+    "due_date",
+    "cost_code",
+    "discipline"
   ],
   "workspace": "construction",
   "tools": [

--- a/services/api/modules/bid_solicitation/module.json
+++ b/services/api/modules/bid_solicitation/module.json
@@ -60,7 +60,9 @@
   },
   "list_columns": [
     "trade",
-    "status"
+    "status",
+    "package",
+    "due_date"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/bid_submission/module.json
+++ b/services/api/modules/bid_submission/module.json
@@ -15,6 +15,13 @@
       "fieldset": "Bid"
     },
     {
+      "name": "bidder_company",
+      "label": "Bidder (linked)",
+      "type": "reference",
+      "module": "company",
+      "fieldset": "Bid"
+    },
+    {
       "name": "package",
       "label": "Bid package",
       "type": "reference",

--- a/services/api/modules/budget/module.json
+++ b/services/api/modules/budget/module.json
@@ -63,7 +63,9 @@
   },
   "list_columns": [
     "original",
-    "revised"
+    "revised",
+    "budget",
+    "forecast"
   ],
   "workspace": "construction",
   "tools": [

--- a/services/api/modules/change_event/module.json
+++ b/services/api/modules/change_event/module.json
@@ -64,7 +64,8 @@
       "name": "schedule_impact_days",
       "label": "Schedule Impact (days)",
       "type": "number",
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "unit": "days"
     },
     {
       "name": "source_rfi",
@@ -139,7 +140,9 @@
   },
   "list_columns": [
     "rom",
-    "trades"
+    "trades",
+    "source_rfi",
+    "reason"
   ],
   "revisable": true,
   "workspace": "construction"

--- a/services/api/modules/checklist/module.json
+++ b/services/api/modules/checklist/module.json
@@ -19,6 +19,12 @@
       "type": "text"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location"
+    },
+    {
       "name": "category",
       "label": "Category",
       "type": "text"
@@ -58,7 +64,6 @@
     ]
   },
   "list_columns": [
-    "category",
     "result"
   ],
   "workspace": "construction"

--- a/services/api/modules/climate_site_risk/module.json
+++ b/services/api/modules/climate_site_risk/module.json
@@ -51,6 +51,13 @@
       "fieldset": "Hazard"
     },
     {
+      "name": "location_loc",
+      "label": "Site Location / Zone (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Hazard"
+    },
+    {
       "name": "severity",
       "label": "Severity",
       "type": "select",

--- a/services/api/modules/coi/module.json
+++ b/services/api/modules/coi/module.json
@@ -15,6 +15,13 @@
       "fieldset": "Insured"
     },
     {
+      "name": "vendor_company",
+      "label": "Vendor (linked)",
+      "type": "reference",
+      "module": "company",
+      "fieldset": "Insured"
+    },
+    {
       "name": "subcontract",
       "label": "Subcontract",
       "type": "reference",
@@ -40,6 +47,13 @@
       "name": "carrier",
       "label": "Carrier",
       "type": "text",
+      "fieldset": "Policy"
+    },
+    {
+      "name": "carrier_company",
+      "label": "Carrier (linked)",
+      "type": "reference",
+      "module": "company",
       "fieldset": "Policy"
     },
     {
@@ -111,7 +125,9 @@
   },
   "list_columns": [
     "carrier",
-    "expires"
+    "expires",
+    "subcontract",
+    "additional_insured"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/commissioning/module.json
+++ b/services/api/modules/commissioning/module.json
@@ -15,6 +15,13 @@
       "fieldset": "System"
     },
     {
+      "name": "system_system",
+      "label": "System (linked)",
+      "type": "reference",
+      "module": "building_system",
+      "fieldset": "System"
+    },
+    {
       "name": "asset",
       "label": "Asset",
       "type": "reference",
@@ -96,7 +103,9 @@
   },
   "list_columns": [
     "system",
-    "status"
+    "status",
+    "asset",
+    "test_type"
   ],
   "workspace": "construction",
   "tools": [

--- a/services/api/modules/commitment/module.json
+++ b/services/api/modules/commitment/module.json
@@ -32,6 +32,13 @@
       "fieldset": "Commitment"
     },
     {
+      "name": "vendor_company",
+      "label": "Vendor / Sub (linked)",
+      "type": "reference",
+      "module": "company",
+      "fieldset": "Commitment"
+    },
+    {
       "name": "po_date",
       "label": "PO Date",
       "type": "date",
@@ -47,8 +54,9 @@
     {
       "name": "retainage_pct",
       "label": "Retainage %",
-      "type": "number",
-      "fieldset": "Cost"
+      "type": "percent",
+      "fieldset": "Cost",
+      "unit": "%"
     },
     {
       "name": "cost_code",
@@ -105,5 +113,11 @@
       "dest": "__margin__",
       "label": "Cost-code margin"
     }
+  ],
+  "list_columns": [
+    "cost_code",
+    "type",
+    "amount",
+    "po_date"
   ]
 }

--- a/services/api/modules/comparable/module.json
+++ b/services/api/modules/comparable/module.json
@@ -45,7 +45,8 @@
     {
       "name": "price_psf",
       "label": "$/SF",
-      "type": "number"
+      "type": "number",
+      "unit": "$/sf"
     },
     {
       "name": "price_per_unit",
@@ -65,7 +66,8 @@
     {
       "name": "rent_psf",
       "label": "Rent $/SF/yr",
-      "type": "number"
+      "type": "number",
+      "unit": "$/sf"
     },
     {
       "name": "gba",
@@ -112,7 +114,8 @@
     {
       "name": "distance_mi",
       "label": "Distance to subject (mi)",
-      "type": "number"
+      "type": "number",
+      "unit": "mi"
     },
     {
       "name": "net_adjustment",

--- a/services/api/modules/completion_certificate/module.json
+++ b/services/api/modules/completion_certificate/module.json
@@ -51,7 +51,8 @@
     {
       "name": "punch_complete_pct",
       "label": "Punch List % Complete",
-      "type": "percent"
+      "type": "percent",
+      "unit": "%"
     }
   ],
   "workflow": {
@@ -80,7 +81,9 @@
   },
   "list_columns": [
     "type",
-    "date"
+    "date",
+    "occupancy_date",
+    "punch_complete_pct"
   ],
   "workspace": "construction",
   "tools": [

--- a/services/api/modules/compliance_evidence/module.json
+++ b/services/api/modules/compliance_evidence/module.json
@@ -7,31 +7,134 @@
   "title_field": "requirement",
   "pinnable": false,
   "fields": [
-    { "name": "requirement", "label": "Requirement", "type": "text", "required": true, "fieldset": "Requirement" },
-    { "name": "code_section", "label": "Code / Standard Section", "type": "text", "fieldset": "Requirement" },
-    { "name": "category", "label": "Category", "type": "select",
-      "options": ["Life Safety", "Egress", "Structural", "Fire Protection", "Accessibility", "Energy", "Zoning", "Other"],
-      "fieldset": "Requirement" },
-
-    { "name": "outcome", "label": "Outcome", "type": "select", "required": true,
-      "options": ["Pass", "Fail", "N/A", "Pending"], "fieldset": "Status" },
-    { "name": "responsible", "label": "Responsible Party", "type": "text", "fieldset": "Status" },
-    { "name": "review_date", "label": "Review Date", "type": "date", "fieldset": "Status" },
-
-    { "name": "evidence_type", "label": "Evidence Type", "type": "select",
-      "options": ["Drawing", "Document", "Photo", "Calculation", "Inspection", "Test Report"],
-      "fieldset": "Evidence" },
-    { "name": "evidence_ref", "label": "Evidence Reference", "type": "text", "fieldset": "Evidence" },
-    { "name": "notes", "label": "Notes", "type": "textarea", "fieldset": "Evidence" }
+    {
+      "name": "requirement",
+      "label": "Requirement",
+      "type": "text",
+      "required": true,
+      "fieldset": "Requirement"
+    },
+    {
+      "name": "code_section",
+      "label": "Code / Standard Section",
+      "type": "text",
+      "fieldset": "Requirement"
+    },
+    {
+      "name": "category",
+      "label": "Category",
+      "type": "select",
+      "options": [
+        "Life Safety",
+        "Egress",
+        "Structural",
+        "Fire Protection",
+        "Accessibility",
+        "Energy",
+        "Zoning",
+        "Other"
+      ],
+      "fieldset": "Requirement"
+    },
+    {
+      "name": "outcome",
+      "label": "Outcome",
+      "type": "select",
+      "required": true,
+      "options": [
+        "Pass",
+        "Fail",
+        "N/A",
+        "Pending"
+      ],
+      "fieldset": "Status"
+    },
+    {
+      "name": "responsible",
+      "label": "Responsible Party",
+      "type": "text",
+      "fieldset": "Status"
+    },
+    {
+      "name": "responsible_contact",
+      "label": "Responsible Party (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Status"
+    },
+    {
+      "name": "review_date",
+      "label": "Review Date",
+      "type": "date",
+      "fieldset": "Status"
+    },
+    {
+      "name": "evidence_type",
+      "label": "Evidence Type",
+      "type": "select",
+      "options": [
+        "Drawing",
+        "Document",
+        "Photo",
+        "Calculation",
+        "Inspection",
+        "Test Report"
+      ],
+      "fieldset": "Evidence"
+    },
+    {
+      "name": "evidence_ref",
+      "label": "Evidence Reference",
+      "type": "text",
+      "fieldset": "Evidence"
+    },
+    {
+      "name": "notes",
+      "label": "Notes",
+      "type": "textarea",
+      "fieldset": "Evidence"
+    }
   ],
   "workflow": {
     "initial": "open",
-    "states": ["open", "evidenced", "signed_off"],
+    "states": [
+      "open",
+      "evidenced",
+      "signed_off"
+    ],
     "transitions": [
-      { "from": "open", "to": "evidenced", "action": "attach_evidence", "party": ["Architect", "PM", "GC"], "requires": ["evidence_ref"] },
-      { "from": "evidenced", "to": "signed_off", "action": "sign_off", "party": ["Architect", "OwnersRep", "GC"], "requires": ["responsible"] }
+      {
+        "from": "open",
+        "to": "evidenced",
+        "action": "attach_evidence",
+        "party": [
+          "Architect",
+          "PM",
+          "GC"
+        ],
+        "requires": [
+          "evidence_ref"
+        ]
+      },
+      {
+        "from": "evidenced",
+        "to": "signed_off",
+        "action": "sign_off",
+        "party": [
+          "Architect",
+          "OwnersRep",
+          "GC"
+        ],
+        "requires": [
+          "responsible"
+        ]
+      }
     ]
   },
-  "list_columns": ["category", "outcome", "evidence_type"],
+  "list_columns": [
+    "category",
+    "outcome",
+    "evidence_type"
+  ],
   "workspace": "construction"
 }

--- a/services/api/modules/coordination_issue/module.json
+++ b/services/api/modules/coordination_issue/module.json
@@ -46,6 +46,12 @@
       "type": "text"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location"
+    },
+    {
       "name": "clash_hash",
       "label": "Clash group ID",
       "type": "text"
@@ -126,7 +132,9 @@
   },
   "list_columns": [
     "discipline",
-    "priority"
+    "priority",
+    "meeting",
+    "clash_count"
   ],
   "workspace": "design"
 }

--- a/services/api/modules/cor/module.json
+++ b/services/api/modules/cor/module.json
@@ -53,7 +53,8 @@
       "name": "schedule_days",
       "label": "Schedule Days",
       "type": "number",
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "unit": "days"
     },
     {
       "name": "labor_cost",
@@ -154,5 +155,11 @@
     ]
   },
   "revisable": true,
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "cost_code",
+    "reason",
+    "amount",
+    "labor_cost"
+  ]
 }

--- a/services/api/modules/daily_report/module.json
+++ b/services/api/modules/daily_report/module.json
@@ -35,7 +35,8 @@
       "name": "temp_f",
       "label": "Temp (Â°F)",
       "type": "number",
-      "fieldset": "Conditions"
+      "fieldset": "Conditions",
+      "unit": "°F"
     },
     {
       "name": "weather_impact",

--- a/services/api/modules/decision/module.json
+++ b/services/api/modules/decision/module.json
@@ -50,7 +50,8 @@
     {
       "name": "schedule_impact_days",
       "label": "Schedule Impact (days)",
-      "type": "number"
+      "type": "number",
+      "unit": "days"
     },
     {
       "name": "decided_by",

--- a/services/api/modules/deficiency/module.json
+++ b/services/api/modules/deficiency/module.json
@@ -19,6 +19,12 @@
       "type": "text"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location"
+    },
+    {
       "name": "inspection",
       "label": "Source Inspection",
       "type": "reference",

--- a/services/api/modules/design_option/module.json
+++ b/services/api/modules/design_option/module.json
@@ -2,7 +2,7 @@
   "key": "design_option",
   "name": "Design Options",
   "section": "Design",
-  "icon": "\ud83c\udfa8",
+  "icon": "🎨",
   "ref_prefix": "OPT",
   "title_field": "name",
   "pinnable": false,
@@ -37,7 +37,8 @@
       "name": "gross_area_sf",
       "label": "Gross area (sf)",
       "type": "number",
-      "fieldset": "Program"
+      "fieldset": "Program",
+      "unit": "sf"
     },
     {
       "name": "unit_count",
@@ -48,8 +49,9 @@
     {
       "name": "efficiency_pct",
       "label": "Efficiency (%)",
-      "type": "number",
-      "fieldset": "Program"
+      "type": "percent",
+      "fieldset": "Program",
+      "unit": "%"
     },
     {
       "name": "building_type",
@@ -95,8 +97,9 @@
     {
       "name": "irr_pct",
       "label": "Levered IRR (%)",
-      "type": "number",
-      "fieldset": "Economics"
+      "type": "percent",
+      "fieldset": "Economics",
+      "unit": "%"
     }
   ],
   "workflow": {

--- a/services/api/modules/design_review/module.json
+++ b/services/api/modules/design_review/module.json
@@ -67,7 +67,8 @@
   "revisable": true,
   "list_columns": [
     "discipline",
-    "status"
+    "status",
+    "drawing"
   ],
   "workspace": "design"
 }

--- a/services/api/modules/direct_cost/module.json
+++ b/services/api/modules/direct_cost/module.json
@@ -43,6 +43,12 @@
       "type": "text"
     },
     {
+      "name": "vendor_company",
+      "label": "Vendor (linked)",
+      "type": "reference",
+      "module": "company"
+    },
+    {
       "name": "date",
       "label": "Date",
       "type": "date"

--- a/services/api/modules/directive/module.json
+++ b/services/api/modules/directive/module.json
@@ -101,5 +101,11 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "change_event",
+    "mode",
+    "basis",
+    "not_to_exceed"
+  ]
 }

--- a/services/api/modules/drainage_area/module.json
+++ b/services/api/modules/drainage_area/module.json
@@ -31,7 +31,8 @@
       "name": "area_sf",
       "label": "Area (sf)",
       "type": "number",
-      "fieldset": "Catchment"
+      "fieldset": "Catchment",
+      "unit": "sf"
     },
     {
       "name": "runoff_coefficient",
@@ -63,7 +64,8 @@
       "name": "rainfall_depth_in",
       "label": "Storm Depth (in)",
       "type": "number",
-      "fieldset": "Storm"
+      "fieldset": "Storm",
+      "unit": "in"
     }
   ],
   "workflow": {

--- a/services/api/modules/environmental_monitoring/module.json
+++ b/services/api/modules/environmental_monitoring/module.json
@@ -52,6 +52,13 @@
       "fieldset": "Reading"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Reading"
+    },
+    {
       "name": "permit",
       "label": "Permit",
       "type": "reference",

--- a/services/api/modules/equipment_log/module.json
+++ b/services/api/modules/equipment_log/module.json
@@ -53,5 +53,10 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "daily_report",
+    "date",
+    "hours"
+  ]
 }

--- a/services/api/modules/estimate/module.json
+++ b/services/api/modules/estimate/module.json
@@ -55,7 +55,8 @@
   },
   "list_columns": [
     "amount",
-    "date"
+    "date",
+    "basis"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/eticket/module.json
+++ b/services/api/modules/eticket/module.json
@@ -77,5 +77,11 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "change_event",
+    "work_date",
+    "labor_total",
+    "material_total"
+  ]
 }

--- a/services/api/modules/evm_snapshot/module.json
+++ b/services/api/modules/evm_snapshot/module.json
@@ -71,8 +71,9 @@
     {
       "name": "percent_complete",
       "label": "% complete",
-      "type": "number",
-      "fieldset": "Forecast"
+      "type": "percent",
+      "fieldset": "Forecast",
+      "unit": "%"
     },
     {
       "name": "notes",

--- a/services/api/modules/fca_element/module.json
+++ b/services/api/modules/fca_element/module.json
@@ -43,6 +43,13 @@
       "fieldset": "Element"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Element"
+    },
+    {
       "name": "condition_rating",
       "label": "Condition",
       "type": "select",
@@ -65,7 +72,8 @@
       "name": "expected_life_years",
       "label": "Expected Life (yrs)",
       "type": "number",
-      "fieldset": "Condition"
+      "fieldset": "Condition",
+      "unit": "yr"
     },
     {
       "name": "replacement_cost",

--- a/services/api/modules/field_verification/module.json
+++ b/services/api/modules/field_verification/module.json
@@ -8,27 +8,132 @@
   "pinnable": true,
   "workspace": "construction",
   "fields": [
-    {"name": "guid", "label": "Element GlobalId", "type": "text", "required": true, "fieldset": "Element"},
-    {"name": "element", "label": "Element", "type": "text", "fieldset": "Element"},
-    {"name": "ifc_class", "label": "IFC Class", "type": "text", "fieldset": "Element"},
-    {"name": "deviation_mm", "label": "Deviation (mm)", "type": "number", "fieldset": "As-built"},
-    {"name": "method", "label": "Method", "type": "select",
-     "options": ["Total station", "Reality capture", "Point cloud", "Visual", "CV"], "fieldset": "As-built"},
-    {"name": "activity", "label": "Schedule Activity", "type": "reference", "module": "schedule_activity", "fieldset": "As-built"},
-    {"name": "observed_date", "label": "Observed", "type": "date", "fieldset": "As-built"},
-    {"name": "photo", "label": "Photo", "type": "file", "fieldset": "As-built"},
-    {"name": "note", "label": "Note", "type": "textarea", "fieldset": "As-built"}
+    {
+      "name": "guid",
+      "label": "Element GlobalId",
+      "type": "text",
+      "required": true,
+      "fieldset": "Element"
+    },
+    {
+      "name": "element",
+      "label": "Element",
+      "type": "text",
+      "fieldset": "Element"
+    },
+    {
+      "name": "ifc_class",
+      "label": "IFC Class",
+      "type": "text",
+      "fieldset": "Element"
+    },
+    {
+      "name": "deviation_mm",
+      "label": "Deviation (mm)",
+      "type": "number",
+      "fieldset": "As-built",
+      "unit": "mm"
+    },
+    {
+      "name": "method",
+      "label": "Method",
+      "type": "select",
+      "options": [
+        "Total station",
+        "Reality capture",
+        "Point cloud",
+        "Visual",
+        "CV"
+      ],
+      "fieldset": "As-built"
+    },
+    {
+      "name": "activity",
+      "label": "Schedule Activity",
+      "type": "reference",
+      "module": "schedule_activity",
+      "fieldset": "As-built"
+    },
+    {
+      "name": "observed_date",
+      "label": "Observed",
+      "type": "date",
+      "fieldset": "As-built"
+    },
+    {
+      "name": "photo",
+      "label": "Photo",
+      "type": "file",
+      "fieldset": "As-built"
+    },
+    {
+      "name": "note",
+      "label": "Note",
+      "type": "textarea",
+      "fieldset": "As-built"
+    }
   ],
   "workflow": {
     "initial": "captured",
-    "states": ["captured", "verified", "deviated", "resolved"],
+    "states": [
+      "captured",
+      "verified",
+      "deviated",
+      "resolved"
+    ],
     "transitions": [
-      {"from": "captured", "to": "verified", "action": "verify", "party": ["GC", "Subcontractor", "Consultant"]},
-      {"from": "captured", "to": "deviated", "action": "flag", "party": ["GC", "Subcontractor", "Consultant"]},
-      {"from": "deviated", "to": "resolved", "action": "resolve", "party": ["GC", "Subcontractor"]},
-      {"from": "verified", "to": "captured", "action": "reopen", "party": ["GC", "Consultant"]},
-      {"from": "resolved", "to": "verified", "action": "accept", "party": ["GC", "Consultant"]}
+      {
+        "from": "captured",
+        "to": "verified",
+        "action": "verify",
+        "party": [
+          "GC",
+          "Subcontractor",
+          "Consultant"
+        ]
+      },
+      {
+        "from": "captured",
+        "to": "deviated",
+        "action": "flag",
+        "party": [
+          "GC",
+          "Subcontractor",
+          "Consultant"
+        ]
+      },
+      {
+        "from": "deviated",
+        "to": "resolved",
+        "action": "resolve",
+        "party": [
+          "GC",
+          "Subcontractor"
+        ]
+      },
+      {
+        "from": "verified",
+        "to": "captured",
+        "action": "reopen",
+        "party": [
+          "GC",
+          "Consultant"
+        ]
+      },
+      {
+        "from": "resolved",
+        "to": "verified",
+        "action": "accept",
+        "party": [
+          "GC",
+          "Consultant"
+        ]
+      }
     ]
   },
-  "list_columns": ["ifc_class", "method", "deviation_mm"]
+  "list_columns": [
+    "ifc_class",
+    "method",
+    "deviation_mm"
+  ]
 }

--- a/services/api/modules/flood_risk/module.json
+++ b/services/api/modules/flood_risk/module.json
@@ -34,13 +34,15 @@
       "name": "ground_elevation_ft",
       "label": "Ground / Lowest Floor Elev (ft)",
       "type": "number",
-      "fieldset": "Site"
+      "fieldset": "Site",
+      "unit": "ft"
     },
     {
       "name": "bfe_ft",
       "label": "Base Flood Elevation (ft)",
       "type": "number",
-      "fieldset": "Design Flood"
+      "fieldset": "Design Flood",
+      "unit": "ft"
     },
     {
       "name": "flood_design_class",
@@ -58,7 +60,8 @@
       "name": "freeboard_ft",
       "label": "Freeboard (ft, blank = ASCE 24 default)",
       "type": "number",
-      "fieldset": "Design Flood"
+      "fieldset": "Design Flood",
+      "unit": "ft"
     },
     {
       "name": "notes",

--- a/services/api/modules/incident/module.json
+++ b/services/api/modules/incident/module.json
@@ -139,13 +139,15 @@
       "name": "lost_days",
       "label": "Days Away",
       "type": "number",
-      "fieldset": "OSHA"
+      "fieldset": "OSHA",
+      "unit": "days"
     },
     {
       "name": "restricted_days",
       "label": "Restricted / Transfer Days",
       "type": "number",
-      "fieldset": "OSHA"
+      "fieldset": "OSHA",
+      "unit": "days"
     },
     {
       "name": "reported_to",

--- a/services/api/modules/info_requirement/module.json
+++ b/services/api/modules/info_requirement/module.json
@@ -153,7 +153,9 @@
   },
   "list_columns": [
     "req_type",
-    "due_date"
+    "due_date",
+    "derives_from",
+    "loin_geometry"
   ],
   "workspace": "design",
   "tools": [

--- a/services/api/modules/inspection/module.json
+++ b/services/api/modules/inspection/module.json
@@ -21,6 +21,13 @@
       "fieldset": "Inspection"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Inspection"
+    },
+    {
       "name": "result",
       "label": "Result",
       "type": "select",
@@ -52,6 +59,13 @@
       "fieldset": "Result"
     },
     {
+      "name": "inspector_contact",
+      "label": "Inspector (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Result"
+    },
+    {
       "name": "date",
       "label": "Date",
       "type": "date",
@@ -68,6 +82,13 @@
       "name": "spec_section",
       "label": "Spec Section",
       "type": "text",
+      "fieldset": "Record"
+    },
+    {
+      "name": "spec_section_spec",
+      "label": "Spec Section (linked)",
+      "type": "reference",
+      "module": "spec_section",
       "fieldset": "Record"
     },
     {

--- a/services/api/modules/investor/module.json
+++ b/services/api/modules/investor/module.json
@@ -60,12 +60,14 @@
     {
       "name": "ownership_pct",
       "label": "Ownership / interest %",
-      "type": "number"
+      "type": "percent",
+      "unit": "%"
     },
     {
       "name": "pref_return_pct",
       "label": "Preferred return %",
-      "type": "number"
+      "type": "percent",
+      "unit": "%"
     },
     {
       "name": "date_committed",

--- a/services/api/modules/issue/module.json
+++ b/services/api/modules/issue/module.json
@@ -39,6 +39,12 @@
       "type": "text"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location"
+    },
+    {
       "name": "assignee_name",
       "label": "Assigned To",
       "type": "text"
@@ -71,7 +77,6 @@
     ]
   },
   "list_columns": [
-    "category",
     "priority"
   ],
   "workspace": "construction"

--- a/services/api/modules/itp/module.json
+++ b/services/api/modules/itp/module.json
@@ -7,34 +7,148 @@
   "title_field": "activity",
   "pinnable": false,
   "fields": [
-    { "name": "activity", "label": "Work Activity", "type": "text", "required": true, "fieldset": "Activity" },
-    { "name": "work_package", "label": "Work Package", "type": "text", "fieldset": "Activity" },
-    { "name": "spec_section", "label": "Spec Section", "type": "text", "fieldset": "Activity" },
-    { "name": "discipline", "label": "Discipline", "type": "text", "fieldset": "Activity" },
-
-    { "name": "point_type", "label": "Inspection Point", "type": "select", "required": true,
-      "options": ["Hold Point", "Witness Point", "Review Point", "Surveillance", "Monitor"],
-      "fieldset": "Inspection & Test" },
-    { "name": "method", "label": "Method", "type": "select",
-      "options": ["Visual", "Measurement", "Test", "Document Review", "Sampling", "Survey"],
-      "fieldset": "Inspection & Test" },
-    { "name": "acceptance_criteria", "label": "Acceptance Criteria", "type": "textarea", "fieldset": "Inspection & Test" },
-    { "name": "frequency", "label": "Frequency", "type": "text", "fieldset": "Inspection & Test" },
-
-    { "name": "responsible_party", "label": "Responsible Party", "type": "select",
-      "options": ["Contractor", "Subcontractor", "Consultant", "Owner", "Third-Party Agency"],
-      "fieldset": "Responsibility" },
-    { "name": "verifying_party", "label": "Verifying Party", "type": "text", "fieldset": "Responsibility" },
-    { "name": "record_form", "label": "Record / Form Required", "type": "text", "fieldset": "Responsibility" }
+    {
+      "name": "activity",
+      "label": "Work Activity",
+      "type": "text",
+      "required": true,
+      "fieldset": "Activity"
+    },
+    {
+      "name": "work_package",
+      "label": "Work Package",
+      "type": "text",
+      "fieldset": "Activity"
+    },
+    {
+      "name": "work_package_package",
+      "label": "Work Package (linked)",
+      "type": "reference",
+      "module": "bid_package",
+      "fieldset": "Activity"
+    },
+    {
+      "name": "spec_section",
+      "label": "Spec Section",
+      "type": "text",
+      "fieldset": "Activity"
+    },
+    {
+      "name": "spec_section_spec",
+      "label": "Spec Section (linked)",
+      "type": "reference",
+      "module": "spec_section",
+      "fieldset": "Activity"
+    },
+    {
+      "name": "discipline",
+      "label": "Discipline",
+      "type": "text",
+      "fieldset": "Activity"
+    },
+    {
+      "name": "point_type",
+      "label": "Inspection Point",
+      "type": "select",
+      "required": true,
+      "options": [
+        "Hold Point",
+        "Witness Point",
+        "Review Point",
+        "Surveillance",
+        "Monitor"
+      ],
+      "fieldset": "Inspection & Test"
+    },
+    {
+      "name": "method",
+      "label": "Method",
+      "type": "select",
+      "options": [
+        "Visual",
+        "Measurement",
+        "Test",
+        "Document Review",
+        "Sampling",
+        "Survey"
+      ],
+      "fieldset": "Inspection & Test"
+    },
+    {
+      "name": "acceptance_criteria",
+      "label": "Acceptance Criteria",
+      "type": "textarea",
+      "fieldset": "Inspection & Test"
+    },
+    {
+      "name": "frequency",
+      "label": "Frequency",
+      "type": "text",
+      "fieldset": "Inspection & Test"
+    },
+    {
+      "name": "responsible_party",
+      "label": "Responsible Party",
+      "type": "select",
+      "options": [
+        "Contractor",
+        "Subcontractor",
+        "Consultant",
+        "Owner",
+        "Third-Party Agency"
+      ],
+      "fieldset": "Responsibility"
+    },
+    {
+      "name": "verifying_party",
+      "label": "Verifying Party",
+      "type": "text",
+      "fieldset": "Responsibility"
+    },
+    {
+      "name": "record_form",
+      "label": "Record / Form Required",
+      "type": "text",
+      "fieldset": "Responsibility"
+    }
   ],
   "workflow": {
     "initial": "planned",
-    "states": ["planned", "active", "verified"],
+    "states": [
+      "planned",
+      "active",
+      "verified"
+    ],
     "transitions": [
-      { "from": "planned", "to": "active", "action": "release", "party": ["PM", "OwnersRep", "Architect"] },
-      { "from": "active", "to": "verified", "action": "verify", "party": ["PM", "OwnersRep", "Architect"], "requires": ["acceptance_criteria"] }
+      {
+        "from": "planned",
+        "to": "active",
+        "action": "release",
+        "party": [
+          "PM",
+          "OwnersRep",
+          "Architect"
+        ]
+      },
+      {
+        "from": "active",
+        "to": "verified",
+        "action": "verify",
+        "party": [
+          "PM",
+          "OwnersRep",
+          "Architect"
+        ],
+        "requires": [
+          "acceptance_criteria"
+        ]
+      }
     ]
   },
-  "list_columns": ["point_type", "spec_section", "responsible_party"],
+  "list_columns": [
+    "point_type",
+    "spec_section",
+    "responsible_party"
+  ],
   "workspace": "construction"
 }

--- a/services/api/modules/labor_rate/module.json
+++ b/services/api/modules/labor_rate/module.json
@@ -47,7 +47,8 @@
   },
   "list_columns": [
     "trade",
-    "rate"
+    "rate",
+    "unit"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/lease/module.json
+++ b/services/api/modules/lease/module.json
@@ -27,7 +27,8 @@
       "name": "rentable_sf",
       "label": "Rentable SF",
       "type": "number",
-      "required": true
+      "required": true,
+      "unit": "sf"
     },
     {
       "name": "base_rent_annual",
@@ -60,7 +61,8 @@
     {
       "name": "escalation_pct",
       "label": "Annual escalation %",
-      "type": "number"
+      "type": "percent",
+      "unit": "%"
     },
     {
       "name": "renewal_options",
@@ -70,12 +72,14 @@
     {
       "name": "free_rent_months",
       "label": "Free rent (months)",
-      "type": "number"
+      "type": "number",
+      "unit": "mo"
     },
     {
       "name": "ti_allowance_psf",
       "label": "TI allowance $/SF",
-      "type": "number"
+      "type": "number",
+      "unit": "$/sf"
     },
     {
       "name": "security_deposit",
@@ -85,7 +89,8 @@
     {
       "name": "recovery_psf",
       "label": "Recoveries (CAM/tax) $/SF",
-      "type": "number"
+      "type": "number",
+      "unit": "$/sf"
     },
     {
       "name": "notes",

--- a/services/api/modules/leed_credit/module.json
+++ b/services/api/modules/leed_credit/module.json
@@ -59,6 +59,13 @@
       "fieldset": "Tracking"
     },
     {
+      "name": "responsible_contact",
+      "label": "Responsible (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Tracking"
+    },
+    {
       "name": "documentation",
       "label": "Documentation",
       "type": "textarea",

--- a/services/api/modules/lien_waiver/module.json
+++ b/services/api/modules/lien_waiver/module.json
@@ -14,6 +14,12 @@
       "required": true
     },
     {
+      "name": "vendor_company",
+      "label": "Vendor (linked)",
+      "type": "reference",
+      "module": "company"
+    },
+    {
       "name": "amount",
       "label": "Through Amount",
       "type": "currency",
@@ -75,7 +81,9 @@
   },
   "list_columns": [
     "waiver_type",
-    "amount"
+    "amount",
+    "subcontract",
+    "through_date"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/listing/module.json
+++ b/services/api/modules/listing/module.json
@@ -100,7 +100,8 @@
     {
       "name": "price_psf",
       "label": "$/SF",
-      "type": "number"
+      "type": "number",
+      "unit": "$/sf"
     },
     {
       "name": "public_description",

--- a/services/api/modules/manpower_log/module.json
+++ b/services/api/modules/manpower_log/module.json
@@ -14,6 +14,12 @@
       "required": true
     },
     {
+      "name": "company_company",
+      "label": "Company (linked)",
+      "type": "reference",
+      "module": "company"
+    },
+    {
       "name": "date",
       "label": "Date",
       "type": "date"
@@ -64,7 +70,9 @@
   },
   "list_columns": [
     "trade",
-    "headcount"
+    "headcount",
+    "daily_report",
+    "date"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/market_assumption/module.json
+++ b/services/api/modules/market_assumption/module.json
@@ -8,28 +8,111 @@
   "pinnable": false,
   "revisable": true,
   "fields": [
-    { "name": "name", "label": "Scenario", "type": "text", "required": true },
-    { "name": "region", "label": "Region", "type": "select",
-      "options": ["global_average", "north_america", "europe", "australia_nz", "asia",
-                  "middle_east", "latin_america", "africa"] },
-    { "name": "sector", "label": "Sector", "type": "select",
-      "options": ["data_center", "advanced_manufacturing", "life_sciences", "lab", "infrastructure",
-                  "healthcare", "hotel", "mixed_use", "industrial", "warehouse", "residential",
-                  "multifamily", "office", "commercial", "retail"] },
-    { "name": "construction_start_year", "label": "Construction start (year)", "type": "number" },
-    { "name": "duration_months", "label": "Construction duration (months)", "type": "number" },
-    { "name": "escalation_override_pct", "label": "Escalation override (%/yr)", "type": "number" },
-    { "name": "location_override", "label": "Location index override (1.0 = US avg)", "type": "number" },
-    { "name": "notes", "label": "Notes", "type": "textarea" }
+    {
+      "name": "name",
+      "label": "Scenario",
+      "type": "text",
+      "required": true
+    },
+    {
+      "name": "region",
+      "label": "Region",
+      "type": "select",
+      "options": [
+        "global_average",
+        "north_america",
+        "europe",
+        "australia_nz",
+        "asia",
+        "middle_east",
+        "latin_america",
+        "africa"
+      ]
+    },
+    {
+      "name": "sector",
+      "label": "Sector",
+      "type": "select",
+      "options": [
+        "data_center",
+        "advanced_manufacturing",
+        "life_sciences",
+        "lab",
+        "infrastructure",
+        "healthcare",
+        "hotel",
+        "mixed_use",
+        "industrial",
+        "warehouse",
+        "residential",
+        "multifamily",
+        "office",
+        "commercial",
+        "retail"
+      ]
+    },
+    {
+      "name": "construction_start_year",
+      "label": "Construction start (year)",
+      "type": "number"
+    },
+    {
+      "name": "duration_months",
+      "label": "Construction duration (months)",
+      "type": "number",
+      "unit": "mo"
+    },
+    {
+      "name": "escalation_override_pct",
+      "label": "Escalation override (%/yr)",
+      "type": "percent",
+      "unit": "%"
+    },
+    {
+      "name": "location_override",
+      "label": "Location index override (1.0 = US avg)",
+      "type": "number"
+    },
+    {
+      "name": "notes",
+      "label": "Notes",
+      "type": "textarea"
+    }
   ],
   "workflow": {
     "initial": "draft",
-    "states": ["draft", "adopted", "superseded"],
+    "states": [
+      "draft",
+      "adopted",
+      "superseded"
+    ],
     "transitions": [
-      { "from": "draft", "to": "adopted", "action": "adopt", "party": ["Owner", "OwnersRep", "GC"] },
-      { "from": "adopted", "to": "superseded", "action": "supersede", "party": ["Owner", "OwnersRep", "GC"] }
+      {
+        "from": "draft",
+        "to": "adopted",
+        "action": "adopt",
+        "party": [
+          "Owner",
+          "OwnersRep",
+          "GC"
+        ]
+      },
+      {
+        "from": "adopted",
+        "to": "superseded",
+        "action": "supersede",
+        "party": [
+          "Owner",
+          "OwnersRep",
+          "GC"
+        ]
+      }
     ]
   },
-  "list_columns": ["region", "sector", "construction_start_year"],
+  "list_columns": [
+    "region",
+    "sector",
+    "construction_start_year"
+  ],
   "workspace": "developer"
 }

--- a/services/api/modules/material_rate/module.json
+++ b/services/api/modules/material_rate/module.json
@@ -41,5 +41,8 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "rate"
+  ]
 }

--- a/services/api/modules/material_request/module.json
+++ b/services/api/modules/material_request/module.json
@@ -89,5 +89,10 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "activity",
+    "needed_by",
+    "qty"
+  ]
 }

--- a/services/api/modules/meeting/module.json
+++ b/services/api/modules/meeting/module.json
@@ -43,6 +43,13 @@
       "fieldset": "Meeting"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Meeting"
+    },
+    {
       "name": "attendees",
       "label": "Attendees",
       "type": "textarea",
@@ -106,7 +113,8 @@
   },
   "list_columns": [
     "meeting_type",
-    "date"
+    "date",
+    "next_meeting"
   ],
   "workspace": "construction|design"
 }

--- a/services/api/modules/mep_equipment/module.json
+++ b/services/api/modules/mep_equipment/module.json
@@ -88,6 +88,13 @@
       "fieldset": "Rating"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Rating"
+    },
+    {
       "name": "notes",
       "label": "Notes",
       "type": "textarea",

--- a/services/api/modules/meter_reading/module.json
+++ b/services/api/modules/meter_reading/module.json
@@ -52,7 +52,9 @@
   },
   "list_columns": [
     "reading_date",
-    "consumption"
+    "consumption",
+    "meter",
+    "cost"
   ],
   "workspace": "construction",
   "tools": [

--- a/services/api/modules/noc/module.json
+++ b/services/api/modules/noc/module.json
@@ -60,7 +60,8 @@
       "name": "schedule_days",
       "label": "Schedule Days",
       "type": "number",
-      "fieldset": "Impact"
+      "fieldset": "Impact",
+      "unit": "days"
     },
     {
       "name": "issued_date",
@@ -104,7 +105,9 @@
   },
   "list_columns": [
     "cost_estimate",
-    "schedule_days"
+    "schedule_days",
+    "direction",
+    "reason"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/observation/module.json
+++ b/services/api/modules/observation/module.json
@@ -28,6 +28,12 @@
       "type": "text"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location"
+    },
+    {
       "name": "category",
       "label": "Type",
       "type": "select",

--- a/services/api/modules/om_manual/module.json
+++ b/services/api/modules/om_manual/module.json
@@ -21,6 +21,13 @@
       "fieldset": "Manual"
     },
     {
+      "name": "system_system",
+      "label": "System (linked)",
+      "type": "reference",
+      "module": "building_system",
+      "fieldset": "Manual"
+    },
+    {
       "name": "submittal",
       "label": "Submittal",
       "type": "reference",
@@ -31,6 +38,13 @@
       "name": "spec_section",
       "label": "Spec Section",
       "type": "text",
+      "fieldset": "Manual"
+    },
+    {
+      "name": "spec_section_spec",
+      "label": "Spec Section (linked)",
+      "type": "reference",
+      "module": "spec_section",
       "fieldset": "Manual"
     },
     {
@@ -60,6 +74,13 @@
       "label": "Responsible Sub",
       "type": "text",
       "fieldset": "Status"
+    },
+    {
+      "name": "responsible_contact",
+      "label": "Responsible Sub (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Status"
     }
   ],
   "workflow": {
@@ -81,7 +102,9 @@
   },
   "list_columns": [
     "system",
-    "status"
+    "status",
+    "submittal",
+    "format"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/orientation/module.json
+++ b/services/api/modules/orientation/module.json
@@ -19,6 +19,12 @@
       "type": "text"
     },
     {
+      "name": "company_company",
+      "label": "Company (linked)",
+      "type": "reference",
+      "module": "company"
+    },
+    {
       "name": "date",
       "label": "Date",
       "type": "date"

--- a/services/api/modules/owner_invoice/module.json
+++ b/services/api/modules/owner_invoice/module.json
@@ -96,7 +96,8 @@
   },
   "list_columns": [
     "amount",
-    "status"
+    "status",
+    "prime_contract"
   ],
   "workspace": "construction",
   "tools": [

--- a/services/api/modules/pco_request/module.json
+++ b/services/api/modules/pco_request/module.json
@@ -43,7 +43,8 @@
       "name": "schedule_impact_days",
       "label": "Schedule Impact (days)",
       "type": "number",
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "unit": "days"
     },
     {
       "name": "received_from",
@@ -100,5 +101,11 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "source_rfi",
+    "origin",
+    "rough_cost",
+    "schedule_impact_days"
+  ]
 }

--- a/services/api/modules/photo/module.json
+++ b/services/api/modules/photo/module.json
@@ -19,6 +19,12 @@
       "type": "text"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location"
+    },
+    {
       "name": "date",
       "label": "Date",
       "type": "date"
@@ -64,7 +70,8 @@
   },
   "list_columns": [
     "location",
-    "date_taken"
+    "date_taken",
+    "date"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/pm_schedule/module.json
+++ b/services/api/modules/pm_schedule/module.json
@@ -32,7 +32,8 @@
       "label": "Frequency (days)",
       "type": "number",
       "required": true,
-      "fieldset": "Schedule"
+      "fieldset": "Schedule",
+      "unit": "days"
     },
     {
       "name": "last_done",
@@ -50,7 +51,8 @@
       "name": "est_hours",
       "label": "Est. Hours",
       "type": "number",
-      "fieldset": "Schedule"
+      "fieldset": "Schedule",
+      "unit": "hr"
     }
   ],
   "workflow": {
@@ -82,7 +84,9 @@
   },
   "list_columns": [
     "frequency_days",
-    "next_due"
+    "next_due",
+    "asset",
+    "last_done"
   ],
   "workspace": "construction",
   "tools": [

--- a/services/api/modules/prequalification/module.json
+++ b/services/api/modules/prequalification/module.json
@@ -2,7 +2,7 @@
   "key": "prequalification",
   "name": "Prequalification",
   "section": "Preconstruction",
-  "icon": "\u2713",
+  "icon": "✓",
   "ref_prefix": "PQ",
   "title_field": "company",
   "pinnable": false,
@@ -15,6 +15,13 @@
       "fieldset": "Company"
     },
     {
+      "name": "company_company",
+      "label": "Company (linked)",
+      "type": "reference",
+      "module": "company",
+      "fieldset": "Company"
+    },
+    {
       "name": "trade",
       "label": "Trade",
       "type": "text",
@@ -24,6 +31,13 @@
       "name": "contact",
       "label": "Contact",
       "type": "text",
+      "fieldset": "Company"
+    },
+    {
+      "name": "contact_contact",
+      "label": "Contact (linked)",
+      "type": "reference",
+      "module": "contact",
       "fieldset": "Company"
     },
     {

--- a/services/api/modules/price_observation/module.json
+++ b/services/api/modules/price_observation/module.json
@@ -35,6 +35,12 @@
       "type": "text"
     },
     {
+      "name": "vendor_company",
+      "label": "Vendor / Supplier (linked)",
+      "type": "reference",
+      "module": "company"
+    },
+    {
       "name": "date",
       "label": "Observed",
       "type": "date"
@@ -43,7 +49,12 @@
       "name": "source",
       "label": "Source",
       "type": "select",
-      "options": ["quote", "invoice", "po", "manual"]
+      "options": [
+        "quote",
+        "invoice",
+        "po",
+        "manual"
+      ]
     }
   ],
   "workflow": {
@@ -63,5 +74,11 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "source",
+    "unit_price",
+    "date",
+    "qty"
+  ]
 }

--- a/services/api/modules/prime_contract/module.json
+++ b/services/api/modules/prime_contract/module.json
@@ -21,6 +21,13 @@
       "fieldset": "Contract"
     },
     {
+      "name": "owner_company",
+      "label": "Owner / Client (linked)",
+      "type": "reference",
+      "module": "company",
+      "fieldset": "Contract"
+    },
+    {
       "name": "type",
       "label": "Type",
       "type": "select",
@@ -66,26 +73,30 @@
     {
       "name": "retainage_pct",
       "label": "Retainage %",
-      "type": "number",
-      "fieldset": "Cost"
+      "type": "percent",
+      "fieldset": "Cost",
+      "unit": "%"
     },
     {
       "name": "overhead_pct",
       "label": "Overhead %",
-      "type": "number",
-      "fieldset": "GMP markups"
+      "type": "percent",
+      "fieldset": "GMP markups",
+      "unit": "%"
     },
     {
       "name": "fee_pct",
       "label": "Fee / Profit %",
-      "type": "number",
-      "fieldset": "GMP markups"
+      "type": "percent",
+      "fieldset": "GMP markups",
+      "unit": "%"
     },
     {
       "name": "contingency_pct",
       "label": "GC Contingency %",
-      "type": "number",
-      "fieldset": "GMP markups"
+      "type": "percent",
+      "fieldset": "GMP markups",
+      "unit": "%"
     },
     {
       "name": "substantial_completion",
@@ -97,7 +108,8 @@
       "name": "ld_per_day",
       "label": "Liquidated Damages / day",
       "type": "currency",
-      "fieldset": "Schedule"
+      "fieldset": "Schedule",
+      "unit": "$/day"
     },
     {
       "name": "invoiced",
@@ -139,5 +151,11 @@
       "dest": "__wip__",
       "label": "WIP schedule"
     }
+  ],
+  "list_columns": [
+    "type",
+    "notice_family",
+    "value",
+    "ld_per_day"
   ]
 }

--- a/services/api/modules/production_quantity/module.json
+++ b/services/api/modules/production_quantity/module.json
@@ -53,5 +53,9 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "cost_code",
+    "quantity"
+  ]
 }

--- a/services/api/modules/productivity_log/module.json
+++ b/services/api/modules/productivity_log/module.json
@@ -33,6 +33,13 @@
       "fieldset": "Entry"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Entry"
+    },
+    {
       "name": "quantity",
       "label": "Quantity installed",
       "type": "number",

--- a/services/api/modules/project_charter/module.json
+++ b/services/api/modules/project_charter/module.json
@@ -7,37 +7,153 @@
   "title_field": "title",
   "pinnable": false,
   "fields": [
-    { "name": "title", "label": "Charter Title", "type": "text", "required": true, "fieldset": "Charter" },
-    { "name": "sponsor", "label": "Project Sponsor", "type": "text", "fieldset": "Charter" },
-    { "name": "project_manager", "label": "Project Manager", "type": "text", "fieldset": "Charter" },
-    { "name": "authorized_date", "label": "Authorized Date", "type": "date", "fieldset": "Charter" },
-
-    { "name": "business_case", "label": "Business Case / Justification", "type": "textarea", "fieldset": "Purpose" },
-    { "name": "objectives", "label": "Objectives (SMART)", "type": "textarea", "fieldset": "Purpose" },
-    { "name": "success_criteria", "label": "Success Criteria", "type": "textarea", "fieldset": "Purpose" },
-
-    { "name": "scope_in", "label": "In Scope", "type": "textarea", "fieldset": "Scope" },
-    { "name": "scope_out", "label": "Out of Scope", "type": "textarea", "fieldset": "Scope" },
-    { "name": "key_deliverables", "label": "Key Deliverables", "type": "textarea", "fieldset": "Scope" },
-
-    { "name": "budget_authority", "label": "Budget Authority", "type": "currency", "fieldset": "Budget & Schedule" },
-    { "name": "target_completion", "label": "Target Completion", "type": "date", "fieldset": "Budget & Schedule" },
-    { "name": "key_milestones", "label": "Key Milestones", "type": "textarea", "fieldset": "Budget & Schedule" },
-
-    { "name": "assumptions", "label": "Assumptions", "type": "textarea", "fieldset": "Risks & Assumptions" },
-    { "name": "constraints", "label": "Constraints", "type": "textarea", "fieldset": "Risks & Assumptions" },
-    { "name": "high_level_risks", "label": "High-Level Risks", "type": "textarea", "fieldset": "Risks & Assumptions" },
-
-    { "name": "key_stakeholders", "label": "Key Stakeholders", "type": "textarea", "fieldset": "Stakeholders" }
+    {
+      "name": "title",
+      "label": "Charter Title",
+      "type": "text",
+      "required": true,
+      "fieldset": "Charter"
+    },
+    {
+      "name": "sponsor",
+      "label": "Project Sponsor",
+      "type": "text",
+      "fieldset": "Charter"
+    },
+    {
+      "name": "sponsor_contact",
+      "label": "Project Sponsor (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Charter"
+    },
+    {
+      "name": "project_manager",
+      "label": "Project Manager",
+      "type": "text",
+      "fieldset": "Charter"
+    },
+    {
+      "name": "authorized_date",
+      "label": "Authorized Date",
+      "type": "date",
+      "fieldset": "Charter"
+    },
+    {
+      "name": "business_case",
+      "label": "Business Case / Justification",
+      "type": "textarea",
+      "fieldset": "Purpose"
+    },
+    {
+      "name": "objectives",
+      "label": "Objectives (SMART)",
+      "type": "textarea",
+      "fieldset": "Purpose"
+    },
+    {
+      "name": "success_criteria",
+      "label": "Success Criteria",
+      "type": "textarea",
+      "fieldset": "Purpose"
+    },
+    {
+      "name": "scope_in",
+      "label": "In Scope",
+      "type": "textarea",
+      "fieldset": "Scope"
+    },
+    {
+      "name": "scope_out",
+      "label": "Out of Scope",
+      "type": "textarea",
+      "fieldset": "Scope"
+    },
+    {
+      "name": "key_deliverables",
+      "label": "Key Deliverables",
+      "type": "textarea",
+      "fieldset": "Scope"
+    },
+    {
+      "name": "budget_authority",
+      "label": "Budget Authority",
+      "type": "currency",
+      "fieldset": "Budget & Schedule"
+    },
+    {
+      "name": "target_completion",
+      "label": "Target Completion",
+      "type": "date",
+      "fieldset": "Budget & Schedule"
+    },
+    {
+      "name": "key_milestones",
+      "label": "Key Milestones",
+      "type": "textarea",
+      "fieldset": "Budget & Schedule"
+    },
+    {
+      "name": "assumptions",
+      "label": "Assumptions",
+      "type": "textarea",
+      "fieldset": "Risks & Assumptions"
+    },
+    {
+      "name": "constraints",
+      "label": "Constraints",
+      "type": "textarea",
+      "fieldset": "Risks & Assumptions"
+    },
+    {
+      "name": "high_level_risks",
+      "label": "High-Level Risks",
+      "type": "textarea",
+      "fieldset": "Risks & Assumptions"
+    },
+    {
+      "name": "key_stakeholders",
+      "label": "Key Stakeholders",
+      "type": "textarea",
+      "fieldset": "Stakeholders"
+    }
   ],
   "workflow": {
     "initial": "draft",
-    "states": ["draft", "in_review", "approved"],
+    "states": [
+      "draft",
+      "in_review",
+      "approved"
+    ],
     "transitions": [
-      { "from": "draft", "to": "in_review", "action": "submit_for_review", "party": ["PM", "OwnersRep"] },
-      { "from": "in_review", "to": "approved", "action": "authorize", "party": ["Owner", "OwnersRep"], "requires": ["business_case", "objectives"] }
+      {
+        "from": "draft",
+        "to": "in_review",
+        "action": "submit_for_review",
+        "party": [
+          "PM",
+          "OwnersRep"
+        ]
+      },
+      {
+        "from": "in_review",
+        "to": "approved",
+        "action": "authorize",
+        "party": [
+          "Owner",
+          "OwnersRep"
+        ],
+        "requires": [
+          "business_case",
+          "objectives"
+        ]
+      }
     ]
   },
-  "list_columns": ["sponsor", "project_manager", "target_completion"],
+  "list_columns": [
+    "sponsor",
+    "project_manager",
+    "target_completion"
+  ],
   "workspace": "construction|developer"
 }

--- a/services/api/modules/project_phase/module.json
+++ b/services/api/modules/project_phase/module.json
@@ -42,7 +42,8 @@
       "name": "design_fee_pct",
       "label": "A/E Design Fee %",
       "type": "percent",
-      "fieldset": "Commercial"
+      "fieldset": "Commercial",
+      "unit": "%"
     },
     {
       "name": "iso_status",

--- a/services/api/modules/proposal/module.json
+++ b/services/api/modules/proposal/module.json
@@ -44,7 +44,8 @@
     {
       "name": "schedule_days",
       "label": "Schedule Days",
-      "type": "number"
+      "type": "number",
+      "unit": "days"
     }
   ],
   "workflow": {
@@ -93,7 +94,8 @@
   "revisable": true,
   "list_columns": [
     "amount",
-    "schedule_days"
+    "schedule_days",
+    "cost_code"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/pull_plan_task/module.json
+++ b/services/api/modules/pull_plan_task/module.json
@@ -44,10 +44,18 @@
       "fieldset": "Task"
     },
     {
+      "name": "responsible_contact",
+      "label": "Responsible (last planner) (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Task"
+    },
+    {
       "name": "duration_days",
       "label": "Duration (days)",
       "type": "number",
-      "fieldset": "Sequence"
+      "fieldset": "Sequence",
+      "unit": "days"
     },
     {
       "name": "planned_week",

--- a/services/api/modules/punchlist/module.json
+++ b/services/api/modules/punchlist/module.json
@@ -21,6 +21,13 @@
       "fieldset": "Item"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Item"
+    },
+    {
       "name": "trade",
       "label": "Trade",
       "type": "text",
@@ -48,6 +55,13 @@
       "name": "responsible",
       "label": "Responsible",
       "type": "text",
+      "fieldset": "Assignment"
+    },
+    {
+      "name": "responsible_contact",
+      "label": "Responsible (linked)",
+      "type": "reference",
+      "module": "contact",
       "fieldset": "Assignment"
     },
     {

--- a/services/api/modules/responsibility/module.json
+++ b/services/api/modules/responsibility/module.json
@@ -66,5 +66,9 @@
       "dest": "__responsibility__",
       "label": "Responsibility matrix"
     }
+  ],
+  "list_columns": [
+    "phase",
+    "category"
   ]
 }

--- a/services/api/modules/rfi/module.json
+++ b/services/api/modules/rfi/module.json
@@ -55,6 +55,13 @@
       "fieldset": "Question"
     },
     {
+      "name": "spec_section_spec",
+      "label": "Spec Section (linked)",
+      "type": "reference",
+      "module": "spec_section",
+      "fieldset": "Question"
+    },
+    {
       "name": "location",
       "label": "Location",
       "type": "reference",

--- a/services/api/modules/risk/module.json
+++ b/services/api/modules/risk/module.json
@@ -69,7 +69,8 @@
     {
       "name": "schedule_days",
       "label": "Schedule Days",
-      "type": "number"
+      "type": "number",
+      "unit": "days"
     },
     {
       "name": "trigger",

--- a/services/api/modules/safety_violation/module.json
+++ b/services/api/modules/safety_violation/module.json
@@ -19,6 +19,12 @@
       "type": "text"
     },
     {
+      "name": "company_company",
+      "label": "Company (linked)",
+      "type": "reference",
+      "module": "company"
+    },
+    {
       "name": "observation",
       "label": "Source observation",
       "type": "reference",
@@ -64,7 +70,8 @@
   },
   "list_columns": [
     "severity",
-    "due_date"
+    "due_date",
+    "observation"
   ],
   "workspace": "construction"
 }

--- a/services/api/modules/schedule_activity/module.json
+++ b/services/api/modules/schedule_activity/module.json
@@ -56,6 +56,13 @@
       "fieldset": "Activity"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Activity"
+    },
+    {
       "name": "weather_sensitivity",
       "label": "Weather Sensitivity",
       "type": "select",
@@ -114,7 +121,7 @@
     {
       "name": "percent",
       "label": "% Complete",
-      "type": "number",
+      "type": "percent",
       "fieldset": "Dates"
     },
     {

--- a/services/api/modules/selection/module.json
+++ b/services/api/modules/selection/module.json
@@ -19,6 +19,12 @@
       "type": "text"
     },
     {
+      "name": "location_loc",
+      "label": "Room/Location (linked)",
+      "type": "reference",
+      "module": "location"
+    },
+    {
       "name": "category",
       "label": "Category",
       "type": "select",

--- a/services/api/modules/site_logistics/module.json
+++ b/services/api/modules/site_logistics/module.json
@@ -30,6 +30,12 @@
       "type": "text"
     },
     {
+      "name": "company_company",
+      "label": "Booked By (linked)",
+      "type": "reference",
+      "module": "company"
+    },
+    {
       "name": "description",
       "label": "Description",
       "type": "textarea"

--- a/services/api/modules/sov/module.json
+++ b/services/api/modules/sov/module.json
@@ -49,7 +49,8 @@
     {
       "name": "retainage_pct",
       "label": "Retainage %",
-      "type": "number"
+      "type": "percent",
+      "unit": "%"
     },
     {
       "name": "prime_contract",
@@ -81,5 +82,11 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "cost_code",
+    "retainage_pct",
+    "scheduled_value",
+    "completed_prev"
+  ]
 }

--- a/services/api/modules/space_program/module.json
+++ b/services/api/modules/space_program/module.json
@@ -38,7 +38,8 @@
       "label": "Target Area (sf each)",
       "type": "number",
       "required": true,
-      "fieldset": "Space"
+      "fieldset": "Space",
+      "unit": "sf"
     },
     {
       "name": "quantity",

--- a/services/api/modules/spec_section/module.json
+++ b/services/api/modules/spec_section/module.json
@@ -91,6 +91,12 @@
       "type": "text"
     },
     {
+      "name": "responsible_contact",
+      "label": "Responsible contractor (linked)",
+      "type": "reference",
+      "module": "contact"
+    },
+    {
       "name": "notes",
       "label": "Notes",
       "type": "textarea"

--- a/services/api/modules/stakeholder/module.json
+++ b/services/api/modules/stakeholder/module.json
@@ -7,29 +7,118 @@
   "title_field": "name",
   "pinnable": false,
   "fields": [
-    { "name": "name", "label": "Name", "type": "text", "required": true, "fieldset": "Identity" },
-    { "name": "organization", "label": "Organization", "type": "text", "fieldset": "Identity" },
-    { "name": "role", "label": "Role / Title", "type": "text", "fieldset": "Identity" },
-    { "name": "category", "label": "Category", "type": "select",
-      "options": ["Client / Owner", "Design team", "Contractor", "Authority / Regulator",
-                  "Community", "Investor / Lender", "End user", "Other"], "fieldset": "Identity" },
-    { "name": "power", "label": "Power / Influence", "type": "select",
-      "options": ["High", "Medium", "Low"], "fieldset": "Assessment" },
-    { "name": "interest", "label": "Interest", "type": "select",
-      "options": ["High", "Medium", "Low"], "fieldset": "Assessment" },
-    { "name": "stance", "label": "Stance", "type": "select",
-      "options": ["Supporter", "Neutral", "Blocker"], "fieldset": "Assessment" },
-    { "name": "engagement_strategy", "label": "Engagement strategy", "type": "textarea", "fieldset": "Engagement" },
-    { "name": "contact", "label": "Contact", "type": "text", "fieldset": "Engagement" }
+    {
+      "name": "name",
+      "label": "Name",
+      "type": "text",
+      "required": true,
+      "fieldset": "Identity"
+    },
+    {
+      "name": "organization",
+      "label": "Organization",
+      "type": "text",
+      "fieldset": "Identity"
+    },
+    {
+      "name": "role",
+      "label": "Role / Title",
+      "type": "text",
+      "fieldset": "Identity"
+    },
+    {
+      "name": "category",
+      "label": "Category",
+      "type": "select",
+      "options": [
+        "Client / Owner",
+        "Design team",
+        "Contractor",
+        "Authority / Regulator",
+        "Community",
+        "Investor / Lender",
+        "End user",
+        "Other"
+      ],
+      "fieldset": "Identity"
+    },
+    {
+      "name": "power",
+      "label": "Power / Influence",
+      "type": "select",
+      "options": [
+        "High",
+        "Medium",
+        "Low"
+      ],
+      "fieldset": "Assessment"
+    },
+    {
+      "name": "interest",
+      "label": "Interest",
+      "type": "select",
+      "options": [
+        "High",
+        "Medium",
+        "Low"
+      ],
+      "fieldset": "Assessment"
+    },
+    {
+      "name": "stance",
+      "label": "Stance",
+      "type": "select",
+      "options": [
+        "Supporter",
+        "Neutral",
+        "Blocker"
+      ],
+      "fieldset": "Assessment"
+    },
+    {
+      "name": "engagement_strategy",
+      "label": "Engagement strategy",
+      "type": "textarea",
+      "fieldset": "Engagement"
+    },
+    {
+      "name": "contact",
+      "label": "Contact",
+      "type": "text",
+      "fieldset": "Engagement"
+    },
+    {
+      "name": "contact_contact",
+      "label": "Contact (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Engagement"
+    }
   ],
   "workflow": {
     "initial": "active",
-    "states": ["active", "inactive"],
+    "states": [
+      "active",
+      "inactive"
+    ],
     "transitions": [
-      { "from": "active", "to": "inactive", "action": "deactivate" },
-      { "from": "inactive", "to": "active", "action": "reactivate" }
+      {
+        "from": "active",
+        "to": "inactive",
+        "action": "deactivate"
+      },
+      {
+        "from": "inactive",
+        "to": "active",
+        "action": "reactivate"
+      }
     ]
   },
-  "list_columns": ["organization", "category", "power", "interest"],
+  "list_columns": [
+    "organization",
+    "category",
+    "power",
+    "interest"
+  ],
   "workspace": "construction|developer|design"
 }

--- a/services/api/modules/sub_invoice/module.json
+++ b/services/api/modules/sub_invoice/module.json
@@ -15,6 +15,13 @@
       "fieldset": "Application"
     },
     {
+      "name": "vendor_company",
+      "label": "Subcontractor (linked)",
+      "type": "reference",
+      "module": "company",
+      "fieldset": "Application"
+    },
+    {
       "name": "subcontract",
       "label": "Subcontract",
       "type": "reference",
@@ -43,8 +50,9 @@
     {
       "name": "retainage_pct",
       "label": "Retainage %",
-      "type": "number",
-      "fieldset": "Cost"
+      "type": "percent",
+      "fieldset": "Cost",
+      "unit": "%"
     },
     {
       "name": "cost_code",

--- a/services/api/modules/subcontract/module.json
+++ b/services/api/modules/subcontract/module.json
@@ -42,8 +42,9 @@
     {
       "name": "retainage_pct",
       "label": "Retainage %",
-      "type": "number",
-      "fieldset": "Cost"
+      "type": "percent",
+      "fieldset": "Cost",
+      "unit": "%"
     },
     {
       "name": "cost_code",
@@ -107,5 +108,11 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "vendor_company",
+    "bond_required",
+    "value",
+    "executed_date"
+  ]
 }

--- a/services/api/modules/submittal/module.json
+++ b/services/api/modules/submittal/module.json
@@ -22,6 +22,13 @@
       "fieldset": "Identification"
     },
     {
+      "name": "spec_section_spec",
+      "label": "Spec Section (linked)",
+      "type": "reference",
+      "module": "spec_section",
+      "fieldset": "Identification"
+    },
+    {
       "name": "type",
       "label": "Type",
       "type": "select",
@@ -68,7 +75,8 @@
       "name": "lead_time_days",
       "label": "Lead Time (days)",
       "type": "number",
-      "fieldset": "Schedule"
+      "fieldset": "Schedule",
+      "unit": "days"
     },
     {
       "name": "required_on_site",

--- a/services/api/modules/test_record/module.json
+++ b/services/api/modules/test_record/module.json
@@ -44,6 +44,12 @@
       "name": "spec_section",
       "label": "Spec Section",
       "type": "text"
+    },
+    {
+      "name": "spec_section_spec",
+      "label": "Spec Section (linked)",
+      "type": "reference",
+      "module": "spec_section"
     }
   ],
   "workflow": {

--- a/services/api/modules/warranty/module.json
+++ b/services/api/modules/warranty/module.json
@@ -21,6 +21,13 @@
       "fieldset": "Warranty"
     },
     {
+      "name": "vendor_company",
+      "label": "Vendor (linked)",
+      "type": "reference",
+      "module": "company",
+      "fieldset": "Warranty"
+    },
+    {
       "name": "warranty_type",
       "label": "Type",
       "type": "select",
@@ -39,6 +46,13 @@
       "fieldset": "Warranty"
     },
     {
+      "name": "contact_contact",
+      "label": "Warranty Contact (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Warranty"
+    },
+    {
       "name": "expires",
       "label": "Expires",
       "type": "date",
@@ -54,7 +68,8 @@
       "name": "term_years",
       "label": "Term (years)",
       "type": "number",
-      "fieldset": "Term"
+      "fieldset": "Term",
+      "unit": "yr"
     },
     {
       "name": "submittal",
@@ -88,5 +103,11 @@
       }
     ]
   },
-  "workspace": "construction"
+  "workspace": "construction",
+  "list_columns": [
+    "submittal",
+    "warranty_type",
+    "expires",
+    "start_date"
+  ]
 }

--- a/services/api/modules/waste_diversion/module.json
+++ b/services/api/modules/waste_diversion/module.json
@@ -47,8 +47,9 @@
     {
       "name": "diversion_pct",
       "label": "Diversion %",
-      "type": "number",
-      "fieldset": "Disposition"
+      "type": "percent",
+      "fieldset": "Disposition",
+      "unit": "%"
     }
   ],
   "workflow": {

--- a/services/api/modules/work_order/module.json
+++ b/services/api/modules/work_order/module.json
@@ -59,6 +59,13 @@
       "fieldset": "Work"
     },
     {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Work"
+    },
+    {
       "name": "due_date",
       "label": "Due",
       "type": "date",
@@ -74,7 +81,8 @@
       "name": "labor_hours",
       "label": "Labor Hours",
       "type": "number",
-      "fieldset": "Cost"
+      "fieldset": "Cost",
+      "unit": "hr"
     },
     {
       "name": "cost",

--- a/services/api/modules/zoning/module.json
+++ b/services/api/modules/zoning/module.json
@@ -34,7 +34,8 @@
       "name": "site_area_sf",
       "label": "Site area (SF)",
       "type": "number",
-      "required": true
+      "required": true,
+      "unit": "sf"
     },
     {
       "name": "far",
@@ -44,12 +45,14 @@
     {
       "name": "height_limit_ft",
       "label": "Height limit (ft)",
-      "type": "number"
+      "type": "number",
+      "unit": "ft"
     },
     {
       "name": "floor_to_floor_ft",
       "label": "Floor-to-floor (ft)",
-      "type": "number"
+      "type": "number",
+      "unit": "ft"
     },
     {
       "name": "max_floors",
@@ -59,37 +62,44 @@
     {
       "name": "lot_coverage_pct",
       "label": "Max lot coverage (%)",
-      "type": "number"
+      "type": "percent",
+      "unit": "%"
     },
     {
       "name": "lot_width_ft",
       "label": "Lot width (ft)",
-      "type": "number"
+      "type": "number",
+      "unit": "ft"
     },
     {
       "name": "lot_depth_ft",
       "label": "Lot depth (ft)",
-      "type": "number"
+      "type": "number",
+      "unit": "ft"
     },
     {
       "name": "front_setback_ft",
       "label": "Front setback (ft)",
-      "type": "number"
+      "type": "number",
+      "unit": "ft"
     },
     {
       "name": "side_setback_ft",
       "label": "Side setback (ft)",
-      "type": "number"
+      "type": "number",
+      "unit": "ft"
     },
     {
       "name": "rear_setback_ft",
       "label": "Rear setback (ft)",
-      "type": "number"
+      "type": "number",
+      "unit": "ft"
     },
     {
       "name": "open_space_pct",
       "label": "Required open space (%)",
-      "type": "number"
+      "type": "percent",
+      "unit": "%"
     },
     {
       "name": "parking_ratio",
@@ -99,12 +109,14 @@
     {
       "name": "avg_unit_sf",
       "label": "Avg unit size (SF)",
-      "type": "number"
+      "type": "number",
+      "unit": "sf"
     },
     {
       "name": "efficiency_pct",
       "label": "Net-to-gross efficiency (%)",
-      "type": "number"
+      "type": "percent",
+      "unit": "%"
     },
     {
       "name": "notes",

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -38,7 +38,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
-         "test_module_config", "test_module_schema", "test_throttle", "test_route_order",
+         "test_module_config", "test_module_schema", "test_module_fields", "test_throttle", "test_route_order",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:

--- a/services/api/src/aec_api/module_schema.py
+++ b/services/api/src/aec_api/module_schema.py
@@ -23,6 +23,10 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 FIELD_TYPES = {"text", "number", "currency", "date", "textarea", "select", "multiselect",
                "reference", "signature", "rollup", "checkbox", "email", "phone", "percent", "file"}
 
+#: Types that hold a magnitude, and so are the only ones a `unit` or a numeric check applies to.
+#: Defined here rather than beside `validate_record` because `validate_module` needs it first.
+_NUMERIC_TYPES = {"number", "currency", "percent"}
+
 
 class FieldDef(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -32,6 +36,11 @@ class FieldDef(BaseModel):
     required: bool = False
     options: list[str] | None = None
     module: str | None = None                 # reference target
+    # MOD-SWEEP — the unit a numeric value is measured in ("ft", "yr", "days", "kWh"). The sweep found
+    # 170 numeric fields with no unit declared, most encoding it in the field NAME instead
+    # (`elevation_ft`, `expected_life_years`). A unit in a name is readable only by a human: it cannot
+    # be rendered beside an input, appended to a table cell, converted, or validated.
+    unit: str | None = None
     # rollup wiring (type == "rollup")
     source_module: str | None = None
     source_field: str | None = None
@@ -159,6 +168,14 @@ def validate_module(mod: dict, *, known_modules: set[str] | None = None,
                 errors.append(f"{key}.{f.name}: reference target module {f.module!r} does not exist")
         if f.type in ("select", "multiselect") and not f.options:
             errors.append(f"{key}.{f.name}: {f.type} field has no options")
+        if f.unit and f.type not in _NUMERIC_TYPES:
+            errors.append(f"{key}.{f.name}: unit {f.unit!r} on a {f.type} field (units are numeric)")
+        # A percentage-named field typed `number` renders as a bare figure and formats as a count, so
+        # 7.5% and 7.5 are indistinguishable in a table. The sweep found 20; this stops the 21st.
+        # `percent` appears anywhere in the name, not just as a suffix — `percent_complete` was the one
+        # the suffix-only rule missed, which is the usual reason to widen a pattern rather than list.
+        if f.type == "number" and ("pct" in f.name or "percent" in f.name):
+            errors.append(f"{key}.{f.name}: named as a percentage but typed 'number' — use 'percent'")
 
     seen_dest: set[str] = set()
     for t in m.tools:
@@ -185,9 +202,6 @@ def validate_module(mod: dict, *, known_modules: set[str] | None = None,
                 if req not in nameset:
                     errors.append(f"{key}: transition {t.action!r} requires non-existent field {req!r}")
     return errors
-
-
-_NUMERIC_TYPES = {"number", "currency", "percent"}
 
 
 def validate_record(mod: dict, data: dict) -> list[str]:

--- a/services/api/test_module_fields.py
+++ b/services/api/test_module_fields.py
@@ -1,0 +1,126 @@
+"""MOD-SWEEP — the field-level invariants a register needs to read as a tool rather than a form.
+
+The R30 sweep asked a different question from `test_module_config` (is this module *well-formed*?) and
+from `test_module_rooms` (is it in the right *room*?). This one asks whether each field carries enough
+declared meaning to be rendered, filtered and trusted. The audit that produced these rules found, over
+133 modules and 1171 fields, that the entire field vocabulary in use was:
+
+    name · label · type · fieldset · options · required · module · source_module · source_field · op · help
+
+Eleven attributes, all structural or presentational. Nothing said what a number *measures*, nothing
+distinguished a percentage from a count, and half the concepts that already had their own register were
+stored as loose strings. Those are the three things asserted here.
+
+Every rule below is a ratchet: it encodes a state already reached, so it cannot be satisfied by
+weakening it, only by fixing the module. Counts are floors, not equalities — adding a module should
+never require editing this file, but removing the work should fail it.
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_module_fields.py
+"""
+import json
+import os
+
+MODULES_DIR = os.path.join(os.path.dirname(__file__), "modules")
+
+mods = {}
+for name in sorted(os.listdir(MODULES_DIR)):
+    p = os.path.join(MODULES_DIR, name, "module.json")
+    if os.path.exists(p):
+        with open(p, encoding="utf-8") as fh:
+            mods[name] = json.load(fh)
+
+assert len(mods) >= 130, f"expected the full module set, read {len(mods)}"
+keys = set(mods)
+NUMERIC = {"number", "currency", "percent"}
+
+# ---- 1. a percentage is typed as one -------------------------------------------------------------
+# 20 fields named `*_pct` were typed `number`, which renders 7.5% and 7.5 identically in a table and
+# formats with thousands separators. `percent` appears anywhere in the name, not just as a suffix —
+# `evm_snapshot.percent_complete` is the one a suffix-only rule missed.
+bad_pct = [f"{k}.{f['name']}" for k, m in mods.items() for f in m.get("fields", [])
+           if f["type"] == "number" and ("pct" in f["name"] or "percent" in f["name"])]
+assert not bad_pct, f"percentage-named fields typed 'number': {bad_pct}"
+
+# ---- 2. a unit belongs to a magnitude, and only to a magnitude -----------------------------------
+united = [(k, f) for k, m in mods.items() for f in m.get("fields", []) if f.get("unit")]
+for k, f in united:
+    assert f["type"] in NUMERIC, f"{k}.{f['name']}: unit {f['unit']!r} on a {f['type']} field"
+assert len(united) >= 60, (
+    f"only {len(united)} fields declare a unit; the sweep moved 67 units out of field NAMES "
+    "(elevation_ft, expected_life_years) and into the schema, where they can be rendered beside an "
+    "input and appended to a cell. A unit in a name is readable only by a human."
+)
+# A calendar year is a point in time, not a duration — the suffix rule could not tell them apart and
+# labelled three of them 'yr'. Named so the distinction cannot be re-lost by a future bulk pass.
+for k, fname in (("capital_plan", "planned_year"), ("fca_element", "recommended_year"),
+                 ("market_assumption", "construction_start_year")):
+    f = next(x for x in mods[k]["fields"] if x["name"] == fname)
+    assert "unit" not in f, f"{k}.{fname} is a calendar year, not a duration — it takes no unit"
+
+# ---- 3. the table a user first sees shows enough to decide whether to open a row ------------------
+thin = sorted(k for k, m in mods.items() if len(m.get("list_columns") or []) < 3)
+assert len(thin) <= 17, (
+    f"{len(thin)} registers show fewer than 3 columns: {thin}. 15 had none at all and 40 had two, so "
+    "the table was a title and a status chip — a list you must open every row of is not a register."
+)
+# columns must name real fields (test_module_config checks this too; kept so this file stands alone)
+for k, m in mods.items():
+    names = {f["name"] for f in m.get("fields", [])}
+    for c in m.get("list_columns") or []:
+        assert c in names, f"{k}: list_column {c!r} is not a field"
+
+# A reference is the most useful column in a register — *who* it is with — and it appeared in only 2
+# of 133 registers' columns while 98 reference fields existed. The tool had the relationship and the
+# table did not show it.
+with_ref = [k for k, m in mods.items()
+            if any(f["type"] == "reference" for f in m.get("fields", [])
+                   if f["name"] in (m.get("list_columns") or []))]
+assert len(with_ref) >= 30, f"only {len(with_ref)} registers surface a reference as a column"
+
+# ---- 4. relationships: the additive text+reference pattern ----------------------------------------
+# 74 text fields named a concept that already had its own register. They are NOT converted in place:
+# a reference stores a uuid, and a converted field's legacy string used to render as a link labelled
+# with its first 8 characters — a control that looked resolved and opened nothing. The codebase already
+# had the safe pattern in three places (investor+investor_company, lease+tenant_company,
+# subcontract+vendor_company): add the reference BESIDE the text, backfill, retire the text later.
+pairs = []
+for k, m in mods.items():
+    by = {f["name"]: f for f in m.get("fields", [])}
+    for n, f in by.items():
+        if f["type"] != "reference":
+            continue
+        for suf in ("_company", "_loc", "_spec", "_system", "_contact", "_package", "_ref", "_id"):
+            stem = n[: -len(suf)] if n.endswith(suf) else None
+            if stem and stem in by and by[stem]["type"] in ("text", "textarea"):
+                pairs.append((k, stem, n))
+                # the pair must be ADJACENT, or the form renders them in different places and nobody
+                # sees that one is the link for the other (same rule as fieldset contiguity)
+                fl = [x["name"] for x in m["fields"]]
+                assert abs(fl.index(stem) - fl.index(n)) == 1, \
+                    f"{k}: {stem!r} and its reference {n!r} are not adjacent"
+                assert by[stem].get("fieldset") == f.get("fieldset"), \
+                    f"{k}: {stem!r} and {n!r} are in different fieldsets"
+assert len(pairs) >= 50, f"only {len(pairs)} additive text+reference pairs; the sweep created 54"
+
+# every reference points at a module that exists (config test covers it; asserted here for the pairs)
+for k, m in mods.items():
+    for f in m.get("fields", []):
+        if f["type"] == "reference":
+            assert f.get("module") in keys, f"{k}.{f['name']}: bad reference target {f.get('module')!r}"
+
+refs = sum(1 for m in mods.values() for f in m.get("fields", []) if f["type"] == "reference")
+islands = [k for k, m in mods.items()
+           if not any(f["type"] == "reference" for f in m.get("fields", []))]
+assert refs >= 150, f"only {refs} reference fields; the sweep took it from 98 to 152"
+assert len(islands) <= 49, (
+    f"{len(islands)} modules have no reference at all (was 69). A record that points at nothing cannot "
+    "take part in a chain, which is most of what separates a register from a spreadsheet."
+)
+
+print(f"MOD-SWEEP OK - {len(mods)} modules, {refs} reference fields ({len(islands)} still islands), "
+      f"{len(united)} fields carry a declared unit, {len(pairs)} additive text+reference pairs are "
+      f"adjacent and share a fieldset, {len(with_ref)} registers surface a reference as a column, and "
+      "no percentage-named field is typed 'number'. Each bound is a FLOOR recording work already done, "
+      "so the file needs no edit when a module is added and fails if the work is undone. The three "
+      "calendar-year fields are asserted to carry NO unit: a suffix rule cannot tell 2027 from "
+      "5 years, and it labelled all three 'yr' before a human read the list.")


### PR DESCRIPTION
Field-level sweep of every module: fields, fieldsets, relationships, and CRUD affordances. Full analysis in `docs/internal/module-field-sweep.md`.

## Two live defects on `main`, and the first gates everything else

A reference column resolved ids against a bounded fetch, then fell back to `String(v).slice(0, 8)` **as a clickable link**. Three unrelated situations took that path and all three were indistinguishable from a resolved reference:

1. the target record was deleted since it was referenced;
2. the target lies past the 500-record resolve bound;
3. the value is legacy free text.

Eight characters is the specific harm — short enough to look like an id, long enough to look deliberate. The same truncation existed a second time in `fmtCell`, on the path taken when a reference is not a resolved column.

`refCell` now separates the three, because they ask different things of the reader: **resolved** → the link · **a UUID absent from the map** → the short id, *not* a link, marked unresolved · **not an id at all** → the value verbatim at full length, marked as unlinked text, because that string is the only handle anyone has for re-linking it.

## Relationships — 74 strings that name a register

74 text fields named a concept that already had its own register (`vendor`, `location`, `spec_section`, `system`, `inspector`, `bidder`, `tenant`, `carrier`), while only 98 reference fields existed across 133 modules and 69 modules had none at all.

**None is converted in place.** Converting one would have turned `"Acme Electrical Inc"` into a link reading `Acme Ele` that opens nothing, across 56 modules, with every gate still green — which is why the renderer fix had to land first. The codebase already held the safe pattern in three places (`investor`+`investor_company`, `lease`+`tenant_company`, `subcontract`+`vendor_company`), so this follows that precedent: **54 references added beside their text twins**, each adjacent and sharing its fieldset, both asserted.

**20 candidates were rejected** and the reasons are the useful part: an AHJ is not a project company (`permit.authority`); a manufacturer is not a project party; `risk.owner` is a *person* and whether that means `contact` or `company` genuinely differs per module; and every plural (`photos`, `deficiencies`, `spec_sections`) is a child **list** needing the table type, where a reference would be wrong in a way that looks right.

## Four automated inferences were wrong, and reading the output caught them

`capital_plan.planned_year`, `fca_element.recommended_year` and `market_assumption.construction_start_year` are **calendar years, not durations** — the suffix rule labelled all three `yr`. And `prime_contract.ld_per_day` is dollars *per* day. The gate now names those three as unit-less so a future bulk pass cannot re-lose the distinction.

## Result

| | before | after |
|---|---|---|
| reference fields | 98 | **152** |
| modules with no reference at all | 69 | **49** |
| `percent`-typed fields | 2 | **22** |
| fields declaring a unit | 0 | **67** |
| registers with fewer than 3 columns | 55 | **17** |
| registers surfacing a reference as a column | 2 | **32** |

`list_columns` was widened **append-only** — the first pass chose by type priority and silently dropped human-chosen columns like `bid_package.trade`, so it was redone to preserve every existing column.

## Reviewing this diff

**Roughly 900 of the 1771 added lines are formatting.** The edits were applied programmatically, so the 90 touched `module.json` files are normalised to the expanded one-key-per-line style already used by the majority (`rfi`, `coi`, `submittal`). Eight further files whose *only* change was that reformatting have been reverted — a diff with no semantic content is noise a reviewer has to read.

`test_module_fields.py` holds each figure as a **floor**, not an equality: adding a module never requires editing it, undoing the work fails it.

## Verification

- Backend **447/447** (`TESTS` length 447, `test_module_fields` registered, manifest guard clean)
- Web **908/908**, `tsc --noEmit` clean, ruff + eslint clean
- Base is current `main` (`3f376fff`, v0.3.804)

No version files or CHANGELOG — the release lane batches those.

## Not done, listed rather than half-built

1. **Per-field filters and server-side sort** — filtering is `q` + `state` only, so on a 20-field register you cannot filter by discipline, vendor, cost code or date range. An API change, not a config change, and the largest remaining CRUD gap.
2. The `table` field type — still the blocker for 22 list-in-a-textarea fields and for `sov`/`estimate`/`bid_submission` being documents rather than rows.
3. Backfilling the 54 new reference fields from their text twins — needs a matcher and review; a wrong auto-link is worse than an empty one.
4. `eticket` → the rate libraries. Reference material for this sweep was [eManagerNYC/django_emanager](https://github.com/eManagerNYC/django_emanager), whose `ticket` composes labor/material/equipment rates into totals; `eticket` has six fields and links to no rate library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
