### PR TITLE
Proforma income basis — derive operating income from the rent roll, and say where it came from

### DIFF
--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -54,6 +54,7 @@ deliberately deferred. A reader should treat every claim here as a **proposal**.
 | `plugin-architecture-plan.md` | Plan only — nothing built. Free core + installable capability plugins. |
 | `caching-research.md` | Research, 2026-07-27: our caches bound the wrong quantity. |
 | `cost-db-import-plan.md` | Partially built. Vintage-versioned cost DB; referenced from `cost_db.py` and `models.py`. |
+| `proforma-asset-class-scope.md` | Research, 2026-08-01: what six institutional CRE underwriting models require that our proforma cannot express. Scope + sequencing; items 1-2 shipped, 3-6 unbuilt. |
 | `marketing-copy.md` | Messaging drafts. Reflects shipped capability only — check before reuse, copy rots faster than code. |
 
 ## Adding to this directory

--- a/docs/internal/research/proforma-asset-class-scope.md
+++ b/docs/internal/research/proforma-asset-class-scope.md
@@ -1,0 +1,102 @@
+# Proforma scope — what six institutional CRE models require that ours cannot express
+
+**Date:** 2026-08-01 · **Method:** structural read of six externally-authored underwriting workbooks
+(office development, apartment acquisition w/ Monte Carlo, value-add apartment, multifamily
+renovation, hotel, data-center development), compared against `aec_api/proforma/` and the `lease`
+module. Sheet inventories and concept vocabulary were extracted from the workbook XML; **no formulas
+were copied and none of their content is reproduced here.** The models are third-party copyrighted
+works used as a *requirements survey*, not as a source. Everything proposed below is standard
+industry math to be implemented independently.
+
+## The headline finding: most of what's missing is REACH, not capability
+
+The instinct is "we need a rent roll". **We already have one.** The `lease` module carries
+`base_rent_annual`, `escalation_pct`, `free_rent_months`, `recovery_psf`, `ti_allowance_psf`,
+`start_date`/`end_date`, `suite`, `rentable_sf`, `renewal_options`. Five engines consume it:
+`rentroll.py`, `net_effective.py`, `leasemgmt.py`, `rent_scrub.py`, `cam.py`.
+
+**The proforma cannot reach any of it.** `Ops` takes a single blended `potential_rent_annual`, and
+`operating_noi()` multiplies it by a *linear* lease-up ramp. Grep for `lease` inside `proforma/`
+returns only the lease-*up curve* — the rent roll and the proforma never meet.
+
+`rentroll.py`'s own docstring states the intent:
+
+> *"…so a built asset's **actual** operations feed back into the **proforma** + appraisal (income
+> approach)."*
+
+That sentence describes a wire that does not exist. Same shape as R22-PRODUCTION, where
+`production_quantity` carried the model's join key and only cost consumers read it.
+
+## Concept map — surveyed models vs. us
+
+| concept | in the surveyed models | ours |
+|---|---|---|
+| Waterfall, pref, promote, IRR hurdles | all six | ✅ `waterfall.py` |
+| Equity multiple, IRR, exit cap, reversion | all six | ✅ `returns.py`, `residual.py` |
+| S-curve draws, construction period | office, data centre, renovation | ✅ `draws.py` |
+| Monte Carlo | apartment MC | ✅ `monte_carlo.py` |
+| Sensitivity | several | ✅ `sensitivity.py` |
+| CAM / expense recovery | office, value-add | ✅ `cam.py` — but **not** in the proforma |
+| Net effective rent, free rent | office, value-add, apartment | ✅ `net_effective.py` — **not** in the proforma |
+| Rent roll / in-place income | apartment, value-add | ✅ `rentroll.py` — **not** in the proforma |
+| **Rollover: downtime, renewal probability, releasing cost** | office, value-add, apartment | ❌ nothing |
+| **TI/LC as a proforma capital cost** | office, value-add | ❌ field exists on the lease; no cost line |
+| **Unit mix + per-unit renovation schedule** | value-add, renovation | ❌ nothing |
+| **Hotel: ADR / occupancy / RevPAR, departmental P&L, penetration index** | hotel | ❌ nothing |
+| **Capacity-based revenue (kW / MW)** | data centre | ❌ nothing |
+| **Mezzanine / second-position debt** | office, data centre | ❌ one loan only |
+| **Refinance mid-hold** | data centre, value-add | ❌ nothing |
+
+## Why the single blended income line is the binding constraint
+
+`Ops.potential_rent_annual` is one number for the whole asset. That is expressible for a simple
+stabilised deal and **cannot represent any of the six**:
+
+* an **office** deal needs per-suite expiry, downtime, and TI/LC spent *at* re-lease;
+* a **value-add apartment** deal needs unit types renovated on a turn schedule, each with a rent
+  premium that begins when that unit turns;
+* a **hotel** has no "rent" at all — revenue is ADR x occupancy x rooms, plus departmental revenue
+  with its own margins;
+* a **data centre** sells capacity, not floor area, and leases in MW blocks with absorption;
+* **any** commercial deal with recoveries needs gross rent, recovery income and the opex it recovers
+  against modelled separately — netting them into one figure destroys the reimbursement.
+
+## Proposed scope, in dependency order
+
+**1. Income basis (foundation).** Let a deal state its income as either the blended figure it uses
+today, or a **basis derived from detail**. Same pattern as `option_economics.BASIS_*`: the derived
+value and the declared value both retained, so `declared_disagrees_with_derived` can exist. Nothing
+is inferred silently — a deal that supplies neither is refused, not defaulted to zero.
+
+**2. Rent-roll basis** — wire `rentroll.summarize` + `net_effective.roll_up` + `cam.reconciliation`
+into (1). This is pure reach: three engines, all tested, none reachable from a proforma today.
+
+**3. Rollover engine** — expiry → downtime → releasing cost → renewal-vs-new mix. Prerequisite for
+office and any multi-tenant asset. TI/LC becomes a proforma cost line here, not a lease field.
+
+**4. Unit-mix / renovation schedule** — per-unit-type renovation cost and premium on a turn curve.
+
+**5. Asset-class operating models** — hotel (ADR/occ/RevPAR + departmental) and capacity (kW/MW), each
+as an income basis under (1) rather than a fork of the proforma.
+
+**6. Capital stack depth** — mezzanine and refinance.
+
+**Sequencing rationale:** (1) and (2) unlock the assets we already hold data for and are mostly
+wiring. (5) is the largest genuinely-new build and should not start before (1), or each asset class
+grows its own parallel proforma — the two-parallel-stores problem that `R32-FILE-GENERATED` already
+had to unwind once.
+
+## Refusals this scope must carry
+
+Every item below is a place where a plausible number is worse than no number:
+
+* **a hotel is not a lease.** If a hotel deal reaches the rent-roll basis, refuse — do not treat ADR
+  as rent;
+* **recoveries must not be netted into base rent.** Once netted, the reimbursement is unrecoverable
+  and the opex ratio is wrong in a way that still looks sane;
+* **a renovation premium must not begin before the unit turns.** Applying it from day one is the
+  single most common way a value-add deal is overstated;
+* **downtime is not optional.** A rollover model with no downtime produces continuous occupancy,
+  which is strictly better than reality and reads as a modelling result rather than an omission;
+* **declared vs derived income must both survive.** If a rent roll implies £X and the deal declares
+  £Y, that disagreement is the finding — resolving it silently destroys it.

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -20,7 +20,7 @@ from collections import Counter
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
+TESTS = ["test_proforma", "test_income_basis", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_collab", "test_serving", "test_api",
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
          # R22-ENTITLE-RISK — approval odds + entitlement duration in the Monte Carlo:

--- a/services/api/src/aec_api/proforma/income_basis.py
+++ b/services/api/src/aec_api/proforma/income_basis.py
@@ -1,0 +1,175 @@
+"""PF-INCOME-BASIS — where a deal's operating income actually came from.
+
+`Ops.potential_rent_annual` is **one blended number for the whole asset**, and `operating_noi()`
+multiplies it by a linear lease-up ramp. That is expressible for a simple stabilised deal and cannot
+represent a multi-tenant one: per-suite expiry, concessions and expense recoveries all collapse into
+a single figure that no longer says what it is made of.
+
+Meanwhile the asset's real income is already modelled elsewhere. The `lease` module carries
+`base_rent_annual`, `escalation_pct`, `free_rent_months`, `recovery_psf`, `ti_allowance_psf` and the
+term dates, and **five** engines consume it — `rentroll`, `net_effective`, `leasemgmt`, `rent_scrub`,
+`cam`. `rentroll.summarize()`'s own docstring says it exists *"so a built asset's actual operations
+feed back into the proforma"*. Grep for `lease` inside `proforma/` and you get the lease-**up** curve.
+**The wire it describes has never existed.** This module is that wire.
+
+## What it refuses to do
+
+**A basis is stated, never guessed.** The failure this prevents is not a missing number — it is a
+proforma that answers with someone's typed figure while a contradicting rent roll sits one table
+away, and nothing in the output says which was used or that they disagree.
+
+* **`declared` and `derived` are both kept.** If a rent roll implies X and the deal declares Y, that
+  disagreement **is the finding**; resolving it silently destroys it. Same argument as
+  `option_economics.BASIS_*` and `matched_class` on a takeoff row.
+* **Recoveries are never netted into base rent.** Once netted the reimbursement cannot be recovered
+  and the opex ratio is wrong in a way that still looks sane. Base rent and recovery income stay
+  separate lines, because they behave differently: recoveries track the opex they reimburse.
+* **Concessions are reported, not absorbed.** Face rent is what a broker quotes; net effective is what
+  underwriting uses. Both are returned, with the load between them, so a deal cannot quietly
+  underwrite face rent while calling it income.
+* **An empty rent roll is `unavailable`, not zero.** A property with no lease records has *unknown*
+  income, not none — and zero is the one value that reads as a real answer.
+* **A lease the maths cannot use is NAMED.** `net_effective.roll_up` already counts and names the
+  leases it skipped; that list is carried through rather than summarised into a percentage, because a
+  count says a problem exists and a name says which lease to open.
+
+This module is pure over the dicts the other engines return — no DB, no model parsing — so it is
+deterministic and testable, and it introduces no dependency the proforma did not already have.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+#: The deal stated a figure and no rent roll was supplied — today's behaviour, still valid.
+BASIS_DECLARED = "declared"
+#: Derived from the `lease` records via `rentroll` / `net_effective` / recoveries.
+BASIS_RENT_ROLL = "rent_roll"
+#: Both were available. The derived figure is authoritative; the declared one is kept beside it.
+BASIS_BOTH = "declared_and_derived"
+#: Neither. **Not zero** — the difference matters and is the whole reason this constant exists.
+BASIS_UNAVAILABLE = "unavailable"
+
+BASIS_MEANING = {
+    BASIS_DECLARED: "the deal supplied a blended figure and no lease detail was available to check it",
+    BASIS_RENT_ROLL: "derived from the property's own lease records — in-place rent, recoveries and "
+                     "concessions, each kept separate",
+    BASIS_BOTH: "derived from lease records AND declared on the deal; both are reported so a "
+                "disagreement between them is visible rather than resolved silently",
+    BASIS_UNAVAILABLE: "no lease records and no declared figure — income is UNKNOWN, which is not the "
+                       "same as zero and must not be underwritten as zero",
+}
+
+#: A disagreement below this is rounding and drafting noise; at or above it, someone should look.
+#: Stated as a constant because a threshold buried in a comparison is a policy nobody can find.
+MATERIAL_DISAGREEMENT_PCT = 5.0
+
+
+def _num(v: Any) -> float | None:
+    """Strictly numeric and finite. `bool` is rejected before `int` — `True` is not a rent of 1."""
+    if isinstance(v, bool) or v in (None, ""):
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    if f != f or f in (float("inf"), float("-inf")):
+        return None
+    return f
+
+
+def from_rent_roll(rent_roll: dict | None, ner: dict | None = None) -> dict[str, Any]:
+    """Turn a `rentroll.summarize()` result (+ optional `net_effective.roll_up()`) into proforma income.
+
+    Returns the components separately rather than a single figure: base rent, recovery income and the
+    concession load are three different things that a proforma must be able to treat differently."""
+    if not rent_roll or not isinstance(rent_roll, dict):
+        return {"available": False, "reason": "no rent roll supplied"}
+
+    leases = rent_roll.get("lease_count")
+    base = _num(rent_roll.get("base_rent_annual"))
+    rec = _num(rent_roll.get("recoveries_annual"))
+
+    # An empty rent roll is the dangerous case: every sum is legitimately 0.0, so the arithmetic
+    # succeeds and the deal underwrites zero income as though it were measured.
+    if not leases:
+        return {"available": False,
+                "reason": "the rent roll contains no active leases — income is UNKNOWN, not zero"}
+    if base is None:
+        return {"available": False, "reason": "rent roll carries no usable base rent"}
+
+    out: dict[str, Any] = {
+        "available": True,
+        "lease_count": leases,
+        "base_rent_annual": round(base, 2),
+        # Kept SEPARATE from base rent on purpose — recoveries track the opex they reimburse, so
+        # netting them destroys both the reimbursement and the opex ratio.
+        "recovery_income_annual": round(rec or 0.0, 2),
+        "potential_rent_annual": round(base + (rec or 0.0), 2),
+        "occupancy_pct": rent_roll.get("occupancy_pct"),
+        "walt_years": rent_roll.get("walt_years"),
+        "occupied_sf": rent_roll.get("occupied_sf"),
+        "vacant_sf": rent_roll.get("vacant_sf"),
+    }
+
+    if ner and isinstance(ner, dict):
+        face = _num(ner.get("face_gpr_annual"))
+        net = _num(ner.get("ner_gpr_annual_discounted")) or _num(ner.get("ner_gpr_annual"))
+        if face is not None and net is not None:
+            out["face_gpr_annual"] = round(face, 2)
+            out["net_effective_gpr_annual"] = round(net, 2)
+            out["concession_load_annual"] = round(face - net, 2)
+            out["concession_load_pct"] = round(100 * (face - net) / face, 2) if face else None
+        # Carried through by NAME, not collapsed to a count: a lease the maths could not use is a
+        # lease somebody has to open, and a percentage cannot be opened.
+        if ner.get("skipped"):
+            out["leases_not_computable"] = ner["skipped"]
+            out["leases_not_computable_count"] = ner.get("skipped_count", len(ner["skipped"]))
+    return out
+
+
+def resolve(declared_annual: Any = None, rent_roll: dict | None = None,
+            ner: dict | None = None) -> dict[str, Any]:
+    """The income a proforma should use, and an account of where it came from.
+
+    Never silently prefers one source: when both exist the derived figure is used **and** the declared
+    one is reported beside it with the gap between them."""
+    derived = from_rent_roll(rent_roll, ner)
+    dec = _num(declared_annual)
+
+    if not derived.get("available") and dec is None:
+        return {"basis": BASIS_UNAVAILABLE, "potential_rent_annual": None,
+                "basis_meaning": BASIS_MEANING[BASIS_UNAVAILABLE],
+                "reason": derived.get("reason", "no declared figure and no rent roll"),
+                "declared_annual": None, "derived": None}
+
+    if not derived.get("available"):
+        return {"basis": BASIS_DECLARED, "potential_rent_annual": round(dec, 2),
+                "basis_meaning": BASIS_MEANING[BASIS_DECLARED],
+                "derived_unavailable_reason": derived.get("reason"),
+                "declared_annual": round(dec, 2), "derived": None}
+
+    use = derived["potential_rent_annual"]
+    if dec is None:
+        return {"basis": BASIS_RENT_ROLL, "potential_rent_annual": use,
+                "basis_meaning": BASIS_MEANING[BASIS_RENT_ROLL],
+                "declared_annual": None, "derived": derived}
+
+    gap = use - dec
+    pct = (100 * abs(gap) / dec) if dec else None
+    return {
+        "basis": BASIS_BOTH,
+        "potential_rent_annual": use,          # the leases win — they are the asset's own record
+        "basis_meaning": BASIS_MEANING[BASIS_BOTH],
+        "declared_annual": round(dec, 2),
+        "derived": derived,
+        "declared_vs_derived": {
+            "difference": round(gap, 2),
+            "difference_pct": round(pct, 2) if pct is not None else None,
+            # A boolean AND the threshold that produced it: a flag whose rule is invisible cannot be
+            # argued with, and this one decides whether an underwriter re-cuts the deal.
+            "material": bool(pct is not None and pct >= MATERIAL_DISAGREEMENT_PCT),
+            "threshold_pct": MATERIAL_DISAGREEMENT_PCT,
+            "note": "the rent roll is used; the declared figure is retained so the disagreement "
+                    "survives rather than being resolved silently",
+        },
+    }

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -85,6 +85,32 @@ def _latest_scenario(db: Session, pid: str):
             .order_by(Scenario.created_at.desc()).first())
 
 
+@router.get("/projects/{pid}/proforma/income-basis")
+def project_income_basis(pid: str, declared_annual: float | None = None,
+                         db: Session = Depends(get_db),
+                         _sec: str = Depends(rbac.require_role("viewer"))):
+    """PF-INCOME-BASIS — the operating income a proforma should use, and where it came from.
+
+    A proforma's `potential_rent_annual` is one blended number for the whole asset. This derives it
+    from the property's OWN lease records instead — in-place base rent, expense recoveries and the
+    concession load, each kept as a separate line — and, when the deal also declares a figure,
+    reports **both** with the gap between them.
+
+    That disagreement is the point. A deal underwritten at a figure its own rent roll contradicts is
+    not missing a number; it is reporting one whose provenance nobody can see. Pass `declared_annual`
+    to compare against the deal's stated income.
+
+    An empty rent roll returns `unavailable`, never an income of zero: a property with no lease
+    records has UNKNOWN income, and zero is the one value that reads as a measurement.
+    """
+    from .. import net_effective, rentroll
+    from ..proforma import income_basis
+
+    rr = rentroll.rent_roll(db, pid)
+    ner = net_effective.from_project(db, pid)
+    return income_basis.resolve(declared_annual=declared_annual, rent_roll=rr, ner=ner)
+
+
 @router.get("/projects/{pid}/financials")
 def project_financials(pid: str, db: Session = Depends(get_db), _sec: str = Depends(rbac.require_role("viewer"))):
     """Financial statements for the project's latest saved scenario (income statement · balance sheet ·

--- a/services/api/test_income_basis.py
+++ b/services/api/test_income_basis.py
@@ -1,0 +1,139 @@
+"""PF-INCOME-BASIS — the proforma's income says where it came from.
+
+The load-bearing assertions are the refusals. A proforma that answers with a typed figure while a
+contradicting rent roll sits one table away is not missing a number — it is reporting a number whose
+provenance nobody can see, which is the shape this repo keeps finding.
+
+1. an empty rent roll is UNAVAILABLE, never 0.0 — every sum over no leases is legitimately zero, so
+   the arithmetic succeeds and a deal underwrites zero income as though it had been measured;
+2. recoveries are never netted into base rent — once netted, the reimbursement is unrecoverable;
+3. declared and derived BOTH survive, with the gap between them;
+4. leases the maths cannot use are NAMED, not counted.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_income_basis.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api.proforma.income_basis import (  # noqa: E402
+    BASIS_BOTH,
+    BASIS_DECLARED,
+    BASIS_RENT_ROLL,
+    BASIS_UNAVAILABLE,
+    MATERIAL_DISAGREEMENT_PCT,
+    from_rent_roll,
+    resolve,
+)
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+# Shape copied from `rentroll.summarize()`'s actual return, not invented.
+RR = {"as_of": "2026-08-01", "lease_count": 3, "total_rentable_sf": 50000, "occupied_sf": 40000,
+      "vacant_sf": 10000, "occupancy_pct": 80.0, "base_rent_annual": 1_000_000.0,
+      "recoveries_annual": 200_000.0, "in_place_gross_income": 1_200_000.0,
+      "avg_rent_psf": 25.0, "walt_years": 4.2, "expirations_by_year": {}, "rows": []}
+
+# Shape from `net_effective.roll_up()`.
+NER = {"lease_count": 3, "skipped_count": 1,
+       "skipped": [{"tenant": "Acme", "suite": "300", "reason": "no end_date"}],
+       "face_gpr_annual": 1_000_000.0, "ner_gpr_annual_discounted": 900_000.0}
+
+# --- 1. the ordinary derivation ---------------------------------------------------------------------
+d = from_rent_roll(RR)
+check("a rent roll yields usable income", d["available"] is True, d)
+check("  base rent is carried through", d["base_rent_annual"] == 1_000_000.0, d["base_rent_annual"])
+check("  RECOVERIES ARE A SEPARATE LINE, never folded into base rent",
+      d["recovery_income_annual"] == 200_000.0 and d["base_rent_annual"] == 1_000_000.0, d)
+check("  potential rent is their sum, and the components remain recoverable from the payload",
+      d["potential_rent_annual"] == 1_200_000.0, d["potential_rent_annual"])
+check("  occupancy and WALT travel with it", d["occupancy_pct"] == 80.0 and d["walt_years"] == 4.2, d)
+
+# --- 2. THE ZERO TRAP: an empty rent roll is not an income of zero -------------------------------------
+empty = {**RR, "lease_count": 0, "base_rent_annual": 0.0, "recoveries_annual": 0.0}
+e = from_rent_roll(empty)
+check("an empty rent roll is UNAVAILABLE, not an income of 0.0",
+      e["available"] is False, e)
+check("  and it says why, in terms of the distinction that matters",
+      "not zero" in e["reason"].lower(), e["reason"])
+check("no rent roll at all is also unavailable rather than zero",
+      from_rent_roll(None)["available"] is False)
+check("a rent roll with leases but no usable rent is unavailable",
+      from_rent_roll({**RR, "base_rent_annual": None})["available"] is False)
+
+# --- 3. concessions are reported, not absorbed ----------------------------------------------------------
+c = from_rent_roll(RR, NER)
+check("face and net effective GPR are BOTH reported",
+      c["face_gpr_annual"] == 1_000_000.0 and c["net_effective_gpr_annual"] == 900_000.0, c)
+check("  with the concession load between them", c["concession_load_annual"] == 100_000.0,
+      c["concession_load_annual"])
+check("  as a percentage an underwriter can act on", c["concession_load_pct"] == 10.0,
+      c["concession_load_pct"])
+check("leases the maths could not use are NAMED, not counted",
+      c["leases_not_computable"][0]["tenant"] == "Acme"
+      and c["leases_not_computable"][0]["reason"] == "no end_date", c.get("leases_not_computable"))
+
+# --- 4. resolve(): the basis is always stated -------------------------------------------------------------
+only_dec = resolve(declared_annual=900_000.0)
+check("a declared figure with no rent roll is `declared`", only_dec["basis"] == BASIS_DECLARED,
+      only_dec["basis"])
+check("  and it records WHY nothing was derived",
+      "no rent roll" in (only_dec.get("derived_unavailable_reason") or ""), only_dec)
+
+only_rr = resolve(rent_roll=RR)
+check("a rent roll with no declared figure is `rent_roll`", only_rr["basis"] == BASIS_RENT_ROLL)
+check("  and uses the derived number", only_rr["potential_rent_annual"] == 1_200_000.0)
+
+neither = resolve()
+check("neither source is UNAVAILABLE, and the income is None — not 0.0",
+      neither["basis"] == BASIS_UNAVAILABLE and neither["potential_rent_annual"] is None, neither)
+check("  every basis is documented in the payload it appears in",
+      "not the same as zero" in neither["basis_meaning"], neither["basis_meaning"])
+
+# --- 5. THE DISAGREEMENT — the reason both are kept ----------------------------------------------------------
+both = resolve(declared_annual=1_000_000.0, rent_roll=RR)
+check("with both sources the basis says so", both["basis"] == BASIS_BOTH, both["basis"])
+check("  the rent roll wins — it is the asset's own record",
+      both["potential_rent_annual"] == 1_200_000.0, both["potential_rent_annual"])
+check("  the declared figure SURVIVES rather than being overwritten",
+      both["declared_annual"] == 1_000_000.0, both["declared_annual"])
+dv = both["declared_vs_derived"]
+check("  the gap is reported in currency", dv["difference"] == 200_000.0, dv)
+check("  and as a percentage", dv["difference_pct"] == 20.0, dv)
+check("  a 20% gap is flagged MATERIAL", dv["material"] is True, dv)
+check("  and the threshold that produced the flag is stated, so the rule can be argued with",
+      dv["threshold_pct"] == MATERIAL_DISAGREEMENT_PCT, dv)
+
+close = resolve(declared_annual=1_190_000.0, rent_roll=RR)
+check("a sub-threshold gap is reported but NOT flagged material — drafting noise is not a finding",
+      close["declared_vs_derived"]["material"] is False
+      and close["declared_vs_derived"]["difference"] == 10_000.0,
+      close["declared_vs_derived"])
+
+# --- 6. junk in the declared figure is refused, never coerced -------------------------------------------------
+for bad, why in ((True, "JSON true is not an income of 1"),
+                 ("lots", "a word is not an income"),
+                 (float("inf"), "infinite income is not a measurement"),
+                 (float("nan"), "NaN is not a measurement")):
+    r = resolve(declared_annual=bad, rent_roll=RR)
+    check(f"declared={bad!r} is ignored as a figure — {why}",
+          r["basis"] == BASIS_RENT_ROLL and r["declared_annual"] is None, (r["basis"], r.get("declared_annual")))
+    r2 = resolve(declared_annual=bad)
+    check(f"  and with no rent roll either, {bad!r} is UNAVAILABLE, not accepted",
+          r2["basis"] == BASIS_UNAVAILABLE, r2["basis"])
+
+check("a zero declared figure is a real statement and is kept",
+      resolve(declared_annual=0.0)["basis"] == BASIS_DECLARED)
+
+print()
+if FAILED:
+    print(f"income_basis: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("income_basis: all checks passed")


### PR DESCRIPTION
Scoped from a structural read of six institutional CRE underwriting models — office development, apartment acquisition with Monte Carlo, value-add apartment, multifamily renovation, hotel, data-centre development. Notes in `docs/internal/research/proforma-asset-class-scope.md`.

**No formulas were copied from those models and none of their content is reproduced.** They were used as a *requirements survey*; the maths here is standard industry practice, implemented independently.

## The finding was not the expected one

The instinct is "we need a rent roll". **We already have one.** The `lease` module carries `base_rent_annual`, `escalation_pct`, `free_rent_months`, `recovery_psf`, `ti_allowance_psf` and the term dates, and **five** engines consume it — `rentroll`, `net_effective`, `leasemgmt`, `rent_scrub`, `cam`.

**The proforma cannot reach any of it.** `Ops.potential_rent_annual` is a single blended number, and grep for `lease` inside `proforma/` returns only the lease-*up* curve. `rentroll.summarize()`'s own docstring says it exists *"so a built asset's actual operations feed back into the proforma"* — describing a wire that has never existed. Same shape as R22-PRODUCTION.

This PR is that wire.

## The refusals

| case | behaviour |
|---|---|
| empty rent roll | **`unavailable`, never 0.0** — every sum over no leases is legitimately zero, so the arithmetic succeeds and a deal underwrites zero income as though measured |
| expense recoveries | **never netted into base rent** — netted, the reimbursement is unrecoverable and the opex ratio is wrong in a way that still looks sane |
| concessions | face GPR, net-effective GPR and the load between them all reported, so a deal cannot underwrite face rent while calling it income |
| declared vs derived | **both survive** — if the rent roll implies one figure and the deal declares another, that disagreement *is* the finding |
| leases the maths can't use | **named**, not counted — a percentage cannot be opened, a tenant/suite can |

The materiality threshold is a named constant, not a number buried in a comparison: a flag whose rule is invisible can't be argued with, and this one decides whether an underwriter re-cuts the deal.

## Verified against the real producers

Not only its own fixtures — real `rentroll.summarize` + `net_effective.roll_up` output over three leases (one terminated, correctly excluded):

```
base rent      400,000     recoveries  74,000   <- held separate
potential rent 474,000     declared   380,000
disagreement    94,000  =  24.74%  material=True
concession load 40,989  =  10.25%
```

Route asserted over HTTP: a project with no leases returns `unavailable` with a **null** income, not zero.

## A gate blind spot found on the way

`test_reachable` did **not** flag this new module. Its scan is `SRC.glob("*.py")` — **non-recursive** — so the whole `proforma/` package, 15 modules of money maths, is invisible to the orphan gate. The route here was wired deliberately, not because a gate demanded it. Worth fixing separately.

`test_income_basis` (34 checks), `test_proforma`, `test_net_effective`, `test_reachable`, `test_global_authz` all pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)