### PR TITLE
MOD-GUID — the first non-negotiable, as a check that can fail

### DIFF
--- a/docs/internal/module-field-sweep.md
+++ b/docs/internal/module-field-sweep.md
@@ -174,6 +174,22 @@ been a bug nobody could locate.
   by `cost.g703` rather than stored. That is the last structural item from §6.
 - **A `reference` column type for tables.** Deliberately excluded (see `TABLE_COLUMN_TYPES`) because a
   picker per row is a real feature and shipping it half-done would put unresolvable ids in rows.
-- **The element link (`§5 T4`).** Ten registers describe things that *are* model elements and only
-  three carry a GUID, all as plain text. This is the largest remaining gap between the platform's
-  stated premise and the layer users touch.
+- ~~**The element link (`§5 T4`).**~~ **Shipped as `MOD-GUID`.** Three defects, and the second was
+  the one worth having:
+  1. All three GlobalId fields were plain `text`, so `"TBD"`, a truncated paste and a *transient
+     viewer id* — the thing the repo's first non-negotiable forbids by name — were indistinguishable
+     from a real one. The rule was prose, and prose cannot fail.
+  2. **Two stores held one fact.** `element_facts._claims` checked `element_guids` **or**
+     `data["guid"]`, so a record could be anchored to element A by its column and element B by its
+     field, with each consumer correct about a different element. It also read only the *singular*
+     `guid`, so `material_request.guids` and `prefab_kit.frozen_guids` never matched at all.
+  3. `parse_guids` was a second reader of the same list format, defined independently.
+
+  **This item was written once and pulled, for a reason that turned out to be wrong.** The stated
+  reason was that it had no legacy story — that live records holding a malformed id would become
+  un-saveable. They would not: `update_record` validates only the fields in the patch, so an
+  untouched bad value keeps saving. The blast radius was also given as ~25 test files; it was **one**
+  (`test_verified_progress`), the rest being element-level fixtures that never reach the module
+  engine. Both figures came from pattern-matching rather than reading, which is the same failure the
+  work itself is about: a confident answer where the honest one was "I have not checked". The claim
+  is now `test_guid_integrity` §2 rather than a belief.

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -38,7 +38,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
-         "test_module_config", "test_module_schema", "test_field_attrs", "test_eticket_tm", "test_ref_backfill", "test_module_tables", "test_module_filters", "test_module_fields", "test_throttle", "test_route_order",
+         "test_module_config", "test_module_schema", "test_field_attrs", "test_eticket_tm", "test_ref_backfill", "test_module_tables", "test_module_filters", "test_guid_integrity", "test_module_fields", "test_throttle", "test_route_order",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:

--- a/services/api/src/aec_api/demo_seed.py
+++ b/services/api/src/aec_api/demo_seed.py
@@ -43,11 +43,37 @@ def _pick(pool, *seed):
     return pool[_h(*seed) % len(pool)]
 
 
+#: The alphabet IfcOpenShell compresses a 128-bit UUID into. Deterministic from the same hash as
+#: every other seeded value, so a demo re-seed produces the same building twice.
+_GUID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$"
+
+
+def _fake_guid(*seed: Any) -> str:
+    n, out = _h(*seed), []
+    for k in range(22):
+        n = (n * 6364136223846793005 + _h(k, *seed)) & ((1 << 64) - 1)
+        out.append(_GUID_ALPHABET[n % 64])
+    return "".join(out)
+
+
 def _value(field: dict, module: str, i: int, today: date) -> Any:
     """A plausible, schema-valid value for one field — or None to leave it unset."""
     ftype = str(field.get("type") or "text")
     name = str(field.get("name") or "")
     seed = (module, name, i)
+
+    # MOD-GUID: a GlobalId field, before the type dispatch — because these fields are `text` and
+    # `textarea`, and both fall through to prose. The seeded demo really did file "Level 2 slab 1"
+    # into `field_verification.guid` and a whole sentence about coordinating before the next pour
+    # into `material_request.guids`. Nothing rejected it, so the demo every new user opens has been
+    # showing the platform's first non-negotiable being broken — a filing accident dressed as data.
+    #
+    # Asked of `module_schema`, not re-listed here: the point of MOD-GUID is that "which fields hold
+    # a GlobalId" has one definition.
+    from .module_schema import _GUID_FIELDS
+    if name in _GUID_FIELDS:
+        n = 2 if name.endswith("guids") else 1        # the plural fields hold a list
+        return "\n".join(_fake_guid(*seed, k) for k in range(n))
 
     if ftype == "select" or ftype == "multiselect":
         opts = [o for o in (field.get("options") or []) if o]

--- a/services/api/src/aec_api/element_facts.py
+++ b/services/api/src/aec_api/element_facts.py
@@ -47,10 +47,18 @@ def _rows(db: Session, key: str, pid: str) -> list[dict[str, Any]]:
 
 
 def _claims(row: dict[str, Any], guid: str) -> bool:
