### PR TITLE
R22-PROVENANCE (slice 1) — one admissibility verdict, and the score it refuses to compute

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -20,7 +20,7 @@ from collections import Counter
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-TESTS = ["test_proforma", "test_renovation", "test_rollover", "test_income_basis", "test_cost", "test_g702_lines", "test_modules", "test_dashboard",
+TESTS = ["test_provenance_report", "test_proforma", "test_renovation", "test_rollover", "test_income_basis", "test_cost", "test_g702_lines", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_connections", "test_presence", "test_collab", "test_serving", "test_api",
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
          # R22-ENTITLE-RISK — approval odds + entitlement duration in the Monte Carlo:

--- a/services/api/src/aec_api/provenance_report.py
+++ b/services/api/src/aec_api/provenance_report.py
@@ -1,0 +1,137 @@
+"""R22-PROVENANCE — one admissibility verdict across all three provenance legs.
+
+Premise-checked before writing, and two thirds of this ring was already built:
+
+* **agent answers** — `cited_answer.py`: `cite_doc(document_id, revision, sheet, page, …)`,
+  coverage, conflict detection, a stale-revision penalty;
+* **estimate lines** — `boe_ledger.py`: `source` / `quote_ref` / `basis_date` per line, with the
+  undocumented lines surfaced;
+* **proforma assumptions** — `assumption_provenance.py`, which closed the third leg.
+
+What did **not** exist is the join. Each leg answers for itself and provenance is exposed only on the
+proforma path, so nothing answers the question the ring is actually for: *is this deal's output
+admissible in an IC memo or a claim?* A reader had to open three endpoints and reconcile them.
+
+**Admissibility is not a score, and this module refuses to produce one.** The tempting join is a
+single 0–100 "provenance score"; it is also the thing that makes an uncited estimate invisible behind
+a well-cited proforma. A memo is not admissible because it scored 82. So the verdict is per-leg,
+the blockers are **named**, and there is no blended number anywhere.
+
+**An empty leg is `no_data`, never coverage — and the two legs prove why.** They disagree about what
+zero means, in opposite directions:
+
+    boe_ledger.ledger([])            -> pct_documented 1.0    "perfectly documented"
+    assumption_provenance.provenance({}) -> coverage_pct 0.0  "nothing cited"
+
+Both describe *the same absence*. Averaging them would be arithmetic over two different claims, and
+either one alone would mislead: a project with no estimate lines is not a project with a perfectly
+documented estimate. So an empty leg reports `no_data` with what is missing, and is excluded from
+the verdict rather than counted as pass or fail.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+STATUS_OK = "cited"
+STATUS_GAPS = "has_uncited"
+STATUS_NO_DATA = "no_data"
+
+VERDICT_ADMISSIBLE = "admissible"
+VERDICT_BLOCKED = "blocked"
+VERDICT_INCOMPLETE = "incomplete"
+
+#: How many named blockers to carry per leg. The count is always exact; the list is capped so a
+#: pathological deal cannot turn a verdict into a payload.
+MAX_NAMED = 25
+
+
+def _leg_assumptions(prov: dict | None) -> dict[str, Any]:
+    if not prov:
+        return {"status": STATUS_NO_DATA, "leg": "assumptions", "counted": 0,
+                "note": "no proforma assumptions were supplied — not an assumption set with nothing "
+                        "to cite"}
+    material = int(prov.get("material_count") or 0)
+    uncited = list(prov.get("uncited") or [])
+    if not material:
+        return {"status": STATUS_NO_DATA, "leg": "assumptions", "counted": 0,
+                "note": ("the scenario declares no MATERIAL assumptions. `coverage_pct` reads 0.0 "
+                         "here, which means 'nothing to cite', not 'nothing cited' — reporting it "
+                         "as 0% coverage would invent a failure")}
+    return {"status": STATUS_OK if not uncited else STATUS_GAPS, "leg": "assumptions",
+            "counted": material, "uncited_count": len(uncited),
+            "uncited": [str(u) for u in uncited[:MAX_NAMED]],
+            "note": "material assumptions with no cited source" if uncited else ""}
+
+
+def _leg_estimate(led: dict | None) -> dict[str, Any]:
+    if not led:
+        return {"status": STATUS_NO_DATA, "leg": "estimate", "counted": 0,
+                "note": "no basis-of-estimate ledger was supplied"}
+    lines = int(led.get("line_count") or 0)
+    undoc = list(led.get("undocumented") or [])
+    if not lines:
+        return {"status": STATUS_NO_DATA, "leg": "estimate", "counted": 0,
+                "note": ("the ledger holds no lines. `pct_documented` reads 1.0 for an empty ledger, "
+                         "which would report a project with NO estimate as having a perfectly "
+                         "documented one — the opposite error to the assumptions leg, from the same "
+                         "absence")}
+    return {"status": STATUS_OK if not undoc else STATUS_GAPS, "leg": "estimate",
+            "counted": lines, "uncited_count": len(undoc),
+            "uncited": [f"{u.get('key')}: missing {', '.join(u.get('missing') or [])}"
+                        for u in undoc[:MAX_NAMED]],
+            "note": "estimate lines with an undocumented basis" if undoc else ""}
+
+
+def _leg_answers(answers: list[dict] | None) -> dict[str, Any]:
+    rows = [a for a in (answers or []) if isinstance(a, dict)]
+    if not rows:
+        return {"status": STATUS_NO_DATA, "leg": "answers", "counted": 0,
+                "note": "no agent answers were supplied — an unanswered deal is not an uncited one"}
+    uncited = [str(a.get("text") or a.get("target") or "answer")[:120]
+               for a in rows if not (a.get("citations") or [])]
+    return {"status": STATUS_OK if not uncited else STATUS_GAPS, "leg": "answers",
+            "counted": len(rows), "uncited_count": len(uncited),
+            "uncited": uncited[:MAX_NAMED],
+            "note": "agent answers carrying no citation" if uncited else ""}
+
+
+def report(assumptions_provenance: dict | None = None, estimate_ledger: dict | None = None,
+           agent_answers: list[dict] | None = None) -> dict[str, Any]:
+    """One admissibility verdict across the three legs — per-leg, never blended.
+
+    Every input is the OUTPUT of the leg that owns it (`assumption_provenance.provenance`,
+    `boe_ledger.ledger`, a list of `cited_answer.claim` results), so this module re-derives nothing
+    and cannot disagree with the engine it summarises.
+    """
+    legs = [_leg_assumptions(assumptions_provenance), _leg_estimate(estimate_ledger),
+            _leg_answers(agent_answers)]
+    present = [x for x in legs if x["status"] != STATUS_NO_DATA]
+    blocking = [x for x in present if x["status"] == STATUS_GAPS]
+    absent = [x["leg"] for x in legs if x["status"] == STATUS_NO_DATA]
+
+    if not present:
+        verdict, why = VERDICT_INCOMPLETE, (
+            "no leg carried any data. This is not an admissible deal with nothing to cite — it is a "
+            "deal with nothing in it, and the two must not read alike.")
+    elif blocking:
+        verdict, why = VERDICT_BLOCKED, (
+            f"{sum(x['uncited_count'] for x in blocking)} item(s) across "
+            f"{len(blocking)} leg(s) carry no source. They are named below rather than counted: a "
+            "count gets quoted in a memo, a list gets fixed.")
+    elif absent:
+        verdict, why = VERDICT_INCOMPLETE, (
+            f"every leg that HAS data is fully cited, but {len(absent)} leg(s) — {', '.join(absent)} "
+            "— hold nothing at all. An absent leg is not a clean one, and calling this admissible "
+            "would let an empty estimate pass as a documented one.")
+    else:
+        verdict, why = VERDICT_ADMISSIBLE, (
+            "every leg carries data and every material item names a source.")
+
+    return {"verdict": verdict, "reason": why, "legs": legs,
+            "legs_with_data": [x["leg"] for x in present], "legs_absent": absent,
+            "blocking_legs": [x["leg"] for x in blocking],
+            "uncited_total": sum(x.get("uncited_count") or 0 for x in present),
+            "note": ("there is deliberately NO blended provenance score. A single percentage lets a "
+                     "well-cited proforma hide an uncited estimate, and a memo is not admissible "
+                     "because it scored well — each leg answers for itself."),
+            }

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from .. import cost as cost_engine
 from .. import modules as me
-from .. import rbac
+from .. import provenance_report, rbac
 from ..db import get_db
 from ..models import Scenario
 from ..proforma import entitlement_risk
@@ -21,7 +21,7 @@ from ..proforma.draws import reforecast
 from ..proforma.monte_carlo import monte_carlo
 from ..proforma.sensitivity import sensitivity
 from ..proforma.solve import solve
-from ..rbac import current_user
+from ..rbac import current_user, require_identified
 
 router = APIRouter()
 
@@ -42,6 +42,33 @@ def solve_stateless(a: Assumptions):
     result = solve(a.model_dump())
     return {**result, "guardrails": underwrite.guardrails(result),
             "provenance": _provenance.derive(_provenance.declared_from(a), result)}
+
+
+@router.post("/proforma/provenance/admissibility")
+def proforma_admissibility(body: dict = Body(default={}), _: str = Depends(require_identified)):
+    """R22-PROVENANCE — one admissibility verdict across all three provenance legs.
+
+    Body: `{assumptions_provenance, estimate_ledger, agent_answers}` — each the OUTPUT of the engine
+    that owns it (`/proforma/provenance` or `assumption_provenance.provenance`, `boe_ledger.ledger`,
+    a list of `cited_answer.claim` results). Nothing is re-derived here, so this cannot disagree with
+    the engine it summarises.
+
+    Each leg already answers for itself; nothing answered the question the ring is actually for —
+    **is this deal's output admissible in an IC memo or a claim?**
+
+    **There is deliberately no blended provenance score.** A single 0–100 lets a well-cited proforma
+    hide an uncited estimate, and a memo is not admissible because it scored 82. The verdict is
+    per-leg and the blockers are NAMED — a count gets quoted in a memo, a list gets fixed.
+
+    **An empty leg reports `no_data`, never coverage.** The two engines disagree about zero in
+    opposite directions — an empty `boe_ledger` reports `pct_documented` 1.0 ("perfectly documented")
+    while empty assumptions report `coverage_pct` 0.0 — and both describe the same absence. A project
+    with no estimate lines is not a project with a perfectly documented estimate, so an absent leg is
+    excluded from the verdict and the deal reads `incomplete` rather than `admissible`.
+    """
+    return provenance_report.report(body.get("assumptions_provenance"),
+                                    body.get("estimate_ledger"),
+                                    body.get("agent_answers"))
 
 
 @router.post("/proforma/provenance")

--- a/services/api/test_provenance_report.py
+++ b/services/api/test_provenance_report.py
@@ -1,0 +1,137 @@
+"""R22-PROVENANCE — one admissibility verdict, and the score it refuses to compute.
+
+Premise-checked: two of three legs were already built (`cited_answer`, `boe_ledger`) and
+`assumption_provenance` closed the third. **The join did not exist** — provenance was exposed only
+on the proforma path, so nothing answered "is this deal's output admissible?" without a reader
+opening three endpoints and reconciling them.
+
+The assertions, and the second is the one the code exists for:
+
+1. **there is no blended score.** A single 0–100 lets a well-cited proforma hide an uncited
+   estimate, and a memo is not admissible because it scored 82. Per-leg verdicts, named blockers;
+2. **an empty leg is `no_data`, never coverage — and the two real engines disagree about zero, in
+   opposite directions.** `boe_ledger.ledger([])` reports `pct_documented 1.0` ("perfect") and
+   `assumption_provenance.provenance({})` reports `coverage_pct 0.0` ("nothing"). Both describe the
+   same absence. Averaging them is arithmetic across two different claims, and either alone
+   misleads: a project with no estimate lines is not one with a perfectly documented estimate;
+3. **blockers are NAMED, not counted** — a count gets quoted in a memo, a list gets fixed;
+4. **the twin of every refusal**: a fully-cited deal must actually come back `admissible`, or the
+   verdict is just a machine for saying no.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_provenance_report.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api import assumption_provenance, boe_ledger  # noqa: E402
+from aec_api.provenance_report import (  # noqa: E402
+    STATUS_GAPS,
+    STATUS_NO_DATA,
+    STATUS_OK,
+    VERDICT_ADMISSIBLE,
+    VERDICT_BLOCKED,
+    VERDICT_INCOMPLETE,
+    report,
+)
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+def leg(r, name):
+    return next(x for x in r["legs"] if x["leg"] == name)
+
+
+# --- 2. THE TWO REAL ENGINES DISAGREE ABOUT ZERO — asserted against them, not assumed ----------------
+empty_ledger = boe_ledger.ledger([])
+empty_assump = assumption_provenance.provenance({})
+check("boe_ledger reports an EMPTY ledger as 100% documented",
+      empty_ledger["pct_documented"] == 1.0, empty_ledger["pct_documented"])
+check("assumption_provenance reports NO assumptions as 0% coverage",
+      empty_assump["coverage_pct"] == 0.0, empty_assump["coverage_pct"])
+check("  they describe the SAME absence with opposite numbers — which is why no average is taken",
+      empty_ledger["pct_documented"] != empty_assump["coverage_pct"])
+
+r = report(empty_assump, empty_ledger, [])
+check("an empty estimate leg is no_data, NOT 'perfectly documented'",
+      leg(r, "estimate")["status"] == STATUS_NO_DATA, leg(r, "estimate"))
+check("  and the reason names the 1.0 that would have misled",
+      "perfectly" in leg(r, "estimate")["note"], leg(r, "estimate")["note"])
+check("an empty assumptions leg is no_data, NOT '0% cited'",
+      leg(r, "assumptions")["status"] == STATUS_NO_DATA, leg(r, "assumptions"))
+check("  distinguishing 'nothing to cite' from 'nothing cited'",
+      "not 'nothing cited'" in leg(r, "assumptions")["note"], leg(r, "assumptions")["note"])
+check("a deal with NO data anywhere is INCOMPLETE, not admissible",
+      r["verdict"] == VERDICT_INCOMPLETE, r["verdict"])
+check("  and says a deal with nothing in it must not read like a clean one",
+      "nothing in it" in r["reason"], r["reason"])
+
+# --- 1. NO BLENDED SCORE ------------------------------------------------------------------------------
+check("the report carries NO overall percentage or score field",
+      not any(k for k in r if "score" in k.lower() or "pct" in k.lower()), sorted(r))
+check("  and says why a single number would be wrong",
+      "hide an uncited estimate" in r["note"], r["note"])
+
+# --- 3. BLOCKERS ARE NAMED -----------------------------------------------------------------------------
+LED = boe_ledger.ledger([
+    {"cost_code": "03-30-00", "description": "concrete", "qty": 10, "unit_cost": 100, "source": "quote",
+     "quote_ref": "Q-1", "basis_date": "2026-01-01", "escalation_pct": 3, "contingency_pct": 5},
+    {"cost_code": "05-12-00", "description": "steel", "qty": 5, "unit_cost": 900},
+])
+gaps = report(empty_assump, LED, [{"text": "IRR is 18%", "citations": []},
+                                  {"text": "cap rate 5%", "citations": [{"source_type": "doc"}]}])
+check("a deal with uncited items is BLOCKED", gaps["verdict"] == VERDICT_BLOCKED, gaps["verdict"])
+check("  the undocumented line is NAMED by its COST CODE, with what it is missing",
+      any("05-12-00" in u for u in leg(gaps, "estimate")["uncited"]), leg(gaps, "estimate")["uncited"])
+check("  the documented line is not named", not any("03-30-00" in u for u in leg(gaps, "estimate")["uncited"]))
+check("  the uncited agent answer is NAMED",
+      leg(gaps, "answers")["uncited"] == ["IRR is 18%"], leg(gaps, "answers")["uncited"])
+check("  the CITED answer is not named", leg(gaps, "answers")["counted"] == 2
+      and leg(gaps, "answers")["uncited_count"] == 1, leg(gaps, "answers"))
+check("  blocking legs are listed", set(gaps["blocking_legs"]) == {"estimate", "answers"},
+      gaps["blocking_legs"])
+check("  with the total across legs", gaps["uncited_total"] == 2, gaps["uncited_total"])
+check("  and the reason says a count gets quoted while a list gets fixed",
+      "a list gets fixed" in gaps["reason"], gaps["reason"])
+
+# --- 4. THE TWIN — a clean deal MUST come back admissible ------------------------------------------------
+CLEAN_LED = boe_ledger.ledger([
+    {"cost_code": "03-30-00", "description": "concrete", "qty": 10, "unit_cost": 100, "source": "quote",
+     "quote_ref": "Q-1", "basis_date": "2026-01-01", "escalation_pct": 3, "contingency_pct": 5}])
+CLEAN_ASSUMP = {"material_count": 4, "uncited": [], "coverage_pct": 100.0}
+ok = report(CLEAN_ASSUMP, CLEAN_LED, [{"text": "cap rate 5%", "citations": [{"source_type": "doc"}]}])
+check("A FULLY CITED DEAL IS ADMISSIBLE — the verdict is not just a machine for saying no",
+      ok["verdict"] == VERDICT_ADMISSIBLE, ok)
+check("  every leg reports cited", all(x["status"] == STATUS_OK for x in ok["legs"]),
+      [(x["leg"], x["status"]) for x in ok["legs"]])
+check("  and nothing is named as a blocker",
+      ok["uncited_total"] == 0 and ok["blocking_legs"] == [], ok)
+
+# a leg that is CLEAN but another absent -> incomplete, never admissible
+part = report(CLEAN_ASSUMP, CLEAN_LED, [])
+check("all present legs clean but one absent is INCOMPLETE, not admissible",
+      part["verdict"] == VERDICT_INCOMPLETE, part["verdict"])
+check("  naming which leg is empty", part["legs_absent"] == ["answers"], part["legs_absent"])
+check("  and saying an absent leg is not a clean one",
+      "absent leg is not a clean one" in part["reason"], part["reason"])
+
+# --- gaps outrank absence: a blocked leg must not be softened by an empty one ----------------------------
+mix = report(CLEAN_ASSUMP, LED, [])
+check("uncited items BLOCK even when another leg is merely absent",
+      mix["verdict"] == VERDICT_BLOCKED, mix["verdict"])
+check("  a partially-cited assumptions leg is has_uncited, not no_data",
+      leg(report({"material_count": 3, "uncited": ["exit.exit_cap"]}, CLEAN_LED,
+                 [{"text": "x", "citations": [{"s": 1}]}]), "assumptions")["status"] == STATUS_GAPS)
+check("nothing supplied at all is INCOMPLETE, not a crash", report()["verdict"] == VERDICT_INCOMPLETE)
+
+print()
+if FAILED:
+    print(f"provenance_report: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("provenance_report: all checks passed")


### PR DESCRIPTION
**A thin slice, cut deliberately** — this is the join, not the whole L-sized ring.

### The premise-check found two thirds already built

| leg | engine | state |
|---|---|---|
| agent answers | `cited_answer.py` — `cite_doc(document_id, revision, sheet, page, …)`, coverage, conflict detection, stale-revision penalty | ✅ built |
| estimate lines | `boe_ledger.py` — `source` / `quote_ref` / `basis_date` per line | ✅ built |
| proforma assumptions | `assumption_provenance.py` (R22-PROVENANCE ②) | ✅ built |
| **the join** | — | ❌ **missing** |

Provenance was exposed **only on the proforma path**, so nothing answered the question the ring is actually for — *is this deal's output admissible in an IC memo or a claim?* — without a reader opening three endpoints and reconciling them. The roadmap entry is stale in the same way R22-PIPELINE's was.

### Admissibility is not a score

The obvious join is a single 0–100. It's also exactly what lets a well-cited proforma hide an uncited estimate. **A memo is not admissible because it scored 82.** So: per-leg verdicts, named blockers, and no blended number anywhere — asserted by checking that no key in the result contains `score` or `pct`.

### An empty leg is `no_data` — and the two engines prove why

They disagree about zero, **in opposite directions**. The test asserts this against the real functions rather than assuming it:

```
boe_ledger.ledger([])                 -> pct_documented 1.0   "perfectly documented"
assumption_provenance.provenance({})  -> coverage_pct   0.0   "nothing cited"
```

Both describe the **same absence**. Averaging them is arithmetic across two different claims, and either alone misleads — *a project with no estimate lines is not a project with a perfectly documented estimate.*

So an empty leg reports `no_data` with what's missing and is excluded from the verdict; a deal where every present leg is clean but one leg is absent is `incomplete`, **never** `admissible`.

Blockers are **named, not counted** — a count gets quoted in a memo, a list gets fixed.

### Verified

28 checks. Mutating the empty-ledger refusal so it trusts `pct_documented == 1.0` is caught by **3**, no traceback.

Per the twin rule from today's post-merge findings, every refusal is paired with its action: **a fully-cited deal must come back `admissible`**, or the verdict is only a machine for saying no.

Found while writing the fixture: `boe_ledger._key` is `cost_code or ref or description` — a supplied `key` field is ignored. My first fixture invented that field; I corrected the fixture rather than loosening the assertion.

### Not in this slice

Wiring the join to a project-scoped route (it needs the three legs gathered per project), and any export gate that would *block* an IC memo on a `blocked` verdict. Both are follow-ups — this slice is the pure verdict, complete and testable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provenance reporting that evaluates assumptions, estimates, and agent answers by leg.
  * Added an API endpoint for retrieving consolidated admissibility results.
  * Reports admissibility, blockers, missing data, citation gaps, and reasons without combining results into a blended score.
  * Limits the number of uncited items displayed for clearer results.

* **Tests**
  * Added coverage for complete, incomplete, blocked, empty, and no-data reporting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->