### PR TITLE
docs(rbac): consume_stepup misattributed its own guarantee (no behaviour change)

### DIFF
--- a/services/api/src/aec_api/rbac.py
+++ b/services/api/src/aec_api/rbac.py
@@ -165,11 +165,21 @@ def consume_stepup(db: Session, token: str, act: str, pw_hash: str, actor: str) 
     charge of THIS work" — and a reusable assertion can only support the weaker "a human re-proved
     their password recently". An agent that captured one token could seal a stack.
 
-    The spend is a PRIMARY KEY insert inside a SAVEPOINT, not a read-then-write: two concurrent
-    replays would both pass an `if already_spent` check and both proceed. Here the second insert
-    violates the constraint and the database refuses it, so the race has no winner to give away.
-    The savepoint means that refusal rolls back only this insert, leaving the caller's transaction
-    (and any audit row it has staged) intact.
+    Two mechanisms, and they guarantee different things. Conflating them is easy and this docstring
+    did it until 2026-07-31, when a mutation test disproved the version written here:
+
+    - The **PRIMARY KEY** is what makes the spend single. A read-then-write (`if already_spent`)
+      would still end with one winner, because the insert itself is what collides. The constraint,
+      not the ordering, is why the race has no winner to give away.
+    - The **SAVEPOINT** is what keeps the loser's refusal LOCAL. Without it the failed insert leaves
+      the caller's session in a rolled-back-pending state, so the loser also discards whatever it had
+      staged — including the audit row for the attempt. Measured: winners stay at 1 either way, but
+      the savepoint-less loser raises `PendingRollbackError` and loses its staged row.
+
+    That second failure is the nastier one and the reason both halves are load-bearing: it is a
+    security control quietly erasing its own evidence while still reporting the correct outcome. A
+    test that only counts winners cannot see it — `test_stepup_race` asserts no spender raised, for
+    exactly that reason, and neither assertion should be "simplified" away.
 
     Returns False for every failure — bad signature, wrong act, expired, someone else's assertion,
     or already spent — so the caller cannot accidentally distinguish them in a response.


### PR DESCRIPTION
Correcting my own docstring on already-merged code (#140 / `dce2eeb4`), after Massing Core's mutation test disproved the story it told and I reproduced the result independently.

## What was wrong

The docstring claimed a read-then-write would let *"two concurrent replays both pass an `if already_spent` check and both proceed"* — implying the **SAVEPOINT** is what prevents a double spend.

It isn't. Measured both ways on the shipped schema:

```
SAVEPOINT (as shipped)   winners=1   loser keeps its staged audit row
bare flush (mutation)    winners=1   loser LOSES it — PendingRollbackError
```

The **PRIMARY KEY** is what makes the spend single; the insert itself is what collides, so the constraint does that work regardless of ordering.

## What the savepoint actually buys

It keeps the loser's refusal **local**. Without it, the failed insert leaves the caller's session rolled-back-pending, so the losing request also discards whatever it staged alongside — **including the audit row for the attempt**.

That's the nastier failure, and the reason both halves are load-bearing: a security control quietly erasing its own evidence while still reporting the correct outcome. A test that only counts winners cannot see it — which is why `test_stepup_race` (incoming from Massing Core) asserts that no spender raised, and why neither assertion should later be "simplified" into the other.

## Scope

Docstring only. No behaviour change — the code was right and the explanation was not. Worth fixing rather than leaving, because an explanation that misnames which mechanism carries the guarantee is how the wrong half gets refactored away later.

`test_seal_identity` green, ruff clean. Merge whenever convenient; it does not touch `run_tests.py`, so it will not conflict with the race test or #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)