-    """Whether a record refers to this element — by pin, or by a `guid` field it stores."""
+    """Whether a record refers to this element — by pin, or by any GlobalId field it stores.
+
+    MOD-GUID: this read only the singular `guid` field, so `material_request.guids` and
+    `prefab_kit.frozen_guids` — the other two fields holding a GlobalId — never matched here. A frozen
+    prefab kit could name an element and this said the element was unclaimed. Now it asks the schema
+    layer which fields hold a GlobalId instead of naming one, so a fourth such field is covered the day
+    it is added rather than the day someone notices.
+    """
+    from .module_schema import guids_from_fields
     if guid in (row.get("element_guids") or []):
         return True
-    return str((row.get("data") or {}).get("guid") or "").strip() == guid
+    return guid in guids_from_fields(row.get("data") or {})
 
 
 def checked(model, guid: str) -> bool | None:

--- a/services/api/src/aec_api/module_schema.py
+++ b/services/api/src/aec_api/module_schema.py
@@ -15,6 +15,7 @@ bearing structure without freezing the format.
 "construction|design" so it shows for both the GC and the architect/engineer."""
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
@@ -35,6 +36,71 @@ FIELD_TYPES = {"text", "number", "currency", "date", "textarea", "select", "mult
 #: is a real feature rather than a column type, and shipping it half-done would put unresolvable ids in
 #: rows, which is the exact defect `refCell` was written to stop.
 TABLE_COLUMN_TYPES = {"text", "number", "currency", "percent", "date", "select", "checkbox"}
+
+#: MOD-GUID — an IFC GlobalId is 22 characters over a fixed base64-ish alphabet (IfcOpenShell's
+#: compressed form of a 128-bit UUID). Anything else in a field labelled "GlobalId" is not one.
+#:
+#: This repo's FIRST non-negotiable is "reference model elements by IFC GlobalId, never by transient
+#: viewer IDs". The three fields that store one were plain `text`, so they accepted "TBD", a truncated
+#: paste, and exactly the transient viewer id the rule forbids — indistinguishably. The rule was
+#: written down and nothing could fail on it.
+#:
+#: THE LEGACY STORY IS ALREADY IN THE ENGINE, which is worth stating because it is easy to assume
+#: otherwise: `validate_record` only checks fields PRESENT in the incoming payload, and `update_record`
+#: passes just the patch. So a record holding a malformed id from before this rule keeps saving as long
+#: as nobody edits that field — the check applies to values being written, not values already stored.
+IFC_GUID_RE = re.compile(r"^[0-9A-Za-z_$]{22}$")
+
+#: Field names whose value IS an IFC GlobalId. Matched by NAME because these fields predate any type
+#: for it; `guids`/`frozen_guids` hold newline- or comma-separated lists.
+_GUID_FIELDS = {"guid", "guids", "frozen_guids", "element_guid", "global_id"}
+
+
+def split_guids(value) -> list[str]:
+    """A GlobalId field's value as a list, whether it holds one or many."""
+    sep = re.compile(r"[\n,;]+")
+    parts = [str(v) for v in value] if isinstance(value, list) else sep.split(str(value or ""))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def guid_errors(name: str, value) -> list[str]:
+    """Every malformed GlobalId, capped at three so one bad paste is not a wall of text."""
+    bad = [g for g in split_guids(value) if not IFC_GUID_RE.match(g)]
+    if not bad:
+        return []
+    out = [f"{name}: {b!r} is not an IFC GlobalId (22 chars over [0-9A-Za-z_$])" for b in bad[:3]]
+    if len(bad) > 3:
+        out.append(f"{name}: …and {len(bad) - 3} more malformed GlobalId(s)")
+    return out
+
+
+def guids_from_fields(data: dict) -> list[str]:
+    """MOD-GUID — the GlobalIds a record's own FIELDS name, for mirroring into `element_guids`.
+
+    TWO STORES HELD ONE FACT. `element_guids` is the record-level column — written by BCF import,
+    clash import, pins and the viewer's anchor-to-selection, and read by `pins.py`, `bcf_io.py` and
+    the 5D map. Three modules ALSO keep a GlobalId in a plain field, and `element_facts._claims`
+    checks both:
+
+        if guid in (row.get("element_guids") or []): return True
+        return str((row.get("data") or {}).get("guid") or "").strip() == guid
+
+    That `or` is the tell: a record could be anchored to element A by its column and element B by its
+    field, with each consumer right about a different element depending on which it read.
+
+    Mirroring on write makes the column a superset — the field stays authoritative for the user (it is
+    what they typed) and every consumer reading the column now sees it too. Additive, so nothing that
+    already anchors a record loses its anchor. Only WELL-FORMED ids are mirrored: a malformed one is
+    already reported by `validate_record`, and copying it into the one place every consumer trusts
+    would spread the bad value rather than contain it.
+    """
+    out: list[str] = []
+    for name in _GUID_FIELDS:
+        v = data.get(name)
+        if v:
+            out.extend(g for g in split_guids(v) if IFC_GUID_RE.match(g))
+    return out
+
 
 #: Types that hold a magnitude, and so are the only ones a `unit` or a numeric check applies to.
 #: Defined here rather than beside `validate_record` because `validate_module` needs it first.
