### PR TITLE
R22-PROVENANCE slice 2 — the project-scoped verdict, and the legs it cannot gather

### DIFF
--- a/services/api/src/aec_api/provenance_report.py
+++ b/services/api/src/aec_api/provenance_report.py
@@ -36,6 +36,14 @@ STATUS_OK = "cited"
 STATUS_GAPS = "has_uncited"
 STATUS_NO_DATA = "no_data"
 
+#: Distinct from `no_data`, and the distinction is the point. `no_data` means a source exists and is
+#: empty — the user can fix that by filling it in. `not_captured` means **this system has nowhere to
+#: put the evidence**: the `estimate` register's `line_items` columns are code/description/qty/unit/
+#: unit_cost/amount, with no `source`, `quote_ref` or `basis_date`, so a basis-of-estimate ledger can
+#: only ever be built from lines posted in a request body. Reporting that as "no data" would send
+#: somebody looking for a field to fill that does not exist.
+STATUS_NOT_CAPTURED = "not_captured"
+
 VERDICT_ADMISSIBLE = "admissible"
 VERDICT_BLOCKED = "blocked"
 VERDICT_INCOMPLETE = "incomplete"
@@ -93,6 +101,63 @@ def _leg_answers(answers: list[dict] | None) -> dict[str, Any]:
             "counted": len(rows), "uncited_count": len(uncited),
             "uncited": uncited[:MAX_NAMED],
             "note": "agent answers carrying no citation" if uncited else ""}
+
+
+#: What each un-gatherable leg would need before a project-scoped verdict could include it. Named
+#: rather than described, so the follow-up is a schema change somebody can action, not a sentiment.
+NOT_CAPTURED_REASON: dict[str, str] = {
+    "estimate": ("the `estimate` register stores line_items as code/description/qty/unit/unit_cost/"
+                 "amount — it captures no `source`, `quote_ref` or `basis_date` per line, which are "
+                 "exactly the fields a basis-of-estimate ledger checks. `boe_ledger` can therefore "
+                 "only run on lines posted in a request body. Capturing those three columns is what "
+                 "would make this leg gatherable"),
+    "answers": ("agent answers are not persisted at all. `cited_answer` is an in-flight contract "
+                "consumed by decision_gate / persona_answer / rfi_qa; no store keeps the answers or "
+                "their citations after the response is returned. A store of answered claims is what "
+                "would make this leg gatherable"),
+}
+
+
+def from_project(db, project_id: str, scenario_id: str | None = None) -> dict[str, Any]:
+    """The admissibility verdict for a project, from what this system actually persists.
+
+    **Only one of the three legs is gatherable, and saying so precisely is the point.** The
+    assumptions leg comes from the project's own scenarios. The other two report `not_captured` with
+    the schema change each would need — because "you have not filled this in" and "this system has
+    nowhere to put it" send a reader to completely different places, and a verdict that conflates
+    them wastes the time of whoever acts on it.
+
+    Pass `scenario_id` to judge one scenario; otherwise the project's most recent is used, since that
+    is the one an IC memo is written from.
+    """
+    from .models import Scenario
+
+    q = db.query(Scenario).filter(Scenario.project_id == project_id)
+    scen = (q.filter(Scenario.id == scenario_id).first() if scenario_id
+            else q.order_by(Scenario.created_at.desc()).first())
+
+    ap = None
+    if scen is not None:
+        from . import assumption_provenance
+        ap = assumption_provenance.scenario_provenance(scen)
+
+    out = report(ap, None, None)
+    for name in ("estimate", "answers"):
+        lg = next(x for x in out["legs"] if x["leg"] == name)
+        lg["status"] = STATUS_NOT_CAPTURED
+        lg["note"] = NOT_CAPTURED_REASON[name]
+    out["legs_absent"] = [x["leg"] for x in out["legs"] if x["status"] == STATUS_NO_DATA]
+    out["legs_not_captured"] = [x["leg"] for x in out["legs"]
+                                if x["status"] == STATUS_NOT_CAPTURED]
+    out["project_id"] = project_id
+    out["scenario_id"] = getattr(scen, "id", None)
+    out["verdict"] = VERDICT_INCOMPLETE if out["verdict"] == VERDICT_ADMISSIBLE else out["verdict"]
+    out["note"] = (
+        "a project-scoped verdict can never read `admissible` today: two of the three legs are "
+        "NOT_CAPTURED — the system has nowhere to store their evidence — so no project can satisfy "
+        "them. That is a statement about this schema, not about the deal, and it is reported rather "
+        "than hidden by scoring only the leg that happens to work. " + out["note"])
+    return out
 
 
 def report(assumptions_provenance: dict | None = None, estimate_ledger: dict | None = None,

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -14,14 +14,14 @@ from .. import cost as cost_engine
 from .. import modules as me
 from .. import provenance_report, rbac
 from ..db import get_db
-from ..models import Scenario
+from ..models import Project, Scenario
 from ..proforma import entitlement_risk
 from ..proforma import provenance as _provenance
 from ..proforma.draws import reforecast
 from ..proforma.monte_carlo import monte_carlo
 from ..proforma.sensitivity import sensitivity
 from ..proforma.solve import solve
-from ..rbac import current_user, require_identified
+from ..rbac import current_user, require_identified, require_role
 
 router = APIRouter()
 
@@ -42,6 +42,35 @@ def solve_stateless(a: Assumptions):
     result = solve(a.model_dump())
     return {**result, "guardrails": underwrite.guardrails(result),
             "provenance": _provenance.derive(_provenance.declared_from(a), result)}
+
+
+@router.get("/projects/{pid}/provenance/admissibility")
+def project_admissibility(pid: str, scenario_id: str | None = None,
+                          db: Session = Depends(get_db),
+                          _: str = Depends(require_role("viewer"))):
+    """R22-PROVENANCE — the admissibility verdict for a project, from what this system PERSISTS.
+
+    The stateless sibling takes all three legs in a request body. This one gathers them, and the
+    honest answer is that **only one of the three is gatherable**:
+
+    * **assumptions** — real, from the project's own scenarios (most recent unless `scenario_id`);
+    * **estimate** — `not_captured`. The `estimate` register stores line_items as
+      code/description/qty/unit/unit_cost/amount and captures no `source`, `quote_ref` or
+      `basis_date`, which are precisely the fields a basis-of-estimate ledger checks;
+    * **answers** — `not_captured`. Agent answers are never persisted; `cited_answer` is an
+      in-flight contract and no store keeps the claims or citations after the response returns.
+
+    **`not_captured` is deliberately distinct from `no_data`.** "You have not filled this in" and
+    "this system has nowhere to put it" send a reader to completely different places — one fills a
+    field, the other changes a schema — and a verdict that conflates them wastes the time of whoever
+    acts on it. Each un-gatherable leg names the change that would make it gatherable.
+
+    Consequently a project verdict cannot read `admissible` today, and it says so rather than
+    quietly scoring only the leg that happens to work.
+    """
+    if not db.get(Project, pid):
+        raise HTTPException(404, "project not found")
+    return provenance_report.from_project(db, pid, scenario_id)
 
 
 @router.post("/proforma/provenance/admissibility")

--- a/services/api/test_provenance_report.py
+++ b/services/api/test_provenance_report.py
@@ -130,6 +130,71 @@ check("  a partially-cited assumptions leg is has_uncited, not no_data",
                  [{"text": "x", "citations": [{"s": 1}]}]), "assumptions")["status"] == STATUS_GAPS)
 check("nothing supplied at all is INCOMPLETE, not a crash", report()["verdict"] == VERDICT_INCOMPLETE)
 
