### PR TITLE
Value-add renovation programme — the premium starts when the unit comes back

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -20,7 +20,7 @@ from collections import Counter
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-TESTS = ["test_proforma", "test_rollover", "test_income_basis", "test_cost", "test_g702_lines", "test_modules", "test_dashboard",
+TESTS = ["test_proforma", "test_renovation", "test_rollover", "test_income_basis", "test_cost", "test_g702_lines", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_collab", "test_serving", "test_api",
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
          # R22-ENTITLE-RISK — approval odds + entitlement duration in the Monte Carlo:

--- a/services/api/src/aec_api/proforma/renovation.py
+++ b/services/api/src/aec_api/proforma/renovation.py
@@ -1,0 +1,215 @@
+"""PF-RENOVATION — a value-add renovation programme, unit by unit, over time.
+
+Scope item 4 from the CRE model survey: three of the six surveyed models are multifamily value-add,
+and all three turn on the same mechanic — buy a property at in-place rents, renovate units as they
+turn, and earn a premium on each unit **once it is back online**.
+
+Nothing here models that today. `test_fit.layout` and `routers/generate` carry `unit_types`, but that
+is *design* unit mix — how many 1BRs fit on a plate — a different domain that happens to share a
+word. This is the economics.
+
+## The refusal this module exists for
+
+**A renovation premium must not begin before the unit turns.** It is the single most common way a
+value-add deal is overstated, and it is invisible in the output: applying the premium from day one
+produces a smooth, plausible income curve that is simply too high, too early, for the whole hold. The
+correct curve has three phases per unit and this module models all three:
+
+1. the unit earns its **in-place** rent until renovation starts;
+2. it earns **nothing** while it is being renovated — that vacancy is the cost of the programme;
+3. it earns the **renovated** rent only from the month it comes back online.
+
+Skipping phase 2 is the second overstatement, and skipping the *lag* in phase 3 is the first.
+
+## What is refused rather than defaulted
+
+* **`units_per_month`** — the renovation pace. Unstated, a model either renovates everything instantly
+  (all premium, no phasing) or nothing at all. Both are legitimate *inputs*; neither is a default.
+* **`downtime_months_per_unit`** — with no downtime a unit earns in-place rent one month and renovated
+  rent the next, so the programme appears to cost only its capex. Stating `0` is allowed; it is then
+  a choice somebody made.
+* **A unit type with no renovated rent is NOT renovated.** Inventing a premium is inventing the entire
+  investment thesis; the type is carried at its in-place rent and named as unimproved.
+
+Sequencing is deterministic and stated: types are renovated in the order supplied, consuming each
+month's pace. Real programmes pick an order for real reasons (worst units first, or a stack), and a
+silent proportional split would produce fractional units nobody can schedule.
+
+Pure arithmetic over the supplied unit types — no DB, deterministic, unit-testable.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+STATUS_OK = "scheduled"
+STATUS_MISSING_ASSUMPTION = "assumptions_incomplete"
+
+REQUIRED = ("units_per_month", "downtime_months_per_unit")
+
+REQUIRED_WHY = {
+    "units_per_month": "the renovation pace. Unstated, the model either renovates everything at once "
+                       "(all premium, no phasing) or nothing — both are legitimate inputs, neither is "
+                       "a legitimate default",
+    "downtime_months_per_unit": "with no downtime a unit earns in-place rent one month and renovated "
+                                "rent the next, so the programme appears to cost only its capex. Zero "
+                                "is allowed — but chosen",
+}
+
+
+def _num(v: Any) -> float | None:
+    """Strictly numeric and finite. `bool` is rejected before `int`."""
+    if isinstance(v, bool) or v in (None, ""):
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    if f != f or f in (float("inf"), float("-inf")):
+        return None
+    return f
+
+
+def _assumptions(a: dict | None) -> tuple[dict, list[str]]:
+    a = a or {}
+    clean: dict[str, float] = {}
+    missing: list[str] = []
+    for k in REQUIRED:
+        v = _num(a.get(k))
+        if v is None or v < 0:
+            missing.append(k)
+        else:
+            clean[k] = v
+    return clean, sorted(set(missing))
+
+
+def _prepare(unit_types: list[dict] | None) -> tuple[list[dict], list[dict]]:
+    """Split unit types into renovatable and not, naming the reason for each exclusion."""
+    ok: list[dict] = []
+    excluded: list[dict] = []
+    for i, t in enumerate(unit_types or []):
+        d = t.get("data") or t
+        name = str(d.get("type") or d.get("name") or f"#{i}")
+        count = _num(d.get("count"))
+        cur = _num(d.get("current_rent_monthly"))
+        new = _num(d.get("renovated_rent_monthly"))
+        cost = _num(d.get("renovation_cost"))
+        if count is None or count <= 0:
+            excluded.append({"type": name, "reason": "no positive unit count"})
+            continue
+        if cur is None:
+            excluded.append({"type": name, "reason": "no in-place rent stated"})
+            continue
+        if new is None:
+            # Not an error — a type nobody intends to renovate. It keeps earning in-place rent and is
+            # NAMED, because inventing a premium here would invent the investment thesis itself.
+            excluded.append({"type": name, "count": int(count), "reason":
+                             "no renovated rent stated — carried at in-place rent, not renovated"})
+            continue
+        ok.append({"type": name, "count": int(count), "current_rent_monthly": cur,
+                   "renovated_rent_monthly": new, "renovation_cost": cost or 0.0,
+                   "premium_monthly": new - cur})
+    return ok, excluded
+
+
+def schedule(unit_types: list[dict] | None, assumptions: dict | None = None,
+             months: int = 60) -> dict[str, Any]:
+    """Month-by-month renovation programme: capex, downtime cost, and premium once units are back."""
+    a, missing = _assumptions(assumptions)
+    if missing:
+        return {"status": STATUS_MISSING_ASSUMPTION, "missing": missing,
+                "why": {k: REQUIRED_WHY[k] for k in missing},
+                "note": "no schedule was produced. Defaulting these would apply the full premium with "
+                        "no phasing and no vacancy, which is the standard way a value-add deal is "
+                        "overstated and is indistinguishable in the output from a correct one.",
+                "by_month": [], "total_renovation_cost": None}
+
+    renovatable, excluded = _prepare(unit_types)
+    pace = a["units_per_month"]
+    downtime = int(round(a["downtime_months_per_unit"]))
+    months = max(0, int(months))
+
+    # Expand to a per-unit queue, in the order the caller supplied. Explicit rather than proportional:
+    # a fractional unit cannot be scheduled, and a silent split would produce them.
+    # Each queue entry is (index, type). The index makes every unit DISTINCT: expanding with
+    # `[t] * count` would put N references to one dict in the queue, and removing a completed unit by
+    # value would then drop every unit of that type at once — a bug that shows up as a renovation
+    # programme finishing far too early, with no error anywhere.
+    queue: list[tuple[int, dict]] = []
+    for t in renovatable:
+        for _ in range(t["count"]):
+            queue.append((len(queue), t))
+
+    started: list[int] = []          # completion month per started unit
+    rows: list[dict] = []
+    cursor = 0
+    in_place_total = sum(t["current_rent_monthly"] * t["count"] for t in renovatable)
+
+    completions: dict[int, list[tuple[int, dict]]] = {}
+    capex_by_month: dict[int, float] = {}
+    starts_by_month: dict[int, list[tuple[int, dict]]] = {}
+
+    m = 0
+    budget = 0.0
+    while cursor < len(queue) and m < months:
+        take = int(min(pace, len(queue) - cursor))
+        for _ in range(take):
+            idx, t = queue[cursor]
+            cursor += 1
+            starts_by_month.setdefault(m, []).append((idx, t))
+            capex_by_month[m] = capex_by_month.get(m, 0.0) + t["renovation_cost"]
+            completions.setdefault(m + downtime, []).append((idx, t))
+            started.append(m + downtime)
+        m += 1
+
+    online: list[dict] = []
+    offline: dict[int, dict] = {}          # keyed by unit index, so completions remove exactly one
+    cum_capex = 0.0
+    for month in range(months):
+        for idx, t in completions.get(month, []):
+            offline.pop(idx, None)
+            online.append(t)
+        for idx, t in starts_by_month.get(month, []):
+            offline[idx] = t
+
+        capex = capex_by_month.get(month, 0.0)
+        cum_capex += capex
+        # Phase 2: a unit under renovation earns NOTHING. The rent it would have earned is the
+        # programme's carrying cost and is reported, not netted into the premium.
+        downtime_rent_loss = sum(t["current_rent_monthly"] for t in offline.values())
+        # Phase 3: the premium applies ONLY to units already back online.
+        premium = sum(t["premium_monthly"] for t in online)
+        rows.append({
+            "month": month,
+            "units_started": len(starts_by_month.get(month, [])),
+            "units_completed": len(completions.get(month, [])),
+            "units_online_renovated": len(online),
+            "units_in_renovation": len(offline),
+            "renovation_capex": round(capex, 2),
+            "cumulative_capex": round(cum_capex, 2),
+            "downtime_rent_loss": round(downtime_rent_loss, 2),
+            "premium_income": round(premium, 2),
+            "net_effect": round(premium - downtime_rent_loss - capex, 2),
+        })
+        budget += capex
+
+    total_units = sum(t["count"] for t in renovatable)
+    return {
+        "status": STATUS_OK,
+        "assumptions_used": {"units_per_month": pace, "downtime_months_per_unit": downtime},
+        "months": months,
+        "renovatable_units": total_units,
+        "units_renovated_in_window": len(started),
+        "units_not_reached": max(0, total_units - len(started)),
+        "in_place_rent_monthly": round(in_place_total, 2),
+        "total_renovation_cost": round(budget, 2),
+        "total_downtime_rent_loss": round(sum(r["downtime_rent_loss"] for r in rows), 2),
+        "total_premium_income": round(sum(r["premium_income"] for r in rows), 2),
+        "stabilised_premium_monthly": round(
+            sum(t["premium_monthly"] * t["count"] for t in renovatable), 2),
+        "unit_types": renovatable,
+        "excluded_unit_types": excluded,
+        "by_month": rows,
+        "note": "a unit earns in-place rent until it starts, NOTHING while it is being renovated, and "
+                "the renovated rent only from the month it comes back online. Applying the premium "
+                "from day one is the standard overstatement and is invisible in the output.",
+    }

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -144,6 +144,32 @@ def project_income_basis(pid: str, declared_annual: float | None = None,
     return income_basis.resolve(declared_annual=declared_annual, rent_roll=rr, ner=ner)
 
 
+@router.post("/projects/{pid}/proforma/renovation")
+def project_renovation(pid: str, body: dict = Body(...), db: Session = Depends(get_db),
+                       _sec: str = Depends(rbac.require_role("viewer"))):
+    """PF-RENOVATION — a value-add renovation programme, unit by unit, over time.
+
+    Body: `{unit_types: [{type, count, current_rent_monthly, renovated_rent_monthly,
+    renovation_cost}], assumptions: {units_per_month, downtime_months_per_unit}, months?}`.
+
+    A unit earns its in-place rent until it starts, **nothing** while it is being renovated, and the
+    renovated rent only from the month it comes back online. Applying the premium from day one is the
+    standard way a value-add deal is overstated — it produces a smooth, plausible income curve that is
+    simply too high, too early, for the whole hold.
+
+    `units_per_month` and `downtime_months_per_unit` are required and NOT defaulted: without them the
+    model either renovates everything instantly or costs only its capex, and either result is
+    indistinguishable from a correct one. Stating zero downtime is allowed — it is then a choice.
+    """
+    from ..models import Project
+    from ..proforma import renovation
+
+    if not db.get(Project, pid):
+        raise HTTPException(404, "project not found")
+    return renovation.schedule(body.get("unit_types") or [], body.get("assumptions") or {},
+                               months=int(body.get("months") or 60))
+
+
 @router.get("/projects/{pid}/financials")
 def project_financials(pid: str, db: Session = Depends(get_db), _sec: str = Depends(rbac.require_role("viewer"))):
     """Financial statements for the project's latest saved scenario (income statement · balance sheet ·

--- a/services/api/test_renovation.py
+++ b/services/api/test_renovation.py
@@ -1,0 +1,151 @@
+"""PF-RENOVATION — a value-add programme, and the three ways its income curve goes quietly wrong.
+
+The arithmetic is easy; the assertions worth having are about *timing*. A unit has three phases and
+every overstatement skips one:
+
+1. in-place rent until it starts;
+2. **nothing** while it is being renovated — skipping this makes the programme look like capex only;
+3. renovated rent **only from the month it comes back online** — skipping the lag is the single most
+   common way a value-add deal is overstated, and it produces a smooth, plausible, too-high curve.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_renovation.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api.proforma.renovation import (  # noqa: E402
+    STATUS_MISSING_ASSUMPTION,
+    STATUS_OK,
+    schedule,
+)
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+# 10 units at $1,000 -> $1,300 after a $15,000 renovation. Premium $300/unit/month.
+T1 = {"type": "1BR", "count": 10, "current_rent_monthly": 1000,
+      "renovated_rent_monthly": 1300, "renovation_cost": 15000}
+A = {"units_per_month": 2, "downtime_months_per_unit": 1}
+
+s = schedule([T1], A, months=12)
+by = {r["month"]: r for r in s["by_month"]}
+
+# --- 1. THE LAG: the premium starts when the unit comes BACK, not when work starts -------------------
+check("a programme is produced", s["status"] == STATUS_OK, s["status"])
+check("month 0 starts 2 units", by[0]["units_started"] == 2, by[0])
+check("  and earns NO premium — the units are being renovated, not re-let",
+      by[0]["premium_income"] == 0.0, by[0]["premium_income"])
+check("  while losing their in-place rent: 2 x $1,000",
+      by[0]["downtime_rent_loss"] == 2000.0, by[0]["downtime_rent_loss"])
+check("  and incurring their capex: 2 x $15,000", by[0]["renovation_capex"] == 30000.0, by[0])
+
+check("month 1 is when the first two come back online",
+      by[1]["units_completed"] == 2 and by[1]["units_online_renovated"] == 2, by[1])
+check("  NOW the premium appears: 2 x $300", by[1]["premium_income"] == 600.0,
+      by[1]["premium_income"])
+check("  and the next two are offline, so the loss continues",
+      by[1]["downtime_rent_loss"] == 2000.0, by[1]["downtime_rent_loss"])
+
+check("by month 4, 8 units are back and earning", by[4]["units_online_renovated"] == 8,
+      by[4]["units_online_renovated"])
+check("  premium is 8 x $300", by[4]["premium_income"] == 2400.0, by[4]["premium_income"])
+
+# The whole point, stated as one assertion: at NO month does the premium exceed what the units
+# actually back online can produce. A day-one-premium model fails this at month 0.
+worst = max((r["premium_income"] - r["units_online_renovated"] * 300.0) for r in s["by_month"])
+check("THE REFUSAL: premium never exceeds units actually back online, in any month",
+      abs(worst) < 1e-9, worst)
+check("  and month 0 in particular earns nothing, which a day-one-premium model would not",
+      by[0]["premium_income"] == 0.0)
+
+# --- 2. the programme completes, and stops -----------------------------------------------------------
+check("all 10 units are renovated within the window", s["units_renovated_in_window"] == 10,
+      s["units_renovated_in_window"])
+check("  none are left unreached", s["units_not_reached"] == 0, s["units_not_reached"])
+check("  total capex is 10 x $15,000", s["total_renovation_cost"] == 150000.0,
+      s["total_renovation_cost"])
+check("  stabilised premium is 10 x $300/month", s["stabilised_premium_monthly"] == 3000.0,
+      s["stabilised_premium_monthly"])
+check("once complete, no units remain in renovation", by[11]["units_in_renovation"] == 0, by[11])
+check("  and the premium is the full stabilised figure", by[11]["premium_income"] == 3000.0, by[11])
+
+# --- 3. THE SHARED-OBJECT TRAP -------------------------------------------------------------------------
+# Units of one type are identical dicts. If completions are removed by VALUE rather than by identity,
+# finishing one unit removes every unit of that type from the in-renovation set, and the programme
+# appears to finish far too early with no error anywhere.
+slow = schedule([{"type": "2BR", "count": 6, "current_rent_monthly": 1000,
+                  "renovated_rent_monthly": 1200, "renovation_cost": 1000}],
+                {"units_per_month": 1, "downtime_months_per_unit": 3}, months=12)
+sb = {r["month"]: r for r in slow["by_month"]}
+check("with a 3-month downtime and 1 unit/month, three units are in renovation at once",
+      sb[2]["units_in_renovation"] == 3, sb[2])
+check("  and NONE has completed yet at month 2", sb[2]["units_online_renovated"] == 0, sb[2])
+check("  the first completes at month 3, leaving three still in progress",
+      sb[3]["units_online_renovated"] == 1 and sb[3]["units_in_renovation"] == 3, sb[3])
+check("  downtime loss tracks units in renovation, not units of that TYPE",
+      sb[3]["downtime_rent_loss"] == 3000.0, sb[3]["downtime_rent_loss"])
+
+# --- 4. refusals ------------------------------------------------------------------------------------------
+for partial, name in (({"downtime_months_per_unit": 1}, "units_per_month"),
+                      ({"units_per_month": 2}, "downtime_months_per_unit"),
+                      ({}, "both")):
+    r = schedule([T1], partial, months=12)
+    check(f"missing {name} refuses rather than defaulting", r["status"] == STATUS_MISSING_ASSUMPTION,
+          r["status"])
+    check("  no schedule and no cost are produced",
+          r["by_month"] == [] and r["total_renovation_cost"] is None, r)
+    check("  and the refusal says what defaulting would have hidden",
+          all(len(v) > 40 for v in r["why"].values()), r.get("why"))
+
+check("zero downtime is ACCEPTED — it is a choice, not a default",
+      schedule([T1], {**A, "downtime_months_per_unit": 0}, months=12)["status"] == STATUS_OK)
+for bad in (-1, "fast", True, float("nan")):
+    check(f"a non-numeric/negative pace ({bad!r}) is UNSTATED, not coerced",
+          schedule([T1], {**A, "units_per_month": bad})["status"] == STATUS_MISSING_ASSUMPTION)
+
+# --- 5. a type with no renovated rent is NOT renovated, and is NAMED ------------------------------------------
+mixed = schedule([T1, {"type": "3BR", "count": 4, "current_rent_monthly": 1500}], A, months=12)
+check("a type with no renovated rent is excluded from the programme",
+      mixed["renovatable_units"] == 10, mixed["renovatable_units"])
+check("  and is NAMED with the reason, not silently dropped",
+      any(e["type"] == "3BR" and "not renovated" in e["reason"]
+          for e in mixed["excluded_unit_types"]), mixed["excluded_unit_types"])
+check("  its unit count is retained so nobody thinks the property is smaller",
+      any(e.get("count") == 4 for e in mixed["excluded_unit_types"]), mixed["excluded_unit_types"])
+
+for bad, why in (({"type": "X", "count": 0, "current_rent_monthly": 1, "renovated_rent_monthly": 2},
+                  "zero units is not a unit type"),
+                 ({"type": "Y", "count": 5, "renovated_rent_monthly": 2},
+                  "no in-place rent means no premium can be computed")):
+    r = schedule([bad], A, months=6)
+    check(f"excluded: {why}", r["renovatable_units"] == 0 and r["excluded_unit_types"], r)
+
+# --- 6. a premium can legitimately be negative, and is not silently floored --------------------------------------
+down = schedule([{"type": "Z", "count": 2, "current_rent_monthly": 1200,
+                  "renovated_rent_monthly": 1100, "renovation_cost": 500}],
+                {"units_per_month": 2, "downtime_months_per_unit": 0}, months=3)
+check("a renovated rent BELOW the in-place rent produces a negative premium, not zero",
+      down["stabilised_premium_monthly"] == -200.0, down["stabilised_premium_monthly"])
+
+# --- 7. the window can be too short, and says so ---------------------------------------------------------------
+short = schedule([T1], {"units_per_month": 1, "downtime_months_per_unit": 1}, months=4)
+check("a window too short to finish reports the units it did not reach",
+      short["units_not_reached"] == 6, short["units_not_reached"])
+check("  and does not claim the full stabilised premium as achieved",
+      short["by_month"][-1]["premium_income"] < short["stabilised_premium_monthly"],
+      (short["by_month"][-1]["premium_income"], short["stabilised_premium_monthly"]))
+check("an empty unit list schedules nothing rather than erroring",
+      schedule([], A, months=6)["renovatable_units"] == 0)
+
+print()
+if FAILED:
+    print(f"renovation: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("renovation: all checks passed")


### PR DESCRIPTION
Scope item 4 from the CRE model survey (#152). Three of the six surveyed models are multifamily value-add, and all three turn on one mechanic: buy at in-place rents, renovate units over time, earn a premium on each unit **once it is back online**.

Premise-checked: nothing modelled this. `test_fit.layout` and `routers/generate` carry `unit_types`, but that is **design** unit mix — how many 1BRs fit on a plate — a different domain sharing a word. Worth keeping distinct; name collisions have caused three false conclusions this week.

## Three phases, and every overstatement skips one

1. in-place rent until renovation starts;
2. **nothing** while it is being renovated — that vacancy is the cost of the programme;
3. renovated rent **only from the month it comes back online**.

**Applying the premium from day one is the single most common way a value-add deal is overstated**, and it is invisible in the output: it produces a smooth, plausible income curve that is simply too high, too early, across the whole hold. Skipping phase 2 makes the programme look like capex only.

## Refused rather than defaulted

`units_per_month` and `downtime_months_per_unit` are required. Without them the model either renovates everything instantly or costs only its capex — and either result is indistinguishable from a correct one. Stating zero downtime is **accepted**; it is then a choice somebody made.

A unit type with no renovated rent is **not** renovated, and is named with its count. Inventing a premium there would invent the investment thesis.

## Two defects of my own, caught before they shipped — both silent

- **`queue.extend([t] * count)` put N references to one dict in the queue.** Removing a completed unit *by value* would have dropped every unit of that type at once — a programme finishing far too early, with no error anywhere. Units are now `(index, type)` and the in-renovation set is keyed by index, so a completion removes exactly one.
- a dead `sum(...) * 0.0` term that could only ever contribute zero while reading as though it accounted for the unimproved types.

## Mutation-proved, not assumed

| mutation | result |
|---|---|
| premium applied to units still in renovation (**the classic error**) | **killed** by the month-0 assertion |
| downtime rent loss removed | **killed** by the carrying-cost assertion |
| baseline, before and after | passes — the suite is not simply always-red |

## Verified over HTTP

`POST /projects/{pid}/proforma/renovation` — 10 units at 2/month with 1 month downtime: month 0 premium **0**, month 1 **600**, month 4 **2,400**, total capex 150,000, stabilised premium 3,000/month. Omitting the assumptions returns `assumptions_incomplete` naming both; unknown project 404s.

41 checks; `test_reachable`, `test_proforma`, `test_rollover`, `test_global_authz`, `test_protected_prefix_coverage` all pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)