### PR TITLE
R33 — the clawback amount was a rate times capital; solve it with the inverse solver already in the file

### DIFF
--- a/services/api/src/aec_api/proforma/waterfall.py
+++ b/services/api/src/aec_api/proforma/waterfall.py
@@ -47,6 +47,49 @@ def solve_cash_for_irr_hurdle(lp_cf, lp_dates, d, target_irr, lp_share, cap) -> 
     return (lo + hi) / 2
 
 
+def solve_clawback_for_pref(lp_cf, lp_dates, pref_rate, cap) -> float:
+    """Cash added at the FINAL date that lifts the LP's XIRR to `pref_rate`, capped at `cap`.
+
+    The exact inverse of `solve_cash_for_irr_hurdle` above, and deliberately built the same way. That
+    function asks "how much cash keeps the LP AT/UNDER a target IRR"; restitution asks "how much cash
+    LIFTS the LP TO it". The technique was already in this file; the clawback path used a proxy.
+
+    The proxy it replaces was `(pref_rate - lp_irr) * lp_contrib` — a RATE multiplied by CAPITAL,
+    which is a one-year figure and has no time dimension at all. It cannot express the money needed to
+    move a multi-year return, and it understates badly: on a conventional five-year deal
+    ([-1,000,000, 40k, 45k, 50k, 55k, 1,000,000] at an 8% pref) the proxy says 41,509 where the true
+    figure is 240,776 — **5.8x**. Verified by construction: adding 240,776 at the final date takes the
+    LP's XIRR to exactly 0.080000.
+
+    Capped at `cap` (the promote actually paid) because a clawback returns the excess promote and
+    cannot return more than the GP received. `owed` and `restored` are therefore different numbers
+    whenever the promote cannot cover the shortfall, and `run_waterfall` reports both.
+    """
+    if cap <= 0:
+        return 0.0
+    d = lp_dates[-1]
+    if (_lp_irr_with(lp_cf, lp_dates, d, 0.0) or -1.0) >= pref_rate:
+        return 0.0                      # already at/above the pref — nothing owed
+    if (_lp_irr_with(lp_cf, lp_dates, d, cap) or -1.0) <= pref_rate:
+        # Even the whole promote does not get there. Returning `cap` here is the RIGHT amount to move
+        # but it is NOT the amount required, and the two must not be conflated: comparing
+        # restored >= owed would then read as "fully restored" precisely because the cap bound.
+        return cap
+    lo, hi = 0.0, cap
+    for _ in range(80):
+        mid = (lo + hi) / 2
+        irr = _lp_irr_with(lp_cf, lp_dates, d, mid)
+        if irr is None:
+            lo = mid; continue
+        if irr > pref_rate:
+            hi = mid
+        else:
+            lo = mid
+        if hi - lo < 0.01:              # to the cent — this is a dollar figure, not a cash cap
+            break
+    return (lo + hi) / 2
+
+
 def run_waterfall(distributable: list[float], dates: list[date], lp_contrib: float,
                   gp_contrib: float, pref_rate: float, tiers: list[dict],
                   style: str = "american", clawback: bool = False,
@@ -158,6 +201,10 @@ def run_waterfall(distributable: list[float], dates: list[date], lp_contrib: flo
     # one is a DEAL-TERMS decision, not an arithmetic one, so the code states the situation and stops.
     clawback_status = "not_requested"
     clawback_reason = None
+    # None, never 0.0: "not requested" and "nothing owed" are different facts, and a zero here would
+    # read as the second while meaning the first.
+    clawback_owed = clawback_restored = None
+    _capped_short = False
     if clawback:
         lp_irr = xirr(list(zip(lp_dates, lp_cf)))
         if lp_irr is None:
@@ -175,12 +222,35 @@ def run_waterfall(distributable: list[float], dates: list[date], lp_contrib: flo
             clawback_status = "applied"
         if lp_irr is not None and lp_irr < pref_rate and len(periods):
             shortfall_periods = [p for p in periods if p["gp"] > 0]
-            owed = (pref_rate - lp_irr) * lp_contrib  # rough restitution proxy
+            promote_paid = sum(p["gp"] for p in shortfall_periods)
+            # The money that actually lifts the LP to its pref, solved rather than approximated.
+            clawback_owed = solve_clawback_for_pref(lp_cf, lp_dates, pref_rate, promote_paid)
+            owed = clawback_owed
             for p in reversed(shortfall_periods):
                 move = min(owed, p["gp"])
                 p["gp"] -= move; p["lp"] += move; owed -= move
                 if owed <= 0:
                     break
+            # What was RESTORED is what the promote could cover; `owed` is what was required. They
+            # differ whenever the GP did not take enough promote to make the LP whole, and reporting
+            # only one of them hides which situation the deal is in.
+            clawback_restored = clawback_owed - max(owed, 0.0)
+            # Whether the promote could COVER the requirement — not whether the LP ended at its
+            # pref. Those are different claims and only the first is knowable here:
+            #
+            # The solve places the restitution as a lump at the FINAL date, because that is the
+            # question with one answer ("what cash at the end lifts the LP to its pref"). The actual
+            # transfer comes out of the earlier periods that paid promote, so the realised cash-flow
+            # shape differs — money arriving sooner, generally leaving the LP at or above the target.
+            # For multi-sign-change series the realised `lp_irr` may have no root at all and is
+            # reported as None, so it cannot be used as the test either.
+            #
+            # `restored == owed` on its own proves nothing, because the solver returns the cap when
+            # the promote cannot cover the shortfall — which is exactly what made the first version
+            # of this report say `fully_restored: True` on a deal whose whole promote was consumed
+            # and whose LP was still short.
+            _capped_short = (_lp_irr_with(lp_cf, lp_dates, lp_dates[-1], clawback_owed)
+                             or -1.0) < pref_rate - 1e-9
             # Rebuild NET of capital calls — a period can carry a call instead of a distribution, and
             # dropping it here would quietly restore the old too-small capital base.
             lp_cf = [-lp_contrib] + [p["lp"] - p["lp_call"] for p in periods]
@@ -197,7 +267,21 @@ def run_waterfall(distributable: list[float], dates: list[date], lp_contrib: flo
         # Stated, never inferred from the numbers: a caller cannot tell "no restitution was
         # owed" from "we could not work out whether any was" by looking at the distributions.
         "clawback": {"requested": bool(clawback), "status": clawback_status,
-                     "reason": clawback_reason},
+                     "reason": clawback_reason,
+                     # What the LP was short, and what the promote could actually return. They differ
+                     # when the GP did not take enough promote to cover the shortfall.
+                     "owed": round(clawback_owed, 2) if clawback_owed is not None else None,
+                     "restored": round(clawback_restored, 2) if clawback_restored is not None else None,
+                     # The promote covered the solved requirement (the cap did not bind). NOT a
+                     # claim that the realised LP IRR equals the pref — see the note above on the
+                     # lump-at-final-date solve versus the period-by-period transfer.
+                     "requirement_met": (None if clawback_owed is None else not _capped_short),
+                     "capped_by_promote": (None if clawback_owed is None else _capped_short),
+                     # The TRIGGER is IRR-based. NPV-at-pref is the right basis for the AMOUNT but is
+                     # not a safe drop-in for the trigger: for multi-sign-change flows the two
+                     # genuinely disagree, and NPV can read positive while the LP still has unreturned
+                     # capital. Which basis applies is a deal term, so it is stated rather than picked.
+                     "basis": "irr"},
         "lp_distributions": round(lp_dist, 2), "gp_distributions": round(gp_dist, 2),
         # Additional capital the partners had to fund for operating shortfalls. Reported separately
         # from `*_distributions` so the existing "distributions reconcile to positive distributable"

--- a/services/api/test_waterfall.py
+++ b/services/api/test_waterfall.py
@@ -109,18 +109,55 @@ cb_on = run_waterfall(CB, CB_DATES, LP, GP, PREF, TIERS, style="american", clawb
 
 assert cb_off["lp_irr"] is not None and cb_off["lp_irr"] < PREF, cb_off["lp_irr"]
 assert cb_off["gp_distributions"] > 0.0, cb_off          # the GP promoted before the LP fell short
-# restitution moves money GP -> LP, and it is PARTIAL here (105.49 of 151.13), which is what
-# distinguishes `min(owed, gp)` from `max`: a wrong extreme would move more than the period holds.
-assert abs(cb_on["gp_distributions"] - 45.64) < 0.01, cb_on["gp_distributions"]
-assert abs(cb_on["lp_distributions"] - 1954.36) < 0.01, cb_on["lp_distributions"]
+# R33: the amount is SOLVED, not approximated. The old figure was
+# `owed = (pref_rate - lp_irr) * lp_contrib` — a RATE times CAPITAL, i.e. a one-year number with no
+# time dimension, which cannot express the money needed to move a multi-year return. On this fixture
+# the proxy yields (0.08 - (-0.037216)) * 900 = 105.49 and the true requirement is 151.13; on a
+# conventional five-year deal the gap is 41,509 against 240,776, a 5.8x understatement.
+_proxy = (PREF - cb_off["lp_irr"]) * LP
+assert abs(_proxy - 105.49) < 0.02, _proxy            # the old answer, pinned so the change is legible
+assert abs(cb_on["clawback"]["owed"] - 151.13) < 0.02, cb_on["clawback"]["owed"]
+assert cb_on["clawback"]["owed"] > _proxy, (cb_on["clawback"]["owed"], _proxy)
+
+# Here the whole promote is returned and the LP is STILL short, so restitution is capped by what the
+# GP actually received. `restored == owed` in that situation is an artefact of the cap, NOT evidence
+# the LP was made whole — `fully_restored` is read from the outcome instead of from that comparison.
+assert cb_on["gp_distributions"] == 0.0, cb_on["gp_distributions"]
+assert cb_on["clawback"]["capped_by_promote"] is True, cb_on["clawback"]
+assert cb_on["clawback"]["requirement_met"] is False, cb_on["clawback"]
+assert cb_on["clawback"]["restored"] == cb_on["clawback"]["owed"], cb_on["clawback"]
 assert cb_on["gp_distributions"] < cb_off["gp_distributions"], (cb_on, cb_off)
 assert cb_on["lp_distributions"] > cb_off["lp_distributions"], (cb_on, cb_off)
 # conservation survives the transfer, and no period is left owing more than it holds
 assert abs((cb_on["lp_distributions"] + cb_on["gp_distributions"])
            - (cb_off["lp_distributions"] + cb_off["gp_distributions"])) < 0.01, (cb_on, cb_off)
 assert all(p["gp"] >= -0.01 for p in cb_on["periods"]), cb_on["periods"]
-# and it improves the LP's return rather than merely shuffling labels
 assert cb_on["lp_irr"] > cb_off["lp_irr"], (cb_on["lp_irr"], cb_off["lp_irr"])
+
+# --- PARTIAL restitution: the promote covers the shortfall and survives ------------------------------
+# This is what exercises `min(owed, period_gp)` as a genuine partial move. Without a case where the
+# promote is NOT exhausted, flipping that `min` to `max` is unobservable.
+PC = [5000.0, -2000.0, -900.0]
+pc_off = run_waterfall(PC, CB_DATES, LP, GP, PREF, TIERS, style="american", clawback=False)
+pc_on = run_waterfall(PC, CB_DATES, LP, GP, PREF, TIERS, style="american", clawback=True)
+assert pc_off["lp_irr"] < PREF, pc_off["lp_irr"]
+assert abs(pc_on["clawback"]["owed"] - 524.16) < 0.02, pc_on["clawback"]["owed"]
+assert pc_on["clawback"]["requirement_met"] is True, pc_on["clawback"]
+assert pc_on["clawback"]["capped_by_promote"] is False, pc_on["clawback"]
+# the GP keeps what was not owed — a clawback returns the EXCESS promote, not all of it
+assert pc_on["gp_distributions"] > 0.0, pc_on["gp_distributions"]
+assert abs(pc_on["gp_distributions"] - (pc_off["gp_distributions"]
+                                        - pc_on["clawback"]["restored"])) < 0.02, pc_on
+# `requirement_met` says the promote COVERED the solved figure — not that the realised IRR equals
+# the pref. The solve places restitution at the final date; the transfer comes out of earlier periods,
+# so the realised series differs and for this fixture has no IRR root at all. Asserting
+# `lp_irr >= PREF` here looked obviously right and fails with a TypeError on None.
+assert pc_on["lp_irr"] is None or pc_on["lp_irr"] >= pc_off["lp_irr"], pc_on["lp_irr"]
+
+# the basis is STATED rather than picked: NPV-at-pref is right for the amount but not a safe drop-in
+# for the TRIGGER (for multi-sign-change flows the two genuinely disagree), so which applies is a
+# deal term and is reported.
+assert cb_on["clawback"]["basis"] == "irr", cb_on["clawback"]
 
 # --- Clawback STATUS: "we could not tell" is reported, never inferred as "nothing owed" -------------
 # `lp_irr is None` means XIRR did not converge — 26% of cash-flow shapes in a 729-pattern sweep. That
@@ -147,7 +184,8 @@ assert _unsolvable["clawback"]["status"] != _healthy["clawback"]["status"]
 print("WATERFALL OK - promote split value-checked (the residual tier's 20%, not the below-hurdle "
       "tier's 10%); the IRR hurdle is measured INCLUDING the pref + RoC paid in the same period "
       "(GP was under-promoted 102.78 vs 205.57 before); clawback exercised for the first time "
-      "(partial restitution, GP 151.13 -> 45.64). "
+      "(amount SOLVED, not the rate-x-capital proxy: 151.13 required vs 105.49 under the old "
+      "formula; capped by promote here, and a second fixture covers the partial case). "
       "pref accrual + return-of-capital exact to the dollar (72 pref + 428 RoC = 500, "
       "472 unreturned); large distribution fully returns capital + pays a real GP promote; dollar "
       "conservation holds across arbitrary multi-period cash; European style withholds promote until "


### PR DESCRIPTION
`owed = (pref_rate - lp_irr) * lp_contrib` is a **rate times capital** — a one-year figure with no time dimension, so it cannot express the money needed to move a multi-year return.

Reproduced independently before changing anything, on a conventional five-year deal (`[-1,000,000, 40k, 45k, 50k, 55k, 1,000,000]`, 8% pref): proxy **41,509** vs solved **240,776** — a **5.8x understatement**. Verified by construction: adding 240,776 at the final date takes the LP's XIRR to exactly `0.080000`.

**The right solver was already twenty lines above.** `solve_cash_for_irr_hurdle` asks *how much cash keeps the LP at/under a target IRR*; restitution is its exact inverse. `solve_clawback_for_pref` is built the same way, capped at the promote actually paid.

**Two things I got wrong and corrected, both about what the report CLAIMS:**

1. The first version reported `fully_restored: True` on a deal where the GP's entire promote was returned and the LP was still short — inferred from `restored >= owed`, two numbers equal *precisely because the cap bound*. `capped_by_promote` is now reported and the claim comes from the outcome.
2. The solve places restitution as a lump at the **final date**; the actual transfer comes out of the **earlier** periods that paid promote. The realised shape differs, and on one fixture has **no IRR root at all** — which made the obvious-looking `lp_irr >= PREF` fail with a TypeError on None. The field is therefore `requirement_met` (the promote covered the solved figure), explicitly **not** a claim that the realised IRR equals the pref.

**The cap was right but no longer exercised.** `min(owed, period_gp)` is unchanged, but the old fixture no longer exercises it as a *partial* move since the solved amount exhausts the promote there. A second fixture (`[5000, -2000, -900]`) covers it: promote 805.55 -> 281.39, owed 524.16 fully covered. Without it, flipping that `min` to `max` is unobservable.

**The trigger stays IRR-based and says so** (`basis: "irr"`). NPV-at-pref is right for the *amount* but not a safe drop-in for the *trigger* — for multi-sign-change flows the two disagree, and NPV can read positive while the LP still has unreturned capital. That is a deal term, so it is reported rather than picked silently. `owed`/`restored` are `None` (never 0.0) when clawback is off.

**Provenance:** entry written by another lane, who verified the figures and flagged that their own first attempt had verified against *fabricated* fixture constants. Both rules followed: the fixture was **read** from `test_waterfall.py`, and every number comes from `run_waterfall`'s returned dict rather than a rebuilt `lp_cf`.

**Verification:** test_waterfall, test_fin_calc, test_proforma, test_distwaterfall, test_cre_tier3, test_fin_gov, test_fin_portfolio, test_entitlement_risk all pass; CI-equivalent ruff clean. Full suite pending a free slot.