### PR TITLE
test(gate): the test manifest is hand-maintained, so it gets a test

### DIFF
--- a/.claude/skills/backend-tests/SKILL.md
+++ b/.claude/skills/backend-tests/SKILL.md
@@ -18,7 +18,13 @@ PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe -X utf8 test_<name>.py  
 Use `-X utf8` — some tests print `→`/`²`/`³` and crash on the default Windows cp1252 console (a false failure; CI uses utf-8).
 
 ## The manifest guard — REGISTER NEW TESTS
-`run_tests.py` has a hand-maintained `TESTS` list and a `_manifest_guard()` that **fails the whole run** if any `test_*.py` on disk isn't in the list. After adding `test_foo.py`, add `"test_foo"` to the `TESTS` list or CI fails before running anything.
+`run_tests.py` has a hand-maintained `TESTS` list and a `manifest_problems()` guard that **fails the whole run before any suite starts** if the list and the `test_*.py` files on disk are not a 1:1 map. It enforces three rules:
+
+1. **no duplicate registration** — a name listed twice would run the suite twice, burning wall time;
+2. **every registered name has a file** — the runner used to silently drop missing entries, so a typo still printed "N/N suites passed";
+3. **every file on disk is registered** — a test nobody runs is worse than no test.
+
+After adding `test_foo.py`, add `"test_foo"` to the `TESTS` list or CI fails before running anything. `test_manifest.py` asserts the live manifest is clean *and* drives each rule with a synthetic violation to prove the guard can still go red — keep those synthetic cases if you touch the guard.
 
 ## Two test idioms
 - **DB-backed API test**: set `os.environ["DATABASE_URL"]`, `STORAGE_DIR`, and (if it uploads a source IFC) `IFC_DIR` — all to `./test_*`-prefixed local paths (gitignored). `os.environ.pop("AEC_RBAC", None)`. Use `TestClient(app)` + `X-User` header. Upload a model via `POST /projects/{pid}/source-ifc?publish=false`.

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import time
+from collections import Counter
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -69,15 +70,45 @@ TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
          # observability (error alerting + distributed tracing) — env-gated, no-op when unconfigured:
          "test_sentry", "test_otel", "test_docs_module_schema", "test_schema_strictness",
          # public docs are a shipped surface: competitor names for interop only, never comparison:
-         "test_no_comparative_names"]
+         "test_no_comparative_names",
+         # this list is itself hand-maintained, so it gets a test of its own:
+         "test_manifest"]
 
 
-def _manifest_guard() -> list[str]:
-    """Every test_*.py on disk must be registered in TESTS. The manifest is hand-maintained (so it can
-    order/skip and set per-test env), which means a newly-added test file silently escapes the gate
-    unless it's listed. Fail loudly on drift instead — a test nobody runs is worse than no test."""
-    on_disk = {p.stem for p in HERE.glob("test_*.py")}
-    return sorted(on_disk - set(TESTS))
+def manifest_problems(tests: list[str] | None = None,
+                      on_disk: set[str] | None = None) -> list[str]:
+    """The TESTS manifest must be a faithful 1:1 map of the test_*.py files on disk.
+
+    It is hand-maintained (so it can order/skip and set per-test env), and a hand-maintained list
+    drifts in three directions — only one of which used to be caught:
+
+      1. a name registered TWICE      -> the suite runs it twice, quietly burning wall time
+      2. a name with NO FILE on disk  -> silently dropped by the runner's .exists() filter
+      3. a file with NO REGISTRATION  -> a test nobody runs, which is worse than no test
+
+    (2) was the dangerous one, and it is the same shape as the G-8 RBAC prefix list: the runner
+    filtered registered-but-missing entries out without a word, so a typo'd or deleted suite still
+    printed "N/N suites passed". A count that shrinks silently reads exactly like a clean run.
+
+    `tests`/`on_disk` are injectable so test_manifest.py can drive each rule with a synthetic
+    violation and prove it FIRES. A gate nobody has watched fail is not known to work.
+
+    Returns a list of human-readable problems, empty when the manifest is sound.
+    """
+    tests = TESTS if tests is None else tests
+    if on_disk is None:
+        on_disk = {p.stem for p in HERE.glob("test_*.py")}
+    problems: list[str] = []
+    if dupes := sorted(n for n, c in Counter(tests).items() if c > 1):
+        problems.append("registered more than once — each suite must run exactly once: "
+                        + ", ".join(dupes))
+    if missing := sorted(set(tests) - on_disk):
+        problems.append("registered in TESTS but no such file on disk (typo, or the file was "
+                        "deleted without being de-registered): " + ", ".join(missing))
+    if unregistered := sorted(on_disk - set(tests)):
+        problems.append("test file(s) on disk not registered in TESTS (add to run_tests.py): "
+                        + ", ".join(unregistered))
+    return problems
 
 
 def _run_one(t: str, base: dict) -> tuple[str, bool, float, str]:
@@ -99,10 +130,9 @@ def _run_one(t: str, base: dict) -> tuple[str, bool, float, str]:
 
 
 def main() -> int:
-    unregistered = _manifest_guard()
-    if unregistered:
-        print("FAIL  run_tests manifest: test file(s) not registered in TESTS "
-              f"(add to run_tests.py): {', '.join(unregistered)}")
+    if problems := manifest_problems():
+        for p in problems:
+            print(f"FAIL  run_tests manifest: {p}")
         return 1
     # api src + the data service src (analysis/export bridge), mirroring the runtime image
     pp = os.pathsep.join([str(HERE / "src"), str(HERE.parent / "data" / "src")])
