### PR TITLE
Carry HOW a cost code was matched into the production reconciliation

### DIFF
--- a/services/api/src/aec_api/production.py
+++ b/services/api/src/aec_api/production.py
@@ -73,6 +73,31 @@ UNIT_FACTORS: dict[str, tuple[str, float]] = {
     "lb": ("weight", 0.45359237), "lbs": ("weight", 0.45359237), "ton": ("weight", 907.18474),
 }
 
+#: HOW a cost code was matched to the elements behind it — `qto.cost_code_for()` matches by IFC class
+#: *including inherited classes*, and reports the key it hit as `matched_class` on every takeoff row.
+#:
+#: This has to travel into the reconciliation because `reconcile()` aggregates by `cost_code`, and one
+#: cost code can be reached through more than one key: some elements matching their own class, others
+#: priced through an ancestor. Blended into a single line, "walls 40% complete" silently rests part of
+#: its denominator on a general key that may be pricing things the estimator never had in mind. A
+#: quantity matched by inheritance is a weaker claim than one matched exactly, and the difference is
+#: invisible once the quantities are summed — which is the same reason the takeoff surfaces the key at
+#: all, one layer up.
+MATCH_EXACT = "exact"          # every element matched a key naming its own class
+MATCH_INHERITED = "inherited"  # priced through an ancestor class key
+MATCH_MIXED = "mixed"          # BOTH — the modelled quantity blends two strengths of claim
+
+#: `None` for `match_basis` means the takeoff never stated how it matched — a producer older than
+#: `matched_class`. That is UNSTATED, and must not be reported as `exact`: assuming the strongest
+#: reading of silence is how a weak claim gets quoted as a strong one.
+MATCH_MEANING = {
+    MATCH_EXACT: "every element was priced by a cost-map key naming its own IFC class",
+    MATCH_INHERITED: "priced through an ANCESTOR class key — the map did not name these classes, so "
+                     "it may be pricing element types the estimator did not have in mind",
+    MATCH_MIXED: "some elements matched exactly and some by inheritance, so this one quantity blends "
+                 "two different strengths of claim",
+}
+
 STATUS_OK = "reconciled"
 STATUS_OVER = "over_installed"
 STATUS_NOT_STARTED = "not_started"
@@ -149,8 +174,17 @@ def model_by_code(takeoff_rows: list[dict]) -> tuple[dict[str, dict], dict[str, 
         qty = _model_quantity(r)
         slot = by.setdefault(code, {"cost_code": code, "dimension": str(r.get("unit") or "").lower(),
                                     "modeled": 0.0, "elements": 0,
-                                    "description": r.get("cost_description")})
+                                    "description": r.get("cost_description"),
+                                    "matched_keys": set(), "exact": 0, "inherited": 0, "unstated": 0})
         slot["elements"] += 1
+        # How this element was matched. A row carrying a cost_code but no `matched_class` came from a
+        # takeoff older than that field: counted as `unstated`, never folded into `exact`.
+        mk, ic = r.get("matched_class"), r.get("ifc_class")
+        if not mk:
+            slot["unstated"] += 1
+        else:
+            slot["matched_keys"].add(str(mk))
+            slot["exact" if str(mk) == str(ic) else "inherited"] += 1
         if qty is None:
             if len(unquantified) < 50:
                 unquantified.append(str(r.get("guid") or "?"))
