### PR TITLE
sec(G-1): gitleaks findings now fail the build, with a baseline that states its reasons

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -72,22 +72,31 @@ jobs:
         # into a world-readable Actions log, so the scanner would CREATE the exposure it exists to
         # report. Do not remove it.
         #
-        # FINDINGS are report-only for now; a TOOL FAILURE is not. `set -euo pipefail` and the
-        # explicit binary check mean a bad URL, a renamed release asset or a failed extract fail this
-        # step loudly. Putting `continue-on-error` on the whole step would make all three
-        # indistinguishable from "no secrets found" — a scanner that never ran, reporting clean.
-        # Gating on findings follows once CI has published one baseline; that is the order bandit
-        # went through, and the reason its HIGH gate could start green.
+        # FINDINGS NOW GATE. A tool failure always did: `set -euo pipefail` and the explicit binary
+        # check mean a bad URL, a renamed release asset or a failed extract fail this step loudly.
+        # `continue-on-error` on the whole step would make all three indistinguishable from "no
+        # secrets found" — a scanner that never ran, reporting clean.
+        #
+        # The baseline this waited for is `.gitleaksignore`: five fingerprints, each with a reason,
+        # all triaged 2026-08-02 as false positives with nothing to rotate. Same order bandit went
+        # through, and the reason its HIGH gate could start green.
+        #
+        # An UNKNOWN finding now fails the build. That is the whole point, and it is also the one
+        # way this step can hurt: the fix for a real secret is to ROTATE IT FIRST and then purge it
+        # from history — never to add a line to .gitleaksignore, which silences the report while
+        # leaving the credential published in the objects for anyone who clones.
         env:
           GITLEAKS_VERSION: "8.30.1"
         run: |
           set -euo pipefail
+          GITLEAKS_RC=0          # set -u: must exist before the || below can assign it
           curl -sSfL -o gitleaks.tar.gz             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           tar -xzf gitleaks.tar.gz gitleaks
           test -x ./gitleaks
           ./gitleaks version
-          # --exit-code=0 means FINDINGS do not fail the step. Everything else here still can.
-          ./gitleaks detect --source=. --redact --no-banner --exit-code=0             --report-format=json --report-path=gitleaks-report.json
+          # --exit-code=1: an UNKNOWN finding fails the step. Known ones live in .gitleaksignore
+          # with a reason each. Report is still written either way, so a red run is diagnosable.
+          ./gitleaks detect --source=. --redact --no-banner --exit-code=1             --report-format=json --report-path=gitleaks-report.json || GITLEAKS_RC=$?
           COUNT=$(python -c "import json;print(len(json.load(open('gitleaks-report.json'))))")
           echo "## gitleaks — $COUNT finding(s) over the full history" >> "$GITHUB_STEP_SUMMARY"
           if [ "$COUNT" -gt 0 ]; then
@@ -97,7 +106,14 @@ jobs:
             python -c "import json;[print('- \`%s\` in \`%s\`:%s (commit %s)' % (f.get('RuleID','?'), f.get('File','?'), f.get('StartLine','?'), str(f.get('Commit',''))[:8])) for f in json.load(open('gitleaks-report.json'))]" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Clean. After one clean run, drop --exit-code=0 to make findings blocking." >> "$GITHUB_STEP_SUMMARY"