@@ -372,6 +438,10 @@ def validate_record(mod: dict, data: dict) -> list[str]:
                     errors.append(f"{name}: {n:g} is above the maximum {float(hi):g}")
         elif f.get("type") == "table":
             errors.extend(_table_errors(name, f, value))
+        elif name in _GUID_FIELDS:
+            # MOD-GUID: the only place that can tell a GlobalId from the transient viewer id the
+            # non-negotiable forbids — a viewer id is a small integer, a GlobalId is 22 characters.
+            errors.extend(guid_errors(name, value))
     return errors
 
 

--- a/services/api/src/aec_api/modules.py
+++ b/services/api/src/aec_api/modules.py
@@ -24,7 +24,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Session
 
-from . import fin_gov, rbac
+from . import fin_gov, module_schema, rbac
 from .models import EnumOption, RecordActivity, RecordComment
 
 # the read + workflow-evaluation base is a leaf over the registry (no writes, no cycles); re-exported
@@ -208,7 +208,13 @@ def create_record(db: Session, key: str, project_id: str, body: dict, actor: str
         "workflow_state": mod.get("workflow", {}).get("initial", "open"),
         "party_owner": party, "assignee": body.get("assignee"),
         "created_by": actor, "created_at": _now(), "modified_at": _now(),
-        "anchor": body.get("anchor"), "element_guids": body.get("element_guids"),
+        # MOD-GUID: the union of what the caller anchored and what the record's own GlobalId fields
+        # name, so the canonical column can never be a subset of the record's own data. `or` keeps a
+        # caller-supplied None as None rather than turning it into [].
+        "anchor": body.get("anchor"),
+        "element_guids": (sorted({*(body.get("element_guids") or []),
+                                  *module_schema.guids_from_fields(data)})
+                          or body.get("element_guids")),
         "links": body.get("links") or [], "data": data,
     }
     db.execute(insert(t).values(**row))
