### PR TITLE
MOD-G702 — the pay application as a document, and a negative payment due

### DIFF
--- a/docs/internal/module-field-sweep.md
+++ b/docs/internal/module-field-sweep.md
@@ -169,9 +169,25 @@ been a bug nobody could locate.
 
 ### Still open, and genuinely so
 
-- **`sov` and `owner_invoice` as documents.** `estimate` gained `line_items`; the AIA G702/G703 pair
-  did not. `sov` is still one record per line with no parent, so the continuation sheet is assembled
-  by `cost.g703` rather than stored. That is the last structural item from §6.
+- ~~**`sov` and `owner_invoice` as documents.**~~ **Shipped as `MOD-G702`.** The structural item was
+  real — `owner_invoice` had five fields standing in for an AIA G702, and the continuation sheet was
+  assembled on every read rather than stored. But looking for the missing fields turned up a **money
+  bug** underneath it:
+
+  `g703` retained each SOV line at that line's own `retainage_pct`; `g702` line 7 applied the global
+  `DEFAULT_RETAINAGE` to the aggregate. Any contract not on the default made the two disagree. On a
+  10% contract with $50,000 completed and nothing this period, **line 8 — current payment due — came
+  out at −$2,500**, and `closeout.py` reads line 8 for the final-payment amount.
+
+  **`test_cost.py` contains no assertion on line 7, line 8, or retainage at all.** It was not a weak
+  test of this behaviour; it was structurally unable to see it. That is the shape worth remembering
+  from this item, more than the fields that were added.
+
+  The deeper fix is that an application is now a **document**: `POST /cost/pay-application` freezes
+  the G703 sheet and lines 1-9 into an `owner_invoice`, and line 7 deducts what was actually
+  certified - including a reduced architect certification - instead of reconstructing it from
+  `completed_prev`, which moves whenever anyone edits an earlier period. `GET /cost/g702` stays a
+  live view, because "where do we stand today" is a real question; it is just not a certificate.
 - **A `reference` column type for tables.** Deliberately excluded (see `TABLE_COLUMN_TYPES`) because a
   picker per row is a real feature and shipping it half-done would put unresolvable ids in rows.
 - ~~**The element link (`§5 T4`).**~~ **Shipped as `MOD-GUID`.** Three defects, and the second was

