### PR TITLE
MOD-FIELDATTRS — min, max, placeholder, default complete the field vocabulary

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -234,6 +234,14 @@ export interface ModuleField {
    *  converted, or checked. Declaring it makes the number self-describing, which is most of the
    *  difference between a form and a tool. */
   unit?: string;
+  /** MOD-FIELDATTRS — numeric bounds. Rendered as input attributes AND enforced server-side; the
+   *  HTML attribute is advice to one browser and nothing to a CSV import or an integration. */
+  min?: number;
+  max?: number;
+  /** Hint text inside an empty input. Only on types that HAVE a text box to put it in. */
+  placeholder?: string;
+  /** Pre-filled on a NEW record only — re-filling on update would make "empty" unreachable. */
+  default?: string | number | boolean;
   /** MOD-TABLE — the columns of a `table` field (line items). Absent on every other type. */
   columns?: ModuleColumn[];
   /** Numeric column summed into a footer total. Validated server-side to name a numeric column. */

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -2552,9 +2552,20 @@ export class PortalUI {
         // the field-sweep branch, which is merged to `main` but not into this one — and it cannot be
         // merged in right now without git overwriting two files another session is holding dirty. A
         // local structural read is correct on both sides of that merge and costs nothing once it lands.
-        const unit = (f as { unit?: string }).unit;
-        if (unit) { inp.placeholder = unit; inp.setAttribute("aria-description", `in ${unit}`); }
-        inp.value = String(cur(f.name) ?? "");
+        const unit = f.unit;
+        // MOD-FIELDATTRS: an explicit placeholder wins over the unit hint — the unit was only ever a
+        // fallback for "this box has no guidance at all".
+        if (f.placeholder) inp.placeholder = f.placeholder;
+        else if (unit) inp.placeholder = unit;
+        if (unit) inp.setAttribute("aria-description", `in ${unit}`);
+        if (f.min != null) inp.min = String(f.min);
+        if (f.max != null) inp.max = String(f.max);
+        // A default is for a NEW record. On an edit, an absent value is a value the user cleared.
+        const existing = cur(f.name);
+        // `@today` is resolved on both sides: the form shows the date the user is about to save, and
+        // the server fills it for any caller that never opened a form (import, integration, script).
+        const dflt = f.default === "@today" ? new Date().toISOString().slice(0, 10) : f.default;
+        inp.value = String(existing ?? (editing ? "" : (dflt ?? "")));
       }
       inputs[f.name] = el; wrap.appendChild(el);
       if (f.type === "select" || f.type === "multiselect") wrap.appendChild(addOptBtn(f, el as HTMLSelectElement));

--- a/docs/authoring-modules.md
+++ b/docs/authoring-modules.md
@@ -148,6 +148,37 @@ column type.
 
 **Do not use a `textarea` for a list.** Prose cannot be summed, filtered, or read by the engines.
 
+## Bounds, hints and defaults
+
+`min` / `max` (numeric only) are enforced **server-side** in `validate_record`, not just rendered as
+input attributes — an HTML `min` is advice to one browser and nothing to a CSV import, an integration
+or a script, which is how out-of-range values actually arrive.
+
+A bound that rejects a real value is worse than no bound: it makes the honest number un-enterable and
+pushes it somewhere unvalidated. `percent` means *proportion*, not *0..100* — an IRR is negative on a
+losing deal and over 100% on a fast one, and escalation is negative under deflation. Bound a
+percentage only when the quantity genuinely cannot leave the range.
+
+`placeholder` is hint text inside an empty box, so it is rejected on types that have no box (select,
+checkbox, table, reference, …) rather than declared and silently never rendered.
+
+**`default` is different in kind from the other three, and is deliberately rare.** They constrain or
+explain a value the user supplies; a default **writes a value nobody chose**. Default `retainage_pct`
+to 10 and every record on a 5% job carries the wrong number — formatted correctly, in the right
+field, looking exactly like something somebody decided.
+
+Use it only where the value is a fact about the **record**, never a **policy**:
+
+```json
+{ "name": "report_date", "type": "date", "default": "@today" }
+```
+
+`@today` resolves on both sides — the form shows the date about to be saved, the server fills it for
+any caller that never opened a form. Applied on **create only**: re-filling on update would make
+"empty" unreachable and a user's clearing look like it failed. An explicit `0` is an answer and
+survives. `test_field_attrs.py` caps the number of defaulted fields — the only **ceiling** in the
+module gates, because here the risk runs the other way.
+
 ## 3. Workflow (states + buttons)
 
 Add a `workflow` to give records a lifecycle (draft → submitted → answered → closed). Each transition

--- a/docs/internal/module-field-sweep.md
+++ b/docs/internal/module-field-sweep.md
@@ -147,13 +147,33 @@ link does not.
 requires editing it, undoing the work fails it. It also asserts the pair-adjacency and shared-fieldset
 rules, and the three calendar-year exceptions by name.
 
-## 8. Not done
+## 8. Not done — CLOSED 2026-07-31
 
-1. **Per-field filters and server-side sort** (§6) — the biggest remaining CRUD gap.
-2. **The `table` field type** — still the blocker for the 22 list-in-a-textarea fields and for `sov`,
-   `estimate`, `bid_submission` being documents rather than rows.
-3. **Backfilling the 54 new reference fields** from their text twins — needs a matcher and a review
-   step; a wrong auto-link is worse than an empty one.
-4. **`eticket` → rate libraries** (§4), the highest-value relationship still missing.
-5. **`default`, `min`/`max`, `placeholder`, `readonly`** — the rest of the field vocabulary.
-6. **Fieldsets on the remaining 62 modules** with none.
+All six items shipped. Kept with their outcomes rather than deleted, because what each one turned
+into is more useful than the fact that it is finished.
+
+| # | Item | Shipped as | What it actually turned out to be |
+|---|---|---|---|
+| 1 | Per-field filters + server-side sort | `MOD-FILTER` (#109) | The sort was the real defect: it ran in the browser over the fetched page, so "sort by amount" on a 500-row register ordered 200 rows and presented them as the largest. Nothing looked wrong; it was the wrong 200 rows |
+| 2 | The `table` field type | `MOD-TABLE` (#111) | Shippable only because a **legacy string is preserved**, not rejected — 22 of these were textareas, so live records hold prose where rows are expected |
+| 3 | Backfill the 54 references | `MOD-BACKFILL` (#113) | A refusal engine. Exact-match-only, unique-or-nothing, every skip reported. *An empty reference is visibly empty and gets filled; a wrong one resolves, opens a real record, shows a plausible name, and is never questioned* |
+| 4 | `eticket` → rate libraries | `MOD-TOTALS` (#134) | The rate is **snapshot, not referenced** — re-pricing the library must not change what is already owed. And the workflow had three states *named* for signing with no `requires`, so a ticket reached `super_signed` unsigned |
+| 5 | `min` / `max` / `placeholder` / `default` | `MOD-FIELDATTRS` | `default` is different in kind from the other three: it **writes a value nobody chose**. Four fields in 133 modules carry one, and the gate is a **ceiling** |
+| 6 | Fieldsets on 62 modules | `MOD-FIELDSET` (#112) | Surfaced three modules non-contiguous since before the sweep, because `test_modules` checked contiguity for an *enumerated list of thirteen* |
+
+**`readonly` was dropped rather than built.** It was listed here as a field attribute, but nothing in
+the sweep found a field that needed one: a value the user must not edit is either computed (`rollup`,
+or a table's `totals_into` target) or set by a workflow transition. A `readonly` flag would have been
+a fourth way to say the same thing, and the first place it disagreed with the other three would have
+been a bug nobody could locate.
+
+### Still open, and genuinely so
+
+- **`sov` and `owner_invoice` as documents.** `estimate` gained `line_items`; the AIA G702/G703 pair
+  did not. `sov` is still one record per line with no parent, so the continuation sheet is assembled
+  by `cost.g703` rather than stored. That is the last structural item from §6.
+- **A `reference` column type for tables.** Deliberately excluded (see `TABLE_COLUMN_TYPES`) because a
+  picker per row is a real feature and shipping it half-done would put unresolvable ids in rows.
+- **The element link (`§5 T4`).** Ten registers describe things that *are* model elements and only
+  three carry a GUID, all as plain text. This is the largest remaining gap between the platform's
+  stated premise and the layer users touch.

--- a/services/api/modules/as_built/module.json
+++ b/services/api/modules/as_built/module.json
@@ -37,7 +37,8 @@
       "name": "sheet_count",
       "label": "# Sheets",
       "type": "number",
-      "fieldset": "Drawing"
+      "fieldset": "Drawing",
+      "min": 0
     },
     {
       "name": "status",

--- a/services/api/modules/asset_register/module.json
+++ b/services/api/modules/asset_register/module.json
@@ -80,13 +80,15 @@
       "label": "Expected Life (yrs)",
       "type": "number",
       "fieldset": "Reserve Study",
-      "unit": "yr"
+      "unit": "yr",
+      "min": 0
     },
     {
       "name": "replacement_cost",
       "label": "Replacement Cost",
       "type": "currency",
-      "fieldset": "Reserve Study"
+      "fieldset": "Reserve Study",
+      "min": 0
     },
     {
       "name": "system",

--- a/services/api/modules/bid_package/module.json
+++ b/services/api/modules/bid_package/module.json
@@ -24,7 +24,8 @@
       "name": "budget",
       "label": "Budget",
       "type": "currency",
-      "fieldset": "Package"
+      "fieldset": "Package",
+      "min": 0
     },
     {
       "name": "estimate",

--- a/services/api/modules/bid_submission/module.json
+++ b/services/api/modules/bid_submission/module.json
@@ -32,7 +32,8 @@
       "name": "amount",
       "label": "Amount",
       "type": "currency",
-      "fieldset": "Pricing"
+      "fieldset": "Pricing",
+      "min": 0
     },
     {
       "name": "base_bid",

--- a/services/api/modules/budget/module.json
+++ b/services/api/modules/budget/module.json
@@ -24,7 +24,8 @@
       "name": "budget",
       "label": "Budget",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "committed",

--- a/services/api/modules/cam_expense/module.json
+++ b/services/api/modules/cam_expense/module.json
@@ -44,7 +44,8 @@
       "name": "budget_annual",
       "label": "Budget (annual)",
       "type": "currency",
-      "fieldset": "Amounts"
+      "fieldset": "Amounts",
+      "min": 0
     },
     {
       "name": "actual_annual",

--- a/services/api/modules/capital_plan/module.json
+++ b/services/api/modules/capital_plan/module.json
@@ -51,7 +51,8 @@
       "label": "Estimated Cost",
       "type": "currency",
       "required": true,
-      "fieldset": "Plan"
+      "fieldset": "Plan",
+      "min": 0
     },
     {
       "name": "priority",

--- a/services/api/modules/clash_run/module.json
+++ b/services/api/modules/clash_run/module.json
@@ -23,31 +23,36 @@
       "name": "active_count",
       "label": "Active",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "clash_count",
       "label": "Raw clashes",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "group_count",
       "label": "Coordination issues",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "new_count",
       "label": "New",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "reappeared_count",
       "label": "Reappeared",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "reduction",
@@ -59,7 +64,8 @@
       "name": "resolved_count",
       "label": "Resolved",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     }
   ],
   "list_columns": [

--- a/services/api/modules/commitment/module.json
+++ b/services/api/modules/commitment/module.json
@@ -49,14 +49,17 @@
       "label": "Committed Amount",
       "type": "currency",
       "required": true,
-      "fieldset": "Cost"
+      "fieldset": "Cost",
+      "min": 0
     },
     {
       "name": "retainage_pct",
       "label": "Retainage %",
       "type": "percent",
       "fieldset": "Cost",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "cost_code",

--- a/services/api/modules/comparable/module.json
+++ b/services/api/modules/comparable/module.json
@@ -90,20 +90,23 @@
       "name": "price",
       "label": "Sale price",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "price_per_unit",
       "label": "$/unit",
       "type": "number",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "price_psf",
       "label": "$/SF",
       "type": "number",
       "unit": "$/sf",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "rent_psf",
@@ -116,7 +119,8 @@
       "name": "cap_rate",
       "label": "Cap rate %",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "distance_mi",
@@ -135,7 +139,8 @@
       "name": "land_area",
       "label": "Land area (SF)",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "net_adjustment",

--- a/services/api/modules/completion_certificate/module.json
+++ b/services/api/modules/completion_certificate/module.json
@@ -48,7 +48,9 @@
       "label": "Punch List % Complete",
       "type": "percent",
       "unit": "%",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "record_model_version",

--- a/services/api/modules/coordination_issue/module.json
+++ b/services/api/modules/coordination_issue/module.json
@@ -55,7 +55,8 @@
       "name": "clash_count",
       "label": "Clashes in group",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "severity_score",

--- a/services/api/modules/cor/module.json
+++ b/services/api/modules/cor/module.json
@@ -19,7 +19,8 @@
       "label": "Amount",
       "type": "currency",
       "required": true,
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "min": 0
     },
     {
       "name": "reason",
@@ -54,31 +55,36 @@
       "label": "Schedule Days",
       "type": "number",
       "fieldset": "Cost & schedule",
-      "unit": "days"
+      "unit": "days",
+      "min": 0
     },
     {
       "name": "labor_cost",
       "label": "Labor",
       "type": "currency",
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "min": 0
     },
     {
       "name": "material_cost",
       "label": "Material",
       "type": "currency",
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "min": 0
     },
     {
       "name": "equipment_cost",
       "label": "Equipment",
       "type": "currency",
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "min": 0
     },
     {
       "name": "markup_cost",
       "label": "Overhead & profit",
       "type": "currency",
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "min": 0
     },
     {
       "name": "justification",

--- a/services/api/modules/daily_report/module.json
+++ b/services/api/modules/daily_report/module.json
@@ -12,7 +12,8 @@
       "label": "Date",
       "type": "date",
       "required": true,
-      "fieldset": "Conditions"
+      "fieldset": "Conditions",
+      "default": "@today"
     },
     {
       "name": "weather",

--- a/services/api/modules/design_option/module.json
+++ b/services/api/modules/design_option/module.json
@@ -44,20 +44,24 @@
       "label": "Gross area (sf)",
       "type": "number",
       "fieldset": "Program",
-      "unit": "sf"
+      "unit": "sf",
+      "min": 0
     },
     {
       "name": "unit_count",
       "label": "Units / key rooms",
       "type": "number",
-      "fieldset": "Program"
+      "fieldset": "Program",
+      "min": 0
     },
     {
       "name": "efficiency_pct",
       "label": "Efficiency (%)",
       "type": "percent",
       "fieldset": "Program",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "building_type",
@@ -86,7 +90,8 @@
       "name": "hard_cost",
       "label": "Hard cost ($)",
       "type": "number",
-      "fieldset": "Economics"
+      "fieldset": "Economics",
+      "min": 0
     },
     {
       "name": "energy_eui",

--- a/services/api/modules/direct_cost/module.json
+++ b/services/api/modules/direct_cost/module.json
@@ -63,7 +63,8 @@
       "label": "Actual Amount",
       "type": "currency",
       "required": true,
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "commitment",

--- a/services/api/modules/drainage_area/module.json
+++ b/services/api/modules/drainage_area/module.json
@@ -32,7 +32,8 @@
       "label": "Area (sf)",
       "type": "number",
       "fieldset": "Catchment",
-      "unit": "sf"
+      "unit": "sf",
+      "min": 0
     },
     {
       "name": "runoff_coefficient",
@@ -65,7 +66,8 @@
       "label": "Storm Depth (in)",
       "type": "number",
       "fieldset": "Storm",
-      "unit": "in"
+      "unit": "in",
+      "min": 0
     }
   ],
   "workflow": {

--- a/services/api/modules/drawing_issuance/module.json
+++ b/services/api/modules/drawing_issuance/module.json
@@ -74,7 +74,8 @@
       "name": "sheet_count",
       "label": "Sheets",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "description",

--- a/services/api/modules/due_diligence/module.json
+++ b/services/api/modules/due_diligence/module.json
@@ -62,7 +62,8 @@
       "name": "cost",
       "label": "Study Cost",
       "type": "currency",
-      "fieldset": "Commercial"
+      "fieldset": "Commercial",
+      "min": 0
     },
     {
       "name": "ordered_date",

--- a/services/api/modules/envelope_assembly/module.json
+++ b/services/api/modules/envelope_assembly/module.json
@@ -33,14 +33,24 @@
       "name": "climate_zone",
       "label": "Climate zone (IECC)",
       "type": "select",
-      "options": ["1", "2", "3", "4", "5", "6", "7", "8"],
+      "options": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8"
+      ],
       "fieldset": "Assembly"
     },
     {
       "name": "r_value",
       "label": "R-value (h·ft²·°F/Btu)",
       "type": "number",
-      "fieldset": "Thermal"
+      "fieldset": "Thermal",
+      "min": 0
     },
     {
       "name": "u_factor",
@@ -57,16 +67,27 @@
   ],
   "workflow": {
     "initial": "proposed",
-    "states": ["proposed", "approved"],
+    "states": [
+      "proposed",
+      "approved"
+    ],
     "transitions": [
       {
         "from": "proposed",
         "to": "approved",
         "action": "approve",
-        "party": ["Engineer", "Architect", "PM"]
+        "party": [
+          "Engineer",
+          "Architect",
+          "PM"
+        ]
       }
     ]
   },
-  "list_columns": ["element_type", "climate_zone", "r_value"],
+  "list_columns": [
+    "element_type",
+    "climate_zone",
+    "r_value"
+  ],
   "workspace": "design"
 }

--- a/services/api/modules/environmental_monitoring/module.json
+++ b/services/api/modules/environmental_monitoring/module.json
@@ -18,7 +18,8 @@
       "name": "value",
       "label": "Value",
       "type": "number",
-      "fieldset": "Reading"
+      "fieldset": "Reading",
+      "min": 0
     },
     {
       "name": "date",

--- a/services/api/modules/equipment_log/module.json
+++ b/services/api/modules/equipment_log/module.json
@@ -18,13 +18,15 @@
       "name": "date",
       "label": "Date",
       "type": "date",
-      "fieldset": "Dates"
+      "fieldset": "Dates",
+      "default": "@today"
     },
     {
       "name": "hours",
       "label": "Hours",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "daily_report",

--- a/services/api/modules/equipment_rate/module.json
+++ b/services/api/modules/equipment_rate/module.json
@@ -16,7 +16,8 @@
     {
       "name": "rate",
       "label": "Rate $/hr",
-      "type": "currency"
+      "type": "currency",
+      "min": 0
     },
     {
       "name": "unit",

--- a/services/api/modules/estimate/module.json
+++ b/services/api/modules/estimate/module.json
@@ -37,7 +37,8 @@
       "name": "amount",
       "label": "Amount",
       "type": "number",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "line_items",

--- a/services/api/modules/estimate_set/module.json
+++ b/services/api/modules/estimate_set/module.json
@@ -63,7 +63,8 @@
       "label": "Total Estimate",
       "type": "currency",
       "required": true,
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "gsf",

--- a/services/api/modules/eticket/module.json
+++ b/services/api/modules/eticket/module.json
@@ -19,13 +19,15 @@
       "label": "Date of Work",
       "type": "date",
       "required": true,
-      "fieldset": "Dates"
+      "fieldset": "Dates",
+      "default": "@today"
     },
     {
       "name": "labor_total",
       "label": "Labor",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "labor_lines",
@@ -86,7 +88,8 @@
       "name": "material_total",
       "label": "Material",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "material_lines",
@@ -127,7 +130,8 @@
       "name": "equipment_total",
       "label": "Equipment",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "equipment_lines",

--- a/services/api/modules/evm_snapshot/module.json
+++ b/services/api/modules/evm_snapshot/module.json
@@ -73,7 +73,9 @@
       "label": "% complete",
       "type": "percent",
       "fieldset": "Forecast",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "notes",

--- a/services/api/modules/fca_element/module.json
+++ b/services/api/modules/fca_element/module.json
@@ -73,13 +73,15 @@
       "label": "Expected Life (yrs)",
       "type": "number",
       "fieldset": "Condition",
-      "unit": "yr"
+      "unit": "yr",
+      "min": 0
     },
     {
       "name": "replacement_cost",
       "label": "Replacement Cost (CRV)",
       "type": "currency",
-      "fieldset": "Condition"
+      "fieldset": "Condition",
+      "min": 0
     },
     {
       "name": "deficiency",
@@ -91,7 +93,8 @@
       "name": "deficiency_cost",
       "label": "Repair / Deferred Cost",
       "type": "currency",
-      "fieldset": "Deficiency"
+      "fieldset": "Deficiency",
+      "min": 0
     },
     {
       "name": "recommended_year",

--- a/services/api/modules/incident/module.json
+++ b/services/api/modules/incident/module.json
@@ -162,14 +162,16 @@
       "label": "Days Away",
       "type": "number",
       "fieldset": "OSHA",
-      "unit": "days"
+      "unit": "days",
+      "min": 0
     },
     {
       "name": "restricted_days",
       "label": "Restricted / Transfer Days",
       "type": "number",
       "fieldset": "OSHA",
-      "unit": "days"
+      "unit": "days",
+      "min": 0
     },
     {
       "name": "reported_to",

--- a/services/api/modules/investor/module.json
+++ b/services/api/modules/investor/module.json
@@ -81,14 +81,18 @@
       "label": "Ownership / interest %",
       "type": "percent",
       "unit": "%",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "pref_return_pct",
       "label": "Preferred return %",
       "type": "percent",
       "unit": "%",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "notes",

--- a/services/api/modules/journal_batch/module.json
+++ b/services/api/modules/journal_batch/module.json
@@ -34,19 +34,22 @@
       "name": "entry_count",
       "label": "GL entries",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "total_credits",
       "label": "Total credits",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "total_debits",
       "label": "Total debits",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "approved_by",

--- a/services/api/modules/labor_rate/module.json
+++ b/services/api/modules/labor_rate/module.json
@@ -16,7 +16,8 @@
     {
       "name": "rate",
       "label": "Rate $/hr",
-      "type": "currency"
+      "type": "currency",
+      "min": 0
     },
     {
       "name": "unit",

--- a/services/api/modules/lease/module.json
+++ b/services/api/modules/lease/module.json
@@ -76,7 +76,8 @@
       "label": "Free rent (months)",
       "type": "number",
       "unit": "mo",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "recovery_psf",
@@ -91,20 +92,23 @@
       "type": "number",
       "required": true,
       "unit": "sf",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "security_deposit",
       "label": "Security deposit",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "ti_allowance_psf",
       "label": "TI allowance $/SF",
       "type": "number",
       "unit": "$/sf",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "notes",

--- a/services/api/modules/lien_waiver/module.json
+++ b/services/api/modules/lien_waiver/module.json
@@ -50,7 +50,8 @@
       "label": "Through Amount",
       "type": "currency",
       "required": true,
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "subcontract",

--- a/services/api/modules/listing/module.json
+++ b/services/api/modules/listing/module.json
@@ -57,7 +57,8 @@
       "name": "list_price",
       "label": "List price",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "noi",
@@ -70,7 +71,8 @@
       "label": "$/SF",
       "type": "number",
       "unit": "$/sf",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "baths",
@@ -88,7 +90,8 @@
       "name": "cap_rate",
       "label": "Cap rate %",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "lot_sqft",

--- a/services/api/modules/manpower_log/module.json
+++ b/services/api/modules/manpower_log/module.json
@@ -31,25 +31,29 @@
       "name": "date",
       "label": "Date",
       "type": "date",
-      "fieldset": "Dates"
+      "fieldset": "Dates",
+      "default": "@today"
     },
     {
       "name": "count",
       "label": "Headcount",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "headcount",
       "label": "Workers",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "hours",
       "label": "Hours",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "daily_report",

--- a/services/api/modules/market_assumption/module.json
+++ b/services/api/modules/market_assumption/module.json
@@ -72,7 +72,8 @@
       "label": "Construction duration (months)",
       "type": "number",
       "unit": "mo",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "location_override",

--- a/services/api/modules/material_rate/module.json
+++ b/services/api/modules/material_rate/module.json
@@ -16,7 +16,8 @@
     {
       "name": "rate",
       "label": "Unit Rate",
-      "type": "currency"
+      "type": "currency",
+      "min": 0
     },
     {
       "name": "unit",

--- a/services/api/modules/material_request/module.json
+++ b/services/api/modules/material_request/module.json
@@ -30,7 +30,8 @@
       "name": "qty",
       "label": "Quantity",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "activity",

--- a/services/api/modules/mep_equipment/module.json
+++ b/services/api/modules/mep_equipment/module.json
@@ -52,7 +52,8 @@
       "name": "capacity",
       "label": "Capacity",
       "type": "number",
-      "fieldset": "Rating"
+      "fieldset": "Rating",
+      "min": 0
     },
     {
       "name": "capacity_unit",

--- a/services/api/modules/meter_reading/module.json
+++ b/services/api/modules/meter_reading/module.json
@@ -40,7 +40,8 @@
       "name": "cost",
       "label": "Utility Cost",
       "type": "currency",
-      "fieldset": "Reading"
+      "fieldset": "Reading",
+      "min": 0
     }
   ],
   "workflow": {

--- a/services/api/modules/noc/module.json
+++ b/services/api/modules/noc/module.json
@@ -54,14 +54,16 @@
       "name": "cost_estimate",
       "label": "Est. Cost",
       "type": "currency",
-      "fieldset": "Impact"
+      "fieldset": "Impact",
+      "min": 0
     },
     {
       "name": "schedule_days",
       "label": "Schedule Days",
       "type": "number",
       "fieldset": "Impact",
-      "unit": "days"
+      "unit": "days",
+      "min": 0
     },
     {
       "name": "issued_date",

--- a/services/api/modules/owner_invoice/module.json
+++ b/services/api/modules/owner_invoice/module.json
@@ -24,7 +24,8 @@
       "name": "amount",
       "label": "Amount",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "status",

--- a/services/api/modules/pco_request/module.json
+++ b/services/api/modules/pco_request/module.json
@@ -37,7 +37,8 @@
       "name": "rough_cost",
       "label": "Rough Order Cost",
       "type": "currency",
-      "fieldset": "Cost & schedule"
+      "fieldset": "Cost & schedule",
+      "min": 0
     },
     {
       "name": "schedule_impact_days",

--- a/services/api/modules/permit/module.json
+++ b/services/api/modules/permit/module.json
@@ -2,7 +2,7 @@
   "key": "permit",
   "name": "Permitting",
   "section": "Approvals",
-  "icon": "\u25a3",
+  "icon": "▣",
   "ref_prefix": "PMT",
   "title_field": "name",
   "pinnable": false,
@@ -81,7 +81,8 @@
       "name": "fee",
       "label": "Permit Fee",
       "type": "currency",
-      "fieldset": "Status & dates"
+      "fieldset": "Status & dates",
+      "min": 0
     }
   ],
   "workflow": {

--- a/services/api/modules/pm_schedule/module.json
+++ b/services/api/modules/pm_schedule/module.json
@@ -33,14 +33,16 @@
       "type": "number",
       "required": true,
       "fieldset": "Schedule",
-      "unit": "days"
+      "unit": "days",
+      "min": 0
     },
     {
       "name": "est_hours",
       "label": "Est. Hours",
       "type": "number",
       "fieldset": "Schedule",
-      "unit": "hr"
+      "unit": "hr",
+      "min": 0
     },
     {
       "name": "last_done",

--- a/services/api/modules/prequalification/module.json
+++ b/services/api/modules/prequalification/module.json
@@ -56,7 +56,8 @@
       "name": "bonding_capacity",
       "label": "Bonding Capacity",
       "type": "number",
-      "fieldset": "Capacity"
+      "fieldset": "Capacity",
+      "min": 0
     },
     {
       "name": "annual_revenue",

--- a/services/api/modules/pretask_plan/module.json
+++ b/services/api/modules/pretask_plan/module.json
@@ -24,7 +24,8 @@
       "name": "crew_size",
       "label": "Crew Size",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "controls",

--- a/services/api/modules/price_observation/module.json
+++ b/services/api/modules/price_observation/module.json
@@ -56,13 +56,15 @@
       "label": "Unit Price",
       "type": "currency",
       "required": true,
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "qty",
       "label": "Quantity",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     }
   ],
   "workflow": {

--- a/services/api/modules/prime_contract/module.json
+++ b/services/api/modules/prime_contract/module.json
@@ -68,35 +68,44 @@
       "name": "value",
       "label": "Original Value",
       "type": "currency",
-      "fieldset": "Cost"
+      "fieldset": "Cost",
+      "min": 0
     },
     {
       "name": "retainage_pct",
       "label": "Retainage %",
       "type": "percent",
       "fieldset": "Cost",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "overhead_pct",
       "label": "Overhead %",
       "type": "percent",
       "fieldset": "GMP markups",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "fee_pct",
       "label": "Fee / Profit %",
       "type": "percent",
       "fieldset": "GMP markups",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "contingency_pct",
       "label": "GC Contingency %",
       "type": "percent",
       "fieldset": "GMP markups",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "substantial_completion",

--- a/services/api/modules/procurement_package/module.json
+++ b/services/api/modules/procurement_package/module.json
@@ -30,13 +30,15 @@
       "name": "est_cost",
       "label": "Estimated Cost",
       "type": "number",
-      "fieldset": "Package"
+      "fieldset": "Package",
+      "min": 0
     },
     {
       "name": "line_count",
       "label": "Scope Lines",
       "type": "number",
-      "fieldset": "Package"
+      "fieldset": "Package",
+      "min": 0
     },
     {
       "name": "scope_json",
@@ -60,7 +62,8 @@
       "name": "award_amount",
       "label": "Award Amount",
       "type": "number",
-      "fieldset": "Award"
+      "fieldset": "Award",
+      "min": 0
     },
     {
       "name": "notes",
@@ -71,13 +74,46 @@
   ],
   "workflow": {
     "initial": "draft",
-    "states": ["draft", "rfq_sent", "quotes_in", "awarded"],
+    "states": [
+      "draft",
+      "rfq_sent",
+      "quotes_in",
+      "awarded"
+    ],
     "transitions": [
-      {"from": "draft", "to": "rfq_sent", "action": "send_rfq", "party": ["GC"]},
-      {"from": "rfq_sent", "to": "quotes_in", "action": "receive_quotes", "party": ["GC"]},
-      {"from": "quotes_in", "to": "awarded", "action": "award", "party": ["GC"]}
+      {
+        "from": "draft",
+        "to": "rfq_sent",
+        "action": "send_rfq",
+        "party": [
+          "GC"
+        ]
+      },
+      {
+        "from": "rfq_sent",
+        "to": "quotes_in",
+        "action": "receive_quotes",
+        "party": [
+          "GC"
+        ]
+      },
+      {
+        "from": "quotes_in",
+        "to": "awarded",
+        "action": "award",
+        "party": [
+          "GC"
+        ]
+      }
     ]
   },
-  "list_columns": ["name", "trade", "est_cost", "line_count", "rfq_due", "awarded_to"],
+  "list_columns": [
+    "name",
+    "trade",
+    "est_cost",
+    "line_count",
+    "rfq_due",
+    "awarded_to"
+  ],
   "workspace": "construction"
 }