@@ -110,7 +140,9 @@ def main() -> int:
     # test-level parallelism owns the cores (no cpu-1 × cpu-1 oversubscription).
     base = {**os.environ, "PYTHONPATH": pp, "AEC_TRUST_XUSER": "1", "PYTHONUTF8": "1",
             "AEC_GEOM_WORKERS": os.environ.get("AEC_GEOM_WORKERS", "1")}
-    tests = [t for t in TESTS if (HERE / f"{t}.py").exists()]
+    # every entry, no filtering: manifest_problems() above has already proved each one exists, so a
+    # missing file is now a loud failure rather than a silently shorter run.
+    tests = list(TESTS)
     # each test is an isolated subprocess → embarrassingly parallel. TEST_JOBS overrides the worker count
     # (TEST_JOBS=1 forces the old sequential behaviour for debugging a flaky/order-sensitive test).
     jobs = int(os.environ.get("TEST_JOBS") or 0) or max(1, (os.cpu_count() or 2) - 1)

--- a/services/api/test_manifest.py
+++ b/services/api/test_manifest.py
@@ -1,0 +1,72 @@
+"""The test manifest is itself a hand-maintained list, so it gets a test.
+
+`run_tests.py` holds `TESTS`, a hand-written registry of every suite. Nothing derived it from disk
+and nothing checked it, which is the same shape as the G-8 RBAC prefix list that let four
+authorisation holes through: a list a human must remember to update, with no check that they did.
+
+The manifest can drift three ways, and the runner used to notice only the third:
+
+  1. a name registered twice      -> the suite runs twice, burning wall time in a ~22 min gate
+  2. a name with no file on disk  -> the runner's `.exists()` filter dropped it WITHOUT A WORD
+  3. a file with no registration  -> a test nobody runs
+
+This test asserts the live manifest is clean, and then — more importantly — feeds
+`manifest_problems()` a synthetic violation of each rule to prove the detector can actually go red.
+A gate asserted only against the passing case is indistinguishable from `return []`.
+
+Pure list/set comparison: no DB, no TestClient, no env.
+"""
+import sys
+
+import run_tests
+
+FAILED = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}" + (f"   {detail}" if detail else ""))
+    if not ok:
+        FAILED.append(label)
+
+
+# ---------------------------------------------------------------- the live manifest is sound
+problems = run_tests.manifest_problems()
+check("the live TESTS manifest has no problems", not problems, "; ".join(problems))
+
+check("the manifest is not vacuously small", len(run_tests.TESTS) > 400,
+      f"{len(run_tests.TESTS)} suites registered")
+
+# ---------------------------------------------------- each rule fires on a synthetic violation
+# Without these, every assertion above would still pass if manifest_problems() were `return []`.
+DISK = {"test_a", "test_b"}
+
+check("rule 1 fires on a duplicate registration",
+      any("more than once" in p and "test_a" in p
+          for p in run_tests.manifest_problems(["test_a", "test_a", "test_b"], DISK)),
+      "duplicate must be reported AND named")
+
+check("rule 2 fires on a registered entry with no file",
+      any("no such file on disk" in p and "test_ghost" in p
+          for p in run_tests.manifest_problems(["test_a", "test_b", "test_ghost"], DISK)),
+      "the silently-dropped case — this is the one the old runner could not see")
+
+check("rule 3 fires on an unregistered file on disk",
+      any("not registered in TESTS" in p and "test_b" in p
+          for p in run_tests.manifest_problems(["test_a"], DISK)),
+      "unregistered file must be reported AND named")
+
+check("a sound manifest reports nothing",
+      run_tests.manifest_problems(["test_a", "test_b"], DISK) == [],
+      "no false positives on a clean 1:1 map")
+
+# All three at once: a real drifted manifest usually breaks more than one rule, and reporting only
+# the first would send somebody round the loop three times on a 22-minute gate.
+combined = run_tests.manifest_problems(["test_a", "test_a", "test_ghost"], DISK)
+check("all three problems are reported together, not one at a time", len(combined) == 3,
+      f"{len(combined)} problem(s): {' | '.join(combined)}")
+
+print()
+if FAILED:
+    print("FAILED:", ", ".join(FAILED))
+    sys.exit(1)
+print("test_manifest OK")


### PR DESCRIPTION
Opened by the release session — the branch was pushed with no PR and would otherwise have been lost.

## The reported bug did not exist, and finding that out found a real one

I reported `test_modules` and `test_rbac` as double-registered in `run_tests.py`. **That was wrong.**
My check regexed every quoted `test_*` name in the file instead of parsing the registration list, so
it also matched functional code at `run_tests.py:87`:

```python
"AEC_RBAC": "1" if t in ("test_rbac", "test_modules") else ...
```

Verified by AST: `TESTS` is **473 entries, 473 unique, zero duplicates**. The naive scan's 475 = 473 + those 2.
That is the same substring-match trap this repo has hit three times today under different names.

## The real hole was the other direction

`_manifest_guard` only checked disk → registered. `main()` then did:

```python
tests = [t for t in TESTS if (HERE / f"{t}.py").exists()]
```

so a registered entry whose file was typo'd or deleted was **dropped without a word**, and the run
still printed `N/N suites passed`. **A count that shrinks silently reads exactly like a clean run.**
Same shape as the G-8 RBAC prefix list: a hand-maintained list with nothing checking it was updated.

`manifest_problems()` now enforces a 1:1 map in all three directions — no duplicate registration,
every registered name has a file, every file is registered — and reports all problems at once rather
than one per 22-minute round trip. The silent `.exists()` filter is gone. Removing it is a no-op
today: both lists are the same 474.

`test_manifest.py` asserts the live manifest is clean, then feeds the checker a synthetic violation of
each rule, so the guard fails even if someone reduces it to `return []`. Mutation-checked against the
real runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)