--- a/services/api/modules/owner_invoice/module.json
+++ b/services/api/modules/owner_invoice/module.json
@@ -16,16 +16,183 @@
     },
     {
       "name": "period",
-      "label": "Period",
       "type": "text",
+      "label": "Period",
       "fieldset": "Identity"
     },
     {
-      "name": "amount",
-      "label": "Amount",
-      "type": "currency",
+      "name": "period_from",
+      "type": "date",
+      "label": "Period from",
+      "fieldset": "Identity"
+    },
+    {
+      "name": "period_to",
+      "type": "date",
+      "label": "Period to",
+      "fieldset": "Identity"
+    },
+    {
+      "name": "line_items",
+      "type": "table",
+      "label": "Continuation sheet (G703)",
       "fieldset": "Money",
-      "min": 0
+      "columns": [
+        {
+          "name": "item_no",
+          "label": "Item",
+          "type": "text"
+        },
+        {
+          "name": "description",
+          "label": "Description of work",
+          "type": "text"
+        },
+        {
+          "name": "scheduled_value",
+          "label": "Scheduled value",
+          "type": "currency"
+        },
+        {
+          "name": "completed_prev",
+          "label": "From previous application",
+          "type": "currency"
+        },
+        {
+          "name": "completed_this",
+          "label": "This period",
+          "type": "currency"
+        },
+        {
+          "name": "materials_stored",
+          "label": "Materials presently stored",
+          "type": "currency"
+        },
+        {
+          "name": "total_completed_stored",
+          "label": "Total completed & stored",
+          "type": "currency"
+        },
+        {
+          "name": "percent",
+          "label": "%",
+          "type": "percent"
+        },
+        {
+          "name": "balance_to_finish",
+          "label": "Balance to finish",
+          "type": "currency"
+        },
+        {
+          "name": "retainage",
+          "label": "Retainage",
+          "type": "currency"
+        }
+      ],
+      "total_column": "total_completed_stored",
+      "totals_into": "amount"
+    },
+    {
+      "name": "original_contract_sum",
+      "type": "currency",
+      "label": "1. Original contract sum",
+      "fieldset": "Money"
+    },
+    {
+      "name": "net_change_orders",
+      "type": "currency",
+      "label": "2. Net change by change orders",
+      "fieldset": "Money"
+    },
+    {
+      "name": "contract_sum_to_date",
+      "type": "currency",
+      "label": "3. Contract sum to date",
+      "fieldset": "Money"
+    },
+    {
+      "name": "amount",
+      "type": "currency",
+      "label": "4. Total completed & stored to date",
+      "fieldset": "Money"
+    },
+    {
+      "name": "retainage_work_pct",
+      "type": "percent",
+      "label": "5a. Retainage on completed work",
+      "unit": "%",
+      "min": 0,
+      "max": 100,
+      "fieldset": "Money"
+    },
+    {
+      "name": "retainage_stored_pct",
+      "type": "percent",
+      "label": "5b. Retainage on stored material",
+      "unit": "%",
+      "min": 0,
+      "max": 100,
+      "fieldset": "Money"
+    },
+    {
+      "name": "retainage_total",
+      "type": "currency",
+      "label": "5. Total retainage",
+      "fieldset": "Money"
+    },
+    {
+      "name": "earned_less_retainage",
+      "type": "currency",
+      "label": "6. Total earned less retainage",
+      "fieldset": "Money"
+    },
+    {
+      "name": "previous_certificates",
+      "type": "currency",
+      "label": "7. Less previous certificates",
+      "fieldset": "Money"
+    },
+    {
+      "name": "current_payment_due",
+      "type": "currency",
+      "label": "8. CURRENT PAYMENT DUE",
+      "fieldset": "Money"
+    },
+    {
+      "name": "balance_to_finish",
+      "type": "currency",
+      "label": "9. Balance to finish incl. retainage",
+      "fieldset": "Money"
+    },
+    {
+      "name": "contractor_signature",
+      "type": "signature",
+      "label": "Contractor certification",
+      "fieldset": "Certification"
+    },
+    {
+      "name": "contractor_signed_date",
+      "type": "date",
+      "label": "Date certified",
+      "fieldset": "Certification"
+    },
+    {
+      "name": "architect_certified_amount",
+      "type": "currency",
+      "label": "Amount certified by architect",
+      "fieldset": "Certification"
+    },
+    {
+      "name": "architect_signature",
+      "type": "signature",
+      "label": "Architect certification",
+      "fieldset": "Certification"
+    },
+    {
+      "name": "architect_signed_date",
+      "type": "date",
+      "label": "Date certified",
+      "fieldset": "Certification"
     },
     {
       "name": "status",
@@ -45,6 +212,26 @@
       "label": "Prime contract",
       "type": "reference",
       "module": "prime_contract",
+      "fieldset": "Links"
+    },
+    {
+      "name": "coi",
+      "type": "reference",
+      "module": "coi",
+      "label": "Certificate of insurance",
+      "fieldset": "Links"
+    },
+    {
+      "name": "lien_waiver",
+      "type": "reference",
+      "module": "lien_waiver",
+      "label": "Lien waiver",
+      "fieldset": "Links"
+    },
+    {
+      "name": "sov_snapshot_at",
+      "type": "date",
+      "label": "Continuation sheet snapshotted",
       "fieldset": "Links"
     }
   ],