@@ -808,7 +814,20 @@ def update_record(db: Session, key: str, project_id: str, rid: str, data: dict,
     if (why := fin_gov.locked_reason(key, project_id, rec.get("data"))
             or fin_gov.locked_reason(key, project_id, merged)):
         raise HTTPException(409, why)
-    db.execute(update(t).where(t.c.id == rid).values(data=merged, modified_at=_now()))
+    # MOD-GUID: keep `element_guids` in step with the record's own GlobalId fields. Create-only
+    # mirroring would have missed the ordinary case — file the record, add the GlobalId when you get
+    # back from the field — and left the two stores disagreeing exactly when someone CORRECTS a
+    # mistyped id: the old value would sit in the column forever.
+    #
+    # Not a blind union. Subtract what this record's fields contributed BEFORE, then add what they
+    # contribute now, so a correction moves the anchor while a GlobalId set by another route (a pin,
+    # a BCF import, anchor-to-selection) is untouched — those were never ours to remove.
+    vals = {"data": merged, "modified_at": _now()}
+    was, now = module_schema.guids_from_fields(rec.get("data") or {}), module_schema.guids_from_fields(merged)
+    if was != now:
+        col = (set(rec.get("element_guids") or []) - set(was)) | set(now)
+        vals["element_guids"] = sorted(col) or None
+    db.execute(update(t).where(t.c.id == rid).values(**vals))
     _log(db, project_id, key, rid, actor, party, "update", {"fields": list(data.keys())})
     db.commit()
     return get_record(db, key, project_id, rid)

--- a/services/api/src/aec_api/prefab_kit.py
+++ b/services/api/src/aec_api/prefab_kit.py
@@ -107,11 +107,15 @@ def parse_guids(text: Any) -> list[str]:
     """The frozen list, from a textarea. Newline or comma separated, deduped, order preserved.
 
     Order-preserving rather than sorted: the list is a shop document as much as a data structure, and
-    the order somebody wrote it in is information."""
-    if isinstance(text, (list, tuple)):
-        raw = [str(t) for t in text]
-    else:
-        raw = str(text or "").replace(",", "\n").split("\n")
+    the order somebody wrote it in is information.
+
+    MOD-GUID: the separators are defined once, in `module_schema.split_guids`, because this was the
+    second reader of the same format. Two readers of one format drift — and they drift in the worst
+    direction, where one accepts a separator the other silently folds into a single token, so a list
+    of forty elements validates as one malformed id or, worse, freezes as one.
+    """
+    from .module_schema import split_guids
+    raw = split_guids(text)
     out, seen = [], set()
     for tok in raw:
         g = tok.strip()

--- a/services/api/test_guid_integrity.py
+++ b/services/api/test_guid_integrity.py
@@ -1,0 +1,173 @@
+"""MOD-GUID — the platform's first non-negotiable, as a check that can fail.
+
+`CLAUDE.md` opens with "Reference model elements by IFC GlobalId (GUID), never by transient viewer
+IDs". Three fields store a GlobalId (`field_verification.guid`, `material_request.guids`,
+`prefab_kit.frozen_guids`) and all three were plain `text`. A transient viewer id is a small integer;
+a GlobalId is 22 characters. The field could not tell them apart, so the rule existed only as prose
+and the one thing prose cannot do is fail.
+
+Three separate claims are asserted here, because they fail for different reasons:
+
+  1. FORMAT — a value that is not a GlobalId is rejected on write.
+  2. LEGACY — a record already holding a malformed value stays editable. This is the claim I got
+     wrong: I pulled this work once believing the engine had no legacy story, when `update_record`
+     already validates only the fields in the patch. The check is here because a belief about
+     behaviour that nobody tested is how the mistake happened in the first place.
+  3. RECONCILIATION — a GlobalId in a record's field also lands in `element_guids`, so the two stores
+     that held this one fact cannot disagree.
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_guid_integrity.py
+"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_guid_integrity.db"
+os.environ["STORAGE_DIR"] = "./test_storage_guid"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_guid_integrity.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from aec_api import element_facts  # noqa: E402
+from aec_api import module_schema as ms
+
+GOOD = "1kTvXnbbzCWw8lcMd1dR4o"
+GOOD2 = "0Ln$JgLR9ETfP2m3nQrStU"
+GOOD3 = "2wZq7HcVnB4rT9yUiOpAsD"
+assert all(ms.IFC_GUID_RE.match(g) for g in (GOOD, GOOD2, GOOD3))
+
+# --- 1. what a GlobalId is, and the four shapes of thing that is not one -----------------------------
+for bad, why in [("12345", "a transient viewer id — the exact thing the non-negotiable forbids"),
+                 ("TBD", "a placeholder somebody typed"),
+                 ("1kTvXnbbzCWw8lcMd1dR4", "21 chars: a truncated paste, one short"),
+                 ("1kTvXnbbzCWw8lcMd1dR4oX", "23 chars: a paste that picked up a neighbour"),
+                 ("1kTvXnbbzCWw-lcMd1dR4o", "right length, '-' is outside the alphabet")]:
+    assert not ms.IFC_GUID_RE.match(bad), f"{bad!r} must not validate ({why})"
+    assert ms.guid_errors("guid", bad), why
+
+# a hyphenated UUID is the sharpest near-miss: it IS a globally unique id, just not IFC's compressed
+# form, and it is what you get by copying an id out of this system's own API rather than the model.
+assert not ms.IFC_GUID_RE.match("3f2504e0-4f89-11d3-9a0c-0305e82c3301")
+
+# --- lists: `guids` / `frozen_guids` hold many, separated by newline, comma or semicolon -------------
+assert ms.split_guids(f"{GOOD}\n{GOOD2}") == [GOOD, GOOD2]
+assert ms.split_guids(f" {GOOD} , {GOOD2} ") == [GOOD, GOOD2]
+assert ms.split_guids([GOOD, GOOD2]) == [GOOD, GOOD2], "already-a-list must pass through"
+assert ms.split_guids("") == [] and ms.split_guids(None) == []
+assert ms.guid_errors("guids", f"{GOOD}\nbad1\n{GOOD2}\nbad2"), "one bad id in a list is still bad"
+# capped, so pasting a hundred wrong ids is a readable message rather than a wall
+many = ms.guid_errors("guids", "\n".join(f"x{i}" for i in range(50)))
+assert len(many) == 4 and "47 more" in many[-1], many          # 50 bad, 3 named, 47 counted
+
+# --- 2. THE LEGACY STORY. A partial patch must not re-validate a field it is not touching ------------
+fv = {"fields": [{"name": "guid", "type": "text"}, {"name": "element", "type": "text"}]}
+assert ms.validate_record(fv, {"guid": "legacy-junk"}), "writing a bad guid is an error"
+assert ms.validate_record(fv, {"element": "C-12"}) == [], (
+    "a patch that does not mention `guid` must be clean even though the stored guid is malformed — "
+    "this is what makes the rule shippable against live data")
+
+# --- 3. the two stores, reconciled ------------------------------------------------------------------
+assert ms.guids_from_fields({"guid": GOOD}) == [GOOD]
+assert sorted(ms.guids_from_fields({"frozen_guids": f"{GOOD},{GOOD2}"})) == sorted([GOOD, GOOD2])
+assert ms.guids_from_fields({"guid": "TBD"}) == [], (
+    "a malformed id must NOT be mirrored: validate_record already reports it, and copying it into the "
+    "column every consumer trusts would spread the bad value instead of containing it")
+assert ms.guids_from_fields({"element": GOOD}) == [], "only GlobalId-named fields are GlobalIds"
+
+# `_claims` read only the singular `guid`, so the other two fields never matched here.
+for field in ("guid", "guids", "frozen_guids"):
+    assert element_facts._claims({"data": {field: GOOD}}, GOOD), f"{field} must claim its element"
+    assert not element_facts._claims({"data": {field: GOOD}}, GOOD2)
+assert element_facts._claims({"element_guids": [GOOD], "data": {}}, GOOD), "the column still works"
+
+# --- HTTP: the write path, end to end ---------------------------------------------------------------
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+
+with TestClient(app) as tc:
+    pid = tc.post("/projects", json={"name": "GUID Tower"}).json()["id"]
+
+    bad = tc.post(f"/projects/{pid}/modules/field_verification",
+                  json={"data": {"guid": "12345", "element": "C-1"}})
+    assert bad.status_code == 422, f"a viewer id must be refused, got {bad.status_code}"
+    assert "GlobalId" in bad.text, bad.text[:200]
+
+    ok = tc.post(f"/projects/{pid}/modules/field_verification",
+                 json={"data": {"guid": GOOD, "element": "C-1"}})
+    assert ok.status_code in (200, 201), ok.text[:200]
+    rid = ok.json()["id"]
+
+    # the mirror: the field's GlobalId is now in the column every consumer reads
+    got = tc.get(f"/projects/{pid}/modules/field_verification/{rid}").json()
+    assert GOOD in (got.get("element_guids") or []), (
+        f"guid field must mirror into element_guids, got {got.get('element_guids')!r}")
+
+    # a caller-supplied anchor is not replaced by the mirror, it is joined by it
+    both = tc.post(f"/projects/{pid}/modules/field_verification",
+                   json={"element_guids": [GOOD2], "data": {"guid": GOOD, "element": "C-2"}})
+    assert sorted(both.json()["element_guids"]) == sorted([GOOD, GOOD2]), both.json()["element_guids"]
+
+    # a record with no GlobalId anywhere keeps a null column, not an empty list — the two mean
+    # different things to `pins.py` ("never anchored" vs "anchored to nothing")
+    # (material_request, not field_verification — the latter's `guid` is required, so the create would
+    # 422 and `.get("element_guids")` on an ERROR body is None, which passes this assert for entirely
+    # the wrong reason. Assert the status first so the shape can't stand in for the behaviour.)
+    none = tc.post(f"/projects/{pid}/modules/material_request", json={"data": {"material": "Sealant"}})
+    assert none.status_code in (200, 201), none.text[:200]
+    assert none.json().get("element_guids") is None, none.json().get("element_guids")
+
+    # a list field, and a patch that leaves the GlobalId alone
+    mr = tc.post(f"/projects/{pid}/modules/material_request",
+                 json={"data": {"material": "Rebar", "guids": f"{GOOD}\n{GOOD2}"}})
+    assert mr.status_code in (200, 201), mr.text[:200]
+    assert sorted(mr.json()["element_guids"]) == sorted([GOOD, GOOD2]), mr.json()["element_guids"]
+    patched = tc.patch(f"/projects/{pid}/modules/material_request/{mr.json()['id']}",
+                       json={"material": "Rebar #5"})
+    assert patched.status_code == 200, patched.text[:200]
+
+    # --- the mirror on UPDATE, which is where the ordinary flow lives -------------------------------
+    # file the record now, add the GlobalId when you get back from the field
+    # material_request, because `field_verification.guid` is `required` — the module that lets you
+    # file first and anchor later is the one that exercises the update path
+    later = tc.post(f"/projects/{pid}/modules/material_request", json={"data": {"material": "Anchors"}})
+    lid = later.json()["id"]
+    assert not later.json().get("element_guids")
+    up = tc.patch(f"/projects/{pid}/modules/material_request/{lid}", json={"guids": GOOD})
+    assert up.status_code == 200, up.text[:200]
+    assert (tc.get(f"/projects/{pid}/modules/material_request/{lid}").json()["element_guids"]
+            == [GOOD]), "a GlobalId added after creation must reach the column too"
+
+    # CORRECTING a mistyped id must MOVE the anchor, not accumulate one. This is the case a blind
+    # union gets wrong: the old element stays claimed forever and two records answer for it.
+    tc.patch(f"/projects/{pid}/modules/material_request/{lid}", json={"guids": GOOD2})
+    assert (tc.get(f"/projects/{pid}/modules/material_request/{lid}").json()["element_guids"]
+            == [GOOD2]), "correcting a GlobalId must drop the old one"
+
+    # but an anchor set by another route (pin, BCF import, anchor-to-selection) is not ours to remove
+    tc.post(f"/projects/{pid}/modules/material_request/{lid}/elements", json={"guids": [GOOD]})
+    # patch to a THIRD id, not back to the one already stored: `was == now` short-circuits the whole
+    # branch, so re-patching the same value tests nothing. That is how this assertion first passed
+    # against a mutant that replaced the column outright.
+    tc.patch(f"/projects/{pid}/modules/material_request/{lid}", json={"guids": GOOD3})
+    after = tc.get(f"/projects/{pid}/modules/material_request/{lid}").json()["element_guids"]
+    assert GOOD in after, f"an independently-set anchor must survive a field edit, got {after}"
+    assert GOOD3 in after, f"the new field value must be anchored, got {after}"
+    assert GOOD2 not in after, f"the replaced field value must be dropped, got {after}"
+
+# --- the three fields are still the three fields ----------------------------------------------------
+# Not a floor and not an allowlist: if a module gains a field named `guid`, this fails and whoever
+# added it decides whether it is a GlobalId. A silent fourth field is how `_claims` came to cover one.
+import json  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+found = set()
+for mj in Path("modules").glob("*/module.json"):
+    for f in json.loads(mj.read_text(encoding="utf-8")).get("fields", []):
+        if f["name"] in ms._GUID_FIELDS:
+            found.add(f"{mj.parent.name}.{f['name']}")
+assert found == {"field_verification.guid", "material_request.guids", "prefab_kit.frozen_guids"}, found
+
+print("GUID-INTEGRITY OK - a viewer id, a placeholder, a truncated paste and a hyphenated UUID are "
+      "all refused on write; a record already holding a malformed id stays editable via a patch that "
+      "does not touch it; a GlobalId in a record's field mirrors into element_guids so the two stores "
+      "cannot disagree, and _claims now reads all three fields instead of one.")

