### PR TITLE
docs(gate): comparative competitor names in public docs are a test now, not a rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7359,8 +7359,8 @@ gains **⚖ Level** behind an explicit confirm; re-renders CPM/Gantt on success.
   performance audits. Headline finding: the **backend is far ahead of the frontend** (~72 shipped
   capabilities have no UI), so the new order leads with security/perf hygiene, then UI-surfacing
   waves, then a real workflow state-machine layer, then the twice-validated interop gaps
-  (P6/MSP export round-trip, 4D simulation, model query DSL, Solibri-style rule library, model-CI,
-  Bluebeam-parity markup), then the R14/R15 feature tiers. All deterministic + offline; licenses
+  (P6/MSP export round-trip, 4D simulation, model query DSL, a rule-based model-checking library,
+  model-CI, PDF markup parity), then the R14/R15 feature tiers. All deterministic + offline; licenses
   mapped; non-deterministic AI/photogrammetry features explicitly out of scope.
 - The performance audit's ranked fixes (GEOM-CACHE, ASYNC-BLOCK, QTO-CACHE, CLASH-JOBS, PANEL-LAZY,
   DASH-UNION, PAYLOAD-CAPS, TEST-FASTPATH) are queued as the NOW block for execution.
@@ -10589,7 +10589,7 @@ storey with editable **name** and **elevation** fields — Save re-authors the I
 `rename_storey` / `set_storey_elevation` recipes and republishes, so levels are finally editable, not
 just addable. The storey listing now carries each level's **GUID** so edits target the right storey.
 
-**Named selection sets** (Layers panel, the Navisworks / Bluebeam "search set" pattern) let you save a
+**Named selection sets** (Layers panel, the saved-search-set pattern) let you save a
 search — by name, IFC class, type, discipline, or level — as a named set and **isolate** it in one click;
 "Show all" clears the isolation. Sets persist per-project in the browser (a personal view aid, they never
 touch the model). Verified live on a 108-element federated model: a "structural" set resolves to 75
@@ -10624,8 +10624,8 @@ are still open (see the roadmap).
 
 ## v0.3.237 — Modeling program, phase 6c: cluster the rail Navigate / Author / Coordinate
 