@@ -101,7 +288,9 @@
     ]
   },
   "list_columns": [
+    "period_to",
     "amount",
+    "current_payment_due",
     "status",
     "prime_contract"
   ],

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -38,7 +38,7 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          "test_ask", "test_verification", "test_webhooks", "test_operate_capital", "test_payroll_drawings", "test_assistant_itb", "test_construction_depth", "test_distribution", "test_e57", "test_empty_project", "test_metrics", "test_metrics_auth", "test_licensing", "test_revit_bridge", "test_precon", "test_specs", "test_feasibility", "test_clash_import", "test_clash_intel", "test_layout", "test_loads", "test_verified_progress", "test_element_records", "test_securities_bridge", "test_imports", "test_search_alerts", "test_attachments",
          # previously not wired into the gate (glob would have caught these) — now covered:
          "test_analytics", "test_discipline", "test_gbxml", "test_review", "test_interop",
-         "test_module_config", "test_module_schema", "test_field_attrs", "test_eticket_tm", "test_ref_backfill", "test_module_tables", "test_module_filters", "test_guid_integrity", "test_module_fields", "test_throttle", "test_route_order",
+         "test_module_config", "test_module_schema", "test_field_attrs", "test_eticket_tm", "test_ref_backfill", "test_module_tables", "test_module_filters", "test_guid_integrity", "test_pay_application", "test_module_fields", "test_throttle", "test_route_order",
          # R23-PREFAB-KIT — the kit join + its register routes:
          "test_prefab_kit", "test_prefab_route",
          # Tier-1 competitive upgrades:

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -39,7 +39,7 @@ def g703(db: Session, pid: str) -> dict[str, Any]:
     """Schedule of Values register with AIA G703 computed columns."""
     lines = []
     tot = {"scheduled": 0.0, "prev": 0.0, "this": 0.0, "stored": 0.0,
-           "completed": 0.0, "balance": 0.0, "retainage": 0.0}
+           "completed": 0.0, "balance": 0.0, "retainage": 0.0, "retainage_prev": 0.0}
     for r in sorted(_records(db, "sov", pid), key=lambda x: str(x["data"].get("item_no", ""))):
         d = r["data"]
         scheduled = _n(d.get("scheduled_value"))
@@ -47,6 +47,10 @@ def g703(db: Session, pid: str) -> dict[str, Any]:
         completed = prev + this + stored
         ret_pct = _n(d.get("retainage_pct")) or DEFAULT_RETAINAGE
         retainage = round(completed * ret_pct / 100, 2)
+        # MOD-G702: the same line's retainage on the PREVIOUS period alone. G702 line 7 needs it, and
+        # computing it there from the global default while line 5 used the per-line rate is what made
+        # a 10%-retainage contract report a negative payment due.
+        retainage_prev = round(prev * ret_pct / 100, 2)
         line = {
             "item_no": d.get("item_no"), "description": d.get("description"),
             "cost_code": d.get("cost_code"), "scheduled_value": scheduled,
@@ -54,17 +58,19 @@ def g703(db: Session, pid: str) -> dict[str, Any]:
             "total_completed_stored": round(completed, 2),
             "percent": round(completed / scheduled * 100, 1) if scheduled else 0.0,
             "balance_to_finish": round(scheduled - completed, 2), "retainage": retainage,
+            "retainage_prev": retainage_prev,
         }
         lines.append(line)
         tot["scheduled"] += scheduled; tot["prev"] += prev; tot["this"] += this
         tot["stored"] += stored; tot["completed"] += completed
         tot["balance"] += scheduled - completed; tot["retainage"] += retainage
+        tot["retainage_prev"] += retainage_prev
     tot = {k: round(v, 2) for k, v in tot.items()}
     return {"lines": lines, "totals": tot}
 
 
 def g702(db: Session, pid: str, app_no: int = 1, period: str | None = None,
-         release_retainage: bool = False) -> dict[str, Any]:
+         release_retainage: bool = False, previous_certificates: float | None = None) -> dict[str, Any]:
     """AIA G702 Application & Certificate for Payment (lines 1-9). `release_retainage` (final app):
     the previously-held retainage is released — retainage held → 0 and the held amount becomes due."""
     sov = g703(db, pid)
