### PR TITLE
T&M eTicket — itemise labour/material/equipment, derive the totals, and require a signature

### DIFF
--- a/docs/authoring-modules.md
+++ b/docs/authoring-modules.md
@@ -128,6 +128,24 @@ per-record machinery a repeating row has no room for. A column accepts `label`, 
 `total_column` must name a column that exists **and is numeric**. The register cell shows a summary
 (`3 lines · $118,260`) rather than the grid.
 
+**`totals_into`** writes that sum into a sibling numeric field on every write:
+
+```json
+{ "name": "labor_total", "label": "Labor", "type": "currency" },
+{ "name": "labor_lines", "label": "Labor", "type": "table",
+  "total_column": "amount", "totals_into": "labor_total", "columns": [ … ] }
+```
+
+Use it when an engine or report reads a single number that the rows are the evidence for — an eTicket
+itemises labour but `tm.summarize` reads `labor_total`. The lines win: a hand-typed total cannot
+contradict them, and a `PATCH` touching only the rows still moves the total. The target must exist and
+be numeric.
+
+**Snapshot, do not reference, a rate.** A line that records work done at an agreed rate stores that
+rate. If it pointed at the rate library, re-pricing the library would retroactively change what is
+owed for work already done — an accounting error, not a feature. This is also why `reference` is not a
+column type.
+
 **Do not use a `textarea` for a list.** Prose cannot be summed, filtered, or read by the engines.
 
 ## 3. Workflow (states + buttons)

