### PR TITLE
docs(modules): standardise the module/plugin scheme, and gate the guide against the schema

### DIFF
--- a/docs/authoring-modules.md
+++ b/docs/authoring-modules.md
@@ -38,31 +38,97 @@ record detail, CSV/Excel import, and auto-numbered references (`SV-0001`, `SV-00
 ## 2. Fields
 
 Each field is `{ "name", "label", "type", … }`. `name` is the stored key (don't rename once in use);
-`label` is what the user sees. Optional on any field: `"required": true`, `"description": "hint text"`,
-`"fieldset": "Group name"` (groups fields into sections on the form).
+`label` is what the user sees.
 
-| `type` | Renders as | Notes |
+**Every field type the platform accepts is listed below.** This table is not a summary — it is the
+complete set, and `test_docs_module_schema.py` fails the build if it drifts from
+`module_schema.FIELD_TYPES`. If a type is not here, the loader will refuse it.
+
+| `type` | Renders as | Requires / accepts |
 |---|---|---|
 | `text` | single-line input | |
 | `textarea` | multi-line input | |
-| `number` | numeric input | |
-| `currency` | money input | formatted as currency (use this instead of a plain number for money) |
+| `number` | numeric input | `unit` |
+| `currency` | money input | `unit`. Use this, not `number`, for money |
+| `percent` | numeric input, shown with `%` | `unit`. Use this, not `number`, for any percentage |
 | `date` | date picker | stored ISO `YYYY-MM-DD` |
-| `select` | dropdown | needs `"options": ["A","B",…]` |
-| `multiselect` | multi-pick | needs `"options"` |
-| `reference` | picker of another module's records | needs `"module": "<other_key>"` |
-| `rollup` | read-only aggregate from a related module | see §4 |
+| `checkbox` | tick box | |
+| `email` | email input | |
+| `phone` | telephone input | |
+| `select` | dropdown | **needs** `options: ["A","B",…]` |
+| `multiselect` | multi-pick | **needs** `options` |
+| `reference` | picker of another module's records | **needs** `module: "<other_key>"` |
+| `table` | repeating line-item grid | **needs** `columns`; accepts `total_column`. See §2.3 |
+| `file` | file attachment | |
 | `signature` | typed/drawn signature capture | |
+| `rollup` | read-only aggregate from a related module | `source_module`, `source_field`, `op`. See §4 |
 
-Example with a reference and a fieldset:
+Optional on **any** field: `"required": true`, `"description": "hint text"`, `"fieldset": "Group"`.
+
+### 2.1 `unit` — say what a number measures
+
+A numeric field (`number`, `currency`, `percent`) may declare a `unit`. It renders beside the input and
+after the value in a table cell.
 
 ```json
-{ "name": "rfi", "label": "Related RFI", "type": "reference", "module": "rfi", "fieldset": "Links" }
+{ "name": "expected_life", "label": "Expected life", "type": "number", "unit": "yr" }
 ```
 
-`reference` is how modules relate to each other (an RFI points at a `location`, a change order points
-at a `prime_contract`, etc.). The picker searches the target module; the value stored is that record's
-GUID, so links survive renames.
+**Put the unit here, not in the field name.** `elevation_ft` encodes its unit somewhere only a human
+can read — it cannot be rendered next to an input, appended to a cell, converted, or checked. A `unit`
+on a non-numeric field is refused.
+
+A *calendar year* (2027) is a point in time, not a duration, and takes **no** unit. A *duration* in
+years does.
+
+### 2.2 `reference` — how modules relate
+
+```json
+{ "name": "location", "label": "Location", "type": "reference", "module": "location", "fieldset": "Links" }
+```
+
+The picker searches the target module; the value stored is that record's **id**. The register table
+resolves it to `REF-001 · Title` and links through to the record.
+
+**Converting an existing `text` field to `reference` is not safe.** Every stored string would become an
+unresolvable id. The convention is **additive** — keep the text field and add a reference beside it:
+
+```json
+{ "name": "vendor",         "label": "Vendor",          "type": "text",      "fieldset": "Parties" },
+{ "name": "vendor_company", "label": "Vendor (linked)", "type": "reference", "module": "company",
+  "fieldset": "Parties" }
+```
+
+Recognised suffixes: `_company` · `_loc` · `_spec` · `_system` · `_contact` · `_package`. The pair
+**must be adjacent and share a fieldset** — a pair rendered in two places is a pair nobody recognises —
+and `test_module_fields.py` enforces it. `POST /projects/{pid}/modules/backfill-references` fills the
+reference from the text by exact match; it refuses ambiguous ones rather than guessing.
+
+### 2.3 `table` — line items
+
+For anything that is a *list of rows* rather than one value: a schedule of values, bid unit prices,
+crew by trade, witnesses.
+
+```json
+{
+  "name": "line_items", "label": "Line items", "type": "table", "total_column": "amount",
+  "columns": [
+    { "name": "description", "label": "Description", "type": "text" },
+    { "name": "qty",         "label": "Qty",         "type": "number" },
+    { "name": "amount",      "label": "Amount",      "type": "currency" }
+  ]
+}
+```
+
+Column types are a **deliberate subset** — `checkbox` · `currency` · `date` · `number` · `percent` ·
+`select` · `text`. No nested table, no rollup, no file, no signature, no reference: each needs
+per-record machinery a repeating row has no room for. A column accepts `label`, `required`, `options`
+(for `select`), `unit`, `width`.
+
+`total_column` must name a column that exists **and is numeric**. The register cell shows a summary
+(`3 lines · $118,260`) rather than the grid.
+
+**Do not use a `textarea` for a list.** Prose cannot be summed, filtered, or read by the engines.
 
 ## 3. Workflow (states + buttons)
 
@@ -110,6 +176,44 @@ gate it on fields.
     "source_module": "warranty", "source_field": "name", "op": "count" }
   ```
   `op` is `count` or `sum` (sum a numeric `source_field`). Copy from `asset_register` or `daily_report`.
+
+### 4.1 `fieldset` — sections on the form, and the one rule that bites
+
+`"fieldset": "Money"` groups fields under a heading. Two rules:
+
+- **Fields sharing a fieldset must be adjacent in the `fields` array.** The renderer emits one heading
+  per *run*, so an interleaved fieldset draws its heading twice. This is a renderer constraint, not a
+  style preference, and `test_modules.py` fails the build on it — for every module, not a list of them.
+- **All or nothing.** Either every non-rollup field has a fieldset or none does. A three-field lookup
+  table legitimately has none; a half-grouped form renders an unlabelled group.
+
+`rollup` fields take no fieldset — they are computed and never rendered as inputs.
+
+The core registers use: **Identity · Classification · Parties · Dates · Money · Quantities · Status ·
+Links · Notes**. Reuse them unless your register genuinely needs its own vocabulary.
+
+### 4.2 `tools` — point a register at the panel that operates on it
+
+A register renders a table, a form and a status chip. `tools` is how it says what it can *do*:
+
+```json
+"tools": [
+  { "dest": "__evm__", "label": "Earned value" },
+  { "dest": "__budget__", "label": "Budget" }
+]
+```
+
+`dest` is a first-class destination key (`__evm__`, `__operations__`, `__aiassist__`, …). `label` is
+the button text. `scope` is `register` (default). An unknown `dest` renders nothing rather than a dead
+button, and `moduleTools.test.ts` fails the build if it does not resolve.
+
+### 4.3 Where a module appears
+
+`section` decides the nav group; the **room** is derived from the section by one table
+(`rooms.ROOM_OF_SECTION`), so a new section must be given a room deliberately — an unmapped section is
+a hard failure, never a default, because a module with no room is one nobody can reach.
+
+The seven rooms: **Deal · Design · Planning · Schedule · Cost · Work · Operate**.
 
 ## 5. Validate before you ship
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -33,6 +33,7 @@ here**. Do not cite an archived file as current.
 | `gc-tools-audit.md` | Per-module audit of the 69 GC-portal modules | roadmap + [../gc-portal.md](../gc-portal.md) |
 | `gc-modules-roadmap.md` | Field-vs-office deep dive across the config-driven GC modules | roadmap |
 | `module-room-audit.md` | 133 registers against the seven rooms; sprints 1–2 built, 3–6 proposed | roadmap; the allocation itself is enforced by `test_module_rooms.py` |
+| `module-plugin-system.md` | PLAN, 2026-07-30 — a WordPress/Joomla-style plugin system: rooms as directories, third-party module packs, and the decision that inverts R26 (the directory becomes authoritative for the room, because a third-party module must be reachable without editing a core table) | Nothing built. Sequencing + a cross-lane warning in §7 |
 | `module-field-sweep.md` | Field-level sweep of all 133 modules, 2026-07-29 — fields, fieldsets, relationships, CRUD. Compares against a Django app the user built previously, which uses ForeignKeys where these modules used strings. Applied: 54 additive text+reference pairs, 67 units moved out of field names, 20 percent retypes, 41 widened tables, and two live fake-link defects in the reference renderer | Nothing — **current**. Every number in it is a floor in `test_module_fields.py`; §8 lists what is deliberately not done |
 | `ux-findings.md` | App-wide heuristic UX review | Shipped through the R24 interface ring |
 | `ux-ia.md` | Information-architecture plan for ~100 registers | Shipped as the room spine (`apps/web/src/shell/spine.ts`) |

--- a/docs/internal/module-plugin-system.md
+++ b/docs/internal/module-plugin-system.md
@@ -1,0 +1,189 @@
+# Module plugin system — rooms as directories, third-party registers
+
+**Date:** 2026-07-30 · **Status:** PLAN. Nothing built. Every number below was read from the code, not
+recalled. **Internal** — `docs/` is the Pages web root.
+
+Goal, in the user's words: *a plugin system similar to WordPress and Joomla* — the file tree broken out
+by room, so a user can drop a custom module into the appropriate room directory and the program
+recognises it. Activation/deactivation is explicitly deferred to a later phase.
+
+---
+
+## 0. What already exists (verified, not assumed)
+
+| Thing | State | Where |
+|---|---|---|
+| Plugin model for **authoring recipes** | **Built and mature** | `plugin_registry.py`, `plugins/example-wall-brand/` |
+| Module (register) discovery | Flat, single directory, one level | `modules_registry.load_registry()` |
+| Module dir override | `AEC_MODULES_DIR` (used by the frozen desktop build) | `modules_registry.py:26` |
+| Room of a module | Derived from its **`section`**, via one table | `rooms.ROOM_OF_SECTION` |
+| Plugin sandboxing | On the roadmap, unbuilt | `SEC-PLUGIN-SANDBOX`, Lane C |
+
+**`plugin_registry.py` is the precedent to copy, not to reinvent.** It already solved the hard part for
+recipes, and its three gates are exactly the ones a module pack needs:
+
+1. **Opt-in.** Discovery is off unless `AEC_PLUGINS_ENABLED=1` — never on by default.
+2. **API-version gate.** The manifest declares `api_version`; a MAJOR mismatch refuses the plugin with
+   a reason rather than loading something built against a different contract.
+3. **Namespace + collision refusal.** A key that already exists is *refused*, never silently
+   overwritten, and refusals are returned **and** logged — a half-loaded set is visible, not silent.
+
+A module pack differs from a recipe plugin in one important way: **it ships data, not code.** A
+`module.json` is declarative, so the arbitrary-code risk that makes recipe plugins opt-in does not
+apply. That argues for module packs being discoverable by default while *code* plugins stay gated —
+but see §6, because "declarative" is doing real work in that sentence and deserves a check.
+
+---
+
+## 1. The decision everything else depends on
+
+**Today a module's room comes from its `section`, through one table.** `rooms.py` states the reasoning
+explicitly, and it is good reasoning: a room is a property of the section, not of each module, so one
+readable table decides the allocation and an editing slip cannot put a module in two rooms.
+
+**A directory-based tree contradicts that**, and the contradiction cannot be papered over — it would be
+a *third* encoding of one fact (directory, `section`, `ROOM_OF_SECTION`), which is the drift shape this
+repo has paid for repeatedly.
+
+So one of them must become authoritative, and for a plugin system **the directory has to win**:
+
+> A third-party module dropped into `modules/design/` must be reachable **without editing a core
+> table**. If `ROOM_OF_SECTION` stays authoritative, every third-party module needs a line added to a
+> file inside the product to appear at all — which is not a plugin system, it is a patch.
+
+That is the decisive argument, and it inverts the R26 decision deliberately rather than by accident.
+What changes:
+
+- **The directory names the room.** `modules/<room>/<key>/module.json`.
+- **`section` stays**, demoted to what it always described in practice: a **sub-group within a room**
+  (Design → BIM · Engineering · Specifications …). It keeps its role in the rail and in future
+  sub-rooms, and loses its role in room allocation.
+- **`ROOM_OF_SECTION` is retired**, and `rooms.py` keeps `ROOMS` (the seven rooms, their labels and
+  jobs) plus a new validator: every section appears under exactly one room directory. A section
+  appearing under two rooms is now the failure mode, and it is the one worth a gate.
+
+**The R26 argument survives the inversion.** Its real content was *"one canonical home per module,
+derived from one place, never stored twice"* — that still holds; the one place is now the path. The
+duplication it warned against would be reintroduced only if we kept both.
+
+---
+
+## 2. Layout
+
+```
+services/api/modules/                 ← core registers, shipped
+  deal/          acquisition/ …       ← <room>/<key>/module.json
+  design/
+    rfi/module.json
+    submittal/module.json
+  planning/  schedule/  cost/  operate/  work/
+  _shared/                            ← reserved: cross-room fragments, never a room
+
+<user data dir>/modules/              ← third-party packs, discovered, never shipped
+  design/
+    acme-daily-brief/
+      module.json
+      pack.json                       ← optional manifest; see §3
+```
+
+`_shared/` is reserved from the start precisely so nobody later invents `common/` and `shared/` in
+parallel. A directory whose name is not a known room id is a **refusal with a reason**, not a silent
+skip — the same rule as an unmapped section today.
+
+---
+
+## 3. Manifest
+
+A single `module.json` needs no manifest — the point is that dropping one file in a room directory
+works. A **pack** (several modules shipped together, or anything wanting a version) adds `pack.json`,
+mirroring `plugin.json`:
+
+```jsonc
+{
+  "name": "acme-field-pack",
+  "version": "1.2.0",
+  "api_version": "1.0",        // MAJOR must match MODULE_API_VERSION, as plugin_registry does
+  "modules": ["acme-daily-brief", "acme-toolbox"],
+  "author": "Acme",
+  "description": "Field registers for Acme's daily routine."
+}
+```
+
+`MODULE_API_VERSION` is a **new constant, distinct from `PLUGIN_API_VERSION`**: the module-config
+contract (field types, workflow shape, `tools`, `columns`) versions on its own schedule and pretending
+otherwise would force a lockstep neither side wants.
+
+---
+
+## 4. Discovery
+
+`load_registry()` becomes:
+
+1. Walk `<root>/<room>/<key>/module.json` for each **known room id**, for each root in the search path.
+2. Search path = core `MODULES_DIR`, then the user data dir, then `AEC_MODULES_DIR` if set.
+3. **Later roots cannot override earlier ones.** A third-party module whose `key` collides with a core
+   register is **refused with a reason**, exactly as `plugin_registry` refuses a recipe collision.
+   Silent override is how a plugin quietly replaces the RFI register.
+4. Every refusal is collected and exposed on `GET /modules/health` — not only logged. A half-loaded
+   registry that looks complete is the failure this design most needs to avoid.
+
+**Two things in the loader break and must change with it**, both verified:
+
+- `validate_module(..., folder=mj.parent.name)` asserts `key == folder`. Still correct under the new
+  layout — the folder is still the key — but `known_modules` is built from a one-level glob and must
+  become the union across rooms and roots.
+- `MODULES_DIR.glob("*/module.json")` appears in the **loader and in four test files**
+  (`test_module_rooms`, `test_module_config`, `test_module_fields`, `test_module_tables`). Each reads
+  the tree directly, on purpose — they are the gates that read reality rather than a copy. All four
+  need the two-level walk, and that is a feature: they will fail loudly the moment the layout changes
+  under them.
+
+---
+
+## 5. Activation / deactivation *(deferred, sketched so the data model does not preclude it)*
+
+Deliberately **not** built now. The shape it must not preclude:
+
+- Activation is **per project**, not global — one firm's projects legitimately differ.
+- State lives in a table, not on disk: a module's presence is a *fact about the install*, its activation
+  is a *fact about the project*.
+- **Deactivation must never delete data.** A deactivated module's records stay; the register leaves the
+  rail and its routes 404 with "deactivated", not "unknown".
+- **A core register cannot be deactivated** while another module holds a `reference` to it — the
+  reference graph already exists (`module_graph.build`) and is the check.
+
+---
+
+## 6. What this costs, honestly
+
+- **133 modules move.** One mechanical commit, but it rewrites every path in the repo's most-read
+  directory and will conflict with anything in flight touching `module.json`.
+- **`ROOM_OF_SECTION` retires**, and `test_module_rooms.py` — which asserts the allocation by module
+  name — becomes an assertion about *directories*. That gate was strengthened deliberately two days
+  ago; it must be re-pointed, not weakened.
+- **The demo capture regenerates** (`demoData.json` holds `/modules` and `/rooms`).
+- **"Declarative" is doing real work.** A `module.json` is data, but it drives table creation
+  (`mod_<key>`), FTS indexes, and a Postgres migration requirement. A third-party module therefore
+  **creates a table at runtime**, which is the actual risk here — not code execution. It needs its own
+  answer (a name prefix per pack, a row/table quota, or admin-gated install) and that answer is
+  `SEC-PLUGIN-SANDBOX`'s sibling, not a footnote to it.
+
+---
+
+## 7. Sequencing, and a lane problem worth naming
+
+The roadmap's lanes are disjoint **by path**. This work is not:
+
+| Step | Touches | Lane |
+|---|---|---|
+| `R32-PLUGIN-DISCOVER` — two-level walk, search path, collision refusal, health surface | `modules_registry.py`, `rooms.py` | **C** |
+| `R32-PLUGIN-TREE` — move 133 modules into room dirs; re-point the four gates | `services/api/modules/**`, the gates | **H** |
+| `R32-PLUGIN-MANIFEST` — `pack.json`, `MODULE_API_VERSION`, refusal reasons | `modules_registry.py` | **C** |
+| `R32-PLUGIN-TOGGLE` — per-project activation | new table, router, rail | **C + G + A** |
+
+`R32-PLUGIN-DISCOVER` must land **before** `R32-PLUGIN-TREE` and must accept **both** layouts for one
+release. Otherwise the move is a flag day: every gate fails at once and the only way through is a
+single enormous commit — which is exactly the change nobody can review.
+
+`R32-PLUGIN-TOGGLE` spans three lanes and should be split before it is scheduled, not while it is
+being built.

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -38,7 +38,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
-         "test_module_config", "test_module_schema", "test_module_tables", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
+         "test_module_config", "test_module_schema", "test_docs_module_schema", "test_module_tables", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:

--- a/services/api/test_docs_module_schema.py
+++ b/services/api/test_docs_module_schema.py
@@ -1,0 +1,97 @@
+"""The module-authoring guide lists EXACTLY the field types the platform accepts.
+
+`docs/authoring-modules.md` is the specification a third party writes a module against — the whole
+promise of the config-driven layer is that you need no code, which makes the document the product
+surface. So it is worth exactly as much as it is accurate, and prose has no way to fail.
+
+**It had already drifted.** The guide listed 10 field types; the schema accepted 16. Missing were
+`percent`, `table`, `checkbox`, `email`, `phone` and `file` — including the two most recently added,
+which is the pattern: a type gets added to `FIELD_TYPES`, the loader accepts it, the renderer handles
+it, and the one artefact a stranger reads never learns about it. An author following the guide would
+have used `number` for a percentage and a `textarea` for a list, which is precisely the paper-form
+shape the field sweep spent a week undoing.
+
+This is the same class as the four staleness bugs the docs gates already cover (a README flag 50
+releases stale, a tutorial naming a deleted sample). The fix is the same: **stop asking people to
+remember, and read the file from disk.**
+
+Deliberately a SET comparison in both directions rather than a count:
+  * a type in the schema but not the doc -> an author cannot discover it
+  * a type in the doc but not the schema -> an author is told to use something the loader refuses,
+    which is worse, because it fails only after they have written the module
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_docs_module_schema.py
+"""
+import os
+import re
+
+DOC = os.path.join(os.path.dirname(__file__), "..", "..", "docs", "authoring-modules.md")
+
+from aec_api.module_schema import _NUMERIC_TYPES, FIELD_TYPES, TABLE_COLUMN_TYPES  # noqa: E402
+
+with open(DOC, encoding="utf-8") as fh:
+    text = fh.read()
+
+assert len(text) > 2000, f"{DOC} is suspiciously short — did it move?"
+
+# ---- 1. the field-type table lists exactly FIELD_TYPES -------------------------------------------
+# The table rows look like `| `text` | single-line input | … |`, so the type is the first inline-code
+# cell of a row. Scoped to the section so a stray mention elsewhere in the prose is not counted as a
+# table entry — the population must be the TABLE, not the document.
+sec = text[text.index("## 2. Fields"):text.index("### 2.1")]
+# The HEADER row is also `| `type` | … |`, so it parses as a field type called "type" and the check
+# fails on an extra the guide never claimed. Caught by this test on its first run — a parser that
+# reads its own header as data is the reason to assert both directions rather than just "nothing
+# missing", which would have passed.
+documented = {m.group(1) for m in re.finditer(r"^\|\s*`([a-z]+)`\s*\|(?!\s*Renders as)", sec, re.M)}
+assert documented, "could not parse the field-type table — its shape changed"
+
+missing = sorted(FIELD_TYPES - documented)
+extra = sorted(documented - FIELD_TYPES)
+assert not missing, (
+    f"field types the platform accepts but the guide does not list: {missing}. An author cannot use "
+    "what the documentation does not mention — this is how the guide came to omit `percent` and "
+    "`table` while the loader accepted both.")
+assert not extra, (
+    f"field types the guide lists but the platform refuses: {extra}. Worse than an omission: the "
+    "module fails to load only after it has been written.")
+
+# ---- 2. the table-column subset is documented, and documented as a SUBSET -----------------------
+col_sec = text[text.index("### 2.3"):text.index("## 3.")]
+col_documented = {m.group(1) for m in re.finditer(r"`([a-z]+)`", col_sec)}
+col_missing = sorted(TABLE_COLUMN_TYPES - col_documented)
+assert not col_missing, f"table column types not documented: {col_missing}"
+# and the exclusions are stated, because "why can't I use a reference column" is the first question
+for excluded in ("nested table", "rollup", "reference"):
+    assert excluded in col_sec, f"the guide does not say why {excluded!r} is not a column type"
+
+# ---- 3. the numeric types are named as the ones that take a unit --------------------------------
+unit_sec = text[text.index("### 2.1"):text.index("### 2.2")]
+for t in _NUMERIC_TYPES:
+    assert f"`{t}`" in unit_sec, f"`{t}` takes a unit but §2.1 does not say so"
+
+# ---- 4. the rules a module author will otherwise get wrong ---------------------------------------
+# Each of these is a real constraint enforced by a gate elsewhere. A guide that omits them sends the
+# author to a failing build with no explanation, which is the same defect as an undocumented type.
+for phrase, why in (
+    ("adjacent", "fieldset contiguity — the renderer draws a duplicate heading otherwise"),
+    ("additive", "text->reference conversion is unsafe; the convention is to add beside"),
+    ("total_column", "a table's total must name a numeric column"),
+    ("unmapped section", "a section with no room makes the module unreachable"),
+):
+    assert phrase in text, f"the guide does not cover: {why}"
+
+# ---- 5. the seven rooms, named ------------------------------------------------------------------
+from aec_api.rooms import ROOMS  # noqa: E402
+
+for r in ROOMS:
+    assert r["label"] in text, f"room {r['label']!r} is not named in the guide"
+
+print(f"DOCS MODULE SCHEMA OK - the authoring guide lists exactly the {len(FIELD_TYPES)} field types "
+      f"the platform accepts and the {len(TABLE_COLUMN_TYPES)} allowed table-column types, states why "
+      "the excluded column types are excluded, names the numeric types that take a unit, covers the "
+      "four rules a gate elsewhere enforces (fieldset contiguity, the additive text+reference "
+      "convention, a numeric total_column, and an unmapped section being a hard failure), and names "
+      "all seven rooms. Asserted as a SET in BOTH directions: a type the schema accepts but the guide "
+      "omits cannot be discovered, and a type the guide lists but the schema refuses fails only after "
+      "the module has been written. The guide had drifted to 10 of 16 types before this gate existed.")


### PR DESCRIPTION
Base `bf41a415`, `merge-tree` CLEAN. Docs + one new gate; no engine, no renderer, no `module.json`.

## The guide had drifted: 10 field types documented, 16 accepted

`docs/authoring-modules.md` is the specification a third party writes a module against — the whole promise of the config-driven layer is *no code required*, which makes the document the product surface.

Missing: **`percent`, `table`, `checkbox`, `email`, `phone`, `file`** — including the two most recently added, which is the pattern rather than an accident. A type gets added to `FIELD_TYPES`, the loader accepts it, the renderer handles it, and the one artefact a stranger reads never learns about it.

An author following the guide would have used `number` for a percentage and a `textarea` for a list — precisely the paper-form shape the field sweep spent a week undoing.

## What the scheme now specifies

| | |
|---|---|
| **every field type** | the complete set of 16, with what each requires |
| **`unit`** | say what a number measures — and put it *here*, not in the field name. `elevation_ft` encodes a unit only a human can read: it can't be rendered beside an input, appended to a cell, converted, or checked. A calendar year is a point in time and takes no unit; a duration in years does |
| **`reference`** | and why converting a `text` field to one is **not safe** — every stored string becomes an unresolvable id. The convention is **additive**: keep the text, add the reference beside it, adjacent and sharing a fieldset |
| **`table`** | line items, the deliberate column subset, and *why* nested table / rollup / reference are excluded. `total_column` must name a numeric column |
| **`fieldset`** | the rule that actually bites: fields sharing a fieldset must be **adjacent**, because the renderer emits one heading per run. All-or-nothing per module |
| **`tools`** | how a register points at the panel that operates on it |
| **rooms** | the seven, and that an unmapped section is a hard failure rather than a default |

## The gate is the point

Prose has no way to fail. `test_docs_module_schema.py` reads the guide from disk and compares it to `module_schema` **as a set, in both directions**:

- **in the schema, not the guide** → an author cannot discover it. *This is the drift that happened.*
- **in the guide, not the schema** → worse: the module fails to load only after it has been written.

A count would have agreed with itself forever and missed both.

**Mutation-checked both ways.** Deleting the `percent` row fails with the first message; adding a `richtext` row fails with the second.

And **the gate caught a flaw in itself on its first run** — the table's header is also `` | `type` | … | ``, so it parsed as a field type called `type` and reported an extra the guide never claimed. A parser that reads its own header as data is exactly why this asserts both directions rather than only "nothing missing", which would have passed.

It also asserts the four rules enforced by gates elsewhere are actually written down (fieldset contiguity, the additive reference convention, a numeric `total_column`, unmapped-section-is-fatal). A guide that omits them sends an author to a failing build with no explanation — the same defect as an undocumented type.

## Also: the plugin-system plan

`docs/internal/module-plugin-system.md` — **a plan, nothing built** — for the WordPress/Joomla-style system: rooms as directories, so a third-party module dropped into a room folder is recognised.

Its core finding is that this **inverts the R26 decision deliberately**. Today a module's room comes from its `section` via one table, and that reasoning was good. But a plugin whose room depends on a line in a core file is not a plugin, it is a patch — so the directory must become authoritative and `ROOM_OF_SECTION` retires. R26's real content (*one canonical home, derived from one place, never stored twice*) survives; the one place becomes the path.

It also names the cost honestly: 133 modules move, four gates that read the tree must be re-pointed, the demo capture regenerates, and a third-party `module.json` **creates a table at runtime** — which is the actual risk here, not code execution, and needs its own answer alongside `SEC-PLUGIN-SANDBOX`. §7 flags that `R32-PLUGIN-TOGGLE` spans three lanes and should be split *before* it is scheduled.

## Verification

- `test_docs_module_schema` **PASS**, manifest **457**, `_manifest_guard()` clean, ruff clean
- `docsPublished` + `docsCurrent` (which read these files from disk) **98/98**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