+            echo "Clean — no finding outside .gitleaksignore." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          # Fail LAST, so the summary above is written first: a red step that explains
+          # itself costs one read; a red step that does not costs a re-run.
+          if [ "$GITLEAKS_RC" -ne 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**FAILED** — a finding is not in .gitleaksignore. If it is a real secret, ROTATE IT FIRST, then purge it from history; adding it here only silences the report." >> "$GITHUB_STEP_SUMMARY"
+            exit "$GITLEAKS_RC"
           fi
 
       - name: Upload gitleaks report

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,37 @@
+# gitleaks baseline — SEC-G1.
+#
+# Each line is a FINGERPRINT (commit:path:rule:line) that the scan is allowed to ignore. Every entry
+# needs a reason, because an unexplained line here is indistinguishable from a real secret somebody
+# silenced. Verified 2026-08-02: all five are false positives, nothing to rotate.
+#
+# These are pinned to COMMITS, not to the current file. gitleaks scans history, so a value that was
+# committed and later edited out is still in the objects and still found — the working tree is the
+# one place it is guaranteed not to be. That is the point of scanning history, and it is why fixing
+# the file does not clear the finding: the storage.py entry below was reworded in #169 and its
+# historical commit still matches. Deleting a line here therefore does NOT re-arm a check; it
+# re-opens a finding about the past that no edit to the present can close.
+#
+# Adding an entry is a claim that a human looked. Adding one to make CI green is the failure mode
+# this file exists to make visible.
+
+# storage.py — a source COMMENT that named the validate_key helper followed by a colon and a list
+# of rejected inputs. An identifier ending in "key", a colon, then a token is what generic-api-key
+# matches. No credential; reworded on main in #169, but the pre-reword commit remains in history
+# and still matches.
+#
+# NB: quoting the offending text here reproduced the finding — this very file failed the first
+# gated run, at this line. A baseline that explains a pattern by example becomes an instance of it,
+# which is a small joke and a real rule: describe the shape, never paste it.
+14a9390d4a37d2c80f25f29d3c2ce83f0ffb6262:services/api/src/aec_api/storage.py:generic-api-key:65
+
+# test_license_cloud.py — a fabricated licence key in the shape the parser expects (a MASS- prefix
+# and four hyphenated groups). Not issued, not valid, never accepted by the licence service.
+96c40988891d21aaa238bb44f6f7fbb718110613:services/api/test_license_cloud.py:generic-api-key:24
+
+# test_mfa.py — the RFC 6238 published TOTP test vector, the base32 seed printed in the standard
+# itself. The TOTP tests would be untestable without it.
+2957b990a7d4bbb8922fe3b931ae178018bdeee0:services/api/test_mfa.py:generic-api-key:23
+
+# test_licensing.py — fabricated MASSING_LICENSE_KEY fixtures driving the tier/expiry paths.
+1528d60ec54371809ed896170b30d5defa478fed:services/api/test_licensing.py:generic-api-key:85
+fc0d7767f57653f3ea235db5abaeb646db79c4a1:services/api/test_licensing.py:generic-api-key:49

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -32,7 +32,7 @@ tenancy) · (3) public token-holder → curated share surfaces · (4) API → ou
 | Threat | Control |
 |---|---|
 | Cross-project data access (tenant breakout) | Every `/projects/{pid}` route requires `require_role`; **enforced by a test gate** (`test_route_authz` walks the route table). Portfolio/cross-project rollups scope to `member_project_ids`. SEC-TENANT hardening pass (v0.3.413). |
-| Privilege escalation via side doors | The audited lesson (HARDEN-2): stricter endpoints must not be reachable through generic gates — job queue kinds carry `_KIND_MIN_ROLE`, bulk/MCP dispatch gate per-operation. Checked in hand-audit passes (see the `security-monitoring` skill checklist). |
+| Privilege escalation via side doors | The audited lesson (HARDEN-2): stricter endpoints must not be reachable through generic gates — job queue kinds carry `_KIND_MIN_ROLE`, MCP dispatch gates writes per-operation. **No longer hand-audited:** `test_dispatcher_privilege_coverage` enumerates both registries and fails on an operation classified nowhere, on a frozen entry with no referent, and — read from `_MUTATING_KINDS`, which is derived from the code — on a kind that *starts* mutating behind an unchanged name. Both tables were correct when it was written; what was missing was a reason the next entry has to be. |
 | Public share token abuse | ShareTokens are revocable, read-only, serve a **curated** digest only (no financials unless per-token `show_payments` opt-in at mint); the public decision/comment endpoints are hardened (type/action whitelists, 120/500/1000-char caps, 200-decision and 200-comment hard caps, revoked → 404). |
 | Privilege escalation on **global** (non-project) routes | A project-scoped gate is not valid on a route with no project in its path: it leaves the project identity to be supplied by the request. Firm-wide writes take `rbac.require_platform_admin`, global reads `rbac.require_identified`. **Enforced by a test gate** (`test_global_mutating_authz`), which asserts as a schema property that no global route accepts a caller-supplied project id — so a new one fails the build rather than joining a list. Two firm-standards routes were corrected under this pass (v0.3.800). |
 | Client-side authz bypass | All checks server-side; the web app's role gating is presentation only. |
@@ -102,8 +102,17 @@ tenancy) · (3) public token-holder → curated share surfaces · (4) API → ou
 
 ## Gap backlog (prioritized; honest)
 