+# --- PROJECT-SCOPED (slice 2): only ONE leg is gatherable, and saying which is the point -------------
+# `not_captured` must be distinct from `no_data`. "You have not filled this in" and "this system has
+# nowhere to put it" send a reader to different places — one fills a field, the other changes a
+# schema — and a verdict that conflates them wastes the time of whoever acts on it.
+import os as _os  # noqa: E402
+
+_os.environ["DATABASE_URL"] = "sqlite:///./test_provenance_report.db"
+_os.environ["STORAGE_DIR"] = "./test_storage_prov"
+_os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_provenance_report.db",):
+    if _os.path.exists(_f):
+        _os.remove(_f)
+
+from aec_api import provenance_report as _pr  # noqa: E402
+from aec_api.db import Base as _Base, SessionLocal as _SL, engine as _eng  # noqa: E402
+from aec_api.models import Project as _P, Scenario as _S  # noqa: E402
+
+_Base.metadata.create_all(_eng)
+with _SL() as _db:
+    _db.add(_P(id="pp1", name="Prov"))
+    _db.add(_S(id="s1", project_id="pp1", name="Base case",
+               assumptions={"exit": {"exit_cap": 0.055}, "debt": {"ltc": 0.6}}))
+    _db.commit()
+    FP = _pr.from_project(_db, "pp1")
+    EMPTY = _pr.from_project(_db, "no-project")
+
+check("from_project finds the project's scenario", FP["scenario_id"] == "s1", FP.get("scenario_id"))
+check("  the ASSUMPTIONS leg is real — gathered, not supplied",
+      leg(FP, "assumptions")["status"] in (STATUS_OK, STATUS_GAPS), leg(FP, "assumptions"))
+check("THE ESTIMATE LEG IS not_captured, NOT no_data",
+      leg(FP, "estimate")["status"] == _pr.STATUS_NOT_CAPTURED, leg(FP, "estimate")["status"])
+check("  and names the exact columns that would make it gatherable",
+      all(k in leg(FP, "estimate")["note"] for k in ("quote_ref", "basis_date")),
+      leg(FP, "estimate")["note"])
+check("THE ANSWERS LEG IS not_captured — agent answers are never persisted",
+      leg(FP, "answers")["status"] == _pr.STATUS_NOT_CAPTURED, leg(FP, "answers")["status"])
+check("  naming what would make it gatherable", "store of answered claims"
+      in leg(FP, "answers")["note"], leg(FP, "answers")["note"])
+check("the two are LISTED separately from absent legs",
+      FP["legs_not_captured"] == ["estimate", "answers"], FP.get("legs_not_captured"))
+
+check("A PROJECT VERDICT CANNOT READ admissible TODAY — and says why",
+      FP["verdict"] != VERDICT_ADMISSIBLE, FP["verdict"])
+check("  attributing it to the SCHEMA, not to the deal",
+      "statement about this schema, not about the deal" in FP["note"], FP["note"][:120])
+check("  which is the honest alternative to scoring only the leg that works",
+      "hidden by scoring only the leg" in FP["note"])
+
+check("a project with no scenario still answers, rather than erroring",
+      EMPTY["scenario_id"] is None and EMPTY["verdict"] == VERDICT_INCOMPLETE, EMPTY["verdict"])
+check("  its assumptions leg is no_data — a source EXISTS and is empty",
+      leg(EMPTY, "assumptions")["status"] == STATUS_NO_DATA, leg(EMPTY, "assumptions")["status"])
+check("  so no_data and not_captured coexist in one report, meaning different things",
+      {leg(EMPTY, "assumptions")["status"], leg(EMPTY, "estimate")["status"]}
+      == {STATUS_NO_DATA, _pr.STATUS_NOT_CAPTURED},
+      [(x["leg"], x["status"]) for x in EMPTY["legs"]])
+
+_eng.dispose()
+for _f in ("./test_provenance_report.db",):
+    if _os.path.exists(_f):
+        try:
+            _os.remove(_f)
+        except OSError:
+            pass
+
 print()
 if FAILED:
     print(f"provenance_report: {len(FAILED)} FAILED — {FAILED}")


