### PR TITLE
docs(ship-release): check main is green before tagging — the process prescribed the incident

### DIFF
--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -41,8 +41,40 @@ Confirm `origin/main` is where you branched (`git log origin/main --oneline -1`)
 - Add a `✅ … SHIPPED vX.Y.Z` note to the relevant `docs/roadmap.md` item.
 - Keep competitor names OUT of shipped docs; interop names (Revit, Bonsai, Procore) are fine.
 
-## 4. Commit, push, tag
-Commit with the trailer `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`. Then, guarding against a race:
+## 4. Commit, push, tag — but never onto a red main
+Commit with the trailer `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`.
+
+**First check that main is green.** Step 1 verifies *your* commit; it says nothing about the state of
+main you are appending to. On 2026-07-31 main went red at 06:12 from an unindexed `docs/internal/`
+file, and over the next hour three further commits landed on top — including a **cut and tagged
+release** — because each session had verified its own work and none asked about the build. The gate
+fired correctly within three minutes. Nobody looked. There is a standing directive to query the CodeQL
+alerts API after every push and it was followed every time; there was no equivalent for CI, so the
+security scan got checked and the build did not.
+
+```
+gh run list --branch main --limit 3 --json headSha,status,conclusion   --jq '.[]|"[\(if .status != "completed" then "RUNNING" else .conclusion end)]  \(.headSha[0:8])"'
+```
+**Branch on `status`, never on whether `conclusion` looks empty.** A running job has `conclusion` as
+the empty **string** — truthy in jq — so the obvious `.conclusion // "pending"` never fires and the
+field prints blank. A blank reads as "nothing to worry about", so a pending gate becomes an invisible
+one. `status` is the field that actually states whether the run finished; read that.
+
+Two sessions wrote the `//` form independently the day this section was added, one of them into memory
+as the fix, and it had already printed blank rows that were read as "still running" from context
+rather than noticed as a filter failure.
+
+Related trap, same shape: **`gh --jq` does not accept `--arg`** — it exits with `unknown flag: --arg`
+on stderr and prints nothing on stdout. Under a habit of skimming stdout that reads as a clean result.
+Probe any filter before you loop on it, and prefer piping the JSON to a real interpreter that can be
+made to print "not a verdict" rather than falling through to a reassuring default.
+
+A red or pending main is not automatically a blocker — read it and decide. But **do not tag onto one**:
+a tag is the thing that gets published, downloaded and rolled back, and it is the one step here that is
+awkward to undo. If main is red, fix or wait; if it is pending, either wait for it or push without
+tagging and tag once it lands.
+
+Then, guarding against a race:
 ```
 if [ "$(git rev-parse origin/main)" = "$(git rev-parse HEAD~1)" ]; then
   git push origin HEAD:main && git tag vX.Y.Z && git push origin vX.Y.Z


### PR DESCRIPTION
Step 1 verifies **your** commit. It says nothing about the state of main you are appending to — and step 4 tagged before step 5 ever looked at CI. That ordering isn't a lapse anyone made; **it's what the skill said to do.**

## The timeline, from run history rather than recollection

```
6ee38794  06:09  success
42f67671  06:12  FAILURE     <- unindexed docs/internal/ file
9450eba9  07:10  failure
a69945ee  07:11  failure     <- a cut and TAGGED release
826690ae  07:13  failure
8449572a  07:15  success
```

The gate fired correctly within **three minutes**. Nothing went undetected. Three further commits and a release landed on top over the following hour because each session had verified its own work and none asked about the build.

## The useful part is the asymmetry

There is a standing directive to query the CodeQL alerts API after every push, and it was followed every time — 0 open, correctly reported. **There was no equivalent for CI.** So the security scan got checked and the build did not, by everyone, consistently. That's a missing reflex, not a missing tool.

## What this adds

A main-green precondition with a one-line query, and a line drawn at **tagging** specifically. A red main isn't automatically a blocker — read it and decide. A tag is different: it's what gets published, downloaded and rolled back, and it's the one step here that's awkward to undo.

**I'm not exempt.** `v0.3.807` followed the old order — pushed and tagged, then started a CI watcher. It happened to be green. That's luck, not method.

## One thing worth reading in the diff

The obvious way to write the check is wrong, and I shipped it that way in the first commit before probing it:

```
--jq '.conclusion // "pending"'     # blank for a RUNNING job
```

A still-running job has `conclusion` as the empty **string**, not null, so `//` never fires and the field prints blank — and a blank reads as "nothing to worry about". A pending gate becomes an invisible one. The corrected form and the reason are both in the skill, because this exact mistake produced two false "all clear" readings the day it was written.

## Scope

The durable fix is **required status checks** — the user's decision, already put to them with this timeline attached. This closes the gap in the meantime, where it costs one API call.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)