### PR TITLE
test(docs): the internal index was only checked in one direction

### DIFF
--- a/apps/web/src/shell/docsPublished.test.ts
+++ b/apps/web/src/shell/docsPublished.test.ts
@@ -105,6 +105,33 @@ describe("internal notes live under docs/internal/", () => {
     expect(undocumented, `add these to docs/internal/README.md: ${undocumented.join(", ")}`).toEqual([]);
   });
 
+  it("every name the internal index cites still exists", () => {
+    /**
+     * The mirror of the check above, and the half that was missing. That one asks "is every file in
+     * the index?"; without this one, nothing asks "is every index entry a real file?".
+     *
+     * A dead entry is worse than a missing one, which is why it earns its own assertion rather than
+     * being left to tidiness: the index is the thing people read to decide whether a note still
+     * matters, so a row pointing at a deleted file reads exactly like a live one. This repo has
+     * recorded the same shape twice already — an `AUTHORISING` name with no referent silently becomes
+     * an approved gate the day something reuses it, and `test_claude_md_gates` exists because
+     * backticked paths in the docs drifted from the tree.
+     *
+     * Currently zero, so this starts green and can only be tripped by a future deletion that leaves
+     * its row behind.
+     */
+    const index = read(join(INTERNAL, "README.md"));
+    const real = new Set(
+      DOC_PATHS.filter(isInternal).map((p) => p.split("/").pop()!),
+    );
+    const cited = [...index.matchAll(/`([^`]+\.md)`/g)].map((m) => m[1]!);
+    const dangling = [...new Set(cited)].filter((name) => !real.has(name));
+    expect(
+      dangling,
+      `these are cited in docs/internal/README.md but no such file exists: ${dangling.join(", ")}`,
+    ).toEqual([]);
+  });
+
   /**
    * The content-driven half. A doc that calls itself superseded, or a point-in-time audit, or says
    * nothing is built yet, is a working note by its own admission — so it does not belong on the public


### PR DESCRIPTION
`every internal note is accounted for in the internal index` asks *"is every file in the index?"*. Nothing asked the mirror: **"is every index entry a real file?"**

## Why this earns an assertion rather than tidiness

A dead entry is worse than a missing one. The index is what people read to decide whether a note still matters, so a row pointing at a deleted file reads exactly like a live one.

This repo has recorded the same shape twice already:
- an `AUTHORISING` name with no referent silently becomes an approved gate the day something reuses it
- `test_claude_md_gates` exists because backticked paths drifted from the tree

Same defect class, third location.

## State

Currently **zero** dangling entries (20 cited, 21 real — the extra is `README.md` itself), so it starts green and can only be tripped by a future deletion that leaves its row behind.

Mutation-verified: planting one dangling row fails the check, and the message names it:

```
these are cited in docs/internal/README.md but no such file exists: deleted-note-that-never-existed.md
```

`docsPublished.test.ts` 87 → 88 tests; typecheck clean.

## What this is NOT

This is **not** the `docsPublished.test.ts` expansion that a shared-tree `reset` destroyed. That work is still gone and I cannot reconstruct it — I only ever observed its test count (175 → 85), never its contents, so claiming to restore it would be invention.

That matters because of the chain it sat in: the reset removed a stronger gate → an unindexed `docs/internal/` file reached main → main went red for two commits including a tagged release → and it surfaced on an unrelated PR where the natural inference was that the PR had broken it. The reset didn't just destroy work, it removed the check that would have caught the next defect.

**The lost expansion remains an open, unowned item.** This closes a real gap in what currently exists, which is a different and smaller thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)