@@ -158,6 +192,12 @@ def model_by_code(takeoff_rows: list[dict]) -> tuple[dict[str, dict], dict[str, 
         slot["modeled"] += qty
     for slot in by.values():
         slot["modeled"] = round(slot["modeled"], 4)
+        slot["matched_keys"] = sorted(slot.pop("matched_keys"))
+        e, i = slot.pop("exact"), slot.pop("inherited")
+        slot.pop("unstated")
+        slot["match_basis"] = (MATCH_MIXED if e and i else
+                               MATCH_EXACT if e else
+                               MATCH_INHERITED if i else None)
     return by, {"uncoded_elements": uncoded, "unquantified_elements": len(unquantified),
                 "unquantified_sample": unquantified[:10]}
 
@@ -208,7 +248,8 @@ def reconcile(takeoff_rows: list[dict], field_rows: list[dict]) -> dict[str, Any
 
         line = {"cost_code": code, "description": m["description"], "dimension": dim,
                 "modeled": m["modeled"], "elements": m["elements"],
-                "conversions": converted}
+                "conversions": converted,
+                "match_basis": m["match_basis"], "matched_keys": m["matched_keys"]}
 
         if mismatched:
             # A partial answer here would be worse than none: some rows counted, some silently
@@ -248,6 +289,10 @@ def reconcile(takeoff_rows: list[dict], field_rows: list[dict]) -> dict[str, Any
         "lines": lines,
         "by_status": counts,
         "status_meaning": STATUS_MEANING,
+        "match_meaning": MATCH_MEANING,
+        # Named, not counted — a reader chasing an over-general cost map needs to know WHICH codes.
+        "inherited_codes": sorted(ln["cost_code"] for ln in lines
+                                  if ln.get("match_basis") in (MATCH_INHERITED, MATCH_MIXED)),
         "overall": {
             "pct_complete": round(100.0 * total_installed / total_modeled, 2) if total_modeled else None,
             "modeled": round(total_modeled, 4),

--- a/services/api/test_production.py
+++ b/services/api/test_production.py
@@ -17,6 +17,9 @@ import sys
 sys.path.insert(0, "src")
 
 from aec_api.production import (  # noqa: E402
+    MATCH_EXACT,
+    MATCH_INHERITED,
+    MATCH_MIXED,
     STATUS_NOT_STARTED,
     STATUS_OK,
     STATUS_OVER,
@@ -170,6 +173,51 @@ check("every status used is documented in the payload",
       set(res["by_status"]) <= set(res["status_meaning"]), res["by_status"])
 check("  and `not_started` is documented as absence, not a measured zero",
       "absence of a record" in res["status_meaning"][STATUS_NOT_STARTED])
+
+# --- 10. HOW a code was matched travels with the quantity ------------------------------------------
+# `qto.cost_code_for()` matches by IFC class INCLUDING ancestors and reports the key it hit. A quantity
+# priced through an ancestor is a weaker claim than one priced exactly, and summing hides the
+# difference — the same reason the takeoff surfaces the key at all, one layer up.
+def tm(guid, code, unit, ifc_class, matched, **q):
+    return {"guid": guid, "ifc_class": ifc_class, "matched_class": matched, "cost_code": code,
+            "unit": unit, "cost_description": None, **q}
+
+
+ex = reconcile([tm("w1", "03 30 00", "area", "IfcWall", "IfcWall", area=100.0)], [])
+check("an exactly-matched code reports `exact`",
+      line_for(ex, "03 30 00")["match_basis"] == MATCH_EXACT, line_for(ex, "03 30 00"))
+check("  and names the key that priced it",
+      line_for(ex, "03 30 00")["matched_keys"] == ["IfcWall"], line_for(ex, "03 30 00"))
+
+inh = reconcile([tm("w1", "03 30 00", "area", "IfcWallStandardCase", "IfcWall", area=100.0)], [])
+check("a code priced through an ANCESTOR key reports `inherited`, not `exact`",
+      line_for(inh, "03 30 00")["match_basis"] == MATCH_INHERITED, line_for(inh, "03 30 00"))
+
+# THE CASE THIS EXISTS FOR: one cost code reached by two different keys. Summed, the line would read
+# as a single confident quantity while half its denominator rests on a general key.
+mix = reconcile([tm("w1", "03 30 00", "area", "IfcWall", "IfcWall", area=100.0),
+                 tm("w2", "03 30 00", "area", "IfcWallStandardCase", "IfcWall", area=100.0)], [])
+l_mixb = line_for(mix, "03 30 00")
+check("one code matched BOTH exactly and by inheritance reports `mixed`",
+      l_mixb["match_basis"] == MATCH_MIXED, l_mixb["match_basis"])
+check("  the quantities still sum — mixed is a caveat on the number, not a refusal",
+      l_mixb["modeled"] == 200.0, l_mixb["modeled"])
+check("  and the affected codes are NAMED at the top level, not just counted",
+      mix["inherited_codes"] == ["03 30 00"], mix["inherited_codes"])
+check("an exactly-matched code is NOT listed as inherited", ex["inherited_codes"] == [],
+      ex["inherited_codes"])
+
+# Silence is unstated, never `exact`. A takeoff predating `matched_class` said nothing about how it
+# matched, and reading silence as the strongest option is how a weak claim gets quoted as a strong one.
+old = reconcile([t("w1", "03 30 00", "area", area=100.0)], [])
+check("a takeoff with no `matched_class` reports basis None — unstated, NOT `exact`",
+      line_for(old, "03 30 00")["match_basis"] is None, line_for(old, "03 30 00")["match_basis"])
+check("  and claims no matched key it was never given",
+      line_for(old, "03 30 00")["matched_keys"] == [], line_for(old, "03 30 00")["matched_keys"])
+check("  while the quantity itself is unaffected — provenance is missing, the measurement is not",
+      line_for(old, "03 30 00")["modeled"] == 100.0)
+check("every basis used is documented in the payload",
+      MATCH_MIXED in mix["match_meaning"] and MATCH_INHERITED in mix["match_meaning"])
 
 print()
 if FAILED:


### PR DESCRIPTION
Follow-up to #142 and the `matched_class` work in `50f195cf` / `fd89f106`.

## The gap

`qto.cost_code_for()` matches by IFC class **including ancestors** and reports the key it hit as `matched_class`. `reconcile()` aggregates by `cost_code`, so **one code can be reached through more than one key** — some elements matching their own class, others priced through an ancestor. Summed, that produced a single confident quantity with no way to see the difference.

A quantity matched by inheritance is a **weaker claim** than one matched exactly: the cost map did not name those classes, so it may be pricing element types the estimator never had in mind. That difference is invisible once quantities are added up — which is the same reason the takeoff surfaces the key at all, one layer up.

## The change

Each line carries `match_basis` (`exact` / `inherited` / `mixed`) and the `matched_keys` behind it. `inherited_codes` **names** the affected codes at the top level rather than counting them.

`match_basis` is `None` when the takeoff never stated how it matched — a producer older than `matched_class`. **Unstated is not folded into `exact`**: assuming the strongest reading of silence is how a weak claim gets quoted as a strong one, and it is the same distinction this module already draws between `not_started` and a measured zero.

`mixed` is a **caveat on the number, not a refusal** — the quantities still sum. Unlike a unit mismatch, where no correct number exists, a blended basis has a correct total that simply rests on two strengths of claim.

## Verification

Against the real producer, on the case that motivated the entire chain — a cost map keyed `IfcWall` against a model whose walls are `IfcWallStandardCase`:

```
03 30 00   reconciled   basis=inherited  keys=['IfcWall']  modeled=205.705  pct=19.45
08 11 00   reconciled   basis=exact      keys=['IfcDoor']  modeled=8.0      pct=37.50
inherited_codes: ['03 30 00']
```

Before `50f195cf` those 13 walls priced at **nothing** and were reported as uncoded. They now price, and the line is honest that the map never named their class.

`test_production` (54 checks), `test_reachable`, `test_qto_class_match`, `test_qto_measured_area` all pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)