### PR TITLE
MOD-TABLE — a register field can hold line items, not just a value

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -234,7 +234,21 @@ export interface ModuleField {
    *  converted, or checked. Declaring it makes the number self-describing, which is most of the
    *  difference between a form and a tool. */
   unit?: string;
+  /** MOD-TABLE — the columns of a `table` field (line items). Absent on every other type. */
+  columns?: ModuleColumn[];
+  /** Numeric column summed into a footer total. Validated server-side to name a numeric column. */
+  total_column?: string;
 }
+
+/** MOD-TABLE — one column of a `table` field. A row is not a record: no workflow, no ref, no
+ *  attachments, no id, so a column carries only what is needed to render and read a cell.
+ *  Allowed types mirror `module_schema.TABLE_COLUMN_TYPES`. */
+export interface ModuleColumn {
+  name: string; label?: string; required?: boolean;
+  type: "text" | "number" | "currency" | "percent" | "date" | "select" | "checkbox";
+  options?: string[]; unit?: string; width?: string;
+}
+
 export interface ModuleDef {
   key: string; name: string; section: string; icon: string; pinnable: boolean;
   // a module can belong to one or more workspaces; multi-membership is a "|"-separated list

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -85,6 +85,15 @@ export const READ_ONLY_FIELD_TYPES = [
   "file",        // needs an upload control, not a cell
   "reference",   // edited through the record picker (`inlineRefCell`), not as free text
   "multiselect", // needs a multi-choice control a table cell has no room for
+  // MOD-TABLE. A line-item grid has no cell-sized inline editor: its value is an array of objects,
+  // and a register cell shows the summary ("3 lines · $118,260") instead. Edited in the record form
+  // via `tableEditor`, which is where a grid has room to exist.
+  //
+  // This entry is the gate working as designed. `fieldTypeCoverage.test.ts` was written one PR ago to
+  // catch a type added to `FIELD_TYPES` without a renderer classification — and the very next PR to
+  // add a type was this one. It failed until the type was classified, which is exactly the outcome
+  // that was wanted: the cost of a new type is one deliberate line saying how it renders.
+  "table",
 ] as const;
 
 interface RegisterFilter {
@@ -2060,12 +2069,146 @@ export class PortalUI {
     return m.fields.filter((f) => !["rollup", "signature", "file", "textarea"].includes(f.type));
   }
 
+  /**
+   * MOD-TABLE — the line-item grid for a `table` field.
+   *
+   * The sweep found 22 places a LIST had been flattened into one textarea, and the deeper version of
+   * the same gap: `sov` is one record *per line* with no parent document, and `estimate` is a single
+   * `amount`. A schedule of values, a bid, an estimate and a daily manpower log are all line-item
+   * documents; the config had no way to say so and the form had no way to draw one.
+   *
+   * **A legacy string is shown, not discarded.** Those 22 fields were textareas, so live records hold
+   * prose where rows are now expected. It is rendered above the grid, verbatim and read-only, because
+   * it is the only copy of that information — dropping it on first save would destroy data the config
+   * change never intended to touch, and silently, since nothing else records what was there.
+   */
+  private tableEditor(
+    f: ModuleDef["fields"][number],
+    value: unknown,
+    store: Record<string, Record<string, unknown>[]>,
+  ): HTMLElement {
+    const cols = f.columns ?? [];
+    const wrap = document.createElement("div"); wrap.className = "tbl-field";
+
+    if (typeof value === "string" && value.trim()) {
+      const legacy = document.createElement("pre"); legacy.className = "tbl-legacy";
+      legacy.textContent = value;
+      legacy.title = "This field held free text before it became a line-item table. It is kept "
+        + "verbatim until the lines are entered below — it is the only copy.";
+      const note = document.createElement("div"); note.className = "meta";
+      note.textContent = "Previous free-text entry (kept until itemised):";
+      wrap.append(note, legacy);
+    }
+
+    const rows: Record<string, unknown>[] = Array.isArray(value)
+      ? (value as Record<string, unknown>[]).map((r) => ({ ...r })) : [];
+    store[f.name] = rows;
+
+    const table = document.createElement("table"); table.className = "tbl-grid";
+    const thead = document.createElement("thead"); const htr = document.createElement("tr");
+    for (const c of cols) {
+      const th = document.createElement("th");
+      th.textContent = (c.label || c.name) + (c.unit ? ` (${c.unit})` : "");
+      if (c.width) th.style.width = c.width;
+      htr.appendChild(th);
+    }
+    htr.appendChild(document.createElement("th"));          // row-remove column
+    thead.appendChild(htr); table.appendChild(thead);
+    const tbody = document.createElement("tbody"); table.appendChild(tbody);
+
+    const foot = document.createElement("div"); foot.className = "tbl-total";
+    const isNum = (t: string) => t === "number" || t === "currency" || t === "percent";
+    const retotal = () => {
+      if (!f.total_column) return;
+      const col = cols.find((c) => c.name === f.total_column);
+      const sum = rows.reduce((n, r) => n + (Number(r[f.total_column!]) || 0), 0);
+      // Currency is formatted as currency; a bare count is not dressed up as money.
+      foot.textContent = `${cols.find((c) => c.name === f.total_column)?.label ?? f.total_column}: `
+        + (col?.type === "currency"
+          ? `$${sum.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+          : sum.toLocaleString(undefined, { maximumFractionDigits: 2 }))
+        + (col?.unit ? ` ${col.unit}` : "");
+    };
+
+    const drawRow = (row: Record<string, unknown>) => {
+      const tr = document.createElement("tr");
+      for (const c of cols) {
+        const td = document.createElement("td");
+        let inp: HTMLInputElement | HTMLSelectElement;
+        if (c.type === "select") {
+          inp = document.createElement("select");
+          const blank = document.createElement("option"); blank.value = ""; blank.textContent = "—";
+          inp.appendChild(blank);
+          for (const o of c.options ?? []) {
+            const opt = document.createElement("option"); opt.value = opt.textContent = o;
+            inp.appendChild(opt);
+          }
+        } else {
+          inp = document.createElement("input");
+          const i = inp as HTMLInputElement;
+          i.type = c.type === "checkbox" ? "checkbox" : isNum(c.type) ? "number" : c.type === "date" ? "date" : "text";
+          if (c.type === "currency" || c.type === "percent") i.step = "0.01";
+        }
+        inp.className = "tbl-cell";
+        if (c.type === "checkbox") (inp as HTMLInputElement).checked = !!row[c.name];
+        else inp.value = String(row[c.name] ?? "");
+        inp.oninput = () => {
+          // Numbers are stored as NUMBERS, not the input's string. Storing "5" here is what makes a
+          // SQL comparison go lexicographic later ('9' >= 10 is true), and it is the same defect the
+          // record form had for `percent` fields.
+          row[c.name] = c.type === "checkbox" ? (inp as HTMLInputElement).checked
+            : isNum(c.type) ? (inp.value === "" ? "" : Number(inp.value))
+            : inp.value;
+          retotal();
+        };
+        td.appendChild(inp); tr.appendChild(td);
+      }
+      const rm = document.createElement("td");
+      const del = document.createElement("button"); del.type = "button"; del.className = "tbl-del";
+      del.textContent = "✕"; del.title = "Remove this line";
+      del.onclick = () => {
+        const i = rows.indexOf(row);
+        if (i >= 0) rows.splice(i, 1);
+        tr.remove(); retotal();
+      };
+      rm.appendChild(del); tr.appendChild(rm);
+      tbody.appendChild(tr);
+    };
+
+    for (const r of rows) drawRow(r);
+
+    const add = document.createElement("button"); add.type = "button"; add.className = "tool-btn";
+    add.textContent = "+ Add line";
+    add.onclick = () => { const r: Record<string, unknown> = {}; rows.push(r); drawRow(r); retotal(); };
+
+    wrap.append(table, add);
+    if (f.total_column) { wrap.appendChild(foot); retotal(); }
+    return wrap;
+  }
+
   /** Format a field value for a compact table cell. */
   private fmtCell(f: ModuleDef["fields"][number], v: unknown): string {
     if (v == null || v === "") return "";
     if (f.type === "currency") return `$${Number(v).toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
     if (f.type === "percent") return `${Number(v).toLocaleString(undefined, { maximumFractionDigits: 2 })}%`;
     if (f.type === "multiselect" && Array.isArray(v)) return (v as string[]).join(", ");
+    // MOD-TABLE: a cell has no room for a grid, so it carries the two facts worth scanning — how many
+    // lines, and the total if the field declares one. `String(v)` on an array of objects renders
+    // "[object Object]" per row, which is the kind of output that looks like a rendering bug and is
+    // actually a missing branch. A legacy string still shows as text (see `tableEditor`).
+    if (f.type === "table") {
+      if (typeof v === "string") return v.slice(0, 40);
+      if (!Array.isArray(v)) return "";
+      const n = v.length;
+      const label = `${n} line${n === 1 ? "" : "s"}`;
+      if (!f.total_column || !n) return label;
+      const col = f.columns?.find((c) => c.name === f.total_column);
+      const sum = (v as Record<string, unknown>[]).reduce((t, r) => t + (Number(r[f.total_column!]) || 0), 0);
+      const shown = col?.type === "currency"
+        ? `$${sum.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+        : sum.toLocaleString(undefined, { maximumFractionDigits: 2 });
+      return `${label} · ${shown}`;
+    }
     // Same defect as the old refCell fallback, in the path taken when a reference is NOT a resolved
     // column: eight characters of a value, indistinguishable from a resolved label. A UUID at least
     // announces itself as an id; anything else is shown as the text it is.
@@ -2313,6 +2456,9 @@ export class PortalUI {
       () => (editing ? this.openRecord(m, existing!.id) : this.openModule(m))));
     const inputs: Record<string, HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement> = {};
     const sigs: Record<string, () => string> = {};   // signature field getters (data-URI)
+    // MOD-TABLE: live rows per table field. Held apart from `inputs` because a table's value is an
+    // array of objects, not an `el.value` string — the shape the rest of the form assumes.
+    const tableRows: Record<string, Record<string, unknown>[]> = {};
     const cur = (n: string) => (existing?.data?.[n] as string | number | string[] | undefined);
     let curFieldset: string | undefined;   // F1 — emit a labeled header when the fieldset changes
     for (const f of m.fields) {
@@ -2382,7 +2528,16 @@ export class PortalUI {
             toast(`Added ${tgt?.name ?? f.module}: ${val.trim()}`, "info");
           } catch { toast(`could not create ${tgt?.name ?? f.module}`, "error"); }
         });
-      } else {
+      } else if (f.type === "table") {
+        // MOD-TABLE: a line-item grid is NOT one of the form's three input elements, and it is
+        // deliberately not registered in `inputs` — its value is an array of objects rather than an
+        // `el.value` string, so every consumer of `inputs` (the required check, the save loop, the
+        // invalid-marker) would read it wrongly. `tableRows` holds the live rows; the save path reads
+        // from there. Appending it here and `continue`-ing keeps `el` honestly typed as an input.
+        wrap.appendChild(this.tableEditor(f, cur(f.name), tableRows));
+        this.root.appendChild(wrap);
+        continue;
+            } else {
         el = document.createElement("input");
         const inp = el as HTMLInputElement;
         // MOD-PERCENT: a percent field rendered as `type="text"` — no numeric keypad on a phone, no
@@ -2429,6 +2584,15 @@ export class PortalUI {
       const first = names.map((n) => inputs[n]).find(Boolean); if (first) first.focus();
     };
     const isEmpty = (f: ModuleDef["fields"][number]): boolean => {
+      // MOD-TABLE: checked BEFORE the `!el` guard, because a table is deliberately absent from
+      // `inputs` — and `!el → return false` means "not empty", so a `required` table with zero rows
+      // would have sailed through the check. None of the eight tables shipped here is required, so
+      // this is a hole rather than a bug today; it is the same "plausible answer for the missing
+      // case" shape that keeps costing this codebase, so it is closed at the point it was created.
+      if (f.type === "table") {
+        return !(tableRows[f.name] ?? []).some(
+          (row) => Object.values(row).some((x) => x !== "" && x != null));
+      }
       const el = inputs[f.name]; if (!el) return false;
       if (f.type === "signature") return !sigs[f.name]?.();
       if (f.type === "multiselect") return [...(el as HTMLSelectElement).selectedOptions].length === 0;
@@ -2458,6 +2622,14 @@ export class PortalUI {
         // form last touched the record. Numbers stored as text are also what makes SQL comparison go
         // lexicographic, which is the bug MOD-FILTER's cast exists to survive.
         const v = el.value; if (v) data[f.name] = isNumericField(f.type) ? Number(v) : v;
+      }
+      // MOD-TABLE: rows come from their own state, and are written even when EMPTY — unlike a text
+      // field, "the user deleted every line" is a real edit that must persist. Skipping empty here
+      // would make clearing a schedule of values silently impossible.
+      for (const f of m.fields) {
+        if (f.type !== "table" || !(f.name in tableRows)) continue;
+        data[f.name] = tableRows[f.name]!.filter(
+          (row) => Object.values(row).some((x) => x !== "" && x != null));
       }
       try {
         if (editing) {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -548,6 +548,23 @@ html, body { overflow: hidden; }   /* the app manages its own internal scrolling
    — they just must not read as navigable. No accent colour, no pointer, no underline. */
 .ref-unresolved { color: var(--muted); font-variant-numeric: tabular-nums; cursor: help;
                   border-bottom: 1px dotted var(--line); }
+/* MOD-TABLE — the line-item grid inside a record form.
+   Scrolls inside its own container: a schedule of values can be 60 lines wide in a 700px form, and a
+   grid that widens the form pushes the save button off screen. The legacy block is styled as a quote
+   rather than an input, because it is not editable and must not look like it is. */
+.tbl-field { display: block; }
+.tbl-legacy { margin: 4px 0 8px; padding: 8px 10px; max-height: 140px; overflow: auto;
+              background: var(--panel); border-left: 3px solid var(--line); border-radius: 4px;
+              font-size: 12px; white-space: pre-wrap; color: var(--muted); }
+.tbl-grid { width: 100%; border-collapse: collapse; display: block; overflow-x: auto; }
+.tbl-grid th { text-align: left; font-size: 11px; color: var(--muted); font-weight: 500;
+               padding: 2px 4px; white-space: nowrap; }
+.tbl-grid td { padding: 1px 4px; }
+.tbl-cell { width: 100%; min-width: 90px; box-sizing: border-box; }
+.tbl-del { background: none; border: none; color: var(--muted); cursor: pointer; padding: 0 4px; }
+.tbl-del:hover { color: var(--danger, #e05252); }
+.tbl-total { margin-top: 6px; font-size: 12px; font-weight: 600; text-align: right; }
+
 .ref-unlinked { color: var(--text, inherit); cursor: help; border-bottom: 1px dashed var(--line);
                 opacity: .92; }
 .chip { display: inline-block; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 0 8px; font-size: 11px; margin: 1px 0; }

--- a/services/api/modules/bid_submission/module.json
+++ b/services/api/modules/bid_submission/module.json
@@ -42,14 +42,59 @@
     },
     {
       "name": "alternates",
-      "label": "Alternates (desc + $)",
-      "type": "textarea",
+      "label": "Alternates",
+      "type": "table",
+      "columns": [
+        {
+          "name": "no",
+          "label": "Alt #",
+          "type": "text"
+        },
+        {
+          "name": "description",
+          "label": "Description",
+          "type": "text"
+        },
+        {
+          "name": "amount",
+          "label": "Amount",
+          "type": "currency"
+        },
+        {
+          "name": "accepted",
+          "label": "Accepted",
+          "type": "checkbox"
+        }
+      ],
+      "total_column": "amount",
       "fieldset": "Pricing"
     },
     {
       "name": "unit_prices",
-      "label": "Unit Prices",
-      "type": "textarea",
+      "label": "Unit prices",
+      "type": "table",
+      "columns": [
+        {
+          "name": "item",
+          "label": "Item",
+          "type": "text"
+        },
+        {
+          "name": "unit",
+          "label": "Unit",
+          "type": "text"
+        },
+        {
+          "name": "qty",
+          "label": "Qty",
+          "type": "number"
+        },
+        {
+          "name": "unit_price",
+          "label": "Unit price",
+          "type": "currency"
+        }
+      ],
       "fieldset": "Pricing"
     },
     {

--- a/services/api/modules/daily_report/module.json
+++ b/services/api/modules/daily_report/module.json
@@ -60,7 +60,31 @@
     {
       "name": "crew_by_trade",
       "label": "Crew by trade",
-      "type": "textarea",
+      "type": "table",
+      "columns": [
+        {
+          "name": "trade",
+          "label": "Trade",
+          "type": "text"
+        },
+        {
+          "name": "company",
+          "label": "Company",
+          "type": "text"
+        },
+        {
+          "name": "headcount",
+          "label": "Workers",
+          "type": "number"
+        },
+        {
+          "name": "hours",
+          "label": "Hours",
+          "type": "number",
+          "unit": "hr"
+        }
+      ],
+      "total_column": "headcount",
       "fieldset": "Work"
     },
     {
@@ -77,8 +101,27 @@
     },
     {
       "name": "equipment_on_site",
-      "label": "Equipment On Site",
-      "type": "textarea",
+      "label": "Equipment on site",
+      "type": "table",
+      "columns": [
+        {
+          "name": "equipment",
+          "label": "Equipment",
+          "type": "text"
+        },
+        {
+          "name": "count",
+          "label": "Count",
+          "type": "number"
+        },
+        {
+          "name": "hours",
+          "label": "Hours",
+          "type": "number",
+          "unit": "hr"
+        }
+      ],
+      "total_column": "hours",
       "fieldset": "Site"
     },
     {

--- a/services/api/modules/estimate/module.json
+++ b/services/api/modules/estimate/module.json
@@ -34,6 +34,44 @@
       "name": "date",
       "label": "Date",
       "type": "date"
+    },
+    {
+      "name": "line_items",
+      "label": "Line items",
+      "type": "table",
+      "columns": [
+        {
+          "name": "code",
+          "label": "Cost code",
+          "type": "text"
+        },
+        {
+          "name": "description",
+          "label": "Description",
+          "type": "text"
+        },
+        {
+          "name": "qty",
+          "label": "Qty",
+          "type": "number"
+        },
+        {
+          "name": "unit",
+          "label": "Unit",
+          "type": "text"
+        },
+        {
+          "name": "unit_cost",
+          "label": "Unit cost",
+          "type": "currency"
+        },
+        {
+          "name": "amount",
+          "label": "Amount",
+          "type": "currency"
+        }
+      ],
+      "total_column": "amount"
     }
   ],
   "workflow": {

--- a/services/api/modules/incident/module.json
+++ b/services/api/modules/incident/module.json
@@ -115,7 +115,29 @@
     {
       "name": "witnesses",
       "label": "Witnesses",
-      "type": "textarea",
+      "type": "table",
+      "columns": [
+        {
+          "name": "name",
+          "label": "Name",
+          "type": "text"
+        },
+        {
+          "name": "employer",
+          "label": "Employer",
+          "type": "text"
+        },
+        {
+          "name": "contact",
+          "label": "Contact",
+          "type": "text"
+        },
+        {
+          "name": "statement_taken",
+          "label": "Statement",
+          "type": "checkbox"
+        }
+      ],
       "fieldset": "People"
     },
     {

--- a/services/api/modules/project_charter/module.json
+++ b/services/api/modules/project_charter/module.json
@@ -71,8 +71,25 @@
     },
     {
       "name": "key_deliverables",
-      "label": "Key Deliverables",
-      "type": "textarea",
+      "label": "Key deliverables",
+      "type": "table",
+      "columns": [
+        {
+          "name": "deliverable",
+          "label": "Deliverable",
+          "type": "text"
+        },
+        {
+          "name": "owner",
+          "label": "Owner",
+          "type": "text"
+        },
+        {
+          "name": "due",
+          "label": "Due",
+          "type": "date"
+        }
+      ],
       "fieldset": "Scope"
     },
     {
@@ -89,8 +106,20 @@
     },
     {
       "name": "key_milestones",
-      "label": "Key Milestones",
-      "type": "textarea",
+      "label": "Key milestones",
+      "type": "table",
+      "columns": [
+        {
+          "name": "milestone",
+          "label": "Milestone",
+          "type": "text"
+        },
+        {
+          "name": "target",
+          "label": "Target",
+          "type": "date"
+        }
+      ],
       "fieldset": "Budget & Schedule"
     },
     {

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -38,7 +38,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
-         "test_module_config", "test_module_schema", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
+         "test_module_config", "test_module_schema", "test_module_tables", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:

--- a/services/api/src/aec_api/module_schema.py
+++ b/services/api/src/aec_api/module_schema.py
@@ -19,13 +19,52 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
-# Field types the config-driven CRUD UI knows how to render. Keep in sync with the web form renderer.
+# Field types the config-driven CRUD UI knows how to render. Keep in sync with the web form renderer —
+# `fieldTypeCoverage.test.ts` asserts that every type here is one the form can actually handle, after
+# `percent` spent a release being legal server-side and unrenderable client-side.
 FIELD_TYPES = {"text", "number", "currency", "date", "textarea", "select", "multiselect",
-               "reference", "signature", "rollup", "checkbox", "email", "phone", "percent", "file"}
+               "reference", "signature", "rollup", "checkbox", "email", "phone", "percent", "file",
+               "table"}
+
+#: MOD-TABLE — the column types a `table` field may declare.
+#:
+#: Deliberately a SUBSET, and the exclusions are the point. No nested `table` (a grid inside a grid has
+#: no sane form rendering and no sane CSV export). No `rollup` (it is computed from other *records*,
+#: which a row is not). No `file`/`signature` (each needs its own upload or signing flow, and putting
+#: one in a repeating row multiplies that flow by the row count). No `reference` yet — a picker per row
+#: is a real feature rather than a column type, and shipping it half-done would put unresolvable ids in
+#: rows, which is the exact defect `refCell` was written to stop.
+TABLE_COLUMN_TYPES = {"text", "number", "currency", "percent", "date", "select", "checkbox"}
 
 #: Types that hold a magnitude, and so are the only ones a `unit` or a numeric check applies to.
 #: Defined here rather than beside `validate_record` because `validate_module` needs it first.
 _NUMERIC_TYPES = {"number", "currency", "percent"}
+
+
+class ColumnDef(BaseModel):
+    """MOD-TABLE — one column of a `table` field.
+
+    Same shape as a `FieldDef` minus everything that only makes sense once per record. A row is not a
+    record: it has no workflow, no ref, no attachments and no id, so a column carries only what is
+    needed to render and read a cell.
+    """
+    model_config = ConfigDict(extra="allow")
+    name: str
+    type: str
+    label: str | None = None
+    required: bool = False
+    options: list[str] | None = None
+    unit: str | None = None
+    #: Render narrower/wider than the default. A hint, not a layout engine.
+    width: str | None = None
+
+    @field_validator("type")
+    @classmethod
+    def _known_column_type(cls, v: str) -> str:
+        if v not in TABLE_COLUMN_TYPES:
+            raise ValueError(f"column type {v!r} not allowed in a table "
+                             f"(allowed: {sorted(TABLE_COLUMN_TYPES)})")
+        return v
 
 
 class FieldDef(BaseModel):
@@ -36,6 +75,14 @@ class FieldDef(BaseModel):
     required: bool = False
     options: list[str] | None = None
     module: str | None = None                 # reference target
+    # MOD-TABLE — line items. The sweep found 22 places a LIST had been flattened into one textarea
+    # (`bid_submission.unit_prices`, `daily_report.crew_by_trade`, `incident.witnesses`), and the deeper
+    # version of the same gap: `sov` is one record PER LINE with no parent document, and `estimate` is a
+    # single `amount`. A schedule of values, a bid, an estimate and a daily manpower log are all
+    # line-item documents, and the config had no way to say so.
+    columns: list[ColumnDef] | None = None
+    #: Column whose values are summed into a footer total (must name a numeric column).
+    total_column: str | None = None
     # MOD-SWEEP — the unit a numeric value is measured in ("ft", "yr", "days", "kWh"). The sweep found
     # 170 numeric fields with no unit declared, most encoding it in the field NAME instead
     # (`elevation_ft`, `expected_life_years`). A unit in a name is readable only by a human: it cannot
@@ -170,6 +217,31 @@ def validate_module(mod: dict, *, known_modules: set[str] | None = None,
             errors.append(f"{key}.{f.name}: {f.type} field has no options")
         if f.unit and f.type not in _NUMERIC_TYPES:
             errors.append(f"{key}.{f.name}: unit {f.unit!r} on a {f.type} field (units are numeric)")
+        # ---- MOD-TABLE ----------------------------------------------------------------------------
+        if f.type == "table":
+            if not f.columns:
+                errors.append(f"{key}.{f.name}: table field has no columns")
+            else:
+                cnames = [c.name for c in f.columns]
+                dupes = {n for n in cnames if cnames.count(n) > 1}
+                if dupes:
+                    errors.append(f"{key}.{f.name}: duplicate column(s) {sorted(dupes)}")
+                for c in f.columns:
+                    if c.type in ("select",) and not c.options:
+                        errors.append(f"{key}.{f.name}.{c.name}: select column has no options")
+                    if c.unit and c.type not in _NUMERIC_TYPES:
+                        errors.append(f"{key}.{f.name}.{c.name}: unit on a {c.type} column")
+                if f.total_column:
+                    tc = next((c for c in f.columns if c.name == f.total_column), None)
+                    if tc is None:
+                        errors.append(f"{key}.{f.name}: total_column {f.total_column!r} is not a column")
+                    elif tc.type not in _NUMERIC_TYPES:
+                        # A footer summing a text column would render a number nobody can account for,
+                        # which is worse than no total at all.
+                        errors.append(f"{key}.{f.name}: total_column {f.total_column!r} is "
+                                      f"{tc.type}, not numeric")
+        elif f.columns or f.total_column:
+            errors.append(f"{key}.{f.name}: columns/total_column on a {f.type} field (tables only)")
         # A percentage-named field typed `number` renders as a bare figure and formats as a count, so
         # 7.5% and 7.5 are indistinguishable in a table. The sweep found 20; this stops the 21st.
         # `percent` appears anywhere in the name, not just as a suffix — `percent_complete` was the one
@@ -225,7 +297,40 @@ def validate_record(mod: dict, data: dict) -> list[str]:
                 float(value)
             except (TypeError, ValueError):
                 errors.append(f"{name}: {value!r} is not a number")
+        elif f.get("type") == "table":
+            errors.extend(_table_errors(name, f, value))
     return errors
+
+
+def _table_errors(name: str, f: dict, value) -> list[str]:
+    """Rows of a `table` field: a list of objects, with numeric columns holding numbers.
+
+    A LEGACY STRING IS ACCEPTED, deliberately. 22 of these fields were `textarea` before, so live
+    records hold prose where rows are now expected. Rejecting that would make every one of those
+    records un-saveable the moment anybody edited an unrelated field on it — the config change would
+    break data it never touched. The form shows the legacy text alongside the grid so it can be
+    itemised by hand; this only refuses shapes that are neither.
+    """
+    out: list[str] = []
+    if isinstance(value, str):
+        return out                                # legacy prose from the pre-table field; see above
+    if not isinstance(value, list):
+        return [f"{name}: expected a list of rows, got {type(value).__name__}"]
+    cols = {c.get("name"): c for c in (f.get("columns") or []) if c.get("name")}
+    for i, row in enumerate(value):
+        if not isinstance(row, dict):
+            out.append(f"{name}[{i}]: expected an object, got {type(row).__name__}")
+            continue
+        for cname, cval in row.items():
+            c = cols.get(cname)
+            if c is None or cval in (None, "", [], {}):
+                continue                          # unknown column or blank cell -> allowed, as above
+            if c.get("type") in _NUMERIC_TYPES:
+                try:
+                    float(cval)
+                except (TypeError, ValueError):
+                    out.append(f"{name}[{i}].{cname}: {cval!r} is not a number")
+    return out
 
 
 def validate_dir(modules_dir: Path) -> dict[str, list[str]]:

--- a/services/api/test_module_tables.py
+++ b/services/api/test_module_tables.py
@@ -1,0 +1,149 @@
+"""MOD-TABLE — line-item fields: a register row can hold a document, not just a value.
+
+The field sweep found 22 places a LIST had been flattened into one textarea
+(`bid_submission.unit_prices`, `daily_report.crew_by_trade`, `incident.witnesses`), and the deeper
+version of the same gap: `sov` is one record PER LINE with no parent document, and `estimate` was a
+single `amount`. A schedule of values, a bid, an estimate and a daily manpower log are all line-item
+documents. The config had no way to say so, so `bid_leveling.py` was parsing prose for numbers a
+structured grid would have handed it clean.
+
+Three properties are asserted here, and the third is the one that makes the change safe to ship:
+
+1. **The column vocabulary is a deliberate subset.** No nested table, no rollup, no file/signature, no
+   reference. Each exclusion has a reason (see `module_schema.TABLE_COLUMN_TYPES`); a column type that
+   slipped in without a renderer is exactly how `percent` spent a release broken.
+2. **Numeric cells are numbers.** A cell holding `"1000"` makes SQL comparison lexicographic — the
+   same defect `MOD-FILTER`'s cast exists to survive, and the same one the record form had for
+   `percent`.
+3. **A LEGACY STRING IS ACCEPTED AND PRESERVED.** Those fields were textareas, so live records hold
+   prose where rows are now expected. Rejecting it would make every such record un-saveable the moment
+   somebody edited an unrelated field — a config change breaking data it never touched. Accepting but
+   silently dropping it would be worse: it is the only copy.
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_module_tables.py
+"""
+import json
+import os
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_mod_tables.db"
+os.environ["STORAGE_DIR"] = "./test_storage_mod_tables"
+os.environ["AEC_TRUST_XUSER"] = "1"
+
+for _f in ("./test_mod_tables.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+from aec_api.module_schema import TABLE_COLUMN_TYPES, validate_module, validate_record  # noqa: E402
+
+H = {"X-User": "gc"}
+MODULES = pathlib.Path(__file__).parent / "modules"
+
+# ---- 1. the column vocabulary is a subset, and the exclusions hold ------------------------------
+for banned in ("table", "rollup", "file", "signature", "reference", "multiselect", "textarea"):
+    assert banned not in TABLE_COLUMN_TYPES, f"{banned!r} must not be a table column type"
+    errs = validate_module({"key": "x", "fields": [
+        {"name": "l", "type": "table", "columns": [{"name": "c", "type": banned}]}]})
+    assert errs, f"a {banned!r} column was accepted"
+
+# a table must declare columns; a total must name a NUMERIC column that exists
+for bad, why in (
+    ({"key": "x", "fields": [{"name": "l", "type": "table"}]}, "no columns"),
+    ({"key": "x", "fields": [{"name": "l", "type": "table", "total_column": "zz",
+                              "columns": [{"name": "a", "type": "currency"}]}]}, "total names nothing"),
+    ({"key": "x", "fields": [{"name": "l", "type": "table", "total_column": "a",
+                              "columns": [{"name": "a", "type": "text"}]}]}, "total on a text column"),
+    ({"key": "x", "fields": [{"name": "l", "type": "table",
+                              "columns": [{"name": "a", "type": "text"},
+                                          {"name": "a", "type": "text"}]}]}, "duplicate columns"),
+    ({"key": "x", "fields": [{"name": "l", "type": "table",
+                              "columns": [{"name": "a", "type": "select"}]}]}, "select w/o options"),
+    ({"key": "x", "fields": [{"name": "l", "type": "text",
+                              "columns": [{"name": "a", "type": "text"}]}]}, "columns on a non-table"),
+):
+    assert validate_module(bad), f"accepted an invalid table: {why}"
+
+# ---- 2. record validation: numbers, shapes, and the legacy string --------------------------------
+MOD = {"fields": [{"name": "lines", "type": "table", "total_column": "amount", "columns": [
+    {"name": "description", "type": "text"}, {"name": "qty", "type": "number"},
+    {"name": "amount", "type": "currency"}]}]}
+
+assert not validate_record(MOD, {"lines": [{"description": "Concrete", "qty": 5, "amount": 1000}]})
+assert not validate_record(MOD, {"lines": []})
+assert not validate_record(MOD, {"lines": [{"description": "x", "amount": ""}]})     # blank cell
+assert not validate_record(MOD, {"lines": [{"description": "x", "unknown_col": "y"}]})
+# THE LEGACY CASE: prose from when the field was a textarea must not be rejected
+assert not validate_record(MOD, {"lines": "Concrete 1000\nSteel 2000"}), \
+    "a legacy free-text value was rejected — every pre-conversion record would become un-saveable"
+# and the shapes that are genuinely wrong
+assert validate_record(MOD, {"lines": [{"amount": "abc"}]})
+assert validate_record(MOD, {"lines": ["not a row"]})
+assert validate_record(MOD, {"lines": {"description": "x"}})
+
+# ---- 3. the shipped tables are wired, and round-trip over HTTP ----------------------------------
+SHIPPED = {
+    "bid_submission": ["unit_prices", "alternates"],
+    "daily_report": ["crew_by_trade", "equipment_on_site"],
+    "incident": ["witnesses"],
+    "project_charter": ["key_milestones", "key_deliverables"],
+    "estimate": ["line_items"],
+}
+n_tables = 0
+for key, fnames in SHIPPED.items():
+    mod = json.loads((MODULES / key / "module.json").read_text(encoding="utf-8"))
+    by = {f["name"]: f for f in mod["fields"]}
+    for fn in fnames:
+        f = by.get(fn)
+        assert f, f"{key}.{fn} is missing"
+        assert f["type"] == "table", f"{key}.{fn} is {f['type']}, expected table"
+        assert f.get("columns"), f"{key}.{fn} has no columns"
+        n_tables += 1
+        # every declared column type must be in the allowed subset — asserted against the SHIPPED
+        # config, not just the validator, so a hand-edit cannot introduce an unrenderable column
+        for c in f["columns"]:
+            assert c["type"] in TABLE_COLUMN_TYPES, f"{key}.{fn}.{c['name']}: {c['type']}"
+
+with TestClient(app) as c:
+    pid = c.post("/projects", headers=H, json={"name": "Tables"}).json()["id"]
+
+    # an estimate with real line items, saved and read back with numbers intact
+    lines = [{"code": "03 30 00", "description": "Concrete", "qty": 120, "unit": "cy",
+              "unit_cost": 185.5, "amount": 22260},
+             {"code": "05 12 00", "description": "Structural steel", "qty": 40, "unit": "ton",
+              "unit_cost": 2400, "amount": 96000}]
+    r = c.post(f"/projects/{pid}/modules/estimate", headers=H,
+               json={"data": {"name": "GMP estimate", "line_items": lines}})
+    assert r.status_code == 201, r.text
+    rid = r.json()["id"]
+    got = c.get(f"/projects/{pid}/modules/estimate/{rid}", headers=H).json()
+    back = got["data"]["line_items"]
+    assert len(back) == 2, back
+    assert back[0]["amount"] == 22260 and isinstance(back[0]["amount"], (int, float)), back[0]
+    assert sum(x["amount"] for x in back) == 118260, "line-item totals must survive the round trip"
+
+    # a legacy prose value on a now-table field saves rather than 422-ing
+    r = c.post(f"/projects/{pid}/modules/daily_report", headers=H, json={"data": {
+        "report_date": "2026-07-30", "crew_by_trade": "6 carpenters, 2 laborers"}})
+    assert r.status_code == 201, f"legacy prose rejected on a converted field: {r.text}"
+
+    # and a bad row shape is refused
+    r = c.post(f"/projects/{pid}/modules/estimate", headers=H,
+               json={"data": {"name": "bad", "line_items": [{"amount": "not-a-number"}]}})
+    assert r.status_code in (400, 422), f"a non-numeric cell was accepted ({r.status_code})"
+
+    # the table field survives the register listing, and filters still work alongside it
+    rows = c.get(f"/projects/{pid}/modules/estimate", headers=H).json()
+    assert any(isinstance(x["data"].get("line_items"), list) for x in rows), rows
+
+print(f"MOD-TABLE OK - `table` field type end to end: {n_tables} shipped line-item fields across "
+      f"{len(SHIPPED)} registers, column vocabulary held to a deliberate subset (nested table, rollup, "
+      "file, signature, reference and multiselect all refused, each for a stated reason), numeric cells "
+      "round-trip as NUMBERS rather than strings — the same defect that makes SQL comparison "
+      "lexicographic and that the record form had for `percent` — and a LEGACY FREE-TEXT value on a "
+      "converted field is accepted and preserved rather than rejected. That last one is why the change "
+      "is safe to ship: 22 of these fields were textareas, so live records hold prose where rows are "
+      "now expected, and refusing it would make every one of those records un-saveable the moment "
+      "somebody edited an unrelated field on it.")


### PR DESCRIPTION
Base `42f73677`, `git merge-tree` CLEAN as of that SHA. Item 2 of the field sweep's "not done" list.

## The gap

The sweep found **22 places a list had been flattened into one textarea** (`bid_submission.unit_prices`, `daily_report.crew_by_trade`, `incident.witnesses`), and the deeper version of the same thing: `sov` is one record **per line** with no parent document, and `estimate` was a single `amount`.

A schedule of values, a bid, an estimate and a daily manpower log are all line-item documents. The config had no way to say so — so `bid_leveling.py`, whose entire job is a row-per-scope-item comparison, was parsing prose for numbers a structured grid would have handed it clean.

## The column vocabulary is a deliberate subset

| excluded | why |
|---|---|
| nested `table` | a grid inside a grid has no sane form rendering and no sane CSV export |
| `rollup` | computed from other **records**, which a row is not |
| `file` / `signature` | each needs its own upload or signing flow; a repeating row multiplies it |
| `reference` | a picker per row is a real feature, not a column type. Half-done it would put unresolvable ids in rows — **the exact defect `refCell` was written to stop**, one layer down |

A `total_column` must name a column that exists *and* is numeric: a footer summing a text column renders a number nobody can account for, which is worse than no total.

## What makes it safe to ship: the legacy string

Those 22 fields were textareas, so live records hold prose where rows are now expected.

- **Rejecting it** would make every such record un-saveable the moment somebody edited an unrelated field — a config change breaking data it never touched.
- **Accepting and dropping it** would be worse: it is the only copy.

So `validate_record` accepts a string, and the form renders it above the grid, verbatim and read-only, until the lines are entered. **Mutation-checked** — removing the tolerance fails the test with exactly that message.

## Numeric cells store as numbers

Third place one root cause has surfaced. A number stored as text is what makes SQL comparison lexicographic (`'9' >= 10` is TRUE) — the bug `MOD-FILTER`'s cast exists to survive, and the bug the record form had for `percent`.

## A hole closed at the point it was created

`isEmpty` returns `false` when a field has no entry in `inputs`, and a table is deliberately not registered there — its value is an array of objects, not an `el.value` string, so every consumer of `inputs` would read it wrongly. A **`required` table with zero rows would have passed the client check**. None of the eight shipped tables is required, so it's a hole rather than a live bug — and it's the same "plausible answer for the missing case" shape, so it's handled before the branch rather than after.

## Applied to 8 fields across 5 registers

`bid_submission.unit_prices` + `.alternates` · `daily_report.crew_by_trade` + `.equipment_on_site` · `incident.witnesses` (OSHA 301 asks who witnessed, with employer and statement) · `project_charter.key_milestones` + `.key_deliverables` · new `estimate.line_items` with a G703-shaped column set.

The register table shows `3 lines · $118,260` rather than `[object Object]` per row — a missing branch that renders as a plausible-looking bug.

## Verification

- Backend **447/449**. Both failures are environmental and pass individually: `test_bim_columns` passes with the correct `PYTHONPATH` (`src;../data/src`), `test_scan_cache` passes solo — DB contention from a concurrent web-suite run.
- `test_module_tables` **PASS inside the full suite**, not only alone.
- `tsc --noEmit` clean, re-run **after** the rebase — a rebase can break what a marker check cannot see, which is how #109's resolution passed every grep and failed to compile.
- Built in an isolated git worktree, so the shared checkout was never touched.

## ⚠️ Merge dependency

This adds `table` to `FIELD_TYPES`. **[#109](https://github.com/ibuilder/massing/pull/109)'s `fieldTypeCoverage.test.ts` will correctly fail this branch** until `table` is added to `READ_ONLY_FIELD_TYPES` — a grid has no cell-sized inline editor. I own both branches and will sequence them.

That gate was written one PR ago to catch a new type added without a renderer classification, and it caught the very next one. Worth merging #109 first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