-1. **G-1 (M) Secret scanning in CI** — no gitleaks/trufflehog step (REL-6 tail); audits use ad-hoc
-   grep. Add when tooling is approved.
+1. ✅ **G-1 Secret scanning in CI** — *closed.* `security.yml` runs gitleaks over the **full git
+   history** (`fetch-depth: 0` — a shallow clone would scan one commit and report "clean over the
+   full history"), redacted so a public Actions log cannot itself leak the finding, and **findings
+   now fail the build**. The baseline it waited for is `.gitleaksignore`: five fingerprints, each
+   carrying its reason, all triaged as false positives with nothing to rotate — a fabricated licence
+   key, the published RFC 6238 TOTP test vector, two fixtures, and a source *comment* whose `key:`
+   prefix matched. Fingerprints pin **commits, not files**, which is the property worth knowing: the
+   comment was reworded and its historical commit still matches, because history is exactly what
+   this scans. The documented fix for a real finding is therefore **rotate first, then purge from
+   history** — never a new line in the ignore file, which silences the report and leaves the
+   credential in the objects.
 2. ✅ **G-2 SBOM artifact** — *closed in-sprint:* the Dependency-scan workflow now publishes an
    SPDX SBOM artifact per run (`security.yml` sbom job).
 3. **G-3 (S) Formal access-review cadence** — SCIM handles deprovisioning; a quarterly operator


### PR DESCRIPTION
Closes the last engineering item in the threat model's gap backlog, and corrects two claims in the same document that had gone stale.

## The gate

gitleaks has scanned the full history since #164, but at `--exit-code=0` — findings reported, nothing failed. That was deliberate (the order bandit went through, so its HIGH gate could start green) and it was waiting on a baseline.

The baseline is `.gitleaksignore`: **five fingerprints, each carrying its reason, all triaged as false positives with nothing to rotate** — a fabricated licence key, the published RFC 6238 TOTP test vector, two fixtures, and a source *comment* whose identifier-colon-token shape matched `generic-api-key`.

**Fingerprints pin commits, not files**, and that is the property worth knowing. The comment above was reworded on main in #169 and its historical commit still matches, because history is exactly what this scans — the working tree is the one place a committed secret is guaranteed *not* to be. So the documented fix for a real finding is **rotate first, then purge from history**; adding a line here silences the report while leaving the credential in the objects for anyone who clones. The file says so in its own header, because an unexplained entry is indistinguishable from a real secret somebody quietly muted.

## Verified by dispatch, not by assumption — and it caught me twice

This workflow only triggers on push-to-main, so **a PR cannot exercise it** and a wrong baseline would have gone red on main *after* merge. I dispatched it against the branch instead.

- **Run 1 failed — correctly.** It caught `.gitleaksignore` itself: my comment explaining the `storage.py` false positive **quoted the offending text**, so the file documenting the pattern became an instance of it.
- **Run 2 failed — correctly.** A second paste in the same file, the licence-key example, one line after I had written "describe the shape, never paste it".
- **Run 3 green**, all three jobs.

Both are now described rather than reproduced, and **the branch is squashed** so no intermediate commit carries the literals — history is what gets scanned, so a fix layered on top would have left the finding permanently in main.

The step also fails **last** rather than at the detect call: `set -euo pipefail` would abort before the job summary is written, so a red run would carry no explanation. `GITLEAKS_RC` is initialised because `set -u` would otherwise fail on the `||` assignment.

## Two doc corrections

Both asserted more than was true:

| Claim | Reality |
|---|---|
| G-1: "no gitleaks/trufflehog step" | untrue since #164 |
| §2: side-door escalation "Checked in hand-audit passes" | untrue since #170 landed `test_dispatcher_privilege_coverage` |

## Verification

Dispatched run **30764866930 — success** (python, node, sbom). `test_claude_md_gates`, `test_no_comparative_names`, `test_file_sizes` green. Workflow parses as YAML with `exit-code=1` and the trailing exit present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved secret scanning to block builds when unapproved credentials or sensitive data are detected.
  * Added clearer diagnostic output and remediation guidance for security findings.
  * Documented verified false positives so they can be safely excluded from future scans.
* **Testing**
  * Expanded automated coverage for job processing and operation authorization checks.
* **Documentation**
  * Updated the security threat model to reflect the strengthened scanning and validation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->