### PR TITLE
R31-DESIGN-GROUPS — the sub-rooms existed; the sections made them useless

### DIFF
--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -300,7 +300,10 @@ export interface LifecycleStrip {
   evidence?: Record<string, unknown>;
 }
 
-export interface RoomDef { id: string; label: string; job: string; count: number; modules: string[] }
+/** R31-DESIGN-GROUPS: `groups` is the room's second navigation level, keyed on the same `section`
+ *  that decides the room — one table, refined, never a parallel one. Largest group first. */
+export interface RoomGroup { section: string; count: number; modules: string[] }
+export interface RoomDef { id: string; label: string; job: string; count: number; modules: string[]; groups?: RoomGroup[] }
 export interface RoomAllocation {
   rooms: RoomDef[]; placed: number;
   /** Must always be empty — a module with no room is one nobody can reach. */

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -470,18 +470,39 @@ export class PortalUI {
       if (roomMods.length) {
         // Sub-rooms, by SECTION.
         //
-        // Design owns 39 registers and Schedule 41 — a flat list at that size is precisely the wall
+        // Design owns 32 registers and Schedule 38 — a flat list at that size is precisely the wall
         // the spine was built to replace, so the room needs a second level. The grouping key is the
-        // module's `section`, which is *already* what decides its room: this is a strict refinement
-        // of the existing table, not a new taxonomy competing with it. Inventing a separate
-        // sub-room table would recreate the drift this whole restructure removed.
+        // module's `section`, which is *already* what decides its room: a strict refinement of the
+        // existing table, not a new taxonomy competing with it.
+        //
+        // R31-DESIGN-GROUPS: the ORDER and the membership now come from `/rooms`, for the same reason
+        // stated forty lines up about the room itself — the server already computes this, and a
+        // client that re-derives it is how four competing rails came to exist. The local fallback
+        // stays because the rail must render when `/rooms` fails.
+        //
+        // **The headings were the actual defect, not the absence of them.** This grouping shipped
+        // before the sections were fit to be read as headings: Design's largest was `Engineering`,
+        // nine modules that included drawings, RFIs, submittals and MEP equipment — a heading a user
+        // would open expecting engineering and find a filing accident. Grouping by a meaningless key
+        // produces meaningless groups, confidently labelled, which is worse than a flat list because
+        // it looks like somebody decided.
+        //
+        // Server order is largest-first: the heading most likely to be wanted should not sit under a
+        // three-module one because of its initial letter.
         //
         // Below SUBGROUP_MIN the headings cost more than they explain, so a small room stays flat.
         const SUBGROUP_MIN = 8;
+        const byKey = new Map(roomMods.map((m) => [m.key, m]));
         const bySection = new Map<string, ModuleDef[]>();
-        for (const m of roomMods) {
-          const sec = m.section || "Other";
-          (bySection.get(sec) ?? bySection.set(sec, []).get(sec)!).push(m);
+        for (const g of room.groups ?? []) {
+          const mods = g.modules.map((k) => byKey.get(k)).filter(Boolean) as ModuleDef[];
+          if (mods.length) bySection.set(g.section || "Other", mods);
+        }
+        if (!bySection.size) {
+          for (const m of roomMods) {
+            const sec = m.section || "Other";
+            (bySection.get(sec) ?? bySection.set(sec, []).get(sec)!).push(m);
+          }
         }
         const subgroup = roomMods.length >= SUBGROUP_MIN && bySection.size > 1;
         const rule = document.createElement("div");
@@ -489,7 +510,7 @@ export class PortalUI {
         rule.textContent = `Registers (${roomMods.length})`;
         det.appendChild(rule);
         if (subgroup) {
-          for (const [sec, mods] of [...bySection].sort((a, b) => a[0].localeCompare(b[0]))) {
+          for (const [sec, mods] of bySection) {
             const h = document.createElement("div");
             h.className = "pnav-subsec meta";
             h.textContent = `${sec} · ${mods.length}`;

--- a/services/api/modules/clash_run/module.json
+++ b/services/api/modules/clash_run/module.json
@@ -1,7 +1,7 @@
 {
   "key": "clash_run",
   "name": "Clash Runs",
-  "section": "BIM",
+  "section": "Coordination",
   "icon": "🌂",
   "ref_prefix": "CLR",
   "title_field": "label",

--- a/services/api/modules/concept_render/module.json
+++ b/services/api/modules/concept_render/module.json
@@ -1,7 +1,7 @@
 {
   "key": "concept_render",
   "name": "Concept Renders",
-  "section": "Design",
+  "section": "Design Phases",
   "icon": "🖼",
   "ref_prefix": "REN",
   "title_field": "title",

--- a/services/api/modules/coordination_issue/module.json
+++ b/services/api/modules/coordination_issue/module.json
@@ -1,7 +1,7 @@
 {
   "key": "coordination_issue",
   "name": "Coordination Issues",
-  "section": "BIM",
+  "section": "Coordination",
   "icon": "✶",
   "ref_prefix": "CI",
   "title_field": "subject",

--- a/services/api/modules/design_option/module.json
+++ b/services/api/modules/design_option/module.json
@@ -1,7 +1,7 @@
 {
   "key": "design_option",
   "name": "Design Options",
-  "section": "Design",
+  "section": "Design Phases",
   "icon": "🎨",
   "ref_prefix": "OPT",
   "title_field": "name",

--- a/services/api/modules/design_review/module.json
+++ b/services/api/modules/design_review/module.json
@@ -1,7 +1,7 @@
 {
   "key": "design_review",
   "name": "Design Reviews",
-  "section": "Engineering",
+  "section": "Design Phases",
   "icon": "◉",
   "ref_prefix": "DR",
   "title_field": "subject",

--- a/services/api/modules/design_standard/module.json
+++ b/services/api/modules/design_standard/module.json
@@ -1,7 +1,7 @@
 {
   "key": "design_standard",
   "name": "Design Standards",
-  "section": "Design",
+  "section": "Specifications",
   "icon": "📐",
   "ref_prefix": "STD",
   "title_field": "name",
@@ -87,7 +87,11 @@
         "from": "draft",
         "to": "adopted",
         "action": "adopt",
-        "party": ["OwnersRep", "PM", "Architect"]
+        "party": [
+          "OwnersRep",
+          "PM",
+          "Architect"
+        ]
       }
     ]
   },

--- a/services/api/modules/drawing/module.json
+++ b/services/api/modules/drawing/module.json
@@ -1,7 +1,7 @@
 {
   "key": "drawing",
   "name": "Drawings",
-  "section": "Engineering",
+  "section": "Drawings",
   "icon": "▭",
   "ref_prefix": "DWG",
   "title_field": "number",

--- a/services/api/modules/drawing_issuance/module.json
+++ b/services/api/modules/drawing_issuance/module.json
@@ -1,7 +1,7 @@
 {
   "key": "drawing_issuance",
   "name": "Drawing Issuances",
-  "section": "Engineering",
+  "section": "Drawings",
   "icon": "📤",
   "ref_prefix": "ISS",
   "title_field": "number",

--- a/services/api/modules/drawing_set/module.json
+++ b/services/api/modules/drawing_set/module.json
@@ -1,7 +1,7 @@
 {
   "key": "drawing_set",
   "name": "Drawing Set",
-  "section": "Engineering",
+  "section": "Drawings",
   "icon": "📚",
   "ref_prefix": "SET",
   "title_field": "name",

--- a/services/api/modules/envelope_assembly/module.json
+++ b/services/api/modules/envelope_assembly/module.json
@@ -1,7 +1,7 @@
 {
   "key": "envelope_assembly",
   "name": "Envelope Assemblies",
-  "section": "Engineering",
+  "section": "Model",
   "icon": "🧱",
   "ref_prefix": "ENV",
   "title_field": "name",

--- a/services/api/modules/location/module.json
+++ b/services/api/modules/location/module.json
@@ -1,7 +1,7 @@
 {
   "key": "location",
   "name": "Locations",
-  "section": "Design",
+  "section": "Model",
   "icon": "◎",
   "ref_prefix": "LOC",
   "title_field": "name",

--- a/services/api/modules/mep_equipment/module.json
+++ b/services/api/modules/mep_equipment/module.json
@@ -1,7 +1,7 @@
 {
   "key": "mep_equipment",
   "name": "MEP Equipment",
-  "section": "Engineering",
+  "section": "Model",
   "icon": "🔧",
   "ref_prefix": "EQ",
   "title_field": "tag",

--- a/services/api/modules/rfi/module.json
+++ b/services/api/modules/rfi/module.json
@@ -1,7 +1,7 @@
 {
   "key": "rfi",
   "name": "RFIs",
-  "section": "Engineering",
+  "section": "Coordination",
   "icon": "?",
   "ref_prefix": "RFI",
   "title_field": "subject",

--- a/services/api/modules/selection/module.json
+++ b/services/api/modules/selection/module.json
@@ -1,7 +1,7 @@
 {
   "key": "selection",
   "name": "Selections",
-  "section": "Engineering",
+  "section": "Specifications",
   "icon": "◈",
   "ref_prefix": "SEL",
   "title_field": "item",

--- a/services/api/modules/space_program/module.json
+++ b/services/api/modules/space_program/module.json
@@ -1,7 +1,7 @@
 {
   "key": "space_program",
   "name": "Space Program",
-  "section": "Programming",
+  "section": "Model",
   "icon": "🧩",
   "ref_prefix": "SP",
   "title_field": "name",

--- a/services/api/modules/submittal/module.json
+++ b/services/api/modules/submittal/module.json
@@ -1,7 +1,7 @@
 {
   "key": "submittal",
   "name": "Submittals",
-  "section": "Engineering",
+  "section": "Coordination",
   "icon": "▤",
   "ref_prefix": "SUB",
   "title_field": "title",

--- a/services/api/modules/transmittal/module.json
+++ b/services/api/modules/transmittal/module.json
@@ -1,7 +1,7 @@
 {
   "key": "transmittal",
   "name": "Transmittals",
-  "section": "Coordination",
+  "section": "Drawings",
   "icon": "➟",
   "ref_prefix": "TR",
   "title_field": "subject",

--- a/services/api/src/aec_api/rooms.py
+++ b/services/api/src/aec_api/rooms.py
@@ -93,15 +93,27 @@ ROOM_OF_SECTION: dict[str, str] = {
     # left drawings and specifications looking like they belonged somewhere else — which is exactly
     # where specifications had ended up (filed under Preconstruction, and therefore under Cost).
     # An architect or engineer does all of it here: model, draw, specify, analyse.
-    "BIM": "design",
-    "Design": "design",
-    "Design Phases": "design",
-    "Engineering": "design",
-    "Coordination": "design",        # RFIs, meetings, transmittals — project-wide, but raised against
-                                     # the documents, so they sit beside the documents
+    #
+    # R31-DESIGN-GROUPS (2026-07-31): the sections BELOW are also the groups Design is read in, so the
+    # list is short and each entry names something an architect or engineer would recognise as a place
+    # to go. Four sections were retired to get there, and the reason is worth keeping:
+    #
+    # **"Engineering" held nine modules and described none of them** — `drawing`, `drawing_set` and
+    # `drawing_issuance` (documents), `rfi` and `submittal` (coordination), `design_review` and
+    # `selection` (design process), `envelope_assembly` and `mep_equipment` (model content). It was
+    # not a section, it was the place a module went when nobody decided. `Design`, `BIM` and
+    # `Programming` were the same failure at smaller scale: `Design`, inside the Design room, carried
+    # no information at all.
+    #
+    # A junk-drawer section is invisible while nothing groups by it. The moment the room rail started
+    # rendering groups, "Engineering (9)" became a heading a user would open expecting engineering.
+    "Model": "design",               # the building as modelled, and the space program it satisfies
+    "Drawings": "design",            # the drawn documents and their issue record
     "Specifications": "design",      # the written half of the documents; the drawings are the other
-    "Information Management": "design",
-    "Programming": "design",
+    "Design Phases": "design",       # options, reviews, renders — the design as it develops
+    "Coordination": "design",        # RFIs, submittals, clashes — raised AGAINST the documents, so
+                                     # they sit beside the documents
+    "Information Management": "design",   # LOD, information requirements, the CDE — ISO 19650 work
     "Sustainability": "design",
     "Resilience": "design",
     # ── Planning: turning a design into a bought, contracted, approved scope ────────────────────
@@ -159,6 +171,26 @@ def unmapped_sections(sections: set[str]) -> list[str]:
     return sorted(s for s in sections if s and s not in ROOM_OF_SECTION)
 
 
+#: R31-DESIGN-GROUPS — a room's second level of navigation.
+#:
+#: Design held 32 modules as ONE flat alphabetical list, from `action_item` to `waste_diversion`. A
+#: list that long is not navigation, it is a search box you have to read. (`schedule` holds 38 and has
+#: the same problem; this ships the mechanism, and the sections there are the next thing to fix.)
+#:
+#: **The group IS the section — there is no second table.** The obvious move was a new
+#: `GROUP_OF_SECTION` mapping, and it was the wrong one: this file's own argument for deriving rooms
+#: from sections is that one table cannot disagree with itself, and adding a parallel table to slice
+#: the same modules a second way gives up exactly that. So where a section was too vague to be a
+#: heading, the SECTION was fixed rather than papered over with a group name.
+#:
+#: Ordered largest-first with a stable tie-break on the name. Not alphabetical: the heading a user is
+#: most likely to want should not sit below one holding three modules because it starts with a later
+#: letter. Not hand-ordered either — a hand-ordered list is a fourth place to keep in step.
+def _groups(sections: dict[str, list[str]]) -> list[dict[str, Any]]:
+    return [{"section": sec, "count": len(keys), "modules": keys}
+            for sec, keys in sorted(sections.items(), key=lambda kv: (-len(kv[1]), kv[0]))]
+
+
 def allocate(modules: list[dict[str, Any]]) -> dict[str, Any]:
     """Group modules into rooms, and report anything that could not be placed.
 
@@ -166,18 +198,23 @@ def allocate(modules: list[dict[str, Any]]) -> dict[str, Any]:
     user can no longer reach, and it would otherwise be invisible until someone went looking for it.
     """
     by_room: dict[str, list[str]] = {r["id"]: [] for r in ROOMS}
+    by_group: dict[str, dict[str, list[str]]] = {r["id"]: {} for r in ROOMS}
     unplaced: list[dict[str, str]] = []
     for m in modules or []:
         key = str(m.get("key") or m.get("name") or "?")
         room = room_of(m)
         if room in by_room:
             by_room[room].append(key)
+            by_group[room].setdefault(str(m.get("section") or ""), []).append(key)
         else:
             unplaced.append({"key": key, "section": str(m.get("section") or "")})
     for k in by_room:
         by_room[k].sort()
+        for g in by_group[k].values():
+            g.sort()
     return {
-        "rooms": [{**r, "count": len(by_room[r["id"]]), "modules": by_room[r["id"]]} for r in ROOMS],
+        "rooms": [{**r, "count": len(by_room[r["id"]]), "modules": by_room[r["id"]],
+                   "groups": _groups(by_group[r["id"]])} for r in ROOMS],
         "placed": sum(len(v) for v in by_room.values()),
         "unplaced": sorted(unplaced, key=lambda u: u["key"]),
         "unplaced_count": len(unplaced),

--- a/services/api/test_module_rooms.py
+++ b/services/api/test_module_rooms.py
@@ -139,6 +139,61 @@ odd = rooms.allocate([{"key": "mystery", "section": "Nowhere"}])
 assert odd["unplaced_count"] == 1 and odd["unplaced"][0]["key"] == "mystery", odd
 assert odd["placed"] == 0
 
+# ---- R31-DESIGN-GROUPS: the room's second level ---------------------------------------------------
+# The groups a room is read in ARE its sections. That is the whole design: one table decides the room
+# and refines into the sub-rooms, so the two can never disagree. These assertions exist because the
+# cheap alternative — a parallel GROUP_OF_SECTION table — would pass a naive test just as well and
+# drift within a release.
+for r in alloc["rooms"]:
+    gs = r["groups"]
+    flat = [k for g in gs for k in g["modules"]]
+    assert sorted(flat) == sorted(r["modules"]), (
+        f"{r['id']}: groups must PARTITION the room — every module in exactly one group. "
+        f"missing={sorted(set(r['modules']) - set(flat))} extra={sorted(set(flat) - set(r['modules']))}")
+    assert len(flat) == len(set(flat)), f"{r['id']}: a module appears in two groups"
+    assert all(g["count"] == len(g["modules"]) for g in gs), f"{r['id']}: a group's count lies"
+    # largest first, name as the tie-break — so the heading most likely to be wanted is at the top
+    assert gs == sorted(gs, key=lambda g: (-g["count"], g["section"])),         f"{r['id']}: groups out of order: {[g['section'] for g in gs]}"
+    assert all(g["section"] for g in gs), f"{r['id']}: a group with no section name"
+
+# THE JUNK DRAWER. `Engineering` held nine Design modules and described none of them — drawings, RFIs,
+# submittals, MEP equipment, selections. Harmless while nothing grouped by section; the moment the rail
+# rendered "Engineering · 9" as a heading it became a confident label for a filing accident.
+#
+# Asserted by NAME rather than by a size rule, because size is not the defect: `Field` legitimately
+# holds 14 and `Preconstruction` 12. What made these four wrong is that they named nothing a user
+# would go looking for — and `Design`, as a section INSIDE the Design room, named nothing at all.
+for dead in ("Engineering", "BIM", "Design", "Programming"):
+    assert dead not in rooms.ROOM_OF_SECTION, (
+        f"{dead!r} is back in ROOM_OF_SECTION. It was retired because it was where a module went when "
+        "nobody decided, and a section like that is invisible until something groups by it.")
+
+design = next(r for r in alloc["rooms"] if r["id"] == "design")
+assert design["count"] == 32, design["count"]
+# The largest Design group is capped: past this the heading stops narrowing anything. Not a style
+# rule — 9 of 32 under one meaningless word is what this change was about.
+biggest = design["groups"][0]
+assert biggest["count"] <= 8, f"Design's largest group is {biggest['section']} at {biggest['count']}"
+assert {g["section"] for g in design["groups"]} == {
+    "Model", "Drawings", "Specifications", "Design Phases", "Coordination",
+    "Information Management", "Sustainability", "Resilience"}, [g["section"] for g in design["groups"]]
+
+# the modules that moved, by name, so a later bulk edit cannot quietly undo the reasoning
+for key, sec in [("drawing", "Drawings"), ("drawing_set", "Drawings"), ("transmittal", "Drawings"),
+                 ("rfi", "Coordination"), ("submittal", "Coordination"), ("clash_run", "Coordination"),
+                 ("envelope_assembly", "Model"), ("mep_equipment", "Model"), ("space_program", "Model"),
+                 ("selection", "Specifications"), ("design_standard", "Specifications"),
+                 ("design_review", "Design Phases"), ("concept_render", "Design Phases")]:
+    got = next(m["section"] for m in mods if m["key"] == key)
+    assert got == sec, f"{key} is sectioned {got!r}, expected {sec!r}"
+
+# A room the rail will subgroup (>= SUBGROUP_MIN, the web constant) must have groups worth reading.
+# `schedule` holds 38 in six sections and is the next room to look at; this asserts the mechanism
+# reaches it rather than being a one-room special case.
+for r in alloc["rooms"]:
+    if r["count"] >= 8:
+        assert len(r["groups"]) > 1, f"{r['id']} has {r['count']} modules in a single group"
+
 counts = {r["id"]: r["count"] for r in alloc["rooms"]}
 print(f"R26-MODULE-HOME OK - all {len(mods)} modules resolve to exactly one canonical room "
       f"({counts}), read from the module.json files on disk rather than a hand-maintained list, so a "


### PR DESCRIPTION
> Stacked on #143 (which is stacked on #141). Retarget as those merge.

## The premise was wrong

This item was planned as *"Design: 32 modules in one flat group — split into Model · Drawings · Specs · Analysis · Coordination."* Reading the renderer corrected it: `portal.ts` has grouped a room's registers by `section` since v0.3.767, with a `SUBGROUP_MIN` of 8. The sub-rooms already existed.

## What was actually broken

The groups were **named** by sections that named nothing. Design's largest was `Engineering` — nine modules:

| in `Engineering` | what it actually is |
|---|---|
| `drawing`, `drawing_set`, `drawing_issuance` | the drawn documents |
| `rfi`, `submittal` | coordination |
| `design_review`, `selection` | design process |
| `envelope_assembly`, `mep_equipment` | model content |

It was not a section. It was where a module went when nobody decided. `Design`, `BIM` and `Programming` were the same failure at smaller scale — and `Design`, as a section *inside* the Design room, carried no information at all.

A junk-drawer section is invisible while nothing groups by it. The moment the rail renders **"Engineering · 9"** as a heading, it becomes a confident label for a filing accident — which is worse than a flat list, because it looks like somebody decided.

## The change

**17 modules re-sectioned**, four sections retired. Design now reads:

`Coordination 8 · Design Phases 4 · Drawings 4 · Model 4 · Information Management 3 · Resilience 3 · Specifications 3 · Sustainability 3`

`/rooms` now **states** the grouping rather than the client re-deriving it — the same argument `rooms.py` already makes about the room itself, and the same one the renderer makes forty lines above this code about why it reads `ModuleDef.room` instead of guessing. Ordered largest-first, so the heading most likely to be wanted is not below a three-module one because of its initial letter. The local fallback stays: the rail must render when `/rooms` fails.

**Deliberately not a `GROUP_OF_SECTION` table.** The room is derived from the section precisely so one table cannot disagree with itself; adding a parallel table that slices the same modules a second way gives that up. Where a section was too vague to be a heading, the *section* was fixed rather than papered over with a group name.

## Verification

- `test_module_rooms.py` extended: groups **partition** the room (every module in exactly one), the ordering, the counts, the four retired names asserted absent by name, the thirteen modules that moved asserted by name, and every room ≥ 8 modules having more than one group.
- **Four mutants killed**: alphabetical ordering, groups never populated, `Engineering` restored, `drawing` re-filed.
- Green: `module_rooms`, `modules`, `module_fields`, `workspaces`, `reachable`, `dashboard`; `tsc --noEmit` clean; vitest 926/927 (the one failure is `pdfVendor.test.ts` hitting Vite's fs guard because `node_modules` sits outside the worktree — it passes in the main checkout).

## Next

`schedule` holds **38** modules in six sections — more than Design. This ships the mechanism; that room's sections are the next thing to look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)