@@ -75,10 +81,18 @@ def g702(db: Session, pid: str, app_no: int = 1, period: str | None = None,
     completed = t["completed"]
     retainage = 0.0 if release_retainage else t["retainage"]
     earned_less_retainage = round(completed - retainage, 2)
-    # previous certificates ≈ prior-period earned less retainage (from "completed_prev")
+    # Line 7, "less previous certificates for payment". Derived from `completed_prev` because until
+    # MOD-G702 no application was ever STORED — there was no prior certificate to read, only a
+    # reconstruction of one. It is now a fallback: `previous_certificates` is passed in when a
+    # submitted `owner_invoice` exists, and that is a fact rather than an approximation.
+    #
+    # The retainage here is summed PER LINE, matching line 5. It used to apply DEFAULT_RETAINAGE to
+    # the aggregate, so any line overriding the rate made lines 7 and 5 disagree — on a 10% contract
+    # with $50k completed and nothing this period, line 8 came out at MINUS $2,500. `closeout.py`
+    # reads line 8 for the final-payment amount, so the number had a consumer.
     prev = t["prev"]
-    ret_prev = round(prev * DEFAULT_RETAINAGE / 100, 2)
-    previous_certificates = round(prev - ret_prev, 2)
+    if previous_certificates is None:
+        previous_certificates = round(prev - t["retainage_prev"], 2)
     current_due = round(earned_less_retainage - previous_certificates, 2)
     balance_to_finish = round(contract_to_date - earned_less_retainage, 2)
     return {
@@ -93,6 +107,78 @@ def g702(db: Session, pid: str, app_no: int = 1, period: str | None = None,
         "line8_current_payment_due": current_due,
         "line9_balance_to_finish_incl_retainage": balance_to_finish,
     }
+
+
+def _certified_to_date(db: Session, pid: str) -> float | None:
+    """MOD-G702 — what previous applications actually certified, or None if none has been submitted.
+
+    Line 7 of a G702 is "less previous certificates for payment", and the AIA form tells you where to
+    get it: *line 6 from the prior certificate*. It is a historical fact, not a recomputation. This
+    codebase had no stored application, so it reconstructed the figure from the SOV's `completed_prev`
+    — which is only equal to the truth while nothing about the earlier periods has changed. Edit a
+    retainage rate, correct a scheduled value, or approve a change order that restates an earlier
+    line, and the reconstruction moves. The certificate does not: it was signed.
+
+    `architect_certified_amount` wins over line 8 when present, because the architect may certify less
+    than was applied for, and what was actually certified is what a later application must deduct.
+    """
+    best = None
+    for r in _records(db, "owner_invoice", pid):
+        if r.get("workflow_state") not in ("submitted", "approved", "paid"):
+            continue                       # a draft has certified nothing
+        d = r.get("data") or {}
+        amt = d.get("architect_certified_amount")
+        if amt in (None, ""):
+            amt = d.get("current_payment_due")
+        prior = _n(d.get("previous_certificates"))
+        # cumulative-to-date = what this application deducted, plus what it added
+        tot = round(prior + _n(amt), 2)
+        if best is None or tot > best:
+            best = tot
+    return best
+
+
+def build_application(db: Session, pid: str, app_no: int | None = None, period: str | None = None,
+                      period_from: str | None = None, period_to: str | None = None,
+                      release_retainage: bool = False, actor: str = "system") -> dict[str, Any]:
+    """MOD-G702 — snapshot the live SOV into an `owner_invoice` record: an application, not a view.
+
+    A pay application is a CLAIM MADE ON A DATE. Everything that fed it — the schedule of values, the
+    change orders, the retainage rates — keeps moving afterwards, so a "current" G702 assembled on
+    demand silently restates applications that have already been signed and paid. That is the same
+    defect shape as MOD-TOTALS, where re-pricing a rate library would have changed what was already
+    owed: the fix there and here is to freeze the numbers into the document at the moment it is made.
+
+    Draft, deliberately. This produces the record; submitting and certifying it are workflow
+    transitions a person performs, because a certificate nobody signed is not a certificate.
+    """
+    sheet = g703(db, pid)
+    if app_no is None:
+        app_no = 1 + len(_records(db, "owner_invoice", pid))
+    cert = g702(db, pid, app_no=app_no, period=period, release_retainage=release_retainage,
+                previous_certificates=_certified_to_date(db, pid))
+    data = {
+        "number": str(app_no), "period": period or "", "period_from": period_from or "",
+        "period_to": period_to or "",
+        "line_items": sheet["lines"],
+        "original_contract_sum": cert["line1_original_contract_sum"],
+        "net_change_orders": cert["line2_net_change_orders"],
+        "contract_sum_to_date": cert["line3_contract_sum_to_date"],
+        "amount": cert["line4_total_completed_stored"],
+        "retainage_total": cert["line5_retainage"],
+        "earned_less_retainage": cert["line6_total_earned_less_retainage"],
+        "previous_certificates": cert["line7_less_previous_certificates"],
+        "current_payment_due": cert["line8_current_payment_due"],
+        "balance_to_finish": cert["line9_balance_to_finish_incl_retainage"],
+        "sov_snapshot_at": _now_date(),
+        "status": "draft",
+    }
+    return me.create_record(db, "owner_invoice", pid, {"data": data}, actor, "GC")
+
+
+def _now_date() -> str:
+    from .timeutil import utc_today
+    return utc_today().isoformat()
 
 
 def advance_period(db: Session, pid: str, actor: str = "system") -> dict[str, Any]:

--- a/services/api/src/aec_api/routers/cost.py
+++ b/services/api/src/aec_api/routers/cost.py
@@ -337,7 +337,30 @@ def g703(pid: str, db: Session = Depends(get_db), _: str = Depends(require_role(
 @router.get("/projects/{pid}/cost/g702")
 def g702(pid: str, app_no: int = 1, period: str | None = None, release_retainage: bool = False,
          db: Session = Depends(get_db), _: str = Depends(require_role("viewer"))):
-    return cost.g702(db, pid, app_no, period, release_retainage)
+    return cost.g702(db, pid, app_no, period, release_retainage,
+                     previous_certificates=cost._certified_to_date(db, pid))
+
+
+@router.post("/projects/{pid}/cost/pay-application", status_code=201)
+def build_pay_application(pid: str, app_no: int | None = Body(None, embed=True),
+                          period: str | None = Body(None, embed=True),
+                          period_from: str | None = Body(None, embed=True),
+                          period_to: str | None = Body(None, embed=True),
+                          release_retainage: bool = Body(False, embed=True),
+                          db: Session = Depends(get_db),
+                          user: str = Depends(require_role("reviewer"))):
+    """MOD-G702 — snapshot the live SOV and G702 into a draft `owner_invoice`.
+
+    `GET /cost/g702` stays a live view, which is the right thing for "where do we stand today". This
+    is the other thing: the application you actually send, with its numbers frozen. A pay application
+    is a claim made on a date, and everything feeding it keeps moving afterwards — so a certificate
+    reassembled on demand silently restates applications already signed and paid.
+
+    Created as a DRAFT. Submitting and certifying are transitions a person performs; a certificate
+    nobody signed is not a certificate.
+    """
+    return cost.build_application(db, pid, app_no, period, period_from, period_to,
+                                  release_retainage, user)
 
 
 def _proforma_hard(p) -> float | None:

--- a/services/api/test_pay_application.py
+++ b/services/api/test_pay_application.py
@@ -1,0 +1,165 @@
+"""MOD-G702 — the pay application as a document, and the retainage bug that exposed why it matters.
+
+`estimate` gained `line_items`; the AIA G702/G703 pair did not. `sov` stayed one record per line with
+no parent, so the continuation sheet was assembled by `cost.g703` on every read and the certificate by
+`cost.g702` — both LIVE VIEWS over data that keeps moving. An application is a claim made on a date.
+
+Two claims are asserted here and they fail for different reasons:
+
+  1. THE MONEY. Line 5 used each SOV line's own `retainage_pct`; line 7 applied the global
+     `DEFAULT_RETAINAGE` to the aggregate. Any contract not on the default rate made the two
+     disagree, and on a 10% contract with work completed but none this period, line 8 — the current
+     payment due, which `closeout.py` reads for the final-payment amount — came out NEGATIVE.
+
+  2. THE FREEZE. A certificate reassembled on demand restates applications that were already signed
+     and paid. Editing the SOV after an application is submitted must not change that application.
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_pay_application.py
+"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_pay_application.db"
+os.environ["STORAGE_DIR"] = "./test_storage_g702"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_pay_application.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.main import app  # noqa: E402
+
+FAILED = []
+
+
+def check(label, ok, detail=None):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+with TestClient(app) as c:
+    pid = c.post("/projects", json={"name": "G702 Tower"}).json()["id"]
+
+    def sov(item, desc, sched, prev=0, this=0, stored=0, pct=None):
+        d = {"item_no": item, "description": desc, "scheduled_value": sched,
+             "completed_prev": prev, "completed_this": this, "materials_stored": stored}
+        if pct is not None:
+            d["retainage_pct"] = pct
+        r = c.post(f"/projects/{pid}/modules/sov", json={"data": d})
+        assert r.status_code in (200, 201), r.text[:200]
+        return r.json()
+
+    # --- 1. THE MONEY -------------------------------------------------------------------------------
+    # One line, 10% retainage, $50k completed in earlier periods, nothing this period. Nothing is
+    # owed and nothing is over-claimed: line 8 must be exactly zero.
+    a = sov("01", "Sitework", 100000, prev=50000, pct=10)
+    g = c.get(f"/projects/{pid}/cost/g702").json()
+    check("  line5 uses the per-line 10% rate", g["line5_retainage"] == 5000.0, g["line5_retainage"])
+    check("  line7 uses the SAME rate, not the 5% default",
+          g["line7_less_previous_certificates"] == 45000.0, g["line7_less_previous_certificates"])
+    check("  line8 current payment due is 0.00, not -2500.00",
+          g["line8_current_payment_due"] == 0.0, g["line8_current_payment_due"])
+    check("  and it is not negative", g["line8_current_payment_due"] >= 0, g["line8_current_payment_due"])
+
+    # the default rate still applies where a line declares none — the fix is consistency, not a
+    # behaviour change for contracts that were always on 5%
+    b = sov("02", "Concrete", 100000, prev=50000)
+    g = c.get(f"/projects/{pid}/cost/g702").json()
+    check("  a line with no rate still retains at the 5% default",
+          g["line5_retainage"] == 5000.0 + 2500.0, g["line5_retainage"])
+    check("  mixed rates: line 8 still zero", g["line8_current_payment_due"] == 0.0,
+          g["line8_current_payment_due"])
+    c.delete(f"/projects/{pid}/modules/sov/{b['id']}")
+
+    # real work this period, so there is genuinely something due
+    c.patch(f"/projects/{pid}/modules/sov/{a['id']}", json={"completed_this": 20000})
+    g = c.get(f"/projects/{pid}/cost/g702").json()
+    # completed 70k; retainage 7k; earned 63k; previously certified 50k − 5k = 45k; due 18k
+    check("  $20k of work at 10% retainage is $18,000 due",
+          g["line8_current_payment_due"] == 18000.0, g["line8_current_payment_due"])
+
+    # --- 2. THE FREEZE ------------------------------------------------------------------------------
+    made = c.post(f"/projects/{pid}/cost/pay-application",
+                  json={"period_from": "2026-07-01", "period_to": "2026-07-31"})
+    check("  POST /cost/pay-application creates a record", made.status_code == 201, made.text[:200])
+    app1 = made.json()
+    d1 = app1["data"]
+    check("  it is a DRAFT — a certificate nobody signed is not a certificate",
+          app1["workflow_state"] == "draft", app1["workflow_state"])
+    check("  the continuation sheet is STORED, not assembled on read",
+          isinstance(d1.get("line_items"), list) and len(d1["line_items"]) == 1, d1.get("line_items"))
+    check("  the stored line carries the G703 computed columns",
+          d1["line_items"][0]["total_completed_stored"] == 70000.0, d1["line_items"][0])
+    check("  line 8 is frozen into the document", d1["current_payment_due"] == 18000.0,
+          d1["current_payment_due"])
+    check("  and the period it covers is recorded", d1["period_to"] == "2026-07-31", d1["period_to"])
+
+    # submit it, then move the SOV underneath it
+    tr = c.post(f"/projects/{pid}/modules/owner_invoice/{app1['id']}/transition",
+                json={"action": "submit"})
+    check("  it can be submitted", tr.status_code == 200, tr.text[:200])
+    c.patch(f"/projects/{pid}/modules/sov/{a['id']}", json={"scheduled_value": 250000,
+                                                            "completed_this": 90000})
+    still = c.get(f"/projects/{pid}/modules/owner_invoice/{app1['id']}").json()["data"]
+    check("  a submitted application does NOT restate itself when the SOV moves",
+          still["current_payment_due"] == 18000.0, still["current_payment_due"])
+    check("  nor does its continuation sheet",
+          still["line_items"][0]["scheduled_value"] == 100000.0, still["line_items"][0])
+
+    # --- 3. line 7 now reads a FACT rather than a reconstruction ------------------------------------
+    # App 1 certified $18,000 on top of $45,000 previously → $63,000 certified to date. The live G702
+    # must deduct that, and it must NOT be re-derived from `completed_prev`, which the SOV edit above
+    # has since changed.
+    g = c.get(f"/projects/{pid}/cost/g702").json()
+    check("  line 7 comes from the submitted certificate, not from completed_prev",
+          g["line7_less_previous_certificates"] == 63000.0, g["line7_less_previous_certificates"])
+
+    app2 = c.post(f"/projects/{pid}/cost/pay-application", json={"period_to": "2026-08-31"}).json()
+    check("  the next application numbers itself", app2["data"]["number"] == "2", app2["data"]["number"])
+    check("  and deducts what app 1 certified",
+          app2["data"]["previous_certificates"] == 63000.0, app2["data"]["previous_certificates"])
+    # completed 140k (50k prev + 90k this); retainage 14k; earned 126k; less 63k = 63k due
+    check("  so app 2 asks for the increment only", app2["data"]["current_payment_due"] == 63000.0,
+          app2["data"]["current_payment_due"])
+
+    # an architect who certifies LESS than was applied for is what a later application must deduct
+    c.post(f"/projects/{pid}/modules/owner_invoice/{app2['id']}/transition", json={"action": "submit"})
+    c.patch(f"/projects/{pid}/modules/owner_invoice/{app2['id']}",
+            json={"architect_certified_amount": 50000})
+    g = c.get(f"/projects/{pid}/cost/g702").json()
+    check("  a reduced certification is what counts, not the amount applied for",
+          g["line7_less_previous_certificates"] == 113000.0, g["line7_less_previous_certificates"])
+
+    # a DRAFT certifies nothing — it has been signed by nobody
+    draft = c.post(f"/projects/{pid}/cost/pay-application", json={}).json()
+    g2 = c.get(f"/projects/{pid}/cost/g702").json()
+    check("  an unsubmitted draft does not move line 7",
+          g2["line7_less_previous_certificates"] == 113000.0, g2["line7_less_previous_certificates"])
+    assert draft["workflow_state"] == "draft"
+
+    # --- 4. the form is a form ----------------------------------------------------------------------
+    mods = {m["key"]: m for m in c.get("/modules").json()}
+    oi = mods["owner_invoice"]
+    names = {f["name"] for f in oi["fields"]}
+    for need, why in [("period_from", "an application covers a period, not a vibe"),
+                      ("retainage_work_pct", "G702 5a"),
+                      ("retainage_stored_pct", "G702 5b — stored material is retained separately"),
+                      ("contractor_signature", "the contractor's certification IS the G702"),
+                      ("architect_certified_amount", "the architect may certify less than applied for"),
+                      ("coi", "a pay app travels with insurance"),
+                      ("lien_waiver", "and with a waiver")]:
+        check(f"  owner_invoice carries `{need}` ({why})", need in names)
+    lt = next(f for f in oi["fields"] if f["name"] == "line_items")
+    check("  the continuation sheet totals into line 4", lt.get("totals_into") == "amount",
+          lt.get("totals_into"))
+
+print()
+if FAILED:
+    print(f"PAY-APPLICATION FAILED ({len(FAILED)}): " + "; ".join(FAILED))
+    raise SystemExit(1)
+print("PAY-APPLICATION OK - G702 line 7 now retains at each line's own rate, so a 10% contract no "
+      "longer reports a NEGATIVE payment due (closeout.py reads that number); POST /cost/pay-application "
+      "freezes the G703 continuation sheet and lines 1-9 into an owner_invoice, so editing the SOV "
+      "cannot restate an application already submitted; and line 7 deducts what was actually "
+      "certified — including a reduced architect certification — instead of reconstructing it.")


### PR DESCRIPTION
> Stacked on #141. Base is `feat/mod-guid`; retarget to `main` once that merges.

The sweep listed this as a structural gap: `estimate` gained `line_items`, the AIA G702/G703 pair did not. Looking for the missing fields turned up a money bug underneath them.

## The bug

`g703` retains each SOV line at that line's own `retainage_pct`. `g702` line 7 applied the **global** `DEFAULT_RETAINAGE` to the aggregate. Any contract not on the default rate made lines 5 and 7 disagree:

| | one line, $100k scheduled, 10% retainage, $50k completed previously, **nothing this period** |
|---|---|
| line 5 retainage | `5,000.00` — at 10% |
| line 7 previous certificates | `47,500.00` — at **5%** |
| **line 8 current payment due** | **`-2,500.00`** |

Nothing was earned and nothing was over-claimed, so line 8 should be exactly zero. Instead the application says the contractor owes the owner $2,500. `closeout.py:123` reads `line8_current_payment_due` for the final-payment amount.

**`test_cost.py` contains no assertion on line 7, line 8, or retainage at all.** It was not a weak test of this behaviour — it was structurally unable to see it. That is the part of this PR I would keep if I could keep only one thing.

## The structure

The continuation sheet was assembled by `cost.g703` on every read, and the certificate by `cost.g702` — both live views over data that keeps moving. **A pay application is a claim made on a date.** Everything feeding it (the SOV, the change orders, the retainage rates) carries on changing, so a certificate reassembled on demand silently restates applications that were already signed and paid. Same defect shape as MOD-TOTALS, where re-pricing a rate library would have changed what was already owed.

`POST /cost/pay-application` snapshots the G703 sheet and lines 1–9 into an `owner_invoice` **draft** — submitting and certifying are transitions a person performs, because a certificate nobody signed is not a certificate. `GET /cost/g702` stays live, because "where do we stand today" is a real question; it is just not a certificate.

Line 7 now deducts what was actually **certified**, read from the prior stored application — including a *reduced* architect certification, since the architect may certify less than was applied for and that is what a later application must deduct. It falls back to the old reconstruction only when no application has been submitted, because until now there was never one to read.

## The fields

`owner_invoice`: **5 → 26**. Period dates; 5a/5b retainage rates (stored material is retained separately); the contractor and architect certifications; the COI and lien-waiver links `django_emanager` carried on its `requisition`; and the stored continuation sheet, totalling into line 4.

## Verification

- `test_pay_application.py` — 30 assertions across the money, the freeze, the certified-to-date chain, and the form.
- **Three mutants killed**: reverting line 7 to the global rate, counting a draft as certified, ignoring the architect's amount.
- Green: `cost`, `closeout`, `wip`, `sov_build`, `project_budget`, `assemblies_cost`, `calc_fields`, `fin_gov`, `imports`, `portal_txn`, `status_workflow_parity`, `workspaces`, `global_authz`, `modules`, `module_fields`, `module_tables`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)