--- a/services/api/test_guid_integrity.py
+++ b/services/api/test_guid_integrity.py
@@ -154,6 +154,27 @@ with TestClient(app) as tc:
     assert GOOD3 in after, f"the new field value must be anchored, got {after}"
     assert GOOD2 not in after, f"the replaced field value must be dropped, got {after}"
 
+# --- the DEMO must obey the rule the product enforces ------------------------------------------------
+# The seeded demo filed "Level 2 slab 1" into `field_verification.guid` and a sentence about
+# coordinating before the next pour into `material_request.guids`: the generator falls through to
+# prose for any `text`/`textarea` it does not recognise, and nothing rejected it. So the demo every
+# new user opens was showing the platform's first non-negotiable being broken. `test_demo_seed`
+# validates the whole corpus and catches this now; asserted here too, because the generator is what
+# has to know, and it must learn it from the same list the validator uses.
+from aec_api.demo_seed import _fake_guid, _value  # noqa: E402
+
+for i in range(200):
+    g = _fake_guid("mod", "guid", i)
+    assert ms.IFC_GUID_RE.match(g), g
+assert _fake_guid("a", 1) == _fake_guid("a", 1), "a re-seeded demo must be byte-identical"
+assert len({_fake_guid("m", i) for i in range(200)}) == 200, "distinct rows must differ"
+from datetime import date  # noqa: E402
+
+for fname, ftype, n in [("guid", "text", 1), ("guids", "textarea", 2), ("frozen_guids", "textarea", 2)]:
+    v = _value({"name": fname, "type": ftype}, "m", 0, date.today())
+    got = ms.split_guids(v)
+    assert len(got) == n and all(ms.IFC_GUID_RE.match(g) for g in got), (fname, v)
+
 # --- the three fields are still the three fields ----------------------------------------------------
 # Not a floor and not an allowlist: if a module gains a field named `guid`, this fails and whoever
 # added it decides whether it is a GlobalId. A silent fourth field is how `_claims` came to cover one.

