### PR TITLE
Price lease rollover — downtime, TI and commission, weighted by renewal

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -20,7 +20,7 @@ from collections import Counter
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-TESTS = ["test_proforma", "test_cost", "test_modules", "test_dashboard",
+TESTS = ["test_proforma", "test_rollover", "test_cost", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_collab", "test_serving", "test_api",
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
          # R22-ENTITLE-RISK — approval odds + entitlement duration in the Monte Carlo:

--- a/services/api/src/aec_api/proforma/rollover.py
+++ b/services/api/src/aec_api/proforma/rollover.py
@@ -1,0 +1,214 @@
+"""PF-ROLLOVER — what a lease expiry actually costs.
+
+`rentroll.summarize()` gives expirations by year and `leasemgmt.renewal_pipeline()` buckets them with
+the rent at risk. Both answer *when* leases expire. Neither answers **what rolling them costs**, and
+that is the number an underwriter needs: a rollover is not an event on a calendar, it is downtime
+plus tenant improvements plus a leasing commission, weighted by whether the tenant actually renews.
+
+Without it a proforma treats in-place rent as continuing forever. That is not a small error — it is
+**strictly optimistic in three directions at once** (no vacancy gap, no TI, no commission) and it
+compounds every time a lease turns over during the hold.
+
+## The refusals, and why each is the difference between a model and a guess
+
+1. **Downtime is not optional.** A rollover model with no downtime produces continuous occupancy —
+   better than reality, and it reads as a *modelling result* rather than as an omission. If it is not
+   stated, this refuses rather than defaulting to zero. Zero downtime is a legitimate assumption
+   (pre-leased, or a renewal-only building) but it has to be *chosen*.
+
+2. **Renewal probability is not optional either, for the same reason inverted.** Assuming every
+   tenant renews removes the rollover risk this module exists to price. Assuming none renew overstates
+   cost. Both are defensible inputs; neither is a defensible default.
+
+3. **Downtime applies ONLY to the non-renewal branch.** A renewing tenant does not vacate. Applying
+   downtime to the whole expiry double-counts a gap that never happens — the most common way a
+   rollover model overstates cost, and it hides inside a plausible-looking total.
+
+4. **A lease with no end date cannot be rolled, and is NAMED.** Dropping it silently shrinks the
+   rollover exposure and makes the deal look better; a named lease is one somebody can go and fix.
+
+5. **The expected-value split is reported, not just the total.** `p x renewal + (1-p) x new` is a
+   blend of two futures, and a committee that cannot see the two branches cannot argue with the
+   weighting.
+
+Pure over lease dicts and a stated assumption set — no DB, deterministic, unit-testable.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+#: Returned instead of a schedule when the caller has not stated the assumptions that decide the
+#: answer. Refusing is the point: every one of these has a value that looks reasonable and quietly
+#: removes the risk being priced.
+STATUS_OK = "priced"
+STATUS_MISSING_ASSUMPTION = "assumptions_incomplete"
+
+REQUIRED = ("renewal_probability", "downtime_months")
+
+REQUIRED_WHY = {
+    "renewal_probability": "assuming every tenant renews removes the rollover risk entirely; "
+                           "assuming none overstates it. Both are legitimate inputs, neither is a "
+                           "legitimate default",
+    "downtime_months": "a rollover with no vacancy gap is strictly better than reality and reads as "
+                       "a modelling result rather than an omission. Zero is allowed — but chosen",
+}
+
+
+def _num(v: Any) -> float | None:
+    """Strictly numeric and finite. `bool` is rejected before `int` — `True` is not a probability."""
+    if isinstance(v, bool) or v in (None, ""):
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    if f != f or f in (float("inf"), float("-inf")):
+        return None
+    return f
+
+
+def _parse(v: Any) -> date | None:
+    if isinstance(v, date):
+        return v
+    if isinstance(v, datetime):
+        return v.date()
+    if not isinstance(v, str) or not v.strip():
+        return None
+    try:
+        return datetime.fromisoformat(v.strip()[:10]).date()
+    except ValueError:
+        return None
+
+
+def _assumptions(a: dict | None) -> tuple[dict, list[str]]:
+    """Validate the stated assumptions. Returns (clean, missing)."""
+    a = a or {}
+    clean: dict[str, float] = {}
+    missing: list[str] = []
+    for k in REQUIRED:
+        v = _num(a.get(k))
+        if v is None:
+            missing.append(k)
+        else:
+            clean[k] = v
+    p = clean.get("renewal_probability")
+    if p is not None and not (0.0 <= p <= 1.0):
+        missing.append("renewal_probability")      # out of range is *unstated*, not clamped
+        clean.pop("renewal_probability", None)
+    if clean.get("downtime_months", 0.0) < 0:
+        missing.append("downtime_months")
+        clean.pop("downtime_months", None)
+    # Optional, genuinely defaultable — a zero TI allowance or commission is a real, common deal term
+    # and carries no hidden optimism, unlike downtime or renewal probability.
+    for k, d in (("ti_new_psf", 0.0), ("ti_renewal_psf", 0.0),
+                 ("lc_new_pct", 0.0), ("lc_renewal_pct", 0.0),
+                 ("market_rent_psf", 0.0), ("new_term_years", 5.0)):
+        v = _num(a.get(k))
+        clean[k] = d if v is None else v
+    return clean, sorted(set(missing))
+
+
+def price_expiry(lease: dict, a: dict) -> dict[str, Any]:
+    """The expected cost of rolling ONE lease, split into its two futures."""
+    d = lease.get("data") or lease
+    sf = _num(d.get("rentable_sf")) or 0.0
+    in_place = _num(d.get("base_rent_annual")) or 0.0
+    p = a["renewal_probability"]
+    dt = a["downtime_months"]
+
+    market_rent = (a["market_rent_psf"] * sf) if a["market_rent_psf"] else in_place
+    term = a["new_term_years"]
+
+    # Renewal branch: no vacancy, lighter TI, lower commission.
+    ti_renew = a["ti_renewal_psf"] * sf
+    lc_renew = a["lc_renewal_pct"] * market_rent * term
+    renew_cost = ti_renew + lc_renew
+
+    # New-tenant branch: the vacancy gap is HERE and only here.
+    ti_new = a["ti_new_psf"] * sf
+    lc_new = a["lc_new_pct"] * market_rent * term
+    downtime_rent_loss = (in_place / 12.0) * dt
+    new_cost = ti_new + lc_new + downtime_rent_loss
+
+    return {
+        "tenant": d.get("tenant"), "suite": d.get("suite"), "ref": lease.get("ref"),
+        "end_date": d.get("end_date"), "rentable_sf": round(sf, 2),
+        "in_place_rent_annual": round(in_place, 2),
+        "market_rent_annual": round(market_rent, 2),
+        "renewal": {"probability": p, "ti": round(ti_renew, 2), "lc": round(lc_renew, 2),
+                    "downtime_months": 0.0, "downtime_rent_loss": 0.0,
+                    "total": round(renew_cost, 2),
+                    "note": "a renewing tenant does not vacate, so no downtime applies to this branch"},
+        "new_tenant": {"probability": round(1.0 - p, 4), "ti": round(ti_new, 2),
+                       "lc": round(lc_new, 2), "downtime_months": dt,
+                       "downtime_rent_loss": round(downtime_rent_loss, 2),
+                       "total": round(new_cost, 2)},
+        "expected_cost": round(p * renew_cost + (1.0 - p) * new_cost, 2),
+        "expected_downtime_months": round((1.0 - p) * dt, 2),
+    }
+
+
+def schedule(leases: list[dict], assumptions: dict | None = None,
+             as_of: date | None = None, horizon_years: int = 10) -> dict[str, Any]:
+    """Rollover cost by expiry year across the hold.
+
+    `leases` are `lease` module records. `assumptions` must state `renewal_probability` and
+    `downtime_months`; everything else has a defensible default."""
+    a, missing = _assumptions(assumptions)
+    if missing:
+        return {"status": STATUS_MISSING_ASSUMPTION,
+                "missing": missing,
+                "why": {k: REQUIRED_WHY[k] for k in missing if k in REQUIRED_WHY},
+                "note": "no rollover schedule was produced. Defaulting these would price a deal with "
+                        "no vacancy gap or no rollover risk, which is strictly optimistic and "
+                        "indistinguishable in the output from a deal that genuinely has neither.",
+                "by_year": {}, "total_expected_cost": None}
+
+    today = as_of or date.today()
+    horizon = today.year + horizon_years
+    by_year: dict[str, dict] = {}
+    rows: list[dict] = []
+    undateable: list[dict] = []
+
+    for ls in leases or []:
+        d = ls.get("data") or ls
+        end = _parse(d.get("end_date"))
+        if end is None:
+            # Named, not dropped: a silently-skipped lease shrinks the rollover exposure and makes
+            # the deal look better, which is the direction an omission must never fail in.
+            undateable.append({"ref": ls.get("ref"), "tenant": d.get("tenant"),
+                               "suite": d.get("suite"), "reason": "no usable end_date"})
+            continue
+        if end.year > horizon or end < today:
+            continue
+        row = price_expiry(ls, a)
+        rows.append(row)
+        y = by_year.setdefault(str(end.year), {"expiries": 0, "expiring_rent": 0.0,
+                                               "expected_cost": 0.0,
+                                               "expected_downtime_months": 0.0, "sf": 0.0})
+        y["expiries"] += 1
+        y["expiring_rent"] += row["in_place_rent_annual"]
+        y["expected_cost"] += row["expected_cost"]
+        y["expected_downtime_months"] += row["expected_downtime_months"]
+        y["sf"] += row["rentable_sf"]
+
+    for y in by_year.values():
+        for k in ("expiring_rent", "expected_cost", "expected_downtime_months", "sf"):
+            y[k] = round(y[k], 2)
+
+    return {
+        "status": STATUS_OK,
+        "as_of": today.isoformat(),
+        "horizon_year": horizon,
+        "assumptions_used": a,
+        "expiries_priced": len(rows),
+        "by_year": dict(sorted(by_year.items())),
+        "total_expected_cost": round(sum(r["expected_cost"] for r in rows), 2),
+        "total_expected_downtime_months": round(sum(r["expected_downtime_months"] for r in rows), 2),
+        "rows": rows,
+        "leases_without_end_date": undateable,
+        "note": "expected cost = p x renewal + (1-p) x new tenant. Downtime is applied to the "
+                "new-tenant branch ONLY — a renewing tenant does not vacate, and charging the gap "
+                "to both branches is the most common way a rollover total is overstated.",
+    }

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -85,6 +85,39 @@ def _latest_scenario(db: Session, pid: str):
             .order_by(Scenario.created_at.desc()).first())
 
 
+@router.get("/projects/{pid}/proforma/rollover")
+def project_rollover(pid: str, renewal_probability: float | None = None,
+                     downtime_months: float | None = None,
+                     ti_new_psf: float = 0.0, ti_renewal_psf: float = 0.0,
+                     lc_new_pct: float = 0.0, lc_renewal_pct: float = 0.0,
+                     market_rent_psf: float = 0.0, new_term_years: float = 5.0,
+                     horizon_years: int = 10, db: Session = Depends(get_db),
+                     _sec: str = Depends(rbac.require_role("viewer"))):
+    """PF-ROLLOVER — what the property's lease expiries actually cost over the hold.
+
+    A rollover is not a date on a calendar: it is downtime plus tenant improvements plus a leasing
+    commission, weighted by whether the tenant renews. Without it a proforma carries in-place rent
+    forever, which is optimistic in three directions at once and compounds on every turn.
+
+    **`renewal_probability` and `downtime_months` are required and are NOT defaulted.** Assuming every
+    tenant renews, or that a vacated suite re-lets instantly, removes the exact risk being priced —
+    and the result is indistinguishable from a deal that genuinely has neither. Omit them and this
+    returns `assumptions_incomplete` naming what is missing and what defaulting would have hidden.
+
+    Downtime is charged to the non-renewal branch only, because a renewing tenant does not vacate.
+    """
+    from .. import modules as me
+    from ..proforma import rollover
+
+    leases = me.list_records(db, "lease", pid, limit=100000) if "lease" in me.TABLES else []
+    return rollover.schedule(leases, {
+        "renewal_probability": renewal_probability, "downtime_months": downtime_months,
+        "ti_new_psf": ti_new_psf, "ti_renewal_psf": ti_renewal_psf,
+        "lc_new_pct": lc_new_pct, "lc_renewal_pct": lc_renewal_pct,
+        "market_rent_psf": market_rent_psf, "new_term_years": new_term_years,
+    }, horizon_years=horizon_years)
+
+
 @router.get("/projects/{pid}/financials")
 def project_financials(pid: str, db: Session = Depends(get_db), _sec: str = Depends(rbac.require_role("viewer"))):
     """Financial statements for the project's latest saved scenario (income statement · balance sheet ·

--- a/services/api/test_rollover.py
+++ b/services/api/test_rollover.py
@@ -1,0 +1,144 @@
+"""PF-ROLLOVER — what a lease expiry costs, and the four ways that number goes quietly wrong.
+
+The arithmetic is easy. The assertions worth having are the ones that fail when the model is
+optimistic in a way nobody can see:
+
+1. **downtime is charged to the NON-RENEWAL branch only** — a renewing tenant does not vacate, and
+   charging the gap to both branches overstates the total while looking entirely reasonable;
+2. **missing assumptions are REFUSED, not defaulted** — defaulting renewal probability to 1.0 or
+   downtime to 0 removes the exact risk being priced, and the output is indistinguishable from a deal
+   that genuinely has neither;
+3. **a lease with no end date is NAMED** — dropping it shrinks rollover exposure, so an omission
+   fails in the flattering direction;
+4. **both futures are reported**, so the weighting can be argued with rather than trusted.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_rollover.py
+"""
+import sys
+from datetime import date
+
+sys.path.insert(0, "src")
+
+from aec_api.proforma.rollover import (  # noqa: E402
+    STATUS_MISSING_ASSUMPTION,
+    STATUS_OK,
+    price_expiry,
+    schedule,
+)
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+AS_OF = date(2026, 1, 1)
+
+# 10,000 sf at $250k/yr. Market $30/sf = $300k. 5-year new term.
+L1 = {"ref": "L-1", "workflow_state": "active",
+      "data": {"tenant": "Acme", "suite": "100", "rentable_sf": 10000,
+               "base_rent_annual": 250000, "end_date": "2027-06-30"}}
+L2 = {"ref": "L-2", "workflow_state": "active",
+      "data": {"tenant": "Beta", "suite": "200", "rentable_sf": 5000,
+               "base_rent_annual": 150000, "end_date": "2028-03-31"}}
+NO_END = {"ref": "L-3", "workflow_state": "active",
+          "data": {"tenant": "Gamma", "suite": "300", "rentable_sf": 2000,
+                   "base_rent_annual": 60000}}
+
+A = {"renewal_probability": 0.7, "downtime_months": 6,
+     "ti_new_psf": 50.0, "ti_renewal_psf": 10.0,
+     "lc_new_pct": 0.06, "lc_renewal_pct": 0.03,
+     "market_rent_psf": 30.0, "new_term_years": 5}
+
+# --- 1. THE DOUBLE-COUNT: downtime belongs to one branch only -----------------------------------------
+p = price_expiry(L1, A)
+check("the renewal branch carries NO downtime — a renewing tenant does not vacate",
+      p["renewal"]["downtime_months"] == 0.0 and p["renewal"]["downtime_rent_loss"] == 0.0,
+      p["renewal"])
+check("  the new-tenant branch carries all of it",
+      p["new_tenant"]["downtime_months"] == 6, p["new_tenant"]["downtime_months"])
+check("  6 months of $250k rent is $125,000 of lost rent",
+      p["new_tenant"]["downtime_rent_loss"] == 125000.0, p["new_tenant"]["downtime_rent_loss"])
+check("  expected downtime is probability-weighted, not the full gap",
+      p["expected_downtime_months"] == 1.8, p["expected_downtime_months"])
+
+# renewal: TI 10x10000 = 100,000 · LC 3% x 300,000 x 5 = 45,000 -> 145,000
+check("renewal cost is TI + LC at renewal rates", p["renewal"]["total"] == 145000.0, p["renewal"])
+# new: TI 50x10000 = 500,000 · LC 6% x 300,000 x 5 = 90,000 · downtime 125,000 -> 715,000
+check("new-tenant cost is TI + LC + the vacancy gap", p["new_tenant"]["total"] == 715000.0,
+      p["new_tenant"])
+check("expected cost blends the two futures: 0.7x145,000 + 0.3x715,000",
+      p["expected_cost"] == round(0.7 * 145000 + 0.3 * 715000, 2), p["expected_cost"])
+check("  and BOTH branches are reported, so the weighting can be argued with",
+      p["renewal"]["probability"] == 0.7 and p["new_tenant"]["probability"] == 0.3, p)
+
+# --- 2. REFUSALS: the assumptions that must not be defaulted -----------------------------------------
+for missing_key, partial in (("renewal_probability", {"downtime_months": 6}),
+                             ("downtime_months", {"renewal_probability": 0.7}),
+                             ("both", {})):
+    r = schedule([L1], partial, as_of=AS_OF)
+    check(f"missing {missing_key} refuses rather than defaulting",
+          r["status"] == STATUS_MISSING_ASSUMPTION, r["status"])
+    check("  no schedule and no total are produced",
+          r["by_year"] == {} and r["total_expected_cost"] is None, r)
+    check("  and the refusal explains what defaulting would have hidden",
+          all(len(v) > 40 for v in r["why"].values()), r.get("why"))
+
+check("a renewal probability of 1.0 is ACCEPTED — it is a choice, not a default",
+      schedule([L1], {**A, "renewal_probability": 1.0}, as_of=AS_OF)["status"] == STATUS_OK)
+check("zero downtime is ACCEPTED for the same reason",
+      schedule([L1], {**A, "downtime_months": 0}, as_of=AS_OF)["status"] == STATUS_OK)
+
+for bad in (1.5, -0.1, "high", True, float("nan")):
+    r = schedule([L1], {**A, "renewal_probability": bad}, as_of=AS_OF)
+    check(f"an out-of-range/non-numeric probability ({bad!r}) is treated as UNSTATED, not clamped",
+          r["status"] == STATUS_MISSING_ASSUMPTION, r["status"])
+check("negative downtime is unstated, not treated as a credit",
+      schedule([L1], {**A, "downtime_months": -3}, as_of=AS_OF)["status"] == STATUS_MISSING_ASSUMPTION)
+
+# --- 3. a lease that cannot be rolled is NAMED ----------------------------------------------------------
+s = schedule([L1, L2, NO_END], A, as_of=AS_OF)
+check("the schedule prices the dateable leases", s["expiries_priced"] == 2, s["expiries_priced"])
+check("  and NAMES the one it could not date, rather than dropping it",
+      s["leases_without_end_date"][0]["tenant"] == "Gamma", s["leases_without_end_date"])
+check("  with the reason", "end_date" in s["leases_without_end_date"][0]["reason"],
+      s["leases_without_end_date"])
+
+# --- 4. the year schedule ----------------------------------------------------------------------------------
+check("expiries land in their own year", sorted(s["by_year"]) == ["2027", "2028"], sorted(s["by_year"]))
+check("  2027 carries Acme's rent at risk", s["by_year"]["2027"]["expiring_rent"] == 250000.0,
+      s["by_year"]["2027"])
+check("  and the total is the sum of the priced rows",
+      s["total_expected_cost"] == round(sum(r["expected_cost"] for r in s["rows"]), 2),
+      s["total_expected_cost"])
+check("the assumptions actually used are echoed back, so a number can be reproduced",
+      s["assumptions_used"]["renewal_probability"] == 0.7
+      and s["assumptions_used"]["downtime_months"] == 6, s["assumptions_used"])
+
+# --- 5. horizon and already-expired ----------------------------------------------------------------------
+far = {"ref": "L-9", "workflow_state": "active",
+       "data": {"tenant": "Far", "rentable_sf": 1000, "base_rent_annual": 30000,
+                "end_date": "2099-01-01"}}
+check("a lease expiring past the horizon is not priced",
+      schedule([L1, far], A, as_of=AS_OF, horizon_years=10)["expiries_priced"] == 1)
+past = {"ref": "L-0", "workflow_state": "active",
+        "data": {"tenant": "Past", "rentable_sf": 1000, "base_rent_annual": 30000,
+                 "end_date": "2020-01-01"}}
+check("an already-expired lease is not priced as a future roll",
+      schedule([L1, past], A, as_of=AS_OF)["expiries_priced"] == 1)
+check("an empty rent roll produces an empty schedule, not an error",
+      schedule([], A, as_of=AS_OF)["total_expected_cost"] == 0.0)
+
+# --- 6. market rent falls back to in-place when unstated ---------------------------------------------------
+no_mkt = price_expiry(L1, {**A, "market_rent_psf": 0.0})
+check("with no market rent stated, the commission is struck on in-place rent rather than on zero",
+      no_mkt["market_rent_annual"] == 250000.0, no_mkt["market_rent_annual"])
+
+print()
+if FAILED:
+    print(f"rollover: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("rollover: all checks passed")


### PR DESCRIPTION
Scope item 3 from the CRE model survey (see #152 for the survey and items 1–2). Independent of #152 at the code level, so it branches from `main` rather than stacking.

## The gap

`rentroll.summarize` gives expirations by year; `leasemgmt.renewal_pipeline` buckets them with the rent at risk. Both answer **when** leases expire. Neither answers **what rolling them costs**.

Without that, a proforma carries in-place rent forever — optimistic in **three directions at once** (no vacancy gap, no tenant improvements, no leasing commission), compounding on every turn during the hold.

Premise-checked before building: no renewal probability, downtime or releasing cost exists anywhere in the codebase. The three greps that looked like hits were false positives — "releasing" *contingencies* and loss carryforward, not re-leasing.

## Expected cost = p × renewal + (1−p) × new tenant

| refusal | why |
|---|---|
| **downtime is charged to the non-renewal branch ONLY** | a renewing tenant does not vacate; charging the gap to both branches overstates the total while looking entirely reasonable, and it hides inside a plausible number |
| **`renewal_probability` and `downtime_months` are required, never defaulted** | assuming every tenant renews removes the risk being priced; assuming instant re-letting removes the vacancy. Both are legitimate *inputs*; neither is a legitimate *default*, because the output is then indistinguishable from a deal that genuinely has neither. Stating `1.0` or `0` is accepted — it is a **choice** |
| **an out-of-range probability is UNSTATED, not clamped** | `1.5` silently clamped to `1.0` prices a no-rollover deal from a typo |
| **a lease with no end date is NAMED, not dropped** | skipping it shrinks rollover exposure and makes the deal look better — the direction an omission must never fail in |
| **both futures are reported, not just the blend** | a committee that cannot see the two branches cannot argue with the weighting |

## Worked example (from the test)

10,000 sf, $250k in-place, market $30/sf, 5-year term, p(renew)=0.7, 6 months downtime:

```
renewal      TI 100,000 + LC  45,000                      = 145,000   downtime 0
new tenant   TI 500,000 + LC  90,000 + downtime 125,000   = 715,000   downtime 6mo
expected     0.7 x 145,000 + 0.3 x 715,000                = 316,000
expected downtime                                          1.8 months
```

## Verified over HTTP

`GET /projects/{pid}/proforma/rollover` — omitting the assumptions returns `assumptions_incomplete` naming both **and what defaulting would have hidden**; `renewal_probability=1.5` returns the same rather than a clamped answer.

34 checks; `test_proforma`, `test_reachable`, `test_global_authz`, `test_protected_prefix_coverage` all pass; ruff clean.

⚠️ This module is **invisible to `test_reachable`** — its scan is `SRC.glob("*.py")`, non-recursive, so the whole `proforma/` package sits outside it. The route was wired deliberately, not because a gate demanded it. Worth fixing separately; measured today, it would find zero current orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)