--- a/services/api/modules/production_quantity/module.json
+++ b/services/api/modules/production_quantity/module.json
@@ -24,7 +24,8 @@
       "name": "quantity",
       "label": "Qty Installed",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "activity",

--- a/services/api/modules/productivity_log/module.json
+++ b/services/api/modules/productivity_log/module.json
@@ -43,7 +43,8 @@
       "name": "quantity",
       "label": "Quantity installed",
       "type": "number",
-      "fieldset": "Production"
+      "fieldset": "Production",
+      "min": 0
     },
     {
       "name": "unit",
@@ -61,7 +62,8 @@
       "name": "hours",
       "label": "Hours (per worker)",
       "type": "number",
-      "fieldset": "Production"
+      "fieldset": "Production",
+      "min": 0
     },
     {
       "name": "notes",

--- a/services/api/modules/progress_actual/module.json
+++ b/services/api/modules/progress_actual/module.json
@@ -37,7 +37,8 @@
       "label": "Installed Quantity",
       "type": "number",
       "required": true,
-      "fieldset": "Production"
+      "fieldset": "Production",
+      "min": 0
     },
     {
       "name": "unit",
@@ -73,11 +74,28 @@
   ],
   "workflow": {
     "initial": "logged",
-    "states": ["logged", "verified"],
+    "states": [
+      "logged",
+      "verified"
+    ],
     "transitions": [
-      {"from": "logged", "to": "verified", "action": "verify", "party": ["GC"]}
+      {
+        "from": "logged",
+        "to": "verified",
+        "action": "verify",
+        "party": [
+          "GC"
+        ]
+      }
     ]
   },