--- a/services/api/test_prefab_route.py
+++ b/services/api/test_prefab_route.py
@@ -37,12 +37,17 @@ def el(guid, cls, type_name, storey, qtos=None):
             "storey": storey, "psets": {}, "qtos": qtos or {}}
 
 
+# MOD-GUID: real 22-char GlobalIds. These were G1/G2/G3 — placeholders that could not be
+# an IfcGloballyUniqueId, which is now refused on write. Named constants rather than literals
+# so the assertions below still read as being about three ducts.
+G1, G2, G3 = '1Aq7bR3xM9wZcTf0KpLnEd', '2Bs8cS4yN0xAdUg1LqMoFe', '3Ct9dT5zO1yBeVh2MrNpGf'
+
 ELEMENTS = [
-    el("g1", "IfcDuctSegment", "600x300", "L3",
+    el(G1, "IfcDuctSegment", "600x300", "L3",
        {"Qto_DuctSegmentBaseQuantities": {"Length": 4.0}}),
-    el("g2", "IfcDuctSegment", "600x300", "L3",
+    el(G2, "IfcDuctSegment", "600x300", "L3",
        {"Qto_DuctSegmentBaseQuantities": {"Length": 6.0}}),
-    el("g3", "IfcDuctSegment", "400x200", "L2",
+    el(G3, "IfcDuctSegment", "400x200", "L2",
        {"Qto_DuctSegmentBaseQuantities": {"Length": 3.0}}),
 ]
 
@@ -110,7 +115,7 @@ with TestClient(app) as c:
     check("  it froze the two matching elements", fr.json()["frozen"] == 2, fr.json())
     rec = c.get(f"/projects/{pid}/modules/prefab_kit/{rid}").json()
     check("  and PERSISTED the list onto the record — not just returned it",
-          sorted((rec["data"].get("frozen_guids") or "").split()) == ["g1", "g2"],
+          sorted((rec["data"].get("frozen_guids") or "").split()) == [G1, G2],
           rec["data"].get("frozen_guids"))
 
     # Release it, then change the model underneath. This is the whole feature.
@@ -134,7 +139,7 @@ with TestClient(app) as c:
     check("  and it has not drifted yet", after["drift"]["drifted"] is False, after["drift"])
 
     # A design change: one duct moves off L3, and a new one appears on it.
-    changed = [e for e in ELEMENTS if e["guid"] != "g2"]
+    changed = [e for e in ELEMENTS if e["guid"] != G2]
     changed.append({**ELEMENTS[1], "storey": "L4"})
     changed.append(el("g9", "IfcDuctSegment", "600x300", "L3",
                       {"Qto_DuctSegmentBaseQuantities": {"Length": 5.0}}))
@@ -146,7 +151,7 @@ with TestClient(app) as c:
           drifted["drift"]["drifted"] is True, drifted["drift"])
     check("  the kit still contains what the shop was given", drifted["elements"] == 2)
     check("  the element that left the scope is named",
-          drifted["drift"]["removed"] == ["g2"], drifted["drift"])
+          drifted["drift"]["removed"] == [G2], drifted["drift"])
     check("  and the one that joined it is named separately",
           drifted["drift"]["added"] == ["g9"], drifted["drift"])
     check("  drift is a blocker", "scope_drift" in {b["code"] for b in drifted["blockers"]})

--- a/services/api/test_procurement.py
+++ b/services/api/test_procurement.py
@@ -83,18 +83,23 @@ with TestClient(app) as c:
     assert only["material_count"] == 1, only
 
     # --- PROC-LOOP material requests: pure QTO suggestion maths + the module round-trip ------------
-    rows_tk = [{"guid": "w1", "ifc_class": "IfcWall", "area": 10.0, "volume": 2.0},
-               {"guid": "w2", "ifc_class": "IfcWall", "area": 12.0, "volume": 2.5},
-               {"guid": "d1", "ifc_class": "IfcDoor", "area": None, "volume": None}]
+    # MOD-GUID: real 22-char GlobalIds — "w1"/"w2"/"d1" could not be an IfcGloballyUniqueId and are
+    # now refused on write. Note the separator: `parse_guids` has always split on newline/comma, so
+    # the old "w1 w2" was ONE token to every reader — the fixture only looked like two ids.
+    W1, W2, D1 = "4Du0eU6$P2zCfWi3NsOqHg", "5Ev1fV7aQ3AdGxj4OtPrIh", "6Fw2gW8bR4BeHyk5PuQsJi"
+    rows_tk = [{"guid": W1, "ifc_class": "IfcWall", "area": 10.0, "volume": 2.0},
+               {"guid": W2, "ifc_class": "IfcWall", "area": 12.0, "volume": 2.5},
+               {"guid": D1, "ifc_class": "IfcDoor", "area": None, "volume": None}]
     sug = procurement.suggest_material_requests(rows_tk, None)
     wall = next(s for s in sug if s["ifc_class"] == "IfcWall")
     assert wall["qty"] == 4.5 and wall["unit"] == "m3" and wall["elements"] == 2, wall  # volume preferred
     door = next(s for s in sug if s["ifc_class"] == "IfcDoor")
     assert door["qty"] == 1 and door["unit"] == "ea", door                              # count fallback
-    assert procurement.suggest_material_requests(rows_tk, {"d1"}) == [door | {"guids": ["d1"]}], "guid narrowing"
+    assert procurement.suggest_material_requests(rows_tk, {D1}) == [door | {"guids": [D1]}], "guid narrowing"
     # the module workflow: requested → approved → ordered → delivered
     mr = c.post(f"/projects/{pid}/modules/material_request",
-                json={"data": {"material": "Wall", "qty": 4.5, "unit": "m3", "guids": "w1 w2"}}).json()
+                json={"data": {"material": "Wall", "qty": 4.5, "unit": "m3",
+                               "guids": "\n".join([W1, W2])}}).json()
     assert mr["workflow_state"] == "requested", mr
     for a in ("approve", "order", "receive"):
         tr = c.post(f"/projects/{pid}/modules/material_request/{mr['id']}/transition", json={"action": a})