### PR DESCRIPTION
#183 took all three provenance legs in a request body. This gathers them from what the system actually persists — and the premise-check found that **only one of the three is gatherable.** That's the finding, not an obstacle to it.

| leg | persistent source | gatherable |
|---|---|---|
| **assumptions** | `Scenario.assumptions` | ✅ real |
| **estimate** | register exists — `line_items` is `code/description/qty/unit/unit_cost/amount`, capturing **no** `source` / `quote_ref` / `basis_date` | ❌ `not_captured` |
| **answers** | none — `cited_answer` is in-flight only, nothing keeps claims or citations after the response | ❌ `not_captured` |

That's *why* `boe_ledger` only ever runs on posted lines: the fields it checks for are captured nowhere.

### `not_captured` is a new status, and the distinction is the point

**#183 collapsed "you supplied nothing" and "this system cannot store that" into one `no_data`.** They send a reader to completely different places — one fills in a field, the other changes a schema — and a verdict that conflates them wastes the time of whoever acts on it.

Each un-gatherable leg now **names the change that would make it gatherable**, so the follow-up is actionable rather than a sentiment:

- *estimate* → capture `source`, `quote_ref`, `basis_date` per line item
- *answers* → a store of answered claims

### A project verdict cannot read `admissible` today — and says so

Two of three legs are `not_captured`, so no project can satisfy them. The report attributes that to **the schema, not the deal**.

The alternative — scoring only the leg that happens to work — is the same failure as a blended score, one level up: it would report a clean bill of health for a deal whose estimate and answers were never checkable.

### Verified

**41 checks**, driven against a real DB. Collapsing `not_captured` back into `no_data` is caught by **4**, no traceback.

A project with **no scenario** reports `no_data` for assumptions while the other two stay `not_captured` — the two statuses coexisting in one report, meaning different things, is asserted directly.

Route: `GET /projects/{pid}/provenance/admissibility` (optional `scenario_id`; defaults to most recent, since that's what an IC memo is written from). Under `/projects`, already a protected prefix. `test_reachable`, `test_global_authz`, `test_route_authz`, `test_protected_prefix_coverage` and `test_proforma` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-scoped provenance reports for a selected or latest scenario.
  * Added viewer-authorized access to project provenance admissibility results.
  * Reports now distinguish unavailable evidence capture from empty data and include actionable explanations.
  * Reports identify missing or uncaptured evidence and include project and scenario details.

* **Bug Fixes**
  * Projects with unavailable required evidence are no longer incorrectly marked admissible.
  * Projects without scenarios now return an incomplete, no-data report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->