-  "list_columns": ["activity", "qty", "unit", "cycle_time", "idle_time", "log_date"],
+  "list_columns": [
+    "activity",
+    "qty",
+    "unit",
+    "cycle_time",
+    "idle_time",
+    "log_date"
+  ],
   "workspace": "construction"
 }

--- a/services/api/modules/project_charter/module.json
+++ b/services/api/modules/project_charter/module.json
@@ -96,7 +96,8 @@
       "name": "budget_authority",
       "label": "Budget Authority",
       "type": "currency",
-      "fieldset": "Budget & Schedule"
+      "fieldset": "Budget & Schedule",
+      "min": 0
     },
     {
       "name": "target_completion",

--- a/services/api/modules/project_phase/module.json
+++ b/services/api/modules/project_phase/module.json
@@ -43,7 +43,9 @@
       "label": "A/E Design Fee %",
       "type": "percent",
       "fieldset": "Commercial",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "iso_status",

--- a/services/api/modules/proposal/module.json
+++ b/services/api/modules/proposal/module.json
@@ -19,14 +19,16 @@
       "label": "Proposed Amount",
       "type": "currency",
       "required": true,
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "schedule_days",
       "label": "Schedule Days",
       "type": "number",
       "unit": "days",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "cost_code",

--- a/services/api/modules/pull_plan_task/module.json
+++ b/services/api/modules/pull_plan_task/module.json
@@ -55,7 +55,8 @@
       "label": "Duration (days)",
       "type": "number",
       "fieldset": "Sequence",
-      "unit": "days"
+      "unit": "days",
+      "min": 0
     },
     {
       "name": "planned_week",

--- a/services/api/modules/punchlist/module.json
+++ b/services/api/modules/punchlist/module.json
@@ -74,7 +74,8 @@
       "name": "cost",
       "label": "Est. Cost",
       "type": "currency",
-      "fieldset": "Closeout"
+      "fieldset": "Closeout",
+      "min": 0
     },
     {
       "name": "verified_by",

--- a/services/api/modules/resource_assignment/module.json
+++ b/services/api/modules/resource_assignment/module.json
@@ -68,13 +68,15 @@
       "name": "rate",
       "label": "Rate ($/unit)",
       "type": "currency",
-      "fieldset": "Loading"
+      "fieldset": "Loading",
+      "min": 0
     },
     {
       "name": "budgeted_cost",
       "label": "Budgeted cost ($)",
       "type": "currency",
-      "fieldset": "Loading"
+      "fieldset": "Loading",
+      "min": 0
     },
     {
       "name": "actual_units",

--- a/services/api/modules/risk/module.json
+++ b/services/api/modules/risk/module.json
@@ -82,14 +82,16 @@
       "name": "cost_exposure",
       "label": "Cost Exposure",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "schedule_days",
       "label": "Schedule Days",
       "type": "number",
       "unit": "days",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "contingency",

--- a/services/api/modules/schedule_activity/module.json
+++ b/services/api/modules/schedule_activity/module.json
@@ -79,7 +79,8 @@
       "name": "crew_size",
       "label": "Crew size (workers/day)",
       "type": "number",
-      "fieldset": "Activity"
+      "fieldset": "Activity",
+      "min": 0
     },
     {
       "name": "start",
@@ -97,7 +98,8 @@
       "name": "duration",
       "label": "Duration (days)",
       "type": "number",
-      "fieldset": "Dates"
+      "fieldset": "Dates",
+      "min": 0
     },
     {
       "name": "actual_start",
@@ -122,7 +124,9 @@
       "name": "percent",
       "label": "% Complete",
       "type": "percent",
-      "fieldset": "Dates"
+      "fieldset": "Dates",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "predecessors",
@@ -141,7 +145,8 @@
       "name": "budget",
       "label": "Budgeted Cost",
       "type": "currency",
-      "fieldset": "Links"
+      "fieldset": "Links",
+      "min": 0
     },
     {
       "name": "ev_method",
@@ -167,7 +172,8 @@
       "name": "units_total",
       "label": "Units total",
       "type": "number",
-      "fieldset": "Earned Value"
+      "fieldset": "Earned Value",
+      "min": 0
     }
   ],
   "workflow": {

--- a/services/api/modules/selection/module.json
+++ b/services/api/modules/selection/module.json
@@ -58,13 +58,15 @@
       "name": "actual_cost",
       "label": "Actual Cost",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "allowance",
       "label": "Allowance",
       "type": "currency",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "client_approval",

--- a/services/api/modules/sov/module.json
+++ b/services/api/modules/sov/module.json
@@ -26,14 +26,17 @@
       "label": "Retainage %",
       "type": "percent",
       "unit": "%",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "scheduled_value",
       "label": "Scheduled Value",
       "type": "number",
       "required": true,
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "completed_prev",

--- a/services/api/modules/space_program/module.json
+++ b/services/api/modules/space_program/module.json
@@ -39,13 +39,15 @@
       "type": "number",
       "required": true,
       "fieldset": "Space",
-      "unit": "sf"
+      "unit": "sf",
+      "min": 0
     },
     {
       "name": "quantity",
       "label": "Quantity",
       "type": "number",
-      "fieldset": "Space"
+      "fieldset": "Space",
+      "min": 0
     },
     {
       "name": "level",

--- a/services/api/modules/staffing/module.json
+++ b/services/api/modules/staffing/module.json
@@ -46,13 +46,15 @@
       "name": "count",
       "label": "Headcount",
       "type": "number",
-      "fieldset": "Role"
+      "fieldset": "Role",
+      "min": 0
     },
     {
       "name": "rate",
       "label": "Rate",
       "type": "currency",
-      "fieldset": "Cost"
+      "fieldset": "Cost",
+      "min": 0
     },
     {
       "name": "rate_period",

--- a/services/api/modules/sub_invoice/module.json
+++ b/services/api/modules/sub_invoice/module.json
@@ -45,14 +45,17 @@
       "label": "This Application (gross)",
       "type": "currency",
       "required": true,
-      "fieldset": "Cost"
+      "fieldset": "Cost",
+      "min": 0
     },
     {
       "name": "retainage_pct",
       "label": "Retainage %",
       "type": "percent",
       "fieldset": "Cost",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "cost_code",

--- a/services/api/modules/subcontract/module.json
+++ b/services/api/modules/subcontract/module.json
@@ -37,14 +37,17 @@
       "name": "value",
       "label": "Contract Value",
       "type": "currency",
-      "fieldset": "Cost"
+      "fieldset": "Cost",
+      "min": 0
     },
     {
       "name": "retainage_pct",
       "label": "Retainage %",
       "type": "percent",
       "fieldset": "Cost",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "cost_code",

--- a/services/api/modules/submittal/module.json
+++ b/services/api/modules/submittal/module.json
@@ -76,7 +76,8 @@
       "label": "Lead Time (days)",
       "type": "number",
       "fieldset": "Schedule",
-      "unit": "days"
+      "unit": "days",
+      "min": 0
     },
     {
       "name": "required_on_site",

--- a/services/api/modules/timesheet/module.json
+++ b/services/api/modules/timesheet/module.json
@@ -30,7 +30,8 @@
       "name": "hours",
       "label": "Hours",
       "type": "number",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "cost_code",

--- a/services/api/modules/value_engineering/module.json
+++ b/services/api/modules/value_engineering/module.json
@@ -18,7 +18,8 @@
       "name": "savings",
       "label": "Est. Savings",
       "type": "number",
-      "fieldset": "Money"
+      "fieldset": "Money",
+      "min": 0
     },
     {
       "name": "status",

--- a/services/api/modules/warranty/module.json
+++ b/services/api/modules/warranty/module.json
@@ -69,7 +69,8 @@
       "label": "Term (years)",
       "type": "number",
       "fieldset": "Term",
-      "unit": "yr"
+      "unit": "yr",
+      "min": 0
     },
     {
       "name": "submittal",

--- a/services/api/modules/waste_diversion/module.json
+++ b/services/api/modules/waste_diversion/module.json
@@ -49,7 +49,9 @@
       "label": "Diversion %",
       "type": "percent",
       "fieldset": "Disposition",
-      "unit": "%"
+      "unit": "%",
+      "min": 0,
+      "max": 100
     }
   ],
   "workflow": {

--- a/services/api/modules/work_order/module.json
+++ b/services/api/modules/work_order/module.json
@@ -89,13 +89,15 @@
       "label": "Labor Hours",
       "type": "number",
       "fieldset": "Cost",
-      "unit": "hr"
+      "unit": "hr",
+      "min": 0
     },
     {
       "name": "cost",
       "label": "Cost (parts + labor)",
       "type": "currency",
-      "fieldset": "Cost"
+      "fieldset": "Cost",
+      "min": 0
     }
   ],
   "workflow": {

--- a/services/api/modules/zoning/module.json
+++ b/services/api/modules/zoning/module.json
@@ -38,14 +38,17 @@
       "label": "Avg unit size (SF)",
       "type": "number",
       "unit": "sf",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "efficiency_pct",
       "label": "Net-to-gross efficiency (%)",
       "type": "percent",
       "unit": "%",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "far",
@@ -72,28 +75,33 @@
       "label": "Height limit (ft)",
       "type": "number",
       "unit": "ft",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "lot_coverage_pct",
       "label": "Max lot coverage (%)",
       "type": "percent",
       "unit": "%",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "lot_depth_ft",
       "label": "Lot depth (ft)",
       "type": "number",
       "unit": "ft",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "lot_width_ft",
       "label": "Lot width (ft)",
       "type": "number",
       "unit": "ft",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "max_floors",
@@ -106,7 +114,9 @@
       "label": "Required open space (%)",
       "type": "percent",
       "unit": "%",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0,
+      "max": 100
     },
     {
       "name": "parking_ratio",
@@ -134,7 +144,8 @@
       "type": "number",
       "required": true,
       "unit": "sf",
-      "fieldset": "Quantities"
+      "fieldset": "Quantities",
+      "min": 0
     },
     {
       "name": "notes",

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -38,7 +38,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
-         "test_module_config", "test_module_schema", "test_eticket_tm", "test_ref_backfill", "test_module_tables", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
+         "test_module_config", "test_module_schema", "test_field_attrs", "test_eticket_tm", "test_ref_backfill", "test_module_tables", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:

--- a/services/api/src/aec_api/module_schema.py
+++ b/services/api/src/aec_api/module_schema.py
@@ -92,6 +92,23 @@ class FieldDef(BaseModel):
     # (`elevation_ft`, `expected_life_years`). A unit in a name is readable only by a human: it cannot
     # be rendered beside an input, appended to a table cell, converted, or validated.
     unit: str | None = None
+    # ---- MOD-FIELDATTRS — the rest of the field vocabulary -------------------------------------
+    #
+    # `min`/`max`/`placeholder` CONSTRAIN or EXPLAIN a value the user supplies. `default` is different
+    # in kind: it WRITES A VALUE NOBODY CHOSE, and a wrong one is invisible because it looks
+    # deliberate. Default `retainage_pct` to 10 and every record on a 5% job silently carries the
+    # wrong number, formatted correctly, in the right field. That is this codebase's signature defect
+    # — the plausible answer for the missing case — so `default` is deliberately rare in the shipped
+    # modules and is restricted here to facts that are true of the RECORD rather than of a policy.
+    #
+    # Bounds are enforced SERVER-SIDE in `validate_record`, not only rendered as input attributes: an
+    # HTML `min` is a hint to a browser and nothing to a script, a CSV import, or an integration.
+    min: float | None = None
+    max: float | None = None
+    placeholder: str | None = None
+    #: Pre-filled on a NEW record only. Never applied on update — re-filling a field the user just
+    #: cleared would make "empty" unreachable.
+    default: str | float | bool | None = None
     # rollup wiring (type == "rollup")
     source_module: str | None = None
     source_field: str | None = None
@@ -221,6 +238,34 @@ def validate_module(mod: dict, *, known_modules: set[str] | None = None,
             errors.append(f"{key}.{f.name}: {f.type} field has no options")
         if f.unit and f.type not in _NUMERIC_TYPES:
             errors.append(f"{key}.{f.name}: unit {f.unit!r} on a {f.type} field (units are numeric)")
+        # ---- MOD-FIELDATTRS ----------------------------------------------------------------------
+        if (f.min is not None or f.max is not None) and f.type not in _NUMERIC_TYPES:
+            errors.append(f"{key}.{f.name}: min/max on a {f.type} field (bounds are numeric)")
+        if f.min is not None and f.max is not None and f.min > f.max:
+            # An inverted range accepts NOTHING, and reads as a typo nobody notices until a save fails.
+            errors.append(f"{key}.{f.name}: min {f.min} is greater than max {f.max}")
+        if f.placeholder and f.type in ("select", "multiselect", "checkbox", "table", "rollup",
+                                        "signature", "reference", "file"):
+            # A placeholder is hint text INSIDE an empty text box. On a dropdown or a grid there is no
+            # box to put it in, so it would be declared and never rendered.
+            errors.append(f"{key}.{f.name}: placeholder on a {f.type} field has nowhere to render")
+        if f.default is not None:
+            if f.type in ("rollup", "signature", "table", "file", "reference"):
+                # A default reference would invent a link; a default signature would forge an
+                # attestation. Neither is a value a config file gets to supply.
+                errors.append(f"{key}.{f.name}: a {f.type} field cannot have a default")
+            elif f.type in _NUMERIC_TYPES:
+                try:
+                    d = float(f.default)
+                except (TypeError, ValueError):
+                    errors.append(f"{key}.{f.name}: default {f.default!r} is not a number")
+                else:
+                    if f.min is not None and d < f.min:
+                        errors.append(f"{key}.{f.name}: default {d} is below min {f.min}")
+                    if f.max is not None and d > f.max:
+                        errors.append(f"{key}.{f.name}: default {d} is above max {f.max}")
+            elif f.type == "select" and f.options and str(f.default) not in f.options:
+                errors.append(f"{key}.{f.name}: default {f.default!r} is not one of the options")
         # ---- MOD-TABLE ----------------------------------------------------------------------------
         if f.type == "table":
             if not f.columns:
@@ -313,9 +358,18 @@ def validate_record(mod: dict, data: dict) -> list[str]:
             continue                          # unknown key or empty -> skip (partial update / clear)
         if f.get("type") in _NUMERIC_TYPES:
             try:
-                float(value)
+                n = float(value)
             except (TypeError, ValueError):
                 errors.append(f"{name}: {value!r} is not a number")
+            else:
+                # MOD-FIELDATTRS — bounds enforced HERE, not only as HTML input attributes. An HTML
+                # `min` is advice to one browser and nothing at all to a CSV import, an integration
+                # or a script, which is how out-of-range values get in.
+                lo, hi = f.get("min"), f.get("max")
+                if lo is not None and n < float(lo):
+                    errors.append(f"{name}: {n:g} is below the minimum {float(lo):g}")
+                if hi is not None and n > float(hi):
+                    errors.append(f"{name}: {n:g} is above the maximum {float(hi):g}")
         elif f.get("type") == "table":
             errors.extend(_table_errors(name, f, value))
     return errors

--- a/services/api/src/aec_api/modules.py
+++ b/services/api/src/aec_api/modules.py
@@ -80,6 +80,37 @@ def _validate_fields(mod: dict, data: dict) -> None:
         raise HTTPException(422, f"missing required field(s): {', '.join(missing)}")
 
 
+def apply_defaults(mod: dict, data: dict) -> dict:
+    """MOD-FIELDATTRS — fill declared defaults on a NEW record, and only where the caller said nothing.
+
+    Create-only, deliberately. Applying a default on update would re-fill a field the user had just
+    cleared, making "empty" unreachable and the clearing look like it failed.
+
+    Only fills a key that is ABSENT or empty-string. A caller that sent `0`, `false` or `""` meaning
+    "no" has expressed an intent, and a default that overrode it would be the config out-voting the
+    user — which is the whole risk of defaults: the value is invisible precisely because it looks
+    like something somebody chose.
+    """
+    for f in mod.get("fields", []):
+        d = f.get("default")
+        if d is None:
+            continue
+        cur = data.get(f["name"])
+        if cur is None or cur == "":
+            data[f["name"]] = _resolve_default(d)
+    return data
+
+
+#: Defaults that are computed rather than literal. Only one so far, and it earns its keep: a daily
+#: report, a T&M ticket and a manpower log are all filed for the day they happened, so "today" is a
+#: fact about the record. A literal date in config would be wrong the day after it was written.
+def _resolve_default(d):
+    if d == "@today":
+        from .timeutil import utc_today
+        return utc_today().isoformat()
+    return d
+
+
 def apply_table_totals(mod: dict, merged: dict) -> dict:
     """MOD-TOTALS — a `table` field with `totals_into` writes its sum into the named numeric field.
 
@@ -156,6 +187,8 @@ def create_record(db: Session, key: str, project_id: str, body: dict, actor: str
     # scripts and integrations don't have to special-case each module's field name.
     if title_field and title_field != "subject" and not data.get(title_field) and data.get("subject"):
         data[title_field] = data["subject"]
+    apply_defaults(mod, data)            # MOD-FIELDATTRS: before the required check, so a defaulted
+                                         # field satisfies `required` rather than failing it
     _validate_fields(mod, data)
     _validate_values(mod, data)
     apply_table_totals(mod, data)        # MOD-TOTALS: line items drive the total the engines read

--- a/services/api/test_field_attrs.py
+++ b/services/api/test_field_attrs.py
@@ -1,0 +1,168 @@
+"""MOD-FIELDATTRS — the rest of the field vocabulary: min, max, placeholder, default.
+
+The sweep found the whole vocabulary was eleven attributes and every one was structural or
+presentational. `unit` closed part of that; this closes the rest. Three of the four merely CONSTRAIN
+or EXPLAIN a value the user supplies. The fourth is different in kind and most of this file is about
+it.
+
+**A `default` writes a value nobody chose.** Default `retainage_pct` to 10 and every record on a 5%
+job silently carries the wrong number — formatted correctly, in the right field, looking exactly like
+something somebody decided. That is this codebase's signature defect, the plausible answer for the
+missing case, and it is why only FOUR fields in 133 modules carry a default: each is a fact about the
+*record* (a daily report is filed for today) rather than a *policy* (retainage is 10%).
+
+**A bound must be enforced where the data enters, not where it is typed.** An HTML `min` is advice to
+one browser and nothing at all to a CSV import, an integration or a script — which is how
+out-of-range values actually arrive. Enforced in `validate_record`.
+
+**A bound that rejects a real value is worse than no bound**: it makes the honest number un-enterable
+and pushes it somewhere unvalidated. Three of the 22 percent fields are asserted to be UNBOUNDED for
+exactly that reason.
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_field_attrs.py
+"""
+import json
+import os
+import pathlib
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_field_attrs.db"
+os.environ["STORAGE_DIR"] = "./test_storage_field_attrs"
+os.environ["AEC_TRUST_XUSER"] = "1"
+
+for _f in ("./test_field_attrs.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+from aec_api.module_schema import validate_module, validate_record  # noqa: E402
+from aec_api.modules import apply_defaults  # noqa: E402
+from aec_api.timeutil import utc_today  # noqa: E402
+
+H = {"X-User": "gc"}
+MODULES = pathlib.Path(__file__).parent / "modules"
+
+# ---- 1. the misconfigurations that must be refused ----------------------------------------------
+for label, mod in (
+    ("min on a text field", {"key": "x", "fields": [{"name": "a", "type": "text", "min": 0}]}),
+    ("inverted range", {"key": "x", "fields": [{"name": "a", "type": "number", "min": 10, "max": 5}]}),
+    ("placeholder with nowhere to render",
+     {"key": "x", "fields": [{"name": "a", "type": "select", "options": ["y"], "placeholder": "hi"}]}),
+    ("default on a signature", {"key": "x", "fields": [{"name": "a", "type": "signature", "default": "s"}]}),
+    ("default below its own min",
+     {"key": "x", "fields": [{"name": "a", "type": "number", "min": 5, "default": 1}]}),
+    ("default outside the options",
+     {"key": "x", "fields": [{"name": "a", "type": "select", "options": ["y"], "default": "z"}]}),
+    ("non-numeric default on a number",
+     {"key": "x", "fields": [{"name": "a", "type": "number", "default": "abc"}]}),
+):
+    assert validate_module(mod, known_modules={"x"}), f"accepted: {label}"
+
+# a default REFERENCE would invent a link and a default SIGNATURE would forge an attestation —
+# neither is a value a config file gets to supply
+assert validate_module({"key": "x", "fields": [
+    {"name": "b", "type": "text"},
+    {"name": "a", "type": "reference", "module": "x", "default": "z"}]}, known_modules={"x"})
+
+# ---- 2. bounds are enforced on the VALUE, not just rendered --------------------------------------
+MOD = {"fields": [{"name": "p", "type": "percent", "min": 0, "max": 100},
+                  {"name": "q", "type": "number", "min": 0}]}
+assert not validate_record(MOD, {"p": 50, "q": 0})
+assert validate_record(MOD, {"p": 5000})          # a percentage of 5000 rendered as "5,000%" happily
+assert validate_record(MOD, {"p": -1})
+assert validate_record(MOD, {"q": -3})
+assert not validate_record(MOD, {"p": ""})        # blank is still "not answered", not a violation
+
+# ---- 3. defaults fill only what was not answered, and only on create -----------------------------
+DMOD = {"fields": [{"name": "d", "type": "date", "default": "@today"},
+                   {"name": "n", "type": "number", "default": 5},
+                   {"name": "s", "type": "text"}]}
+filled = apply_defaults(DMOD, {})
+assert filled["d"] == utc_today().isoformat(), filled
+assert filled["n"] == 5
+# a caller that said something keeps it — INCLUDING a zero, which is an answer, not an absence
+assert apply_defaults(DMOD, {"n": 0})["n"] == 0, "a default overrode an explicit 0"
+assert apply_defaults(DMOD, {"n": 99})["n"] == 99
+# a field with no default is not invented
+assert "s" not in apply_defaults(DMOD, {})
+
+with TestClient(app) as c:
+    pid = c.post("/projects", headers=H, json={"name": "Attrs"}).json()["id"]
+
+    # ---- 4. the default reaches a caller that never opened a form ---------------------------------
+    r = c.post(f"/projects/{pid}/modules/daily_report", headers=H,
+               json={"data": {"weather": "Clear"}})
+    assert r.status_code == 201, r.text
+    rid = r.json()["id"]
+    got = c.get(f"/projects/{pid}/modules/daily_report/{rid}", headers=H).json()["data"]
+    assert got["report_date"] == utc_today().isoformat(), got
+    # ...and it satisfies `required` rather than failing it: report_date is a required field, so the
+    # default has to be applied BEFORE the required check or an API create would 422 on a field the
+    # config says it can fill itself.
+
+    # ---- 5. AN UPDATE NEVER RE-FILLS ---------------------------------------------------------------
+    # The case create-only exists for: re-filling on update makes "empty" unreachable, and the user's
+    # clearing look like it silently failed.
+    c.patch(f"/projects/{pid}/modules/daily_report/{rid}", headers=H, json={"report_date": ""})
+    got = c.get(f"/projects/{pid}/modules/daily_report/{rid}", headers=H).json()["data"]
+    assert got["report_date"] == "", f"an update re-applied the default: {got['report_date']!r}"
+
+    # ---- 6. an out-of-range value is refused over HTTP, not merely un-typeable --------------------
+    r = c.post(f"/projects/{pid}/modules/prime_contract", headers=H,
+               json={"data": {"name": "PC", "retainage_pct": 500}})
+    assert r.status_code == 422, f"a 500% retainage was accepted ({r.status_code})"
+    r = c.post(f"/projects/{pid}/modules/prime_contract", headers=H,
+               json={"data": {"name": "PC", "retainage_pct": 10}})
+    assert r.status_code == 201, r.text
+
+# ---- 7. THE SHIPPED BOUNDS, INCLUDING THE FIELDS DELIBERATELY LEFT UNBOUNDED ---------------------
+mods = {p.parent.name: json.loads(p.read_text(encoding="utf-8"))
+        for p in MODULES.glob("*/module.json")}
+fields = {(k, f["name"]): f for k, m in mods.items() for f in m.get("fields", [])}
+
+pct = [(k, f) for (k, n), f in fields.items() if f["type"] == "percent"]
+bounded = [f for _k, f in pct if f.get("min") == 0 and f.get("max") == 100]
+assert len(bounded) >= 18, f"only {len(bounded)} percent fields are bounded 0..100"
+
+# `percent` says "this is a proportion", NOT "this is between 0 and 100". These three are unbounded
+# on purpose, and naming them here stops a future bulk pass from "fixing" them: a bound that rejects a
+# real value makes the honest number un-enterable and pushes it somewhere unvalidated.
+for key, fname, why in (
+    ("design_option", "irr_pct", "an IRR is negative on a losing deal and exceeds 100% on a fast one"),
+    ("market_assumption", "escalation_override_pct", "escalation is negative under deflation"),
+    ("lease", "escalation_pct", "a step-down lease escalates negatively"),
+):
+    f = fields[(key, fname)]
+    assert "min" not in f and "max" not in f, f"{key}.{fname} was bounded — {why}"
+
+# quantities that cannot be negative carry min 0; things that CAN go negative must not
+neg_ok = [(k, n) for (k, n), f in fields.items()
+          if f.get("min") == 0 and any(w in n for w in ("variance", "float", "adjust", "delta"))]
+assert not neg_ok, f"fields that can legitimately go negative were bounded at 0: {neg_ok}"
+zeroed = [1 for f in fields.values() if f.get("min") == 0]
+assert len(zeroed) >= 100, f"only {len(zeroed)} fields carry a non-negative bound"
+
+# DEFAULTS ARE RARE ON PURPOSE. This is a CEILING, not a floor — the only such assertion in the
+# module gates, because the risk here runs the other way. Every default is a value nobody chose, and
+# the temptation to add "helpful" ones is exactly what makes a register quietly wrong.
+defaulted = sorted(f"{k}.{n}" for (k, n), f in fields.items() if "default" in f)
+assert len(defaulted) <= 8, (
+    f"{len(defaulted)} fields carry a default: {defaulted}. Each writes a value nobody chose, and a "
+    "wrong one is invisible because it looks deliberate. Add one only when the value is a fact about "
+    "the RECORD (a daily report is filed today), never a policy (retainage is 10%).")
+for d in defaulted:
+    assert d.endswith(("_date", ".date")), f"{d}: the only safe defaults so far are dates-of-record"
+
+print(f"MOD-FIELDATTRS OK - min/max/placeholder/default complete the field vocabulary. "
+      f"{len(bounded)} percent fields bounded 0..100 and {len(zeroed)} quantities held non-negative, "
+      "enforced in validate_record rather than as HTML attributes — an HTML `min` is advice to one "
+      "browser and nothing to a CSV import, an integration or a script, which is how out-of-range "
+      "values actually arrive. THREE percent fields are asserted UNBOUNDED by name (irr_pct, "
+      "escalation_override_pct, lease.escalation_pct): `percent` means proportion, not 0..100, and a "
+      "bound that rejects a real value makes the honest number un-enterable and pushes it somewhere "
+      f"unvalidated. Defaults number {len(defaulted)} across 133 modules and the gate is a CEILING "
+      "rather than a floor — the only such assertion here, because a default writes a value nobody "
+      "chose and a wrong one is invisible precisely because it looks deliberate. Each is a fact about "
+      "the record (a daily report is filed today), never a policy. Applied on CREATE only: re-filling "
+      "on update would make 'empty' unreachable, and an explicit 0 is an answer that survives.")


### PR DESCRIPTION
Base `2a987556`, `git merge-tree` CLEAN as of that SHA. **The last item of the field sweep** — §8 of `docs/internal/module-field-sweep.md` is closed by this PR.

## `default` is different in kind, and that shaped the whole design

`min` / `max` / `placeholder` **constrain or explain** a value the user supplies. A `default` **writes a value nobody chose** — and a wrong one is invisible because it looks deliberate. Default `retainage_pct` to 10 and every record on a 5% job carries the wrong number: formatted correctly, in the right field, indistinguishable from something somebody decided.

So:

- **Four fields across 133 modules** carry a default, all `@today` on a date-of-record — a fact about the **record** (a daily report is filed today), never a **policy**
- The gate is a **ceiling, not a floor** — the only such assertion in the module gates, because here the risk runs the other way
- **Create-only.** Re-filling on update would make "empty" unreachable and a user's clearing look like it silently failed
- **An explicit `0` survives** — a default that overrode it would be the config out-voting the user

## Bounds enforced where data enters

19 percent fields bounded 0–100, 140 quantities held non-negative, in `validate_record` — not as HTML attributes. An HTML `min` is advice to one browser and nothing to a CSV import, an integration or a script, which is how out-of-range values actually arrive. A 500% retainage now 422s over HTTP.

**Three percent fields are unbounded on purpose, asserted by name.** My first pass bounded all 22; reading the output caught it. An **IRR is negative on a losing deal and over 100% on a fast one**, escalation is negative under deflation, a step-down lease escalates negatively. `percent` means *proportion*, not *0..100* — and a bound that rejects a real value is worse than no bound, because it makes the honest number un-enterable and pushes it somewhere unvalidated.

**`readonly` was dropped rather than built.** Nothing in the sweep found a field needing one: a value the user must not edit is either computed (`rollup`, a `totals_into` target) or set by a workflow transition. A fourth way to say the same thing, and the first place it disagreed with the other three would have been a bug nobody could locate.

Mutation-checked three ways: removing server-side enforcement, applying defaults on update, and letting a default override an explicit `0`.

## What I built alongside this and deliberately left out

A GUID-format check — validating that the three fields storing an IFC GlobalId actually hold one, since `CLAUDE.md`'s first non-negotiable is *"reference model elements by IFC GlobalId, never by transient viewer IDs"* and all three were plain `text` accepting `"TBD"`, a truncated paste, and exactly the transient viewer id the rule forbids.

**It broke `test_verified_progress`** (fixture GUID `'gA'`), and 25 test files carry synthetic GUID fixtures like `"G-WALL-1"` and `"0"`.

But the blast radius is not the real reason it is out. **It had no legacy story.** For `table` I was careful that existing prose must not make a record un-saveable on the next unrelated edit; for `guid` I enforced a format with no such care, so any live record holding a non-conforming value would become un-saveable. Same defect shape, opposite treatment, in work written the same hour. It comes back as its own PR with that story worked out.

The investigation was still worth it, and the finding was **not the one the audit predicted**. The audit said "ten registers need an element link". Wrong: `element_guids` already exists as a record-level column, written by BCF import, clash import, pins and the viewer's anchor-to-selection. The defect is **duplication** — `element_facts._claims` checks both stores with an `or`, so a record can be anchored to element A by its column and element B by its field, each consumer right about a different element. That is what the follow-up PR should fix.

## Verification

- `test_field_attrs`, `test_verified_progress`, `test_module_config`, `test_modules`, `test_module_fields` all **PASS**; ruff clean; manifest **464**, guard clean — all re-run **after** the rebase, by running rather than grepping
- **Honest caveat:** no clean full local suite. This machine exhausted its virtual memory mid-session and every subsequent run was cut short. One earlier run was also invalid because a heredoc escape had left `module_schema.py` syntactically broken while it ran — 137 failures, all `SyntaxError` on import, which I initially misread as a real regression. **CI on the merged tree is the number that counts.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
