### PR TITLE
MOD-FILTER — per-field filters + server-side sort · MOD-PERCENT — the form layer didn't know `percent` existed

### DIFF
--- a/apps/web/src/api/modules.ts
+++ b/apps/web/src/api/modules.ts
@@ -13,7 +13,7 @@
  *  moving a method is invisible to it, losing one fails it by number.
  */
 import type {
-  ModuleBoard, ModuleDef, ModuleRecord, RecordAttachmentMeta, RelatedRecords,
+  ModuleBoard, ModuleDef, ModuleFilterOp, ModuleRecord, RecordAttachmentMeta, RelatedRecords,
   SavedViewDef,
 } from "./types";
 
@@ -176,12 +176,44 @@ export function withModules<TBase extends Ctor<HttpCore>>(Base: TBase) {
     return this.json<{ ok: number; failed: { id: string; error: string }[] }>(
       `/projects/${pid}/modules/${key}/bulk`, { method: "POST", body: JSON.stringify({ ids, action, value }) });
   }
-  moduleRecordsFiltered(pid: string, key: string, opts: { q?: string; state?: string; limit?: number; offset?: number } = {}) {
+  /**
+   * MOD-FILTER — a register page, narrowed and ordered by the SERVER.
+   *
+   * `filters` becomes one `f.<field>[.<op>]=<value>` parameter each, and `sort`/`sort_dir` order the
+   * whole register rather than the fetched page. Both matter for the same reason: narrowing or
+   * ordering a page after it arrives answers a different question than the one asked, and the wrong
+   * answer is indistinguishable from the right one. "Sort by amount" on a 500-row register used to
+   * order the 200 rows already in the browser.
+   *
+   * An unknown field or operator is a 400 from the server, deliberately — a filter that is quietly
+   * dropped returns MORE rows than were requested, which reads as data rather than as a bug.
+   */
+  moduleRecordsFiltered(pid: string, key: string, opts: {
+    q?: string; state?: string; limit?: number; offset?: number;
+    /**
+     * A LIST, not a map keyed by field — a range is two clauses on one field (`amount.gte` **and**
+     * `amount.lte`), so a field-keyed map cannot express it: the second entry overwrites the first and
+     * a range silently collapses to a single bound, which is a narrower result that looks correct.
+     */
+    filters?: { field: string; op?: ModuleFilterOp; value?: string }[];
+    sort?: string; sortDir?: "asc" | "desc";
+  } = {}) {
     const p = new URLSearchParams();
     if (opts.q) p.set("q", opts.q);
     if (opts.state) p.set("state", opts.state);
     if (opts.limit != null) p.set("limit", String(opts.limit));
     if (opts.offset) p.set("offset", String(opts.offset));
+    for (const { field, op = "eq", value } of opts.filters ?? []) {
+      // `empty`/`nonempty` are predicates on their own; every other op needs a value, and sending a
+      // blank one would filter for the empty string rather than not filtering at all.
+      if (op !== "empty" && op !== "nonempty" && (value == null || value === "")) continue;
+      // `append`, not `set`: two clauses on one field must both survive into the query string.
+      p.append(op === "eq" ? `f.${field}` : `f.${field}.${op}`, value ?? "1");
+    }
+    if (opts.sort) {
+      p.set("sort", opts.sort);
+      p.set("sort_dir", opts.sortDir === "desc" ? "desc" : "asc");
+    }
     const qs = p.toString();
     return this.json<ModuleRecord[]>(`/projects/${pid}/modules/${key}${qs ? `?${qs}` : ""}`);
   }

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -218,6 +218,10 @@ export interface Viewpoint {
 
 export interface Vec3 { x: number; y: number; z: number; }
 
+/** MOD-FILTER — the operators a per-field register filter may use. Mirrors `modules_query.FILTER_OPS`;
+ *  the server rejects anything else with a 400 rather than ignoring it. */
+export type ModuleFilterOp = "eq" | "ne" | "gte" | "lte" | "contains" | "in" | "empty" | "nonempty";
+
 export interface ModuleField {
   name: string; label: string; type: string; required?: boolean; options?: string[];
   module?: string;   // for type:"reference" — the target module key

--- a/apps/web/src/portal/fieldTypeCoverage.test.ts
+++ b/apps/web/src/portal/fieldTypeCoverage.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { EDITABLE_FIELD_TYPES, NUMERIC_FIELD_TYPES, READ_ONLY_FIELD_TYPES } from "./portal";
+
+/**
+ * MOD-PERCENT — every field type a shipped module declares is one the form layer can actually render.
+ *
+ * **The defect this exists for.** `percent` was a legal field type and the form layer did not know it.
+ * Three separate places asked `f.type === "number" || f.type === "currency"`, and `percent` was in
+ * none of them, so a percent field was not inline-editable, rendered as `<input type="text">` with no
+ * numeric keypad or validation, and — quietest of the three — saved as the STRING `"5"`, because the
+ * `Number(v)` coercion was behind the same ternary. `validate_record` calls `float(value)`, so it
+ * passed; every consumer coerces, so nothing failed. The column simply accumulated a mixture of `5`
+ * and `"5"` depending on which form last touched the record.
+ *
+ * It survived because it was invisible from both directions. The backend gate reads config *shape* and
+ * says nothing about whether a UI can render it; the web suite never built a form containing a percent
+ * field. Two green suites, one type nothing handled.
+ *
+ * **Why this is a coverage test and not a DOM test.** Rendering a form and asserting one input is
+ * `type="number"` would prove `percent` works and nothing about the next type. What actually failed
+ * here was *completeness* — a hand-maintained list of types, with no check that it covered the types
+ * in use. So this asserts the partition instead: every type the 133 shipped modules declare is either
+ * editable or deliberately read-only, and every type whose NAME says it holds a magnitude is treated
+ * as numeric. Add a field type tomorrow and forget the form layer, and this fails then, not after it
+ * has quietly mangled a column.
+ */
+
+const MODULES_DIR = resolve(__dirname, "../../../../services/api/modules");
+const SCHEMA_PY = resolve(__dirname, "../../../../services/api/src/aec_api/module_schema.py");
+
+/** Every field type actually used by a shipped module, with an example so a failure names one. */
+function typesInUse(): Map<string, string> {
+  const seen = new Map<string, string>();
+  for (const e of readdirSync(MODULES_DIR, { withFileTypes: true })) {
+    if (!e.isDirectory()) continue;
+    let mod: { key?: string; fields?: { name: string; type: string }[] };
+    try {
+      mod = JSON.parse(readFileSync(resolve(MODULES_DIR, e.name, "module.json"), "utf8"));
+    } catch { continue; }
+    for (const f of mod.fields ?? []) {
+      if (!seen.has(f.type)) seen.set(f.type, `${mod.key}.${f.name}`);
+    }
+  }
+  return seen;
+}
+
+/** `FIELD_TYPES = {...}` from module_schema.py — the server's own list of legal types. */
+function declaredTypes(): string[] {
+  const src = readFileSync(SCHEMA_PY, "utf8");
+  const block = src.slice(src.indexOf("FIELD_TYPES = {"), src.indexOf("}", src.indexOf("FIELD_TYPES = {")));
+  const out = [...block.matchAll(/"([a-z]+)"/g)].map((m) => m[1]!);
+  expect(out.length, "could not parse FIELD_TYPES — module_schema.py was restructured").toBeGreaterThan(8);
+  return out;
+}
+
+const IN_USE = typesInUse();
+const HANDLED = new Set<string>([...EDITABLE_FIELD_TYPES, ...READ_ONLY_FIELD_TYPES]);
+
+describe("MOD-PERCENT — the form layer handles every field type in use", () => {
+  it("reads the real modules, not a fixture", () => {
+    expect(IN_USE.size).toBeGreaterThan(8);
+  });
+
+  it("every type a shipped module declares is either editable or deliberately read-only", () => {
+    const unhandled = [...IN_USE.entries()]
+      .filter(([t]) => !HANDLED.has(t))
+      .map(([t, eg]) => `${t} (e.g. ${eg})`);
+    expect(unhandled, "a type in neither list is one the form cannot render, and nothing will say so")
+      .toEqual([]);
+  });
+
+  it("no type is in both lists", () => {
+    // Overlap would mean the intent is ambiguous and the behaviour depends on which check runs first.
+    const both = [...EDITABLE_FIELD_TYPES].filter((t) => (READ_ONLY_FIELD_TYPES as readonly string[]).includes(t));
+    expect(both).toEqual([]);
+  });
+
+  it("every magnitude-holding type is treated as numeric", () => {
+    // The specific regression: `percent` holds a magnitude and was not in the numeric set, so it
+    // rendered as text and saved as a string. Asserted by MEANING rather than by listing the three,
+    // so a future "decimal" or "quantity" type is caught by the same rule.
+    const magnitude = declaredTypes().filter((t) => ["number", "currency", "percent"].includes(t));
+    for (const t of magnitude) {
+      expect(NUMERIC_FIELD_TYPES as readonly string[],
+        `${t} holds a magnitude but the form does not treat it as numeric — it will render as text `
+        + "and save as a string").toContain(t);
+    }
+  });
+
+  it("the server's legal types and the form's handled types have not drifted apart", () => {
+    // A type the server accepts but the form cannot render is a module author's trap: the config
+    // validates, the build passes, and the field is broken only when somebody opens the form.
+    const unrenderable = declaredTypes().filter((t) => !HANDLED.has(t));
+    expect(unrenderable, "module_schema.FIELD_TYPES accepts these but the form handles none of them")
+      .toEqual([]);
+  });
+
+  it("percent specifically is editable, numeric, and in use", () => {
+    // The concrete case, kept alongside the general rules: general rules can be satisfied by weakening
+    // them, and this one names the field type that actually broke.
+    expect(IN_USE.has("percent"), "no module uses `percent` — the sweep converted 21 fields").toBe(true);
+    expect(EDITABLE_FIELD_TYPES as readonly string[]).toContain("percent");
+    expect(NUMERIC_FIELD_TYPES as readonly string[]).toContain("percent");
+  });
+});

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -31,6 +31,8 @@ const REF_RESOLVE_LIMIT = 500;
 
 /** A record id is a `uuid.uuid4()` string server-side, so this distinguishes an id from free text. */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
  * MOD-FILTER — everything currently narrowing a register view.
  *
  * `q` and `state` were the whole vocabulary; `fields` is the per-field half. It is threaded through
@@ -38,6 +40,53 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * an inline edit — either passes the filters on deliberately or drops them visibly. A filter
  * surviving in hidden state while the controls show something else is the worst of both.
  */
+/**
+ * MOD-PERCENT — the field types that hold a MAGNITUDE, named once.
+ *
+ * The form layer asked `f.type === "number" || f.type === "currency"` in three separate places, and
+ * `percent` was in none of them. That was survivable while two fields in the whole system were typed
+ * `percent`; the field sweep converted 21 more across 16 registers — every retainage, fee, overhead
+ * and contingency percentage — and each of the three sites failed differently and quietly:
+ *
+ * 1. `EDITABLE` omitted it, so those fields stopped being inline-editable. A capability removed with
+ *    no error and no visible cause.
+ * 2. The record form rendered `<input type="text">` — no numeric keyboard on a phone, no step, no
+ *    browser validation.
+ * 3. The save path skipped `Number(v)`, storing the STRING "5". `validate_record` calls `float(value)`
+ *    so it passes, and every consumer coerces, so nothing ever failed — the column just accumulated a
+ *    mixture of `5` and `"5"` depending on which form last touched the record. That is the worst of
+ *    the three precisely because it never surfaces.
+ *
+ * One list, referenced three times, so adding the next numeric type is one edit rather than three
+ * that can be done two-thirds of the way. `test_module_fields.py` could not have caught any of this:
+ * it reads config shape and says nothing about whether the UI can render it.
+ */
+export const NUMERIC_FIELD_TYPES = ["number", "currency", "percent"] as const;
+const isNumericField = (t: string) => (NUMERIC_FIELD_TYPES as readonly string[]).includes(t);
+
+/**
+ * Field types the table can edit IN PLACE. Hoisted out of the row loop and exported so a test can
+ * compare it against the types the shipped modules actually declare — the check that would have
+ * caught `percent` missing here, and the one that catches the NEXT type rather than this one.
+ *
+ * A type absent from both this list and `READ_ONLY_FIELD_TYPES` is a type the form silently cannot
+ * handle, which is exactly how `percent` went unnoticed: nothing errored, a capability just stopped
+ * existing for 21 fields.
+ */
+export const EDITABLE_FIELD_TYPES = [
+  "text", "textarea", ...NUMERIC_FIELD_TYPES, "date", "select", "checkbox", "email", "phone",
+] as const;
+
+/** Types deliberately NOT inline-editable, each for a stated reason — so "not editable" is a
+ *  decision on the record rather than an omission nobody noticed. */
+export const READ_ONLY_FIELD_TYPES = [
+  "rollup",      // computed from other records; editing it would be editing a derived value
+  "signature",   // captured through the signing flow, which carries the attestation
+  "file",        // needs an upload control, not a cell
+  "reference",   // edited through the record picker (`inlineRefCell`), not as free text
+  "multiselect", // needs a multi-choice control a table cell has no room for
+] as const;
+
 interface RegisterFilter {
   q?: string;
   state?: string;
@@ -1732,7 +1781,11 @@ export class PortalUI {
       // textContent, not innerHTML: titles/field values are user data (stored-XSS guard)
       const cell = (text: string) => { const td = document.createElement("td"); td.textContent = text; tr.appendChild(td); };
       cell(r.ref); cell(r.title ?? "");
-      const EDITABLE = ["text", "textarea", "number", "currency", "date", "select", "checkbox"];
+      // MOD-PERCENT: `percent` was absent from this list, so the 21 fields the sweep converted from
+      // `number` stopped being inline-editable overnight — a capability removed with no error to
+      // notice. Now module-scope and exported, so `fieldTypeCoverage.test.ts` can hold it against the
+      // types the shipped modules actually declare.
+      const EDITABLE = EDITABLE_FIELD_TYPES as readonly string[];
       for (const c of cols) {
         const v = r.data[c.name];
         if (editing && c.type === "reference" && c.module) {
@@ -1859,6 +1912,9 @@ export class PortalUI {
     }
     td.appendChild(span);
     return td;
+  }
+
+  /**
    * MOD-FILTER — the per-field filter bar.
    *
    * One control per field, chosen by type, because the useful question differs by type and offering a
@@ -2326,7 +2382,25 @@ export class PortalUI {
             toast(`Added ${tgt?.name ?? f.module}: ${val.trim()}`, "info");
           } catch { toast(`could not create ${tgt?.name ?? f.module}`, "error"); }
         });
-      } else { el = document.createElement("input"); (el as HTMLInputElement).type = (f.type === "number" || f.type === "currency") ? "number" : f.type === "date" ? "date" : "text"; if (f.type === "currency") (el as HTMLInputElement).step = "0.01"; (el as HTMLInputElement).value = String(cur(f.name) ?? ""); }
+      } else {
+        el = document.createElement("input");
+        const inp = el as HTMLInputElement;
+        // MOD-PERCENT: a percent field rendered as `type="text"` — no numeric keypad on a phone, no
+        // step, no browser validation. It is a magnitude like the other two.
+        inp.type = isNumericField(f.type) ? "number" : f.type === "date" ? "date" : "text";
+        if (f.type === "currency" || f.type === "percent") inp.step = "0.01";
+        // The declared unit is shown beside the input, not only in table cells. A unit that renders in
+        // one place and not the other is half of what declaring it was for: the moment it matters most
+        // is while somebody is TYPING the number.
+        //
+        // Read structurally rather than via `ModuleField.unit`. `unit` is declared on that interface by
+        // the field-sweep branch, which is merged to `main` but not into this one — and it cannot be
+        // merged in right now without git overwriting two files another session is holding dirty. A
+        // local structural read is correct on both sides of that merge and costs nothing once it lands.
+        const unit = (f as { unit?: string }).unit;
+        if (unit) { inp.placeholder = unit; inp.setAttribute("aria-description", `in ${unit}`); }
+        inp.value = String(cur(f.name) ?? "");
+      }
       inputs[f.name] = el; wrap.appendChild(el);
       if (f.type === "select" || f.type === "multiselect") wrap.appendChild(addOptBtn(f, el as HTMLSelectElement));
       this.root.appendChild(wrap);
@@ -2378,7 +2452,12 @@ export class PortalUI {
         const el = inputs[f.name];
         if (!el) continue;
         if (f.type === "multiselect") { data[f.name] = [...(el as HTMLSelectElement).selectedOptions].map((o) => o.value); continue; }
-        const v = el.value; if (v) data[f.name] = (f.type === "number" || f.type === "currency") ? Number(v) : v;
+        // MOD-PERCENT: the quietest of the three. Without `percent` here a percentage saved as the
+        // STRING "5"; `validate_record` does `float(value)` so it passed, and every consumer coerces,
+        // so nothing ever failed — the column simply accumulated a mix of 5 and "5" depending on which
+        // form last touched the record. Numbers stored as text are also what makes SQL comparison go
+        // lexicographic, which is the bug MOD-FILTER's cast exists to survive.
+        const v = el.value; if (v) data[f.name] = isNumericField(f.type) ? Number(v) : v;
       }
       try {
         if (editing) {

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -12,7 +12,7 @@ import { SECTIONS_BY_PERSONA, pushRecent, readDensity, readFavs, readRecents, re
 import { el } from "../ui/dom";
 import { ALL_DESTS, type Dest, stagesFor } from "../shell/destinations";
 import { FALLBACK_ROOMS, type SpineState, destRoom, loadSpine, orderRooms, preselectedRoom, unroomedDests } from "../shell/spine";
-import type { RoomDef } from "../api/types";
+import type { ModuleFilterOp, RoomDef } from "../api/types";
 // PANEL-LAZY (PERF): the ~30 secondary portal panels are DYNAMICALLY imported at first render
 // (see the wrapper methods below), not eagerly bundled into the app shell — each panel file (and
 // its heavy deps: charts, tables, module-graph, etc.) becomes its own chunk fetched only when the
@@ -31,6 +31,20 @@ const REF_RESOLVE_LIMIT = 500;
 
 /** A record id is a `uuid.uuid4()` string server-side, so this distinguishes an id from free text. */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+ * MOD-FILTER — everything currently narrowing a register view.
+ *
+ * `q` and `state` were the whole vocabulary; `fields` is the per-field half. It is threaded through
+ * `openModule` rather than held on the instance so that every re-render — a saved view, a page step,
+ * an inline edit — either passes the filters on deliberately or drops them visibly. A filter
+ * surviving in hidden state while the controls show something else is the worst of both.
+ */
+interface RegisterFilter {
+  q?: string;
+  state?: string;
+  offset?: number;
+  /** field name -> {op, value}. Sent as `f.<field>[.<op>]`; the server 400s on an unknown field. */
+  fields?: Record<string, { op: ModuleFilterOp; value: string }>;
+}
 
 /**
  * GC portal UI — one config-driven engine renders every module's list / form / record pages
@@ -1405,12 +1419,28 @@ export class PortalUI {
 
   private async renderScheduleViews(m: ModuleDef) { return (await import("./panels/schedule")).renderScheduleViews(this.panelCtx(), m); }
 
-  private async openModule(m: ModuleDef, filter: { q?: string; state?: string; offset?: number } = {}) {
+  private async openModule(m: ModuleDef, filter: RegisterFilter = {}) {
     const pid = this.host.projectId()!;
     pushRecent(m.key);
     this.skeleton(`Loading ${m.name}…`);
     const PAGE = 100, offset = filter.offset ?? 0;          // page large modules so they never render 1000s of rows
-    const page = await this.host.api.moduleRecordsFiltered(pid, m.key, { ...filter, limit: PAGE + 1, offset });
+    // MOD-FILTER — per-field filters and the sort go to the SERVER, so both apply to the whole
+    // register rather than to the hundred rows that happen to be on this page.
+    const sortState = this.sort[m.key];
+    const sortField = sortState ? this.serverSortField(m, sortState.col) : null;
+    // A range puts TWO clauses on one field (`amount.gte` and `amount.lte`). The controls key
+    // themselves `<field>__<op>` so both can coexist in the state map; the suffix is stripped here,
+    // into a LIST, which is the shape that can actually carry both. Flattening to a field-keyed map
+    // instead would drop one clause and turn a range into a single bound — a narrower result that
+    // looks entirely correct on screen.
+    const wireFilters = Object.entries(filter.fields ?? {}).map(([k, v]) => ({
+      field: k.includes("__") ? k.slice(0, k.lastIndexOf("__")) : k, op: v.op, value: v.value,
+    }));
+    const page = await this.host.api.moduleRecordsFiltered(pid, m.key, {
+      q: filter.q, state: filter.state, limit: PAGE + 1, offset,
+      filters: wireFilters,
+      ...(sortField ? { sort: sortField, sortDir: sortState!.dir === -1 ? "desc" : "asc" } : {}),
+    });
     const hasMore = page.length > PAGE;
     const records = hasMore ? page.slice(0, PAGE) : page;
     const editing = !!this.editInline[m.key];              // inline-edit mode: data cells become inputs
@@ -1553,6 +1583,7 @@ export class PortalUI {
       actions.append(imp);
     }
     this.root.appendChild(actions);
+    this.root.appendChild(this.filterRow(m, filter));
 
     if (!records.length) {
       // R24-EMPTY-GUIDE ② — an empty register says where its rows come from. "Use + New" restates a
@@ -1598,7 +1629,13 @@ export class PortalUI {
       if (Number.isFinite(xn) && Number.isFinite(yn)) return xn - yn;
       return String(x).localeCompare(String(y), undefined, { numeric: true, sensitivity: "base" });
     };
-    if (sort) records.sort((a, b) => {
+    // MOD-FILTER — the server sorted the whole register, so re-sorting here would be a no-op at best.
+    //
+    // This comparator is correct and stays, but only for a column the server cannot order (see
+    // `serverSortField`). The distinction matters: sorting in the browser orders **the fetched page**,
+    // so "sort by amount" on a 500-row register ordered 200 rows and presented the top of that as the
+    // largest values in the register. Nothing was wrong on screen; it was the wrong 200 rows.
+    if (sort && !this.serverSortField(m, sort.col)) records.sort((a, b) => {
       const x = val(a, sort.col), y = val(b, sort.col);
       const xe = x === "" || x == null, ye = y === "" || y == null;
       if (xe || ye) return xe && ye ? 0 : xe ? 1 : -1;             // blanks stay last even when descending
@@ -1822,6 +1859,149 @@ export class PortalUI {
     }
     td.appendChild(span);
     return td;
+   * MOD-FILTER — the per-field filter bar.
+   *
+   * One control per field, chosen by type, because the useful question differs by type and offering a
+   * single text box for all of them is how you end up with a filter nobody uses:
+   *
+   * - **select / multiselect** → a dropdown of the declared options. The only exact-match control that
+   *   cannot be mistyped, and the options are already in the schema.
+   * - **date** → from / to, i.e. `gte` + `lte`. A single date is almost never the question; a range is.
+   * - **number / currency / percent** → min / max, compared numerically by the server.
+   * - **reference** → a dropdown of the target register's records, so you filter by the record rather
+   *   than by remembering its id.
+   * - **everything else** → `contains`, case-insensitive.
+   *
+   * Collapsed by default and summarised when active ("3 filters"), so a register does not open behind
+   * a wall of controls, and an active filter can never be invisible — a page showing a subset while
+   * looking unfiltered is indistinguishable from missing data.
+   */
+  private filterRow(m: ModuleDef, filter: RegisterFilter): HTMLElement {
+    const active = filter.fields ?? {};
+    const wrap = document.createElement("div"); wrap.className = "filter-row";
+    const count = Object.keys(active).length;
+
+    const toggle = document.createElement("button");
+    toggle.className = "tool-btn" + (count ? " on" : "");
+    toggle.textContent = count ? `⧧ ${count} filter${count === 1 ? "" : "s"}` : "⧧ Filter";
+    toggle.title = "Filter this register by any field — applied by the server, so it narrows every "
+      + "record, not just the page on screen";
+    const body = document.createElement("div"); body.className = "filter-body";
+    body.hidden = count === 0;                       // open when something is already filtered
+    toggle.onclick = () => { body.hidden = !body.hidden; };
+    wrap.append(toggle, body);
+
+    const next: Record<string, { op: ModuleFilterOp; value: string }> = { ...active };
+    const apply = () => {
+      for (const k of Object.keys(next)) {
+        const v = next[k]!;
+        if (v.op !== "empty" && v.op !== "nonempty" && !v.value) delete next[k];
+      }
+      void this.openModule(m, { ...filter, offset: 0, fields: { ...next } });
+    };
+    const label = (f: ModuleDef["fields"][number], node: HTMLElement, suffix = "") => {
+      const cell = document.createElement("label"); cell.className = "filter-cell";
+      const t = document.createElement("span"); t.className = "meta";
+      t.textContent = (f.label || f.name) + suffix;
+      cell.append(t, node); body.appendChild(cell);
+    };
+    const setOn = (name: string, op: ModuleFilterOp, value: string) => {
+      if (value) next[name] = { op, value }; else delete next[name];
+      apply();
+    };
+
+    for (const f of this.filterableFields(m)) {
+      if (f.type === "select" || f.type === "multiselect") {
+        const s = document.createElement("select"); s.className = "sb-sel";
+        const any = document.createElement("option"); any.value = ""; any.textContent = "any";
+        s.appendChild(any);
+        for (const o of f.options ?? []) {
+          const opt = document.createElement("option"); opt.value = opt.textContent = o; s.appendChild(opt);
+        }
+        s.value = active[f.name]?.value ?? "";
+        s.onchange = () => setOn(f.name, "eq", s.value);
+        label(f, s);
+      } else if (f.type === "date") {
+        for (const [op, suffix] of [["gte", " from"], ["lte", " to"]] as const) {
+          const i = document.createElement("input"); i.type = "date"; i.className = "portal-filter";
+          const key = `${f.name}__${op}`;
+          i.value = active[key]?.value ?? "";
+          // A range needs two independent clauses on ONE field, so the second cannot overwrite the
+          // first in a field-keyed map. The `__op` suffix keys them apart here and is stripped when
+          // the request is built, which is why `fields` is keyed by control rather than by field.
+          i.onchange = () => { if (i.value) next[key] = { op, value: i.value }; else delete next[key]; apply(); };
+          label(f, i, suffix);
+        }
+      } else if (f.type === "number" || f.type === "currency" || f.type === "percent") {
+        for (const [op, suffix] of [["gte", " min"], ["lte", " max"]] as const) {
+          const i = document.createElement("input"); i.type = "number"; i.className = "portal-filter";
+          const key = `${f.name}__${op}`;
+          i.value = active[key]?.value ?? "";
+          i.onchange = () => { if (i.value) next[key] = { op, value: i.value }; else delete next[key]; apply(); };
+          // The declared `unit` would belong in this label ("Amount min ($/day)"), but `unit` arrives
+          // with the field sweep on a separate branch. Deliberately not duplicated here: two branches
+          // adding the same schema key is a merge conflict for a label suffix.
+          label(f, i, suffix);
+        }
+      } else if (f.type === "reference" && f.module) {
+        const s = document.createElement("select"); s.className = "sb-sel";
+        const any = document.createElement("option"); any.value = ""; any.textContent = "any";
+        s.appendChild(any);
+        s.onchange = () => setOn(f.name, "eq", s.value);
+        label(f, s);
+        // populated lazily: a register with six reference columns would otherwise fire six fetches
+        // before the user has expressed any interest in filtering at all
+        toggle.addEventListener("click", () => {
+          if (s.dataset.loaded) return;
+          s.dataset.loaded = "1";
+          void this.host.api.moduleRecordsFiltered(this.host.projectId()!, f.module!, { limit: 200 })
+            .then((rs) => {
+              for (const r of rs) {
+                const o = document.createElement("option");
+                o.value = r.id; o.textContent = r.title ? `${r.ref} · ${r.title}` : r.ref;
+                s.appendChild(o);
+              }
+              s.value = active[f.name]?.value ?? "";
+            }).catch(() => { /* leave it as "any" — a filter you cannot populate is not an error */ });
+        }, { once: false });
+      } else {
+        const i = document.createElement("input"); i.type = "search"; i.className = "portal-filter";
+        i.placeholder = "contains…";
+        i.value = active[f.name]?.value ?? "";
+        i.onchange = () => setOn(f.name, "contains", i.value);
+        label(f, i);
+      }
+    }
+
+    if (count) {
+      const clear = document.createElement("button"); clear.className = "tool-btn";
+      clear.textContent = "✕ Clear filters";
+      clear.onclick = () => void this.openModule(m, { ...filter, offset: 0, fields: {} });
+      body.appendChild(clear);
+    }
+    return wrap;
+  }
+
+  /**
+   * MOD-FILTER — the server-side field name for a table column, or null if the server cannot sort it.
+   *
+   * The table shows four pseudo-columns that are not module fields: `ref` and `assignee` are real row
+   * columns, `status` is the row's `workflow_state` under a friendlier heading, and `title` is whatever
+   * the module nominated as its `title_field`. Mapping them here is what lets a header click order the
+   * whole register instead of the fetched page. A column with no mapping falls back to the in-browser
+   * comparator rather than sending a name the server would (correctly) reject with a 400.
+   */
+  private serverSortField(m: ModuleDef, col: string): string | null {
+    if (col === "status") return "workflow_state";
+    if (col === "title") return m.title_field ?? null;
+    if (col === "ref" || col === "assignee") return col;
+    return m.fields.some((f) => f.name === col && f.type !== "rollup" && f.type !== "signature")
+      ? col : null;
+  }
+
+  /** Fields worth offering a filter control for — everything a value can be narrowed by. */
+  private filterableFields(m: ModuleDef): ModuleDef["fields"] {
+    return m.fields.filter((f) => !["rollup", "signature", "file", "textarea"].includes(f.type));
   }
 
   /** Format a field value for a compact table cell. */

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -552,6 +552,20 @@ html, body { overflow: hidden; }   /* the app manages its own internal scrolling
                 opacity: .92; }
 .chip { display: inline-block; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 0 8px; font-size: 11px; margin: 1px 0; }
 
+/* MOD-FILTER — the per-field filter bar.
+   Collapsed by default so a twenty-field register does not open behind a wall of inputs, and the
+   toggle carries the active count ("3 filters") because a page showing a subset while *looking*
+   unfiltered is indistinguishable from missing data. `.on` is the same active marker the column
+   picker already uses, so "this control is doing something" reads the same way across the toolbar. */
+.filter-row { margin: 4px 0 8px; }
+.filter-body { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+               gap: 8px 12px; margin-top: 8px; padding: 10px 12px;
+               background: var(--panel); border: 1px solid var(--line); border-radius: 8px; }
+.filter-cell { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.filter-cell > .meta { font-size: 11px; }
+/* inputs inside a filter cell must not inherit a fixed width from .portal-filter — the grid owns it */
+.filter-cell .portal-filter, .filter-cell .sb-sel { width: 100%; min-width: 0; }
+
 /* UX-CHIPS — the shared status/delta chip vocabulary (ui/chips.ts) */
 .chip2 { display: inline-flex; align-items: center; gap: 4px; border-radius: 10px; padding: 0 7px;
   font-size: 11px; line-height: 18px; border: 1px solid var(--line); background: var(--panel2);

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -38,7 +38,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
-         "test_module_config", "test_module_schema", "test_module_fields", "test_throttle", "test_route_order",
+         "test_module_config", "test_module_schema", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:

--- a/services/api/src/aec_api/modules_query.py
+++ b/services/api/src/aec_api/modules_query.py
@@ -17,11 +17,11 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import Float, String, cast, func, or_, select
 from sqlalchemy.orm import Session
 
 from . import rbac
-from .modules_registry import TABLES
+from .modules_registry import REGISTRY, TABLES
 from .modules_search import _is_postgres, _pg_document, _pg_tsquery
 from .modules_search import search_filter as _search_filter
 
@@ -63,8 +63,116 @@ def _json_text(db: Session, col, jkey: str):
         return col.op("->>")(jkey)
     return func.json_extract(col, f"$.{jkey}")
 
+
+# ---- MOD-FILTER: per-field filtering and sorting over the JSON `data` column ----------------------
+#
+# Until now a register could be narrowed by exactly two things: the full-text `q` and `workflow_state`.
+# On a twenty-field register that means no filtering by discipline, vendor, cost code or date range,
+# and sorting happened in the browser over whichever page had been fetched — so "sort by amount" on a
+# 500-row register sorted 200 rows and silently called it the answer.
+#
+# Two rules make this safe, and they are the whole design:
+#
+# 1. **A field name is never taken from the caller.** `_resolve_field` looks the name up in the
+#    module's declared fields and returns the *declared* definition, or raises. `_json_text`
+#    interpolates `jkey` into a SQLite JSON path, so an unvalidated name would be an injection site —
+#    its docstring already said the key must be module-defined, and this is what enforces it.
+#
+# 2. **A number is compared as a number.** JSON extraction yields text, and text comparison puts 9
+#    above 10 and sorts $1,000 before $900. That is the failure mode this codebase keeps meeting: not
+#    an error, a plausible wrong answer. Numeric and percent fields are cast to float before they are
+#    compared or ordered; dates are left as text because ISO-8601 sorts correctly lexicographically,
+#    which is the one case where the cheap thing is also the right thing.
+
+#: Columns that live on the row rather than inside `data`, and may be filtered/sorted directly.
+SYSTEM_COLUMNS = {"workflow_state", "created_at", "updated_at", "ref", "assignee", "ball_in_court"}
+
+#: The operators a filter may use. `contains` is a case-insensitive substring; `in` takes a
+#: comma-separated list; `empty`/`nonempty` ignore the value.
+FILTER_OPS = {"eq", "ne", "gte", "lte", "contains", "in", "empty", "nonempty"}
+
+_NUMERIC_FIELD_TYPES = {"number", "currency", "percent"}
+
+
+def _resolve_field(mod: dict, name: str) -> dict:
+    """The DECLARED definition of `name`, or HTTP 400. Never trust a caller-supplied field name."""
+    if name in SYSTEM_COLUMNS:
+        return {"name": name, "type": "text", "_system": True}
+    for f in mod.get("fields", []):
+        if f.get("name") == name:
+            return f
+    raise HTTPException(400, f"unknown filter/sort field {name!r} for this module")
+
+
+def _field_expr(db: Session, t, mod: dict, name: str):
+    """A comparable SQL expression for a declared field — cast to float when the field is numeric."""
+    f = _resolve_field(mod, name)
+    if f.get("_system"):
+        return t.c[name], f
+    expr = _json_text(db, t.c.data, name)
+    if f.get("type") in _NUMERIC_FIELD_TYPES:
+        # NULLIF('') so a blank string does not become 0.0 and sort among the real values — an empty
+        # field and a zero are different facts.
+        expr = cast(func.nullif(expr, ""), Float)
+    return expr, f
+
+
+def _apply_filters(db: Session, stmt, t, mod: dict, filters: list[tuple[str, str, str]]):
+    """Add one WHERE clause per (field, op, value). Unknown field or op -> 400, never ignored:
+    a filter that is silently dropped shows MORE rows than the user asked for and looks like data."""
+    for name, op, value in filters:
+        if op not in FILTER_OPS:
+            raise HTTPException(400, f"unknown filter operator {op!r} (expected one of "
+                                     f"{sorted(FILTER_OPS)})")
+        expr, f = _field_expr(db, t, mod, name)
+        numeric = f.get("type") in _NUMERIC_FIELD_TYPES and not f.get("_system")
+        if op == "empty":
+            stmt = stmt.where(or_(expr.is_(None), expr == ("" if not numeric else None)))
+            continue
+        if op == "nonempty":
+            stmt = stmt.where(expr.isnot(None))
+            if not numeric:
+                stmt = stmt.where(expr != "")
+            continue
+        if op == "in":
+            vals = [v.strip() for v in str(value).split(",") if v.strip()]
+            if not vals:
+                continue
+            stmt = stmt.where(expr.in_([_coerce(v, numeric) for v in vals]))
+            continue
+        if op == "contains":
+            # substring match is a TEXT operation; on a numeric field it would be nonsense, so the
+            # cast is bypassed rather than silently comparing a float to a pattern
+            text_expr = t.c[name] if f.get("_system") else _json_text(db, t.c.data, name)
+            stmt = stmt.where(func.lower(cast(text_expr, String)).like(f"%{str(value).lower()}%"))
+            continue
+        v = _coerce(value, numeric)
+        stmt = stmt.where({"eq": expr == v, "ne": expr != v, "gte": expr >= v, "lte": expr <= v}[op])
+    return stmt
+
+
+def _coerce(value: str, numeric: bool):
+    if not numeric:
+        return value
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        raise HTTPException(400, f"{value!r} is not a number, but the field is numeric") from None
+
+
+def _apply_sort(db: Session, stmt, t, mod: dict, sort: str | None, sort_dir: str | None):
+    """Order by a declared field. Returns the statement unchanged when `sort` is absent, so the
+    caller's default ordering still applies."""
+    if not sort:
+        return stmt, False
+    expr, _f = _field_expr(db, t, mod, sort)
+    desc = str(sort_dir or "asc").lower() == "desc"
+    return stmt.order_by(expr.desc() if desc else expr.asc()), True
+
 def list_records(db: Session, key: str, project_id: str, state: str | None = None,
-                 q: str | None = None, limit: int = 200, offset: int = 0) -> list[dict]:
+                 q: str | None = None, limit: int = 200, offset: int = 0,
+                 filters: list[tuple[str, str, str]] | None = None,
+                 sort: str | None = None, sort_dir: str | None = None) -> list[dict]:
     if key not in TABLES:
         raise HTTPException(404, f"unknown module {key!r}")
     t = TABLES[key]
@@ -77,12 +185,26 @@ def list_records(db: Session, key: str, project_id: str, state: str | None = Non
         stmt = stmt.where(_search_filter(db, t, q))
         if _is_postgres(db) and (tsq := _pg_tsquery(q)):
             stmt = stmt.order_by(func.ts_rank(_pg_document(t), func.to_tsquery("english", tsq)).desc())
+    # MOD-FILTER — per-field narrowing, applied in SQL BEFORE the limit for the same reason `q` is:
+    # filtering a page after fetching it answers a different question than the user asked, and looks
+    # identical to the right answer.
+    if filters:
+        stmt = _apply_filters(db, stmt, t, REGISTRY.get(key) or {}, filters)
+    stmt, _explicit_sort = _apply_sort(db, stmt, t, REGISTRY.get(key) or {}, sort, sort_dir)
+    # `created_at` stays as the last ordering key even when an explicit sort is given, so a page is
+    # STABLE across requests. Without a tiebreak, two rows with equal sort values can swap between
+    # pages and a row is then either shown twice or never — the classic pagination hole.
     stmt = stmt.order_by(t.c.created_at).limit(limit).offset(offset)
     return [dict(r._mapping) for r in db.execute(stmt)]
 
 def count_records(db: Session, key: str, project_id: str, state: str | None = None,
-                  q: str | None = None, since: datetime | None = None) -> int:
-    """Count matches for a module filter (state / search / created-since) — for saved-view alerts."""
+                  q: str | None = None, since: datetime | None = None,
+                  filters: list[tuple[str, str, str]] | None = None) -> int:
+    """Count matches for a module filter (state / search / created-since) — for saved-view alerts.
+
+    Takes `filters` for the same reason `list_records` does: a count that ignores a filter the list
+    applied reports a total the page cannot account for, and a total is exactly the number a user
+    trusts without checking."""
     if key not in TABLES:
         return 0
     t = TABLES[key]
@@ -93,6 +215,8 @@ def count_records(db: Session, key: str, project_id: str, state: str | None = No
         stmt = stmt.where(_search_filter(db, t, q))
     if since is not None:
         stmt = stmt.where(t.c.created_at > since)
+    if filters:
+        stmt = _apply_filters(db, stmt, t, REGISTRY.get(key) or {}, filters)
     return int(db.execute(stmt).scalar() or 0)
 
 def state_counts(db: Session, key: str, project_id: str) -> dict[str, int]:

--- a/services/api/src/aec_api/routers/modules.py
+++ b/services/api/src/aec_api/routers/modules.py
@@ -486,13 +486,53 @@ def calc_records(pid: str, key: str, body: dict = Body(default={}), db: Session 
                     "normalized data keys (plus ref/title/workflow_state)."}
 
 
+#: MOD-FILTER — how many per-field filters one request may carry. A bound, because each one is a
+#: separate WHERE over a JSON extraction and an unbounded list is a cheap way to make the server work
+#: hard on someone else's behalf.
+MAX_FILTERS = 12
+
+
+def _parse_filters(qp) -> list[tuple[str, str, str]]:
+    """`?f.discipline=Structural&f.amount.gte=1000` -> [("discipline","eq","Structural"),
+    ("amount","gte","1000")].
+
+    A prefixed key rather than a JSON blob: it stays readable in a log and a bookmark, and each filter
+    survives being edited by hand. The FIELD NAME IS NOT VALIDATED HERE — `modules_query._resolve_field`
+    checks it against the module's declared fields and raises, which is the single place that decision
+    belongs. Doing it in both would let the two drift.
+    """
+    out: list[tuple[str, str, str]] = []
+    for raw, value in qp.multi_items():
+        if not raw.startswith("f."):
+            continue
+        spec = raw[2:]
+        if not spec:
+            continue
+        name, _, op = spec.partition(".")
+        if not name:
+            continue
+        out.append((name, op or "eq", value))
+        if len(out) > MAX_FILTERS:
+            raise HTTPException(400, f"too many filters (max {MAX_FILTERS})")
+    return out
+
+
 @router.get("/projects/{pid}/modules/{key}")
-def list_records(pid: str, key: str, state: str | None = None, q: str | None = None,
-                 limit: int = 200, offset: int = 0, db: Session = Depends(get_db),
+def list_records(request: Request, pid: str, key: str, state: str | None = None, q: str | None = None,
+                 limit: int = 200, offset: int = 0, sort: str | None = None,
+                 sort_dir: str | None = None, db: Session = Depends(get_db),
                  _: str = Depends(require_role("viewer"))):
+    """List a module's records, narrowed by state, full text, and any number of per-field filters.
+
+    MOD-FILTER: before this, a register could be narrowed by `q` and `workflow_state` and nothing else,
+    and sorting happened in the browser over whichever page had been fetched — so "sort by amount" on a
+    500-row register ordered 200 rows and presented it as the answer. Filtering and sorting now happen
+    in SQL, before the limit."""
     # clamp the caller-supplied page size — an unbounded ?limit= materializes the whole module
     limit = max(1, min(int(limit or 200), 1000))
-    return mod_engine.list_records(db, key, pid, state, q, limit, max(0, int(offset or 0)))
+    return mod_engine.list_records(db, key, pid, state, q, limit, max(0, int(offset or 0)),
+                                   filters=_parse_filters(request.query_params),
+                                   sort=sort, sort_dir=sort_dir)
 
 
 @router.post("/projects/{pid}/modules/{key}", status_code=201)

--- a/services/api/test_module_filters.py
+++ b/services/api/test_module_filters.py
@@ -1,0 +1,165 @@
+"""MOD-FILTER — per-field filtering and server-side sorting over a module register.
+
+Before this, a register could be narrowed by exactly two things: the full-text `q` and
+`workflow_state`. On a twenty-field register that means no filtering by discipline, vendor, cost code
+or date range — and sorting happened in the **browser, over whichever page had been fetched**, so
+"sort by amount" on a 500-row register ordered 200 rows and presented the result as the answer.
+
+Two properties are worth more than the feature and are what this file mostly asserts:
+
+**A number must be compared as a number.** JSON extraction yields text. Compared as text, 9 > 10 and
+900 sorts after 1000 — not an error, a plausible wrong answer, which is the failure mode this codebase
+meets most often. Numeric fields are cast before comparison, and the tests below use values (9 vs 10,
+900 vs 1000) chosen so a text comparison FAILS them. A test using 1, 2, 3 would pass either way and
+prove nothing.
+
+**An unknown field or operator must 400, never be ignored.** A silently dropped filter returns MORE
+rows than were asked for, which looks like data rather than a bug. It is also the injection boundary:
+`_json_text` interpolates the field name into a SQLite JSON path, so "reject unknown names" is what
+makes the whole feature safe.
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_module_filters.py
+"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_mod_filters.db"
+os.environ["STORAGE_DIR"] = "./test_storage_mod_filters"
+os.environ["AEC_TRUST_XUSER"] = "1"
+
+for _f in ("./test_mod_filters.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+
+H = {"X-User": "gc"}
+
+with TestClient(app) as c:
+    pid = c.post("/projects", headers=H, json={"name": "Filter Test"}).json()["id"]
+
+    # `cor` carries a currency (`amount`), a select (`reason`) and a date — one record per shape.
+    def mk(subject, amount, reason, days):
+        r = c.post(f"/projects/{pid}/modules/cor", headers=H, json={"data": {
+            "subject": subject, "amount": amount, "reason": reason, "schedule_days": days}})
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    # AMOUNTS ARE POSTED AS STRINGS, and that is the whole point of the fixture.
+    #
+    # The first version of this test posted ints and the numeric cast could be DELETED with every
+    # assertion still passing — the test could not reach the bug it was written for. SQLite types
+    # `json_extract` by what was stored: a JSON number comes back `integer` and compares numerically on
+    # its own, so an int fixture exercises a path the cast does not affect. A JSON *string* comes back
+    # `text`, and in SQLite `'9' >= 10` is TRUE, so a string-stored 9 leaks into `amount >= 10`.
+    #
+    # Strings are the NORMAL case, not the edge: an HTML form field posts a string, a CSV import posts
+    # a string, and `validate_record` only checks that a numeric field parses — it does not coerce. So
+    # the register is full of numbers stored as text, which is exactly where text comparison bites.
+    # Values chosen so a lexicographic comparison FAILS: "9" > "10" and "1000" < "900".
+    mk("nine", "9", "Owner Request", 9)
+    mk("ten", "10", "Design Change", 10)
+    mk("nine hundred", "900", "Owner Request", 90)
+    mk("thousand", "1000", "Field Condition", 100)
+    # one posted as a real number too, so the cast is proven to handle BOTH storage shapes
+    mk("fifty numeric", 50, "Owner Request", 50)
+
+    def rows(**params):
+        r = c.get(f"/projects/{pid}/modules/cor", headers=H, params=params)
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    subjects = lambda rs: [x["data"]["subject"] for x in rs]  # noqa: E731
+
+    # ---- 1. equality on a select ------------------------------------------------------------------
+    got = rows(**{"f.reason": "Owner Request"})
+    assert sorted(subjects(got)) == ["fifty numeric", "nine", "nine hundred"], subjects(got)
+
+    # ---- 2. NUMERIC comparison, not lexicographic -------------------------------------------------
+    # amount >= 10 must exclude 9. Stored as text, `'9' >= 10` is TRUE in SQLite, so without the cast
+    # "nine" leaks in — which is what makes this assertion able to fail.
+    got = rows(**{"f.amount.gte": "10"})
+    assert sorted(subjects(got)) == ["fifty numeric", "nine hundred", "ten", "thousand"], (
+        f"numeric gte compared as text: {subjects(got)}")
+    # amount <= 900 must exclude 1000. Lexicographically "1000" < "900", so 'thousand' leaks in.
+    got = rows(**{"f.amount.lte": "900"})
+    assert "thousand" not in subjects(got), f"lte compared as text: {subjects(got)}"
+    assert sorted(subjects(got)) == ["fifty numeric", "nine", "nine hundred", "ten"], subjects(got)
+    # a range, both bounds at once — and it spans a string-stored and a number-stored row
+    got = rows(**{"f.amount.gte": "10", "f.amount.lte": "900"})
+    assert sorted(subjects(got)) == ["fifty numeric", "nine hundred", "ten"], subjects(got)
+
+    # ---- 3. SORT is numeric and happens on the server ---------------------------------------------
+    # Text ordering would give nine(9), ten(10), thousand(1000), nine hundred(900) — 1000 before 900.
+    got = rows(sort="amount", sort_dir="asc")
+    assert subjects(got) == ["nine", "ten", "fifty numeric", "nine hundred", "thousand"], (
+        f"ascending sort is lexicographic: {subjects(got)}")
+    got = rows(sort="amount", sort_dir="desc")
+    assert subjects(got) == ["thousand", "nine hundred", "fifty numeric", "ten", "nine"], subjects(got)
+
+    # sorting a page must not reorder ACROSS pages inconsistently — `created_at` is the tiebreak, so
+    # two equal values keep a stable order and pagination cannot show one row twice or skip one.
+    page1 = rows(sort="reason", limit=2, offset=0)
+    page2 = rows(sort="reason", limit=2, offset=2)
+    page3 = rows(sort="reason", limit=2, offset=4)
+    ids = [x["id"] for x in page1 + page2 + page3]
+    assert len(set(ids)) == 5, f"paged sort repeated or dropped a row: {ids}"
+
+    # ---- 4. contains / in / empty / nonempty ------------------------------------------------------
+    got = rows(**{"f.subject.contains": "NINE"})            # case-insensitive
+    assert sorted(subjects(got)) == ["nine", "nine hundred"], subjects(got)
+    got = rows(**{"f.reason.in": "Owner Request,Field Condition"})
+    assert sorted(subjects(got)) == ["fifty numeric", "nine", "nine hundred", "thousand"], subjects(got)
+    mk("no reason", 5, "", 0)
+    got = rows(**{"f.reason.empty": "1"})
+    assert subjects(got) == ["no reason"], subjects(got)
+    got = rows(**{"f.reason.nonempty": "1"})
+    assert "no reason" not in subjects(got) and len(got) == 5, subjects(got)
+
+    # ---- 5. filters COMPOSE with state and q -----------------------------------------------------
+    got = rows(**{"f.reason": "Owner Request", "q": "hundred"})
+    assert subjects(got) == ["nine hundred"], subjects(got)
+
+    # ---- 6. an unknown field or operator is a 400, NOT a silently ignored filter ------------------
+    # This is the property that makes the feature safe: the field name reaches a SQLite JSON path, so
+    # anything not declared by the module must be refused rather than interpolated.
+    for bad in ("f.no_such_field", "f.data", "f.id"):
+        r = c.get(f"/projects/{pid}/modules/cor", headers=H, params={bad: "x"})
+        assert r.status_code == 400, f"{bad} was accepted ({r.status_code})"
+    r = c.get(f"/projects/{pid}/modules/cor", headers=H, params={"f.amount.between": "1"})
+    assert r.status_code == 400, f"unknown operator accepted ({r.status_code})"
+    r = c.get(f"/projects/{pid}/modules/cor", headers=H, params={"sort": "no_such_field"})
+    assert r.status_code == 400, f"unknown sort field accepted ({r.status_code})"
+    # a non-numeric value against a numeric field is refused rather than coerced to 0
+    r = c.get(f"/projects/{pid}/modules/cor", headers=H, params={"f.amount.gte": "abc"})
+    assert r.status_code == 400, f"non-numeric value on a numeric field accepted ({r.status_code})"
+
+    # an injection attempt is refused by the same rule — it is not a declared field name
+    r = c.get(f"/projects/{pid}/modules/cor", headers=H,
+              params={"f.amount') OR 1=1 --": "1"})
+    assert r.status_code == 400, "a crafted field name was not refused"
+
+    # ---- 7. system columns are filterable, and `workflow_state` still works the old way -----------
+    got = rows(**{"f.workflow_state": "draft"})
+    assert len(got) == 6, len(got)
+    got = rows(state="draft")
+    assert len(got) == 6, len(got)
+
+    # ---- 8. the filter bound is enforced ---------------------------------------------------------
+    many = {"f.subject.contains": "x"}
+    params = [("f.subject.contains", "x")] * 13
+    r = c.get(f"/projects/{pid}/modules/cor", headers=H, params=params)
+    assert r.status_code == 400, f"more than 12 filters accepted ({r.status_code})"
+    assert many  # noqa: B015  (kept so the dict literal above is not mistaken for dead code)
+
+print("MOD-FILTER OK - per-field filters (eq/ne/gte/lte/contains/in/empty/nonempty) and server-side "
+      "sort run in SQL before the LIMIT, compose with state + full-text q, and are bounded at 12 per "
+      "request. Numeric fields are CAST before comparison: the fixtures are 9/10 and 900/1000 "
+      "precisely so a lexicographic comparison fails these assertions rather than passing them, "
+      "because text ordering puts 9 above 10 and that is a plausible wrong answer rather than an "
+      "error. An unknown field, an unknown operator, a non-numeric value on a numeric field and a "
+      "crafted field name all return 400 rather than being dropped — a silently ignored filter shows "
+      "MORE rows than were asked for, and the field name reaches a SQLite JSON path, so refusing "
+      "undeclared names is what makes the feature safe. Paged sorting keeps created_at as the "
+      "tiebreak, so equal values cannot swap between pages and show a row twice or never.")


### PR DESCRIPTION
Two commits. The second is a **live regression fix for #108** and can be prioritised independently if you'd rather split them.

> This is item 1 on #108's own "not done" list — in flight, not open.

## 1. `MOD-FILTER` — per-field filters and server-side sort

A register could be narrowed by exactly two things: full-text `q` and `workflow_state`. On a twenty-field register that means no filtering by discipline, vendor, cost code or date range. And **sorting ran in the browser over whichever page had been fetched** — "sort by amount" on a 500-row register ordered 200 rows and presented the top of those as the largest values in the register. Nothing looked wrong; it was the wrong 200 rows.

```
?f.discipline=Structural&f.amount.gte=1000&f.amount.lte=5000&sort=amount&sort_dir=desc
```

`eq · ne · gte · lte · contains · in · empty · nonempty`, composing with `state` and `q`, bounded at 12 per request, applied in SQL before the LIMIT. `count_records` takes filters too — a total that ignores a filter the list applied is the number a user trusts without checking.

**Two properties carry the design.**

*A field name is never taken from the caller.* `_resolve_field` looks it up in the module's declared fields and 400s otherwise. This isn't hygiene: `_json_text` interpolates the key into a SQLite JSON path, and its docstring already said the key must be module-defined — this is what enforces it. Refusing rather than ignoring matters separately: a silently dropped filter returns **more** rows than were asked for, which reads as data rather than as a bug.

*A number is compared as a number.* JSON extraction yields text, where 9 > 10 and 1000 sorts before 900.

**The test for that second property was wrong first, and the mutation caught it.** My fixtures posted ints, and the cast could be deleted with every assertion still passing. SQLite types `json_extract` by what was stored: a JSON number returns `integer` and compares numerically unaided, so an int fixture never exercises the cast. A JSON *string* returns `text`, and `'9' >= 10` is TRUE. Strings are the **normal** case — an HTML form posts a string, a CSV import posts a string, and `validate_record` only checks that a numeric field parses. Fixtures re-posted as strings; the mutation now fails with `nine` leaking into `amount >= 10`.

**A range is two clauses on one field**, so the client filter type is a **list**, not a map keyed by field. My first version was a map, where `amount.gte` and `amount.lte` collide and the second overwrites the first — a range silently collapsing to a single bound, i.e. a narrower result that looks entirely correct.

UI: a collapsed filter bar, one control per type — options dropdown for a select, from/to for a date, min/max for a number, a lazily-populated record picker for a reference, case-insensitive `contains` otherwise. The toggle carries the active count, because a page showing a subset while *looking* unfiltered is indistinguishable from missing data. Header sort now asks the server; `serverSortField` maps the four pseudo-columns (`ref`, `status`→`workflow_state`, `assignee`, `title`→the module's `title_field`) and returns null otherwise rather than sending a name the server would rightly reject. Paged sort keeps `created_at` as the tiebreak so equal values can't swap between pages and show a row twice or never.

## 2. `MOD-PERCENT` — a live regression #108 introduced

Found by Massing Core reviewing #108. Three places asked `f.type === "number" || f.type === "currency"` and `percent` was in none. Survivable while **2** fields were typed `percent`; #108 converted **21** more — every retainage, fee, overhead and contingency percentage:

| site | effect |
|---|---|
| `EDITABLE` | those 21 fields stopped being inline-editable, with no error |
| record form | rendered `<input type="text">` — no numeric keypad, no step, no validation |
| **save path** | stored the **string** `"5"` |

The third is the one that matters. `validate_record` calls `float(value)` so it passed, every consumer coerces, so nothing failed — the column just accumulated a mix of `5` and `"5"` depending on which form last touched the record. It also feeds the bug MOD-FILTER's cast exists to survive: **numbers stored as text are what make SQL comparison go lexicographic.** The two halves of this PR are the same defect from opposite ends.

Fixed as one idea, not three ternaries: `NUMERIC_FIELD_TYPES` named once, referenced at all three sites, so the next numeric type is one edit rather than three that can be done two-thirds of the way — which is exactly how this happened. A declared `unit` now also renders **beside the input**, not only in table cells.

**The gate is a coverage test, not a DOM test.** Rendering a form and asserting one input is numeric would prove `percent` works and nothing about the next type. What failed was *completeness* — a hand-maintained list with no check it covered the types in use. `fieldTypeCoverage.test.ts` asserts the partition: every type the 133 modules declare is either editable or deliberately read-only, none is in both, every magnitude-holding type is numeric, and nothing in `module_schema.FIELD_TYPES` is unrenderable. `READ_ONLY_FIELD_TYPES` carries a reason per entry so "not editable" is a decision on the record. **Mutation-checked**: removing `percent` fails 4 of 6 assertions from four independent angles.

## Verification

- Backend **447/448**. The one failure is `test_esign`, which **passes solo** — parallel-sqlite pollution, partly residue from three suite runs I killed. Caveat worth stating: that local run used the *working-tree* `run_tests.py`, which in a shared checkout also carried another session's `test_seal_identity` registration; this branch's committed manifest has 447.
- Web **1011/1012**. The one failure is `pdfVendor` timing out at 20s under load; passes solo in 5.69s.
- `tsc --noEmit` clean for these files. `git merge-tree` against current `main` reports no conflicts.
- No new client methods — `moduleRecordsFiltered` gained parameters, so the api surface ratchet is untouched and `surface.test.ts` passes.

No version files or CHANGELOG — the release lane batches those.

## Note on the sibling branch

`origin/feat/mod-filters` contains these two commits **plus `785462c5`**, an unrelated seal-identity commit from another session that landed on my branch through the shared checkout and which my push published. Nothing is lost and I have not rewritten it — this PR is raised from `feat/mod-filters-pr`, which holds only the two commits above. `785462c5` should be cherry-picked to `main` by its author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