--- a/services/api/modules/eticket/module.json
+++ b/services/api/modules/eticket/module.json
@@ -22,22 +22,180 @@
       "fieldset": "Dates"
     },
     {
-      "name": "equipment_total",
-      "label": "Equipment $",
-      "type": "number",
-      "fieldset": "Quantities"
+      "name": "labor_total",
+      "label": "Labor",
+      "type": "currency",
+      "fieldset": "Money"
     },
     {
-      "name": "labor_total",
-      "label": "Labor $",
-      "type": "number",
-      "fieldset": "Quantities"
+      "name": "labor_lines",
+      "label": "Labor",
+      "type": "table",
+      "total_column": "amount",
+      "fieldset": "Money",
+      "columns": [
+        {
+          "name": "worker",
+          "label": "Worker / crew",
+          "type": "text"
+        },
+        {
+          "name": "trade",
+          "label": "Trade",
+          "type": "text"
+        },
+        {
+          "name": "classification",
+          "label": "Class",
+          "type": "select",
+          "options": [
+            "Journeyman",
+            "Apprentice",
+            "Foreman",
+            "General Foreman",
+            "Superintendent"
+          ]
+        },
+        {
+          "name": "hours",
+          "label": "Hours",
+          "type": "number",
+          "unit": "hr"
+        },
+        {
+          "name": "ot_hours",
+          "label": "OT hours",
+          "type": "number",
+          "unit": "hr"
+        },
+        {
+          "name": "rate",
+          "label": "Rate",
+          "type": "currency",
+          "unit": "$/hr"
+        },
+        {
+          "name": "amount",
+          "label": "Amount",
+          "type": "currency"
+        }
+      ],
+      "totals_into": "labor_total"
     },
     {
       "name": "material_total",
-      "label": "Material $",
-      "type": "number",
-      "fieldset": "Quantities"
+      "label": "Material",
+      "type": "currency",
+      "fieldset": "Money"
+    },
+    {
+      "name": "material_lines",
+      "label": "Material",
+      "type": "table",
+      "total_column": "amount",
+      "fieldset": "Money",
+      "columns": [
+        {
+          "name": "description",
+          "label": "Description",
+          "type": "text"
+        },
+        {
+          "name": "qty",
+          "label": "Qty",
+          "type": "number"
+        },
+        {
+          "name": "unit",
+          "label": "Unit",
+          "type": "text"
+        },
+        {
+          "name": "unit_price",
+          "label": "Unit price",
+          "type": "currency"
+        },
+        {
+          "name": "amount",
+          "label": "Amount",
+          "type": "currency"
+        }
+      ],
+      "totals_into": "material_total"
+    },
+    {
+      "name": "equipment_total",
+      "label": "Equipment",
+      "type": "currency",
+      "fieldset": "Money"
+    },
+    {
+      "name": "equipment_lines",
+      "label": "Equipment",
+      "type": "table",
+      "total_column": "amount",
+      "fieldset": "Money",
+      "columns": [
+        {
+          "name": "equipment",
+          "label": "Equipment",
+          "type": "text"
+        },
+        {
+          "name": "hours",
+          "label": "Hours",
+          "type": "number",
+          "unit": "hr"
+        },
+        {
+          "name": "idle_hours",
+          "label": "Idle hours",
+          "type": "number",
+          "unit": "hr"
+        },
+        {
+          "name": "rate",
+          "label": "Rate",
+          "type": "currency",
+          "unit": "$/hr"
+        },
+        {
+          "name": "amount",
+          "label": "Amount",
+          "type": "currency"
+        }
+      ],
+      "totals_into": "equipment_total"
+    },
+    {
+      "name": "signed_by",
+      "label": "Signed by (field)",
+      "type": "text",
+      "fieldset": "Sign-off"
+    },
+    {
+      "name": "signed_on",
+      "label": "Signed on",
+      "type": "date",
+      "fieldset": "Sign-off"
+    },
+    {
+      "name": "signature",
+      "label": "Field signature",
+      "type": "signature",
+      "fieldset": "Sign-off"
+    },
+    {
+      "name": "gc_approved_by",
+      "label": "Approved by (GC)",
+      "type": "text",
+      "fieldset": "Sign-off"
+    },
+    {
+      "name": "gc_approved_on",
+      "label": "Approved on",
+      "type": "date",
+      "fieldset": "Sign-off"
     },
     {
       "name": "change_event",
@@ -63,6 +221,10 @@
         "party": [
           "Subcontractor",
           "GC"
+        ],
+        "requires": [
+          "signed_by",
+          "signature"
         ]
       },
       {
@@ -71,6 +233,9 @@
         "action": "gc_sign",
         "party": [
           "GC"
+        ],
+        "requires": [
+          "gc_approved_by"
         ]
       },
       {
@@ -85,9 +250,9 @@
   },
   "workspace": "construction",
   "list_columns": [
-    "change_event",
     "work_date",
     "labor_total",
-    "material_total"
+    "material_total",
+    "signed_by"
   ]
 }

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -38,7 +38,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
-         "test_module_config", "test_module_schema", "test_ref_backfill", "test_module_tables", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
+         "test_module_config", "test_module_schema", "test_eticket_tm", "test_ref_backfill", "test_module_tables", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:

--- a/services/api/src/aec_api/module_schema.py
+++ b/services/api/src/aec_api/module_schema.py
@@ -83,6 +83,10 @@ class FieldDef(BaseModel):
     columns: list[ColumnDef] | None = None
     #: Column whose values are summed into a footer total (must name a numeric column).
     total_column: str | None = None
+    #: MOD-TOTALS — the sibling numeric FIELD this table's total is written into on every write.
+    #: Declared rather than inferred from a naming convention, so it is visible in the config and
+    #: cannot surprise a module whose field happens to be named `<table>_total`.
+    totals_into: str | None = None
     # MOD-SWEEP — the unit a numeric value is measured in ("ft", "yr", "days", "kWh"). The sweep found
     # 170 numeric fields with no unit declared, most encoding it in the field NAME instead
     # (`elevation_ft`, `expected_life_years`). A unit in a name is readable only by a human: it cannot
