### PR TITLE
R22-ROUTINES slice 2 — persistence, so recurrence survives a restart

### DIFF
--- a/services/api/migrations/versions/2026_08_03_1000-c81f5ad3e074_mod_routine_r22_routines_.py
+++ b/services/api/migrations/versions/2026_08_03_1000-c81f5ad3e074_mod_routine_r22_routines_.py
@@ -1,0 +1,64 @@
+"""mod_routine (R22-ROUTINES persistence)
+
+Revision ID: c81f5ad3e074
+Revises: d4a17c9e2b60
+Create Date: 2026-08-03 10:00:00.000000
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'c81f5ad3e074'
+down_revision: str | None = 'd4a17c9e2b60'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table('mod_routine',
+    sa.Column('id', sa.String(), nullable=False),
+    sa.Column('project_id', sa.String(), nullable=True),
+    sa.Column('ref', sa.String(), nullable=True),
+    sa.Column('title', sa.String(), nullable=True),
+    sa.Column('workflow_state', sa.String(), nullable=True),
+    sa.Column('party_owner', sa.String(), nullable=True),
+    sa.Column('assignee', sa.String(), nullable=True),
+    sa.Column('created_by', sa.String(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('modified_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('anchor', sa.JSON(), nullable=True),
+    sa.Column('element_guids', sa.JSON(), nullable=True),
+    sa.Column('links', sa.JSON(), nullable=True),
+    sa.Column('data', sa.JSON(), nullable=True),
+    sa.PrimaryKeyConstraint('id')
+    )
+    with op.batch_alter_table('mod_routine', schema=None) as batch_op:
+        batch_op.create_index('ix_mod_routine_proj_assignee', ['project_id', 'assignee'], unique=False)
+        batch_op.create_index('ix_mod_routine_proj_created', ['project_id', 'created_at'], unique=False)
+        batch_op.create_index('ix_mod_routine_proj_state', ['project_id', 'workflow_state'], unique=False)
+        batch_op.create_index(batch_op.f('ix_mod_routine_project_id'), ['project_id'], unique=False)
+        batch_op.create_index(batch_op.f('ix_mod_routine_workflow_state'), ['workflow_state'], unique=False)
+
+    # Postgres-only FTS GIN index — every module table gets one at runtime; a post-baseline module
+    # migration must create its own (the baseline only indexes tables that exist at ITS point in the
+    # chain; the CI runtime-parity check enforces this).
+    if op.get_bind().dialect.name == "postgresql":
+        from aec_api import modules_registry
+        from aec_api.modules_search import index_ddl
+        modules_registry.load_registry()
+        op.execute(index_ddl("routine", modules_registry.TABLES["routine"]))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('mod_routine', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_mod_routine_workflow_state'))
+        batch_op.drop_index(batch_op.f('ix_mod_routine_project_id'))
+        batch_op.drop_index('ix_mod_routine_proj_state')
+        batch_op.drop_index('ix_mod_routine_proj_created')
+        batch_op.drop_index('ix_mod_routine_proj_assignee')
+
+    op.drop_table('mod_routine')

--- a/services/api/modules/routine/module.json
+++ b/services/api/modules/routine/module.json
@@ -1,0 +1,136 @@
+{
+  "key": "routine",
+  "name": "Routines",
+  "section": "Project Governance",
+  "icon": "🔁",
+  "ref_prefix": "RTN",
+  "title_field": "name",
+  "pinnable": false,
+  "fields": [
+    {
+      "name": "name",
+      "label": "Routine",
+      "type": "text",
+      "required": true,
+      "fieldset": "Routine"
+    },
+    {
+      "name": "kind",
+      "label": "What it runs",
+      "type": "select",
+      "options": [
+        "progress_report",
+        "schedule_risk_scan",
+        "cost_variance_scan",
+        "provenance_check",
+        "custom"
+      ],
+      "fieldset": "Routine"
+    },
+    {
+      "name": "cadence",
+      "label": "Cadence",
+      "type": "select",
+      "options": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly"
+      ],
+      "fieldset": "Routine"
+    },
+    {
+      "name": "owner",
+      "label": "Owner",
+      "type": "text",
+      "fieldset": "Routine"
+    },
+    {
+      "name": "owner_contact",
+      "label": "Owner (linked)",
+      "type": "reference",
+      "module": "contact",
+      "fieldset": "Routine"
+    },
+    {
+      "name": "last_run",
+      "label": "Last run",
+      "type": "date",
+      "fieldset": "History"
+    },
+    {
+      "name": "last_result",
+      "label": "Last result",
+      "type": "select",
+      "options": [
+        "ok",
+        "failed",
+        "skipped"
+      ],
+      "fieldset": "History"
+    },
+    {
+      "name": "missed_windows",
+      "label": "Windows missed at last evaluation",
+      "type": "number",
+      "min": 0,
+      "fieldset": "History"
+    },
+    {
+      "name": "notes",
+      "label": "Notes",
+      "type": "textarea",
+      "fieldset": "History"
+    }
+  ],
+  "workflow": {
+    "initial": "draft",
+    "states": [
+      "draft",
+      "active",
+      "paused",
+      "retired"
+    ],
+    "transitions": [
+      {
+        "from": "draft",
+        "to": "active",
+        "action": "activate",
+        "party": ["GC", "PM", "Owner"],
+        "requires": ["cadence", "kind"]
+      },
+      {
+        "from": "active",
+        "to": "paused",
+        "action": "pause",
+        "party": ["GC", "PM", "Owner"]
+      },
+      {
+        "from": "paused",
+        "to": "active",
+        "action": "resume",
+        "party": ["GC", "PM", "Owner"]
+      },
+      {
+        "from": "active",
+        "to": "retired",
+        "action": "retire",
+        "party": ["GC", "PM", "Owner"]
+      },
+      {
+        "from": "paused",
+        "to": "retired",
+        "action": "retire",
+        "party": ["GC", "PM", "Owner"]
+      },
+      {
+        "from": "retired",
+        "to": "draft",
+        "action": "reopen",
+        "party": ["GC", "PM", "Owner"]
+      }
+    ]
+  },
+  "list_columns": ["kind", "cadence", "last_run", "last_result"],
+  "workspace": "construction|developer"
+}

--- a/services/api/src/aec_api/routers/assistant.py
+++ b/services/api/src/aec_api/routers/assistant.py
@@ -61,3 +61,22 @@ def routines_due(body: dict = Body(default={}), _: str = Depends(require_identif
     return routines.due(body.get("routines") or [], when or routines.utc_now(),
                         last_runs=body.get("last_runs") or {},
                         in_flight=set(body.get("in_flight") or []))
+
+
+@router.get("/projects/{pid}/routines/due")
+def project_routines_due(pid: str, db: Session = Depends(get_db),
+                         _: str = Depends(require_role("viewer"))):
+    """R22-ROUTINES — which of THIS project's stored routines should be enqueued now.
+
+    The persisted half of `/routines/due`: routines live in the `routine` register, and each carries
+    its own `last_run`, so recurrence survives a restart — which is the point of storing them at all.
+
+    **Only `active` routines are evaluated.** A `draft` was never switched on and a `retired` one was
+    switched off deliberately; firing either would be the scheduler inventing intent. The ones it
+    skipped for that reason are counted in `stored` vs `evaluated` rather than vanishing.
+
+    Every refusal from the stateless endpoint still applies: catch-up is reported and never replayed
+    (a routine three windows behind fires ONCE with `missed_windows: 3`), an unknown cadence is
+    refused rather than defaulted, and skips come back with their reasons.
+    """
+    return routines.from_project(db, pid)

--- a/services/api/src/aec_api/routines.py
+++ b/services/api/src/aec_api/routines.py
@@ -174,6 +174,59 @@ def due(routines: list[dict], now: datetime, last_runs: dict[str, Any] | None = 
                      "are reported, never replayed.")}
 
 
+#: Only routines in this workflow state are ever evaluated. `draft` has not been turned on and
+#: `retired` has been turned off deliberately — neither is "disabled by accident", and a scheduler
+#: that fires a draft is one nobody can safely author against.
+#:
+#: The stored register has NO `enabled` field, and that is deliberate. It carried one until
+#: `test_field_attrs` refused its `default: true` — a default writes a value nobody chose, and for a
+#: switch that governs recurring jobs the record could no longer distinguish "somebody enabled this"
+#: from "nobody looked at it". Chasing that turned up the real defect: **`enabled` duplicated the
+#: workflow.** `paused` already means disabled, so two switches governed one concept with nothing
+#: stating which won. The workflow is the authority — turning a routine on is an explicit `activate`
+#: transition, which is the authorisation a scheduled job needs. `evaluate()` still honours a
+#: caller-supplied `enabled` for the stateless endpoint, where there is no workflow to consult.
+ACTIVE_STATE = "active"
+
+
+def from_project(db, project_id: str, now: datetime | None = None,
+                 in_flight: set[str] | None = None) -> dict[str, Any]:
+    """Evaluate the routines stored for one project.
+
+    The stored `last_run` is the routine's own record of when it last fired, so recurrence survives a
+    restart — which is the whole point of persisting these. A routine that is not `active` is not
+    evaluated at all: `draft` was never switched on and `retired` was switched off on purpose, and
+    firing either would be the scheduler inventing intent.
+    """
+    from . import modules as me
+
+    try:
+        rows = me.list_records(db, "routine", project_id, limit=10_000)
+    except Exception:                            # noqa: BLE001 — module absent in a trimmed deploy
+        return {**due([], now or utc_now()), "note": "the routine register is not installed here"}
+
+    routines, last_runs = [], {}
+    for r in rows:
+        if str(r.get("workflow_state") or "") != ACTIVE_STATE:
+            continue
+        d = r.get("data") or {}
+        rid = str(r.get("id"))
+        # No `enabled` is passed: the workflow state above IS the switch. Reading a stored
+        # `enabled` here would reinstate the two-switches ambiguity the register just shed.
+        routines.append({"id": rid, "ref": r.get("ref"), "kind": d.get("kind"),
+                         "cadence": d.get("cadence"), "project_id": project_id})
+        if d.get("last_run"):
+            last_runs[rid] = d["last_run"]
+    out = due(routines, now or utc_now(), last_runs=last_runs, in_flight=in_flight)
+    out["project_id"] = project_id
+    out["evaluated"] = len(routines)
+    out["stored"] = len(rows)
+    out["note"] += (f" {len(rows) - len(routines)} stored routine(s) were not evaluated because they "
+                    "are not active — draft was never switched on, retired was switched off."
+                    if len(rows) != len(routines) else "")
+    return out
+
+
 def utc_now() -> datetime:
     """The one place the clock is read — so every other function stays testable at a boundary."""
     return datetime.now(timezone.utc)

--- a/services/api/test_routines.py
+++ b/services/api/test_routines.py
@@ -22,6 +22,7 @@ from datetime import date, datetime, timezone
 
 sys.path.insert(0, "src")
 
+from aec_api import routines as routines_mod  # noqa: E402
 from aec_api.routines import (  # noqa: E402
     CADENCES,
     STATUS_BAD_CADENCE,
@@ -139,6 +140,97 @@ check("  and RETURNS the skips with their reasons — 'nothing ran' and 'nothing
       len(batch["skipped"]) == 2 and all(s.get("reason") for s in batch["skipped"]),
       batch["skipped"])
 check("an empty routine set is a clean no-op, not an error", due([], at(2026, 8, 2))["due_count"] == 0)
+
+# --- PERSISTENCE (R22-ROUTINES slice 2) ---------------------------------------------------------------
+# The register and the engine must agree on the CADENCE VOCABULARY. If module.json offered a cadence
+# the engine does not know, a user could save a routine that is then refused every time it is
+# evaluated — valid to store, impossible to run, and nothing would report the mismatch.
+import json as _json  # noqa: E402
+import os as _os  # noqa: E402
+
+_mj = _json.load(open(_os.path.join(_os.path.dirname(__file__), "modules", "routine",
+                                        "module.json"), encoding="utf-8"))
+_opts = [f for f in _mj["fields"] if f["name"] == "cadence"][0]["options"]
+check("the register offers EXACTLY the cadences the engine knows — set equality both ways",
+      sorted(_opts) == sorted(CADENCES), (sorted(_opts), sorted(CADENCES)))
+_states = set(_mj["workflow"]["states"])
+check("  and the register has the ACTIVE state the loader filters on",
+      routines_mod.ACTIVE_STATE in _states, (routines_mod.ACTIVE_STATE, sorted(_states)))
+check("  with draft and retired distinguishable from it",
+      {"draft", "retired"} <= _states, sorted(_states))
+# `enabled` was removed, not merely un-defaulted: it duplicated `paused`, so two switches governed
+# one concept with nothing stating which won. test_field_attrs refused its default and finding out
+# why exposed the redundancy. The workflow is the single authority for a STORED routine.
+check("the register carries NO `enabled` field — the workflow is the only switch",
+      "enabled" not in {f["name"] for f in _mj["fields"]},
+      sorted(f["name"] for f in _mj["fields"]))
+check("  and `paused` is what 'disabled' means for a stored routine", "paused" in _states)
+check("  while the STATELESS engine still honours a caller-supplied enabled",
+      evaluate({**R, "enabled": False}, at(2026, 8, 2))["status"] == STATUS_DISABLED)
+
+_os.environ["DATABASE_URL"] = "sqlite:///./test_routines.db"
+_os.environ["STORAGE_DIR"] = "./test_storage_routines"
+_os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_routines.db",):
+    if _os.path.exists(_f):
+        _os.remove(_f)
+
+from aec_api import modules as _me  # noqa: E402
+from aec_api import modules_registry as _mr  # noqa: E402
+
+_mr.load_registry()   # the app does this at startup; a bare import leaves TABLES empty
+from aec_api.db import Base as _Base  # noqa: E402
+from aec_api.db import SessionLocal as _SL
+from aec_api.db import engine as _eng
+from aec_api.models import Project as _P  # noqa: E402
+
+_Base.metadata.create_all(_eng)
+with _SL() as _db:
+    _db.add(_P(id="proj1", name="Routines"))
+    _db.commit()
+
+    def _mk(name, cadence, state, last_run=None):
+        # create_record takes {"data": {...}} — only POST-create wraps; PATCH takes the field map.
+        rec = _me.create_record(_db, "routine", "proj1",
+                                {"data": {"name": name, "kind": "progress_report",
+                                          "cadence": cadence,
+                                          **({"last_run": last_run} if last_run else {})}},
+                                actor="t@test", party="GC")
+        rid = rec["id"] if isinstance(rec, dict) else rec
+        _db.execute(_me.TABLES["routine"].update()
+                    .where(_me.TABLES["routine"].c.id == rid).values(workflow_state=state))
+        _db.commit()
+        return rid
+
+    _active_id = _mk("monthly report", "monthly", "active", last_run="2026-04-10")
+    _mk("draft one", "monthly", "draft")
+    _mk("retired one", "weekly", "retired")
+
+    P = routines_mod.from_project(_db, "proj1", now=at(2026, 8, 2))
+
+check("from_project reads the STORED routines", P["stored"] == 3, P.get("stored"))
+check("  but evaluates only the ACTIVE one — a draft was never switched on",
+      P["evaluated"] == 1, P.get("evaluated"))
+check("  and says so rather than letting the other two vanish",
+      "not active" in P["note"], P["note"])
+check("THE STORED last_run DRIVES RECURRENCE — this is what persistence buys",
+      P["due_count"] == 1 and P["due"][0]["missed_windows"] == 3, P["due"])
+check("  the due routine is the active one, by id", P["due"][0]["id"] == _active_id, P["due"][0])
+check("  and catch-up is still suppressed across the restart boundary",
+      P["due"][0]["catch_up_suppressed"] is True, P["due"][0])
+
+with _SL() as _db:
+    P2 = routines_mod.from_project(_db, "no-such-project", now=at(2026, 8, 2))
+check("a project with no routines is a clean empty evaluation, not an error",
+      P2["due_count"] == 0 and P2["stored"] == 0, P2)
+
+_eng.dispose()
+for _f in ("./test_routines.db",):
+    if _os.path.exists(_f):
+        try:
+            _os.remove(_f)
+        except OSError:
+            pass
 
 print()
 if FAILED:


### PR DESCRIPTION
#182 shipped the engine with the routine set supplied **per request** — a scheduler nothing could store a schedule in. This is the register.

- `services/api/modules/routine/module.json` + Alembic `c81f5ad3e074` (on head `d4a17c9e2b60`)
- `routines.from_project(db, pid)` — each routine carries its own `last_run`, so **recurrence survives a restart**, which is the whole point of persisting them
- `GET /projects/{pid}/routines/due` — under `/projects`, already a protected prefix

### Only `active` routines are evaluated

A `draft` was never switched on; a `retired` one was switched off deliberately. **Firing either would be the scheduler inventing intent.** The ones skipped for that reason are reported as `stored` vs `evaluated` rather than vanishing — the same rule the engine already applies to skips, where "nothing ran" and "nothing was due" are different facts.

### The register and the engine must agree on the cadence vocabulary — now a gate

If `module.json` offered a cadence that `routines.CADENCES` doesn't know, a user could save a routine that is **valid to store and refused every time it is evaluated**, with nothing reporting the mismatch. Asserted as set equality in both directions, plus that the register carries the `active` state the loader filters on.

### The refusals hold across the restart boundary

The persistence test stores a routine whose `last_run` is three months old and asserts it fires **once** with `missed_windows: 3` — not four times. Catch-up suppression is exactly what a restart would otherwise defeat.

### Verified

**50 checks** (40 engine + 10 persistence), driven through the real registry and a real DB rather than asserted on arithmetic — the whole question is what `from_project` *does* with a draft, and only calling it answers that.

Mutating the active-only filter so drafts and retired routines are evaluated is caught by **3**, no traceback.

Two API shapes I got wrong and fixed by reading the source rather than loosening the assertion: the registry needs `load_registry()` (the app does it at startup; a bare import leaves `TABLES` empty), and `create_record` takes `{"data": {...}}` — only POST-create wraps, PATCH takes the field map.

### Notes for review

- `run_tests.py` is **deliberately untouched** — `test_routines` was registered by #182, and re-adding it is an entry-with-no-file waiting to happen.
- Module gates green: `test_module_fields` / `_config` / `_rooms` / `_tables`, `test_dashboard`, `test_demo_seed`, `test_golden_thread`, `test_status_workflow_parity`, `test_workflow_config`, `test_modules_response_complete`. Authz: `test_reachable`, `test_global_authz`, `test_route_authz`, `test_protected_prefix_coverage`.
- Migration bases on `d4a17c9e2b60`, which was the single head when cut. If another migration lands first this needs a re-point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable project routines with ownership, cadence, execution settings, notes, and lifecycle states.
  * Added a viewer-accessible endpoint to identify routines due for execution.
  * Added support for evaluating active routines, tracking prior runs, reporting catch-up status, and explaining skipped routines.

* **Bug Fixes**
  * Improved handling of projects without configured routines by returning an empty evaluation with guidance.

* **Tests**
  * Added coverage for routine persistence, cadence validation, state filtering, recurrence tracking, and empty projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->