--- a/services/api/test_verified_progress.py
+++ b/services/api/test_verified_progress.py
@@ -51,9 +51,13 @@ with TestClient(app) as tc:
                 json={"data": {"name": "Columns", "trade": "Structure", "percent": 100}})
     assert a.status_code in (200, 201), a.text[:200]
     # two field-verification records (installed as the module's default 'captured' state)
-    for g in ("gA", "gB"):
+    # MOD-GUID: real 22-char GlobalIds. These were "gA"/"gB" — placeholders that read as element ids
+    # but could not be one, which is exactly what the field now rejects. The `elements`/`acts` fixtures
+    # above keep their short ids on purpose: they exercise the pure rollup, which never sees a module
+    # record, and shortening them there would hide that the check lives on the WRITE path.
+    for g in ("1kTvXnbbzCWw8lcMd1dR4o", "0Ln$JgLR9ETfP2m3nQrStU"):
         rr = tc.post(f"/projects/{pid}/modules/field_verification",
-                     json={"data": {"guid": g, "element": f"C-{g}", "ifc_class": "IfcColumn"}})
+                     json={"data": {"guid": g, "element": f"C-{g[:4]}", "ifc_class": "IfcColumn"}})
         assert rr.status_code in (200, 201), rr.text[:200]
     # the endpoint responds with a rollup shape (records counted) even before a published element index
     r = tc.get(f"/projects/{pid}/verified-progress")