-The left rail's toggles are now grouped into the three workflow clusters every reference tool uses (Revit,
-BlenderBIM/Bonsai, Bluebeam): **Navigate** (Tree · Layers) · **Author** (Tools) · **Coordinate** (Clash ·
+The left rail's toggles are now grouped into the three workflow clusters standard across BIM authoring
+and coordination tools: **Navigate** (Tree · Layers) · **Author** (Tools) · **Coordinate** (Clash ·
 Issues), with a subtle divider/label between them (a thin rule in icon mode, the cluster name when the rail
 is expanded). Each toggle's aria-label is prefixed with its cluster for screen readers. This completes the
 core of the rail redesign — the model workspace now reads as a modeling+coordination cockpit rather than a
@@ -10650,10 +10650,11 @@ next: a docked Properties panel (Revit-style type/instance) and Navigate/Author/
 
 ## v0.3.235 — Modeling program, phase 6a: cut the duplicative rail sections
 
-Starting the left-rail redesign (a modeling+coordination cockpit, grounded in how Revit, BlenderBIM/Bonsai,
-and Bluebeam lay out their panels). The Model workspace's "Tools" panel had become an 11-section dumping
-ground, four sections of which **re-plotted whole other workspaces**: Cost/Pay Apps, Schedule, Drawings (2D),
-and Energy & MEP. A modeler coordinating geometry shouldn't scroll past pay-app tables to reach a tool.
+Starting the left-rail redesign (a modeling+coordination cockpit, grounded in how established BIM
+authoring and markup tools lay out their panels). The Model workspace's "Tools" panel had become an
+11-section dumping ground, four sections of which **re-plotted whole other workspaces**: Cost/Pay Apps,
+Schedule, Drawings (2D), and Energy & MEP. A modeler coordinating geometry shouldn't scroll past
+pay-app tables to reach a tool.
 
 Removed those four from the model rail — and deleted ~700 lines of their now-duplicate builder code — leaving
 a compact **deep-link row** (💰 Cost → Construction · 📅 Schedule → Construction · 📐 Drawings → Drawings ·
@@ -12119,7 +12120,7 @@ client, and server-side page ops via pypdf. Still permissive-only (no PyMuPDF/AG
   `{{user}}/{{date}}/{{time}}/{{file}}` fields resolve at placement. They render on the overlay and
   **flatten into the exported PDF** (stamps in a red box).
 - **Tool sets** — 💾 Save / 📂 Load the whole markup scene (calibration + all markups) as JSON, so a
-  set of stamps/measurements is reusable and shareable across sheets (the Bluebeam Tool Chest idea).
+  set of stamps/measurements is reusable and shareable across sheets (a reusable tool set).
 - **Server PDF ops (`pdfops.py`, pypdf)** — `POST /pdf/{info,merge,split,extract,rotate}`: merge a
   drawing set into one file, split to one-PDF-per-page (zip), extract a page range (`1,3,5-7`), rotate
   by 90°. A **🗂 PDF tools** launcher (merge/split/rotate/extract uploaded PDFs). Non-PDF uploads 422.
@@ -12128,7 +12129,7 @@ Verified: `test_pdfops` (engine + HTTP merge/split/extract/rotate + non-PDF reje
 build + 59 vitest.
 
 ## v0.3.125 — PDF markup: flatten to a real PDF (markup stack, phase 1)
-First phase of a Bluebeam-Revu-style PDF markup/manipulation stack (three decoupled layers: PDF.js
+First phase of a PDF markup/manipulation stack (three decoupled layers: PDF.js
 render · interactive markup · pdf-lib/pypdf persistence). Built on the existing PDF takeoff.
 
 - **Flatten markups into a downloadable PDF** — the ⤓ PDF button in the PDF takeoff burns every markup
@@ -14578,8 +14579,9 @@ BIM-native platform can do, because Massing owns the model + proforma. (See
 
 ### PDF digital signatures (PAdES) + e-sign options
 - **Digitally sign (PAdES)** — a contract/CO can be signed with a certificate-based **PAdES** digital
-  signature (Bluebeam's model) via **pyHanko**: the document is rendered, signed (tamper-evident,
-  self-validating), attached, and the signer + cert **fingerprint** recorded. Uses a self-signed
+  signature (a true digital signature, not a SaaS e-signature) via **pyHanko**: the document is
+  rendered, signed (tamper-evident, self-validating), attached, and the signer + cert
+  **fingerprint** recorded. Uses a self-signed
   platform certificate by default (offline, no cost); set `ESIGN_P12` to sign with your own / a CA cert.
 - **3rd-party bridge (feature-flagged)** — `esign_bridge.py` + `GET /esign/status` scope DocuSign /
   Dropbox Sign / self-hosted DocuSeal·Documenso for legally-binding multi-party signing (off until

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,11 @@ roadmap, it is in the directions.
 ## Verify, don't recall
 Long sessions drift: instructions written early lose influence, and stale file contents linger in
 context beside current ones. The countermeasure is not a better memory, it is **checks that fail**:
-`test_reachable.py` (is it wired?), `ties.test.ts` (do the aliases agree?), `test_no_competitors.py`,
-the size guard in `check_file_sizes.py`. If a rule matters, write it as a test — anything held only
-as prose will drift, including the prose in this file.
+`services/api/test_reachable.py` (is it wired?), `apps/web/src/kernel/ties.test.ts` (do the aliases
+agree?), `services/api/test_no_comparative_names.py` (do the public docs name a competitor
+*comparatively* — as opposed to as a connector, an import format or an SSO provider, which are
+allowed?), and the size guard in `services/api/test_file_sizes.py`. If a rule matters, write it as a
+test — anything held only as prose will drift, **including the prose in this file: two of those four
+names were wrong until 2026-07-31.** `test_no_competitors.py` never existed at all, and the size
+guard is `test_file_sizes.py`, not `check_file_sizes.py`. Cite a gate only after `git ls-files`
+confirms it.

--- a/apps/web/src-tauri/README.md
+++ b/apps/web/src-tauri/README.md
@@ -41,7 +41,7 @@ The same shell ships in two configurations:
 1. **Pro / cloud client** — the frontend points at a hosted API (`VITE_API_URL=https://api.your-host`),
    accounts + admin gates on. This is what `npm run build` + the commands above produce.
 2. **Free single-project app (offline)** — the shell bundles and spawns a **local API sidecar**
-   so the whole platform runs on the machine with no server, à la Bluebeam controlling one site.
+   so the whole platform runs on the machine with no server — one operator, one site, no login.
 
 ### Free single-project build (local sidecar)
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -141,7 +141,7 @@ and front the web service with their TLS.
 ## Free single-project desktop app (.exe)
 The whole platform runs in **one process** for a single operator — FastAPI serving both the API and
 the web SPA on `127.0.0.1:8765`, backed by **SQLite + local files** (no Docker / Postgres / MinIO),
-in **local mode** (no login — the operator owns the one site). This is the "free, Bluebeam-style"
+in **local mode** (no login — the operator owns the one site). This is the free, single-seat desktop
 build; projects are saved/opened as portable `.mmproj` bundles (Open/Save menu).
 
 - **Run from source:** `python -m aec_api.desktop` (from `services/api`, with the venv) — builds the

--- a/docs/esign-options.md
+++ b/docs/esign-options.md
@@ -10,7 +10,7 @@ the contract lifecycle (generate → markup → sign) in the GC portal.
   in the PDF. Makes the document **tamper-evident** and verifiable offline. The PDF profile is
   **PAdES** (PDF Advanced Electronic Signatures): it packages the certificate chain, a timestamp, and
   validation data **into the PDF**, so the signature stays verifiable over time without a live service.
-  This is the model **Bluebeam Revu** uses (Windows Certificate Store / PKCS#12 / Adobe CDS).
+  This is the model established PDF review tools use (Windows Certificate Store / PKCS#12 / Adobe CDS).
 - **AdES vs QES** — an *advanced* signature (AdES/PAdES) proves integrity + signer key. A *qualified*
   signature (QES, eIDAS) additionally uses a certificate from a qualified Trust Service Provider and
   has the legal weight of a handwritten signature in the EU. QES requires a public/qualified CA.
@@ -53,4 +53,4 @@ the contract lifecycle (generate → markup → sign) in the GC portal.
 
 ## Out of scope (for now)
 Running our own qualified CA / trust chain; a live DocuSign/Adobe integration (scoped behind the flag);
-real-time Studio-session co-markup (Bluebeam Studio).
+real-time hosted-session co-markup (multiple reviewers marking up one PDF live).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -834,18 +834,19 @@ is recorded. Filed under Decisions below.
 | 17 | three vocabularies collide | R24-TERMS | ❌ open |
 | 18 | site promises a lifecycle, app opens on a shell | *(none)* | 🟡 R26-VITALS (v0.3.773) is arguably a **better** answer than the audit's lifecycle strip — treat as closed |
 
-**External corroboration** (13-platform UI scan, 2026-07-29). Procore's design system evaluates
-office and field as **separate** UX, not one responsive layout — independent support for #12. Solibri
-beats Navisworks on IFC by making rulesets and checks **durable first-class objects**, and ACC's
-answer to breadth is **saved, re-runnable, shareable** searches — both are the same shape as
-`R24-RUNS-INBOX`, and it is the most externally validated item in the ring. LayOut 2026's tray
-redesign drew open backlash ("bulky, less legible and inefficient", broken shortcuts) — density is a
-**regression risk**, not a taste call, which is why `R24-DENSITY` ships as a user switch and why
-`R24-KEYS` is not optional. Bluebeam Revu 21 deliberately did **not** restyle and invested in
-customizable profiles instead. And two conclusions worth keeping: **no incumbent ships a command
-palette as a primary entry point** — a real opening, and a warning that ⌘K must be *taught*, not just
-bound — and **none of them can trace a number to a GlobalId**. That is the moat and it is still
-uncashed.
+**External corroboration** (13-platform UI scan, 2026-07-29). One major construction-management
+platform's design system evaluates office and field as **separate** UX, not one responsive layout —
+independent support for #12. Among model-checking tools, the ones that lead on IFC do so by making
+rulesets and checks **durable first-class objects**, and the leading common-data-environment answer
+to breadth is **saved, re-runnable, shareable** searches — both are the same shape as
+`R24-RUNS-INBOX`, and it is the most externally validated item in the ring. One 2026 drawing-layout
+tray redesign drew open backlash ("bulky, less legible and inefficient", broken shortcuts) — density
+is a **regression risk**, not a taste call, which is why `R24-DENSITY` ships as a user switch and why
+`R24-KEYS` is not optional. A major PDF review tool's most recent release deliberately did **not**
+restyle and invested in customizable profiles instead. And two conclusions worth keeping: **no
+incumbent ships a command palette as a primary entry point** — a real opening, and a warning that ⌘K
+must be *taught*, not just bound — and **none of them can trace a number to a GlobalId**. That is the
+moat and it is still uncashed.
 
 ---
 

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -67,7 +67,9 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          # R23-DIGEST — the deterministic model digest and its two routes:
          "test_model_digest", "test_digest_route",
          # observability (error alerting + distributed tracing) — env-gated, no-op when unconfigured:
-         "test_sentry", "test_otel", "test_docs_module_schema", "test_schema_strictness"]
+         "test_sentry", "test_otel", "test_docs_module_schema", "test_schema_strictness",
+         # public docs are a shipped surface: competitor names for interop only, never comparison:
+         "test_no_comparative_names"]
 
 
 def _manifest_guard() -> list[str]:

--- a/services/api/test_no_comparative_names.py
+++ b/services/api/test_no_comparative_names.py
@@ -1,0 +1,182 @@
+"""Public docs name competitor products for INTEROP, never for COMPARISON.
+
+The standing directive: no competitor product names in README / CHANGELOG / docs. The repo is
+public, so every one of these files is a shipped surface. But the directive has an edge that a blunt
+"ban the word" gate gets wrong, and getting it wrong is worse than the violation — it would delete
+things the product genuinely does:
+
+  ALLOWED (interop — the name is load-bearing, it identifies a real integration)
+    * "Sign in with Autodesk / Procore / Google / Microsoft"  — SSO providers
+    * "Navisworks XML import", the `smart:` namespace `<clashresult>` export — a file FORMAT we read
+    * "Navisworks, Solibri, BIMcollab, usBIM — connect and sync issues" — connectors
+    * Autodesk APS / Model Derivative — a real, paid RVT->IFC bridge
+
+  BANNED (comparative — the name is decoration, standing in for a capability we could just name)
+    * "Bluebeam-parity markup"            -> "PDF markup parity"
+    * "the Bluebeam Tool Chest idea"      -> "a reusable tool set"
+    * "the Navisworks / Bluebeam 'search set' pattern" -> "the saved-search-set pattern"
+
+Seven comparative mentions of one product accumulated before anyone noticed, which is the whole
+argument for this file: **the directive existed only as prose, and prose has no way to fail.**
+
+Three checks, because the failure has three shapes:
+
+  1. HARD BAN on names with no interop role here. Zero tolerance, no baseline — there is no
+     legitimate sentence in this repo containing them.
+
+  2. A RATCHET on comparative PHRASING around names that DO have an interop role. The shape is the
+     signal, not the name: `X-style`, `X-parity`, `the way X does it`. 29 such uses predate this
+     gate (mostly `Revit-style`, several in version HEADINGS and commit subjects, where a rewrite
+     would rename shipped releases) so they are grandfathered by exact count. The count may only go
+     DOWN. A new phrase fails; a lower count also fails, telling you to tighten the number — a
+     ratchet that is allowed to sag is an allowlist wearing a ratchet's clothes.
+
+  3. The INVERSE: the allowed interop mentions must still EXIST. Without this, the cheapest way to
+     make checks 1-2 green is to delete the SSO buttons and the clash-import docs from the README,
+     and the suite would applaud. This is the mutation check on the gate itself.
+
+Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_no_comparative_names.py
+"""
+import collections
+import os
+import re
+import subprocess
+
+_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+
+# README + CHANGELOG + EVERY doc. `docs/` is the Pages web root — it is copied wholesale to the
+# public site — so scoping this gate to a hand-listed file or three would be the same mistake it
+# exists to catch. The first version of this file did exactly that and missed four hard-ban hits in
+# docs/esign-options.md and docs/deploy.md.
+FILES = ["README.md", "CHANGELOG.md"]
+for _root, _dirs, _names in os.walk(os.path.join(_ROOT, "docs")):
+    for _n in sorted(_names):
+        if _n.endswith((".md", ".html")):
+            FILES.append(os.path.relpath(os.path.join(_root, _n), _ROOT).replace(os.sep, "/"))
+
+# A discovery walk that silently returns nothing turns this whole gate into a no-op that prints OK.
+assert len(FILES) > 50, f"only found {len(FILES)} docs — the discovery walk is broken, not the docs"
+assert "docs/roadmap.md" in FILES, "docs/roadmap.md not discovered — the walk is not reaching docs/"
+
+TEXT = {}
+for rel in FILES:
+    with open(os.path.join(_ROOT, rel), encoding="utf-8") as fh:
+        TEXT[rel] = fh.read()
+assert len(TEXT["README.md"]) > 2000, "README.md is suspiciously short — did it move?"
+assert len(TEXT["CHANGELOG.md"]) > 2000, "CHANGELOG.md is suspiciously short — did it move?"
+
+# The HARD BAN (check 1) runs wider than the ratchet: every TRACKED markdown/html file in a public
+# repo, not just the docs surface. Scoping it to docs/ would have missed the one in
+# apps/web/src-tauri/README.md. `git ls-files` rather than a walk, so the population is exactly what
+# a stranger cloning the repo receives — untracked scratch files are not published and not our
+# problem (see the sample-fixture lesson: if a test reads a repo path, check it is in the archive).
+_tracked = subprocess.run(
+    ["git", "ls-files", "*.md", "*.html"],
+    cwd=_ROOT, capture_output=True, text=True, check=True,
+).stdout.split()
+assert len(_tracked) > 60, f"git ls-files returned only {len(_tracked)} docs — the scan is broken"
+
+# ---- 1. hard ban -------------------------------------------------------------------------------
+# Names with no connector, no import format, no SSO provider and no paid bridge in this product.
+# `revu` is separate from `bluebeam` on purpose: the product has been referred to by either half.
+BANNED = ("bluebeam", "revu")
+
+_banned_hits = []
+for rel in _tracked:
+    with open(os.path.join(_ROOT, rel), encoding="utf-8") as fh:
+        body = fh.read()
+    for i, ln in enumerate(body.splitlines(), 1):
+        for name in BANNED:
+            if re.search(rf"\b{name}\b", ln, re.I):
+                _banned_hits.append(f"{rel}:{i}: {ln.strip()[:100]}")
+                break
+
+assert not _banned_hits, (
+    "a hard-banned product name appears in a tracked doc. It has no connector, import format, SSO "
+    "role or paid bridge here, so every use is comparative — rewrite it as the capability itself "
+    "(e.g. 'a PDF markup/manipulation stack'):\n  " + "\n  ".join(_banned_hits)
+)
+
+# ---- 2. comparative-phrasing ratchet ------------------------------------------------------------
+# Names that ARE legitimate as connectors / formats / SSO / bridges — banned only in a comparative
+# construction. Matching the CONSTRUCTION rather than the name is what lets check 3 coexist.
+INTEROP_NAMES = (
+    r"(?:navisworks|solibri|bimcollab|usbim|revit|revizto|archicad|tekla|procore|sketchup"
+    r"|rhino|vectorworks|allplan|bentley|trimble|plangrid|speckle|autodesk)"
+)
+COMPARATIVE = (
+    # "Revit-style", "Bluebeam-parity", "Navisworks-like"
+    re.compile(INTEROP_NAMES + r"[a-z]*[-‑ ](?:style|parity|like|esque)", re.I),
+    # "the way Revit does it", "beats Navisworks", "unlike Solibri"
+    re.compile(
+        r"(?:like|unlike|than|beats|versus|vs\.?|compared to|the way|how|similar to)\s+"
+        + INTEROP_NAMES,
+        re.I,
+    ),
+)
+
+# Grandfathered as of 2026-07-31. DOWN ONLY. Do not add a key to make a new entry pass — rewrite the
+# entry instead; that is the point of the file.
+BASELINE = {
+    "navisworks-style": 1,
+    "procore parity": 1,
+    "procore-style": 1,
+    "revit-parity": 1,
+    "revit-style": 14,
+    "sketchup-style": 5,
+    "solibri-style": 1,
+    "the way navisworks": 2,
+    "the way revit": 2,
+    "vs revit": 1,
+}
+
+found = collections.Counter()
+for text in TEXT.values():
+    for pat in COMPARATIVE:
+        for m in pat.findall(text):
+            found[" ".join(m.lower().split())] += 1
+
+new = sorted(set(found) - set(BASELINE))
+assert not new, (
+    "new comparative use of a competitor product name in a public doc: "
+    + ", ".join(repr(k) for k in new)
+    + ". Name the capability, not the product — e.g. 'Revit-style shortcuts' -> '2-letter draw-tool "
+    "shortcuts'. These names are allowed ONLY for connectors, import formats, SSO providers and the "
+    "paid Autodesk APS bridge."
+)
+
+grew = {k: (found[k], n) for k, n in BASELINE.items() if found[k] > n}
+assert not grew, "comparative uses INCREASED (found, baseline): " + repr(grew)
+
+shrank = {k: (found[k], n) for k, n in BASELINE.items() if found[k] < n}
+assert not shrank, (
+    "comparative uses were removed — good; now tighten BASELINE in this file so the ratchet cannot "
+    "sag back. (found, baseline): " + repr(shrank)
+)
+
+# ---- 3. the inverse: interop mentions must survive ----------------------------------------------
+# Deleting these would make checks 1-2 greener. They are the product, not a violation.
+REQUIRED = (
+    ("README.md", "Google / Microsoft / Procore", "the SSO provider list"),
+    ("README.md", "Autodesk APS", "the paid RVT->IFC bridge"),
+    ("CHANGELOG.md", "Navisworks XML", "the native clash-report import format"),
+    ("CHANGELOG.md", "clashresult", "the `smart:` namespace export we parse"),
+    ("CHANGELOG.md", "Navisworks, Solibri, BIMcollab, usBIM", "the issue-sync connector list"),
+    ("CHANGELOG.md", "Autodesk APS", "the paid conversion bridge, in Settings > Integrations"),
+)
+for rel, phrase, why in REQUIRED:
+    assert phrase in TEXT[rel], (
+        f"{rel} no longer contains {phrase!r} ({why}). Interop names are ALLOWED — this gate bans "
+        "comparative uses only. Do not blanket-remove competitor names to make it pass."
+    )
+
+print(
+    f"NO COMPARATIVE NAMES OK - {len(_tracked)} tracked docs scanned for the hard ban, "
+    f"{len(FILES)} public docs (README + CHANGELOG + all of docs/) read from disk for the ratchet. "
+    f"{len(BANNED)} names hard-banned (no interop role, zero tolerance); comparative PHRASING "
+    f"({sum(found.values())} grandfathered uses across {len(BASELINE)} phrases) ratcheted DOWN-ONLY, "
+    "so a new 'X-style' or 'the way X does it' fails and a removal forces the baseline to tighten; "
+    f"and {len(REQUIRED)} legitimate interop mentions (SSO providers, the Navisworks XML clash "
+    "format, the connector list, Autodesk APS) asserted PRESENT so the gate cannot be satisfied by "
+    "deleting the integrations it exists to protect."
+)


### PR DESCRIPTION
## What

The standing directive — competitor product names in public docs are for **interop only, never for
comparison** — existed only as prose. Prose has no way to fail, so it drifted. This rewrites the
comparative uses and turns the rule into a gate.

## The count was 12, not 7

The sweep was reported as "~7 places in CHANGELOG". Scoped to the repo rather than to the files
named, it was twelve, in five files:

| File | Hits | Public? |
|---|---|---|
| `CHANGELOG.md` | 7 | yes |
| `docs/roadmap.md` | 1 | yes — Pages |
| `docs/esign-options.md` | 3 | yes — Pages |
| `docs/deploy.md` | 1 | yes — Pages |
| `apps/web/src-tauri/README.md` | 1 | tracked, outside `docs/` |

`README.md` had **0**, not 1. Three of those files are served on the public Pages site; the last is
outside `docs/` entirely, which is why a gate scoped to the docs surface would still have missed it.

## Rewrites

Every one preserves the technical claim exactly — these are historical release notes and the facts
must not move:

- `"<product>-parity markup"` → `"PDF markup parity"`
- `"the <product> Tool Chest idea"` → `"a reusable tool set"`
- `"the X / <product> 'search set' pattern"` → `"the saved-search-set pattern"`
- `"(<product>'s model)"` on PAdES → `"a true digital signature, not a SaaS e-signature"` — keeps the
  digital-vs-e-signature distinction the following bullet depends on
- `'the "free, <product>-style" build'` → `"the free, single-seat desktop build"`

Two edits go **wider than a literal name swap**, flagged for review:

1. `CHANGELOG.md:7362` also carried `"Solibri-style rule library"` on the same line — same
   construction. That vendor is legitimate as a *connector*, not as a design reference.
2. The roadmap's 13-platform UI-scan paragraph ranked **five** products comparatively. Neutralising
   one name inside it would read as an oversight rather than a policy, so the paragraph is
   neutralised whole. Every finding it records is unchanged; only the attributions are generic.

## The gate

`services/api/test_no_comparative_names.py`, registered in `run_tests.py`. Three checks, because the
failure has three shapes:

1. **Hard ban** — zero tolerance, over every tracked `.md`/`.html` (`git ls-files`, 107 files).
   Untracked files are exempt on purpose: not published, not the directive's problem.
2. **A down-only ratchet on comparative *phrasing*** (`X-style`, `X-parity`, `the way X does it`) for
   the names that *do* have an interop role. It matches the **construction, not the name** — that is
   what lets the connectors coexist with it. 29 uses are grandfathered by exact count; several sit in
   version headings and commit subjects, where a rewrite would rename a shipped release. Removing one
   fails the gate until the baseline is tightened, so it cannot sag into an allowlist.
3. **The inverse** — the legitimate interop mentions are asserted **present**: the SSO provider list,
   the native clash-report XML format, the issue-sync connector list, the paid conversion bridge.
   Without this, the cheapest way to go green is to delete the integrations the gate exists to
   protect. It caught a wrong assertion on its own first run.

### Mutation-checked

All seven failure modes go red, and the baseline is green either side:

| Mutation | Result |
|---|---|
| banned name reintroduced | RED |
| banned name outside `docs/` | RED |
| banned name in an **untracked** file | GREEN (correct — unpublished) |
| new comparative phrase (`Archicad-style`) | RED |
| comparative count goes **up** | RED |
| comparative count goes **down** | RED — "tighten the baseline" |
| interop mention deleted (SSO list, XML format) | RED |
| discovery walk broken / `docs/` empty | RED — not a silent OK over 2 files |

## Also

`CLAUDE.md`'s "Verify, don't recall" list named **two gates that do not exist** —
`test_no_competitors.py` never existed at all, and the size guard is `test_file_sizes.py`, not
`check_file_sizes.py`. Both sat inside the paragraph asserting that prose in that file drifts.
Corrected with verified full paths.

## For whoever merges

- **No version bump and no CHANGELOG release section.** You own the release number, and the top of
  `CHANGELOG.md` is the highest-conflict region in a tree several sessions are shipping from. This
  needs a version-numbered entry on merge.
- Rebased onto `origin/main` @ `2fcd8854`. `run_tests.py` auto-merged with the manifest entry added
  upstream (`test_dim_component`) — verified both survived: guard clean, 474 registered, 474 unique.
- **29 comparative uses remain grandfathered**, mostly `Revit-style` (14) and `SketchUp-style` (5).
  Several are in version headings; rewriting them renames shipped releases. Your call, separately.
- Two historical **commit subjects** carry the same phrasing (`6bc4b686`, `32c63b90`). History is
  immutable; a commit-msg hook would only cover future ones. Not included here.

## Verification

- `test_no_comparative_names.py` — green on the rebased tree
- `run_tests.py` manifest guard — clean; 474 registered, 474 unique
- `ruff` — clean on both touched Python files (the 166 repo-wide errors are pre-existing)
- `docsPublished.test.ts` + `roadmapLanes.test.ts` — 91/91 on the rebased tree
- Repo-wide grep for the banned names in tracked docs — **0**
- **Not run:** the full 473-test backend suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