@@ -231,6 +235,8 @@ def validate_module(mod: dict, *, known_modules: set[str] | None = None,
                         errors.append(f"{key}.{f.name}.{c.name}: select column has no options")
                     if c.unit and c.type not in _NUMERIC_TYPES:
                         errors.append(f"{key}.{f.name}.{c.name}: unit on a {c.type} column")
+                if f.totals_into and not f.total_column:
+                    errors.append(f"{key}.{f.name}: totals_into needs a total_column to sum")
                 if f.total_column:
                     tc = next((c for c in f.columns if c.name == f.total_column), None)
                     if tc is None:
@@ -256,6 +262,19 @@ def validate_module(mod: dict, *, known_modules: set[str] | None = None,
         seen_dest.add(t.dest)
 
     nameset = set(names)
+    by_name = {f.name: f for f in m.fields}
+    for f in m.fields:
+        if f.type == "table" and f.totals_into:
+            tgt = by_name.get(f.totals_into)
+            if tgt is None:
+                errors.append(f"{key}.{f.name}: totals_into {f.totals_into!r} is not a field")
+            elif tgt.type not in _NUMERIC_TYPES:
+                # Writing a sum into a text field would store a number the renderer formats as a
+                # string and no engine can add up — a value that looks right and is inert.
+                errors.append(f"{key}.{f.name}: totals_into {f.totals_into!r} is {tgt.type}, "
+                              "not numeric")
+            elif tgt.type == "table":
+                errors.append(f"{key}.{f.name}: totals_into cannot target another table")
     if m.title_field and m.title_field not in nameset:
         errors.append(f"{key}: title_field {m.title_field!r} is not a field")
     for c in m.list_columns:

--- a/services/api/src/aec_api/modules.py
+++ b/services/api/src/aec_api/modules.py
@@ -80,6 +80,43 @@ def _validate_fields(mod: dict, data: dict) -> None:
         raise HTTPException(422, f"missing required field(s): {', '.join(missing)}")
 
 
+def apply_table_totals(mod: dict, merged: dict) -> dict:
+    """MOD-TOTALS — a `table` field with `totals_into` writes its sum into the named numeric field.
+
+    Line items and the number the engines read were two separate facts a user had to keep in
+    agreement by hand. `tm.summarize` reads `eticket.labor_total`; the labour rows live in
+    `labor_lines`; nothing connected them, so itemising a ticket meant typing the total again and
+    every later edit could silently disagree with its own lines.
+
+    Declared rather than inferred. A convention like "`<table>_total`" would be invisible in the
+    config and would surprise the first module whose field happens to be named that way, so the table
+    says where its sum goes and `validate_module` checks the target exists and is numeric.
+
+    Computed over the MERGED record, not the incoming patch: a PATCH that touches only the lines must
+    still update the total, and one that touches only the total must not be able to contradict its
+    lines — the lines win, because they are the evidence and the total is the summary.
+    """
+    for f in mod.get("fields", []):
+        if f.get("type") != "table" or not f.get("totals_into"):
+            continue
+        rows = merged.get(f["name"])
+        if not isinstance(rows, list):
+            continue                      # legacy free text, or the field was never filled in
+        col = f.get("total_column")
+        if not col:
+            continue
+        total = 0.0
+        for r in rows:
+            if not isinstance(r, dict):
+                continue
+            try:
+                total += float(r.get(col) or 0)
+            except (TypeError, ValueError):
+                continue                  # a bad cell is already reported by validate_record
+        merged[f["totals_into"]] = round(total, 2)
+    return merged
+
+
 def _validate_values(mod: dict, data: dict) -> None:
     """Reject clearly-invalid field values (select outside options, non-numeric numbers) before a
     write — so bad data can't slip into the JSON `data` blob. Partial (present-only) so PATCH works."""
@@ -121,6 +158,7 @@ def create_record(db: Session, key: str, project_id: str, body: dict, actor: str
         data[title_field] = data["subject"]
     _validate_fields(mod, data)
     _validate_values(mod, data)
+    apply_table_totals(mod, data)        # MOD-TOTALS: line items drive the total the engines read
     if (why := fin_gov.locked_reason(key, project_id, data)):     # FIN-GOV period lock
         raise HTTPException(409, why)
     rid = str(uuid.uuid4())
@@ -725,7 +763,7 @@ def update_record(db: Session, key: str, project_id: str, rid: str, data: dict,
                                       "message": "This record changed since you opened it — reload to see the latest.",
                                       "modified_at": cur_iso})
     _validate_values(get_module(key), data)         # partial: only the fields being changed
-    merged = {**(rec.get("data") or {}), **data}
+    merged = apply_table_totals(get_module(key), {**(rec.get("data") or {}), **data})
     # FIN-GOV period lock: a record already in a closed month is frozen, and an open-month record
     # can't be re-dated INTO a closed month — both sides of the merge are checked.
     if (why := fin_gov.locked_reason(key, project_id, rec.get("data"))

--- a/services/api/test_docs_module_schema.py
+++ b/services/api/test_docs_module_schema.py
@@ -77,6 +77,7 @@ for phrase, why in (
     ("adjacent", "fieldset contiguity — the renderer draws a duplicate heading otherwise"),
     ("additive", "text->reference conversion is unsafe; the convention is to add beside"),
     ("total_column", "a table's total must name a numeric column"),
+    ("totals_into", "a table can drive a sibling numeric field; engines read that field"),
     ("unmapped section", "a section with no room makes the module unreachable"),
 ):
     assert phrase in text, f"the guide does not cover: {why}"

--- a/services/api/test_eticket_tm.py
+++ b/services/api/test_eticket_tm.py
@@ -1,0 +1,163 @@
+"""MOD-TOTALS / T&M — an eTicket itemises labour, material and equipment, and the lines drive the total.
+
+A time-and-material ticket is the record of *work done on a day at agreed rates*. The register had
+six fields: a subject, a date, three totals somebody typed in, and a link. The rate libraries
+(`labor_rate`, `material_rate`, `equipment_rate`) existed and **nothing consumed them** — the sweep's
+sharpest finding, and the one idea the user's own earlier Django app had that this platform lacked:
+its `ticket` model composes the rate tables into totals.
+
+Two things are asserted here and they are the whole point:
+
+**1. The lines drive the total, on create and on update.** `tm.summarize` reads
+`eticket.labor_total`; the rows live in `labor_lines`. Before `totals_into` those were two facts a
+human kept in agreement by hand, and every later edit could silently disagree with its own lines. A
+PATCH touching only the lines must move the total — otherwise the summary outlives the evidence.
+
+**2. The rate is SNAPSHOT, not referenced.** A T&M line stores the rate it was worked at. If it
+referenced `labor_rate`, updating that library would retroactively change what a contractor is owed
+for work done last month — an accounting error, not a modelling preference. The `table` type forbids
+reference columns for its own reasons; here the constraint and the correct domain model agree, and
+this test pins the behaviour so a future "improvement" to link them has to argue with it.
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_eticket_tm.py
+"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_eticket_tm.db"
+os.environ["STORAGE_DIR"] = "./test_storage_eticket_tm"
+os.environ["AEC_TRUST_XUSER"] = "1"
+
+for _f in ("./test_eticket_tm.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+from aec_api.modules import apply_table_totals  # noqa: E402
+from aec_api.tm import summarize  # noqa: E402
+
+H = {"X-User": "gc"}
+
+# ---- 1. the pure function, before any HTTP ------------------------------------------------------
+MOD = {"fields": [
+    {"name": "labor_total", "type": "currency"},
+    {"name": "labor_lines", "type": "table", "total_column": "amount", "totals_into": "labor_total",
+     "columns": [{"name": "amount", "type": "currency"}]}]}
+
+assert apply_table_totals(MOD, {"labor_lines": [{"amount": 100}, {"amount": 250.5}]})["labor_total"] == 350.5
+assert apply_table_totals(MOD, {"labor_lines": []})["labor_total"] == 0
+# strings are the normal case — a form posts them, a CSV import posts them
+assert apply_table_totals(MOD, {"labor_lines": [{"amount": "100"}, {"amount": "250.5"}]})["labor_total"] == 350.5
+# a blank or junk cell contributes nothing rather than raising: validate_record already reports it,
+# and a write that 500s because one cell is mistyped loses the whole ticket
+assert apply_table_totals(MOD, {"labor_lines": [{"amount": ""}, {"amount": "x"}, {"amount": 5}]})["labor_total"] == 5
+# legacy free text on a converted field must not be summed OR crash
+assert "labor_total" not in apply_table_totals(MOD, {"labor_lines": "4 hrs @ 85"})
+# a table with no rows key at all leaves the total untouched (a PATCH of an unrelated field)
+assert apply_table_totals(MOD, {"labor_total": 999}) == {"labor_total": 999}
+
+with TestClient(app) as c:
+    pid = c.post("/projects", headers=H, json={"name": "T&M"}).json()["id"]
+
+    # rate libraries exist and are the SOURCE a user copies from — they are not linked
+    c.post(f"/projects/{pid}/modules/labor_rate", headers=H,
+           json={"data": {"trade": "Electrician", "rate": 92.5, "unit": "Hour"}})
+    c.post(f"/projects/{pid}/modules/equipment_rate", headers=H,
+           json={"data": {"equipment": "60T crane", "rate": 310}})
+
+    # ---- 2. create: the total is DERIVED, and the value the caller sent is overridden ------------
+    r = c.post(f"/projects/{pid}/modules/eticket", headers=H, json={"data": {
+        "subject": "Emergency conduit reroute", "work_date": "2026-07-30",
+        "labor_total": 1,                       # deliberately wrong; the lines are the evidence
+        "labor_lines": [
+            {"worker": "J. Rivera", "trade": "Electrician", "classification": "Journeyman",
+             "hours": 8, "ot_hours": 2, "rate": 92.5, "amount": 925},
+            {"worker": "P. Osei", "trade": "Electrician", "classification": "Apprentice",
+             "hours": 8, "rate": 61, "amount": 488}],
+        "equipment_lines": [{"equipment": "60T crane", "hours": 4, "rate": 310, "amount": 1240}],
+        "material_lines": [{"description": "EMT 2\"", "qty": 240, "unit": "lf",
+                            "unit_price": 4.15, "amount": 996}],
+        "signed_by": "M. Chen (owner's rep)", "signed_on": "2026-07-30"}})
+    assert r.status_code == 201, r.text
+    rid = r.json()["id"]
+    got = c.get(f"/projects/{pid}/modules/eticket/{rid}", headers=H).json()["data"]
+    assert got["labor_total"] == 1413, got["labor_total"]        # 925 + 488, NOT the 1 that was sent
+    assert got["equipment_total"] == 1240, got["equipment_total"]
+    assert got["material_total"] == 996, got["material_total"]
+
+    # ---- 3. the engine that reads the totals now sees the itemised truth -------------------------
+    s = summarize([{"data": got, "ref": "ETK-001", "workflow_state": "draft"}])
+    assert s["labor_total"] == 1413 and s["equipment_total"] == 1240, s
+    assert s["grand_total"] == 1413 + 1240 + 996, s["grand_total"]
+
+    # ---- 4. PATCHING ONLY THE LINES MOVES THE TOTAL ----------------------------------------------
+    # The case the derivation exists for: without it the summary outlives the evidence.
+    r = c.patch(f"/projects/{pid}/modules/eticket/{rid}", headers=H, json={
+        "labor_lines": [{"worker": "J. Rivera", "hours": 8, "rate": 92.5, "amount": 925}]})
+    assert r.status_code == 200, r.text
+    got = c.get(f"/projects/{pid}/modules/eticket/{rid}", headers=H).json()["data"]
+    assert got["labor_total"] == 925, got["labor_total"]
+    assert got["equipment_total"] == 1240, "an untouched table's total must not be disturbed"
+
+    # ...and a PATCH of the total alone cannot contradict its own lines
+    c.patch(f"/projects/{pid}/modules/eticket/{rid}", headers=H, json={"labor_total": 999999})
+    got = c.get(f"/projects/{pid}/modules/eticket/{rid}", headers=H).json()["data"]
+    assert got["labor_total"] == 925, "a hand-typed total overrode the lines it summarises"
+
+    # ---- 5. THE RATE IS SNAPSHOT ------------------------------------------------------------------
+    # Re-price the library. The ticket must not move: it records what was agreed on the day.
+    rates = c.get(f"/projects/{pid}/modules/labor_rate", headers=H).json()
+    c.patch(f"/projects/{pid}/modules/labor_rate/{rates[0]['id']}", headers=H, json={"rate": 140})
+    got = c.get(f"/projects/{pid}/modules/eticket/{rid}", headers=H).json()["data"]
+    assert got["labor_lines"][0]["rate"] == 92.5, "the ticket followed a later rate change"
+    assert got["labor_total"] == 925, "a library re-price changed what was already owed"
+
+    # ---- 6. A TICKET CANNOT ADVANCE UNSIGNED -----------------------------------------------------
+    # The workflow already had three states NAMED for signing — draft, super_signed, gc_signed — and
+    # not one `requires`, so a ticket could reach `super_signed` with no signature recorded anywhere.
+    # The states described a process nothing enforced. An unsigned T&M ticket is unbillable in the
+    # field and was freely billable here.
+    unsigned = c.post(f"/projects/{pid}/modules/eticket", headers=H, json={"data": {
+        "subject": "No signature yet", "work_date": "2026-07-30",
+        "labor_lines": [{"worker": "A", "hours": 4, "rate": 90, "amount": 360}]}}).json()["id"]
+
+    r = c.post(f"/projects/{pid}/modules/eticket/{unsigned}/transition", headers=H,
+               json={"action": "super_sign"})
+    # 400, not 422: the engine reports an unmet `requires` as a bad request against the state
+    # machine rather than a validation error on the body. Asserted as the code the engine ACTUALLY
+    # returns — the first version of this test guessed 422 and would have passed on a 500.
+    assert r.status_code == 400, f"an unsigned ticket advanced ({r.status_code}): {r.text}"
+    assert "signed_by" in r.text or "signature" in r.text, r.text
+
+    # sign it in the field, and the same transition now goes through
+    c.patch(f"/projects/{pid}/modules/eticket/{unsigned}", headers=H,
+            json={"signed_by": "M. Chen", "signature": "data:image/png;base64,iVBORw0KGgo="})
+    r = c.post(f"/projects/{pid}/modules/eticket/{unsigned}/transition", headers=H,
+               json={"action": "super_sign"})
+    assert r.status_code == 200, r.text
+    assert r.json()["workflow_state"] == "super_signed", r.json()
+
+    # ...and the GC's acceptance is its own gate, not a rubber stamp on the field signature
+    r = c.post(f"/projects/{pid}/modules/eticket/{unsigned}/transition", headers=H,
+               json={"action": "gc_sign"})
+    assert r.status_code == 400, f"gc_sign passed without a GC approver ({r.status_code})"
+    c.patch(f"/projects/{pid}/modules/eticket/{unsigned}", headers=H,
+            json={"gc_approved_by": "R. Patel"})
+    r = c.post(f"/projects/{pid}/modules/eticket/{unsigned}/transition", headers=H,
+               json={"action": "gc_sign"})
+    assert r.status_code == 200 and r.json()["workflow_state"] == "gc_signed", r.text
+
+    # the sign-off is captured on the original ticket too
+    assert got["signed_by"] == "M. Chen (owner's rep)" and got["signed_on"] == "2026-07-30"
+
+print("ETICKET T&M OK - an eTicket now itemises labour (worker, trade, classification, hours, OT, "
+      "rate), material (qty, unit, unit price) and equipment (hours, idle hours, rate), and each "
+      "table's total is DERIVED into the currency field `tm.summarize` reads — on create, and on a "
+      "PATCH that touches only the lines. A hand-typed total cannot contradict its own lines: the "
+      "lines are the evidence, the total is the summary. The rate is SNAPSHOT on the line, never a "
+      "reference to the rate library: re-pricing `labor_rate` afterwards leaves the ticket at what "
+      "was agreed on the day, because a library edit that retroactively changes what a contractor is "
+      "owed is an accounting error rather than a feature. And the field sign-off (who signed, when) "
+      "is captured at last — an unsigned T&M ticket is unbillable, which made it the most "
+      "consequential fact about the record and the one it did not store.")


### PR DESCRIPTION
Base `6f3ead88`, `git merge-tree` CLEAN as of that SHA. The last substantive item from the field sweep's "not done" list.

## The gap

The rate libraries (`labor_rate`, `material_rate`, `equipment_rate`) existed and **nothing consumed them** — the sweep's sharpest finding, and the one structural idea your earlier Django app had that this platform lacked: its `ticket` model composes those tables into totals.

The register had six fields: a subject, a date, three totals somebody typed in, and a link.

It now itemises **labour** (worker, trade, classification, hours, OT, rate), **material** (qty, unit, unit price) and **equipment** (hours, idle hours, rate).

## `totals_into` — the lines drive the number the engines read

`tm.summarize` reads `eticket.labor_total`; the rows live in `labor_lines`. Those were two facts a human kept in agreement by hand, and every later edit could silently disagree with its own lines.

```json
{ "name": "labor_lines", "type": "table", "total_column": "amount", "totals_into": "labor_total" }
```

**Declared, not inferred.** A `<table>_total` naming convention would be invisible in the config and would surprise the first module whose field happened to be named that way. Computed over the **merged** record, so a `PATCH` touching only the rows still moves the total — and a hand-typed total cannot contradict its own lines. The lines are the evidence; the total is the summary.

`validate_module` checks the target exists and is numeric: writing a sum into a text field would store a number the renderer formats as a string and no engine can add up — a value that looks right and is inert.

## The rate is snapshot, not referenced

A line stores the rate it was worked at. If it pointed at `labor_rate`, re-pricing that library would **retroactively change what a contractor is owed for work done last month** — an accounting error, not a modelling preference.

The `table` type forbids `reference` columns for its own reasons; here the constraint and the correct domain model agree. The test pins it, so a future "improvement" to link them has to argue with it.

## Tickets must be signed

The workflow already had three states **named** for signing — `draft → super_signed → gc_signed → billed` — and **not one `requires`**. A ticket reached `super_signed` with no signature recorded anywhere. The states described a process nothing enforced, and an unsigned T&M ticket is unbillable in the field.

`super_sign` now requires the field signature; `gc_sign` requires the GC approver — each its own gate rather than a rubber stamp on the other.

## Also completes a triaged finding

The three totals were typed `number` with a `$` in the label, so the fieldset pass filed them under **Quantities** rather than Money. Retyped to `currency`, which fixes the rendering and the grouping together.

## Verification

- `test_eticket_tm` **PASS**, including inside a full-suite run · `test_module_config`, `test_module_tables`, `test_docs_module_schema`, `test_modules`, `test_module_fields` all PASS · ruff clean
- manifest **459**, `_manifest_guard()` clean · `alembic check` clean (no new table, so no revision)
- **Four mutation checks fire**: dropping the create-path derivation stores the caller's bogus value; dropping the update-path derivation leaves a stale total; removing the signature requirement lets an unsigned ticket advance (200); removing `table` handling breaks the type gate

**Honest caveat on the full suite.** I could not get a clean end-to-end local run — this machine ran out of virtual memory partway through the session (`fork: Resource temporarily unavailable`, `paging file is too small`), and three subsequent runs were cut short at 173–284 of 459 suites. Every failure I spot-checked from those runs passes solo: `test_ref_backfill`, `test_notices_route`, `test_alembic_migrations`, `test_grid`, `test_bim_columns`, `test_scan_cache`. That is my environment, not this branch — **CI on the merged tree is the number that counts here**, and I would rather say so than quote a partial run as if it were a result.

I also corrected myself mid-way: I attributed one batch of 54 failures to "the ifcopenshell DLL signature" when **zero** of them mentioned it. I pattern-matched to a previous failure instead of reading the output.

## Docs

`totals_into` and the snapshot rule are documented in `docs/authoring-modules.md`, and the docs gate widened to require it — the spec has to keep up with the schema it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