### PR DESCRIPTION
`CLAUDE.md` opens with *"Reference model elements by IFC GlobalId (GUID), never by transient viewer IDs."* The three fields that store one (`field_verification.guid`, `material_request.guids`, `prefab_kit.frozen_guids`) were plain `text`. A viewer id is a small integer; a GlobalId is 22 characters. The field could not tell them apart, so the rule existed only as prose — and the one thing prose cannot do is fail.

## Three defects

**1. Format.** An `IfcGloballyUniqueId` is 22 chars over `[0-9A-Za-z_$]`. Now validated on write. The sharpest near-miss is a hyphenated UUID: it *is* a globally unique id, just not IFC's compressed form — and it is exactly what you get by copying an id out of this system's own API rather than out of the model.

**2. Two stores held one fact.** `element_facts._claims` checked `element_guids` **or** `data["guid"]`:

```python
if guid in (row.get("element_guids") or []): return True
return str((row.get("data") or {}).get("guid") or "").strip() == guid
```

That `or` is the tell — a record could be anchored to element A by its column and element B by its field, each consumer right about a different element. It also read only the *singular* `guid`, so two of the three fields never matched there at all.

The column is now a superset on create **and** update. The update arithmetic is deliberately not a blind union: it subtracts what the record's own fields contributed *before*, then adds what they contribute *now* — so correcting a mistyped id **moves** the anchor, while a GlobalId set by a pin, a BCF import or anchor-to-selection survives. Those were never ours to remove.

**3. Two readers of one format.** `prefab_kit.parse_guids` was a second, independent definition of the same separator rules. It now delegates to `module_schema.split_guids`.

## The correction worth reading

**This was written once and pulled, for a reason that was wrong.** The stated reason was that it had no legacy story — that live records holding a malformed id would become un-saveable. They do not: `update_record` validates only the fields in the patch, so an untouched bad value keeps saving. The blast radius was also given as ~25 test files; it was **one**. Both figures came from pattern-matching rather than reading — the same failure the work itself is about. That claim is now `test_guid_integrity` §2 instead of a belief.

## Verification

- `test_guid_integrity.py` — format, the legacy patch case, the two stores, and the three fields as an exact set (not a floor, not an allowlist: a fourth `guid`-named field fails it, and a silent fourth field is how `_claims` came to cover one).
- **All six mutants killed** — including two the gate first missed, because the test patched a field back to a value it already held and `was == now` short-circuits the whole branch.
- One assertion was passing vacuously (a required-field 422 makes `.get("element_guids")` `None`, which satisfied "must be empty"); it now asserts the status first.
- Suites re-run green: `guid_integrity`, `verified_progress`, `prefab_route`, `prefab_kit`, `procurement`, `element_facts`, `element_records`, `claim_type`, `quality_chain`, `lod500`, `detailing`, `modules`, `module_fields`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)