### PR TITLE
R22-ENTITLEMENT ① — conditions of approval as tracked items, never as satisfied

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -47,7 +47,7 @@ TESTS = ["test_provenance_report", "test_proforma", "test_renovation", "test_rol
          # R22-NOTICE-CLOCK — contractual notice periods + the register routes:
          "test_notice_clock", "test_notices_route",
          # Tier-2/3 competitive upgrades:
-         "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
+         "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approval_conditions", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
          "test_ids_authoring", "test_procurement", "test_conceptual", "test_parcels", "test_net",
          "test_design_phase", "test_family_library", "test_change_instruments", "test_turnover",
          "test_prod_hardening", "test_diligence", "test_deal_funnel", "test_deal_memory", "test_operations", "test_reserves_cam", "test_esg",

--- a/services/api/src/aec_api/approval_conditions.py
+++ b/services/api/src/aec_api/approval_conditions.py
@@ -1,0 +1,198 @@
+"""R22-ENTITLEMENT ① — conditions of approval as tracked items, not a paragraph.
+
+Premise-checked, and three of the ring entry's four clauses were already built: jurisdiction
+submittal packages (`jurisdiction_packs.validate`), review cycles (the `entitlement` register's
+draft→submitted→hearing→approved/denied/appealed workflow, plus `permit_timeline`), and comment
+responses (`submittals.py`). The entry's claim that "nothing spans approval" is stale.
+
+The fourth clause — **conditions of approval carried into the model as constraints** — is genuinely
+missing, and it starts one step earlier than the entry assumes. `entitlement.conditions` is a single
+**textarea**. An approval carrying fourteen conditions is one paragraph, so nobody can say which have
+been discharged, and no constraint can be derived from prose nobody has separated.
+
+This splits that paragraph into individually tracked conditions. It does **not** claim to check them
+against the model — that is the next slice, and claiming it here would be the overreach the whole
+ring is meant to prevent.
+
+Three refusals, and the first is the one that matters:
+
+1. **a condition this cannot interpret is `unparsed`, never satisfied.** An approval condition
+   silently treated as met is a building constructed out of compliance while the report said it was
+   fine. Nothing here marks anything satisfied on its own — discharge is a human act, recorded;
+2. **an extracted quantity carries the sentence it came from.** Parsing an agency's prose is
+   extraction, not authority: a reading of "45" that came from "45 dwelling units" and got filed as
+   a height limit would become a silent constraint nobody chose. Every quantity is reported beside
+   its source text so a human can check the reading;
+3. **an approved entitlement with an EMPTY conditions field is `unrecorded`, not unconditioned.**
+   Approvals almost always carry conditions; a blank field far more often means nobody typed them
+   than that the agency imposed none. Same distinction as `no_data` vs `not_captured` in
+   `provenance_report` — absence of evidence, reported as absence of evidence.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+STATUS_OPEN = "open"
+STATUS_DISCHARGED = "discharged"
+STATUS_UNPARSED = "unparsed"
+
+#: An entitlement that reached a terminal approval but records no conditions text.
+STATUS_UNRECORDED = "unrecorded"
+
+#: Approval states in the `entitlement` register that mean conditions should exist.
+APPROVED_STATES = ("approved",)
+
+#: Leading enumerators an agency uses: "1.", "1)", "(1)", "a.", "Condition 3:", "•", "-".
+_ENUM = re.compile(
+    r"^\s*(?:\(?\d{1,3}[.)]|\(?[a-z][.)]|condition\s+\d{1,3}\s*[:.]?|[•\-–—])\s+",
+    re.I)
+
+#: Quantities worth surfacing, with the unit kept as written. Deliberately narrow: a pattern that
+#: matches everything produces confident readings of sentences it did not understand.
+_QTY = re.compile(
+    r"(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ft|feet|foot|m|metres|meters|stor(?:e|ie)ys?|stories|"
+    r"spaces?|units?|percent|%)\b", re.I)
+
+_KEYWORDS = {
+    "height": ("height", "storey", "story", "stories", "storeys"),
+    "setback": ("setback", "set-back", "yard"),
+    "parking": ("parking", "stall", "space"),
+    "landscape": ("landscap", "tree", "planting", "buffer"),
+    "traffic": ("traffic", "trip", "access", "driveway"),
+    "affordable": ("affordable", "inclusionary", "workforce"),
+    "fee": ("fee", "contribution", "exaction", "in-lieu"),
+    "utility": ("sewer", "water", "storm", "utility", "drainage"),
+}
+
+
+def _topic(text: str) -> str | None:
+    """Topic by WHOLE-WORD match, not substring.
+
+    Substring matching tagged "a landscape buffer shall be in-STALL-ed" as *parking*, because
+    "stall" sits inside "installed". A keyword list matched loosely does not mis-tag rarely — it
+    mis-tags exactly the conditions whose wording is most ordinary.
+    """
+    low = text.lower()
+    for topic, words in _KEYWORDS.items():
+        if any(re.search(r"\b" + re.escape(w), low) for w in words):
+            return topic
+    return None
+
+
+def split_conditions(text: str) -> list[str]:
+    """Split an agency's conditions blob into individual conditions.
+
+    Enumerated lines win; failing any enumerator, blank-line-separated paragraphs are used. A blob
+    with neither is returned as ONE condition rather than guessed at by sentence — splitting prose on
+    full stops turns a single condition containing "Fig. 3" into two, and a condition that was
+    invented is worse than one that stayed long.
+    """
+    raw = (text or "").replace("\r\n", "\n").strip()
+    if not raw:
+        return []
+    lines = raw.split("\n")
+    if any(_ENUM.match(ln) for ln in lines):
+        out, cur = [], ""
+        for ln in lines:
+            if _ENUM.match(ln):
+                if cur.strip():
+                    out.append(cur.strip())
+                cur = _ENUM.sub("", ln)
+            else:
+                cur += " " + ln.strip()
+        if cur.strip():
+            out.append(cur.strip())
+        return [c for c in (s.strip() for s in out) if c]
+    paras = [p.strip() for p in re.split(r"\n\s*\n", raw) if p.strip()]
+    return paras or [raw]
+
+
+def parse(text: str) -> list[dict[str, Any]]:
+    """Conditions as tracked items, each carrying the sentence it came from."""
+    out: list[dict[str, Any]] = []
+    for i, body in enumerate(split_conditions(text), start=1):
+        quantities = [{"value": float(m.group("value")), "unit": m.group("unit").lower(),
+                       "source_text": body[max(0, m.start() - 60):m.end() + 20].strip()}
+                      for m in _QTY.finditer(body)]
+        topic = _topic(body)
+        out.append({
+            "seq": i, "text": body, "topic": topic, "quantities": quantities,
+            # Nothing is ever `discharged` by this function. Discharge is a human act; see refusal 1.
+            "status": STATUS_OPEN if topic or quantities else STATUS_UNPARSED,
+            "note": ("" if (topic or quantities) else
+                     "no topic or quantity could be read from this condition — it is tracked as "
+                     "UNPARSED and must be reviewed by a person. It is NOT satisfied, and nothing "
+                     "here will mark it so"),
+        })
+    return out
+
+
+def assess(entitlement: dict[str, Any], discharged_seqs: set[int] | None = None) -> dict[str, Any]:
+    """Condition tracking for one `entitlement` record.
+
+    `discharged_seqs` is what a person has signed off. Nothing is discharged automatically — a
+    condition marked met by a parser is a compliance claim nobody made.
+    """
+    discharged = discharged_seqs or set()
+    state = str(entitlement.get("workflow_state") or "")
+    data = entitlement.get("data") or {}
+    text = data.get("conditions") or ""
+    items = parse(text)
+    for it in items:
+        if it["seq"] in discharged and it["status"] != STATUS_UNPARSED:
+            it["status"] = STATUS_DISCHARGED
+
+    approved = state in APPROVED_STATES
+    if approved and not items:
+        return {"entitlement_id": entitlement.get("id"), "ref": entitlement.get("ref"),
+                "workflow_state": state, "status": STATUS_UNRECORDED,
+                "conditions": [], "counts": {}, "open_count": 0, "unparsed_count": 0,
+                "note": ("this entitlement is APPROVED and records no conditions text. Approvals "
+                         "almost always carry conditions, so a blank field far more often means "
+                         "nobody typed them than that the agency imposed none. Reported as "
+                         "unrecorded — absence of evidence, not evidence of absence")}
+
+    counts: dict[str, int] = {}
+    for it in items:
+        counts[it["status"]] = counts.get(it["status"], 0) + 1
+    unparsed = counts.get(STATUS_UNPARSED, 0)
+    return {
+        "entitlement_id": entitlement.get("id"), "ref": entitlement.get("ref"),
+        "workflow_state": state, "status": "tracked" if items else "no_conditions",
+        "conditions": items, "counts": counts,
+        "open_count": counts.get(STATUS_OPEN, 0),
+        "unparsed_count": unparsed,
+        "discharged_count": counts.get(STATUS_DISCHARGED, 0),
+        "fully_discharged": bool(items) and counts.get(STATUS_DISCHARGED, 0) == len(items),
+        "note": (f"{unparsed} condition(s) could not be read and are tracked as UNPARSED. They are "
+                 "NOT satisfied — an approval condition silently treated as met is a building put "
+                 "up out of compliance while the report said it was fine."
+                 if unparsed else
+                 ("every condition is discharged" if items and counts.get(STATUS_DISCHARGED) == len(items)
+                  else "conditions are tracked; discharge is recorded by a person, never inferred")),
+    }
+
+
+def for_project(db, project_id: str) -> dict[str, Any]:
+    """Condition tracking across a project's entitlements."""
+    from . import modules as me
+
+    try:
+        rows = me.list_records(db, "entitlement", project_id, limit=10_000)
+    except Exception:                            # noqa: BLE001 — register absent in a trimmed deploy
+        return {"project_id": project_id, "entitlements": [], "unrecorded": [],
+                "note": "the entitlement register is not installed here"}
+    out = [assess(r) for r in rows]
+    return {
+        "project_id": project_id,
+        "entitlements": out,
+        "entitlement_count": len(out),
+        "unrecorded": [x["ref"] or x["entitlement_id"] for x in out
+                       if x["status"] == STATUS_UNRECORDED],
+        "total_open": sum(x.get("open_count") or 0 for x in out),
+        "total_unparsed": sum(x.get("unparsed_count") or 0 for x in out),
+        "note": ("conditions are tracked, never auto-satisfied. An UNPARSED condition is one nobody "
+                 "has read yet, and an APPROVED entitlement with no conditions recorded is reported "
+                 "as unrecorded rather than as clean."),
+    }

--- a/services/api/src/aec_api/routers/design.py
+++ b/services/api/src/aec_api/routers/design.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
-from .. import adjacency, design_phase, resilience, soft_costs, spine
+from .. import adjacency, approval_conditions, design_phase, resilience, soft_costs, spine
 from .. import modules as me
 from ..db import get_db
 from ..models import Project
@@ -516,3 +516,28 @@ def diligence_readiness(pid: str, db: Session = Depends(get_db), _: str = Depend
         "go": bool(dd_total and dd_cleared == dd_total and not high_risk
                    and not ents_pending and not ent_counts.get("denied")),
     }
+
+
+@router.get("/projects/{pid}/entitlements/conditions")
+def entitlement_conditions(pid: str, db: Session = Depends(get_db),
+                           _: str = Depends(require_role("viewer"))):
+    """R22-ENTITLEMENT — an approval's conditions as tracked items rather than one paragraph.
+
+    `entitlement.conditions` is a single textarea, so an approval carrying fourteen conditions is one
+    blob and nobody can say which have been discharged. This splits it, tags each condition by topic,
+    and extracts quantities **beside the sentence they came from** — parsing an agency's prose is
+    extraction, not authority, and a reading a human cannot check is a constraint nobody chose.
+
+    **Nothing here is ever marked satisfied.** A condition whose topic and quantity cannot be read is
+    `unparsed`, and an approval condition silently treated as met is a building put up out of
+    compliance while the report said it was fine. Discharge is a human act, recorded — and an
+    `unparsed` condition cannot be discharged at all, because signing off text nobody read is the
+    same failure wearing a signature.
+
+    An **approved** entitlement with an empty conditions field reports `unrecorded`, not
+    unconditioned: approvals almost always carry conditions, so a blank field far more often means
+    nobody typed them than that the agency imposed none.
+    """
+    if not db.get(Project, pid):
+        raise HTTPException(404, "project not found")
+    return approval_conditions.for_project(db, pid)

--- a/services/api/test_approval_conditions.py
+++ b/services/api/test_approval_conditions.py
@@ -1,0 +1,143 @@
+"""R22-ENTITLEMENT ① — conditions of approval as tracked items, and the one it must never satisfy.
+
+Premise-check first: three of the ring entry's four clauses were already built — jurisdiction packs
+(`jurisdiction_packs.validate`), review cycles (the `entitlement` register's own workflow plus
+`permit_timeline`), and comment responses (`submittals.py`). The entry's "nothing spans approval" is
+stale. The fourth clause, conditions carried into the model as constraints, is real — and starts
+earlier than the entry assumes, because `entitlement.conditions` is a single **textarea**.
+
+The assertions:
+
+1. **an uninterpretable condition is UNPARSED, never satisfied.** An approval condition silently
+   treated as met is a building constructed out of compliance while the report said it was fine.
+   Nothing here marks anything discharged on its own;
+2. **an extracted quantity carries its source sentence** — parsing an agency's prose is extraction,
+   not authority, and a "45" read out of "45 dwelling units" must be checkable by a human;
+3. **an APPROVED entitlement with an empty conditions field is `unrecorded`, not unconditioned** —
+   absence of evidence reported as absence of evidence;
+4. **the twin**: splitting must actually split. A tracker that returns one blob has done nothing.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_approval_conditions.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api.approval_conditions import (  # noqa: E402
+    STATUS_DISCHARGED,
+    STATUS_UNPARSED,
+    STATUS_UNRECORDED,
+    assess,
+    parse,
+    split_conditions,
+)
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+NUMBERED = """1. Maximum building height shall not exceed 45 feet.
+2. Provide a minimum front setback of 20 ft.
+3) Applicant shall provide 1.5 parking spaces per unit.
+(4) A landscape buffer of 10 feet shall be installed along the north property line.
+5. Applicant shall comply with all applicable requirements of the City Engineer."""
+
+# --- 4. THE TWIN: SPLITTING MUST ACTUALLY SPLIT --------------------------------------------------------
+parts = split_conditions(NUMBERED)
+check("an enumerated blob splits into its conditions", len(parts) == 5, len(parts))
+check("  and the enumerator is stripped, leaving the condition text",
+      parts[0].startswith("Maximum building height"), parts[0])
+check("  mixed enumerator styles (1. / 3) / (4)) all split",
+      parts[2].startswith("Applicant shall provide") and parts[3].startswith("A landscape buffer"),
+      parts[2:4])
+check("blank-line paragraphs split when there are no enumerators",
+      len(split_conditions("First condition here.\n\nSecond condition here.")) == 2)
+check("a single unenumerated blob stays ONE condition, not guessed apart by sentence",
+      len(split_conditions("Applicant shall comply with Fig. 3 of the plan set. No exceptions.")) == 1,
+      split_conditions("Applicant shall comply with Fig. 3 of the plan set. No exceptions."))
+check("empty text yields no conditions at all", split_conditions("") == [])
+
+# --- 2. QUANTITIES CARRY THEIR SOURCE ------------------------------------------------------------------
+items = parse(NUMBERED)
+h = items[0]
+check("a height quantity is extracted", h["quantities"][0]["value"] == 45.0, h["quantities"])
+check("  with the unit as written", h["quantities"][0]["unit"] == "feet", h["quantities"][0])
+check("  and the SOURCE TEXT it came from, so a person can check the reading",
+      "height" in h["quantities"][0]["source_text"], h["quantities"][0]["source_text"])
+check("  the condition is topic-tagged", h["topic"] == "height", h["topic"])
+check("a parking condition is tagged parking", items[2]["topic"] == "parking", items[2]["topic"])
+check("a landscape condition is tagged landscape", items[3]["topic"] == "landscape", items[3]["topic"])
+# Extraction requires the number and unit to be ADJACENT. "45 dwelling units" yields nothing, and
+# that is the correct answer: the alternative is associating a number with a unit a word or more
+# away, which is precisely how "45" from "45 dwelling units" becomes a height limit nobody imposed.
+# A missed quantity is tracked as an unparsed condition a person reads; an invented one is a
+# constraint nobody chose.
+_far = parse("Project limited to 45 dwelling units.")[0]
+check("a number NOT adjacent to its unit is not extracted — conservative on purpose",
+      _far["quantities"] == [], _far["quantities"])
+check("  and the condition is therefore tracked as UNPARSED for a person to read",
+      _far["status"] == STATUS_UNPARSED, _far["status"])
+check("  while an ADJACENT quantity IS extracted with its unit as written",
+      parse("Limited to 45 units.")[0]["quantities"][0]["unit"] == "units",
+      parse("Limited to 45 units.")[0]["quantities"])
+check("  a landscape condition containing 'installed' is NOT tagged parking (stall/installed)",
+      parse("A landscape buffer shall be installed.")[0]["topic"] == "landscape",
+      parse("A landscape buffer shall be installed.")[0]["topic"])
+
+# --- 1. NOTHING IS EVER SATISFIED BY THIS CODE ---------------------------------------------------------
+check("NO condition is discharged by parsing — discharge is a human act",
+      all(i["status"] != STATUS_DISCHARGED for i in items),
+      [i["status"] for i in items])
+vague = parse("Applicant shall satisfy the Director prior to issuance.")[0]
+check("a condition with no topic and no quantity is UNPARSED",
+      vague["status"] == STATUS_UNPARSED, vague)
+check("  and explicitly NOT satisfied", vague["status"] != STATUS_DISCHARGED)
+check("  with a note saying a person must read it",
+      "must be reviewed by a person" in vague["note"], vague["note"])
+
+ENT = {"id": "e1", "ref": "ENT-001", "workflow_state": "approved", "data": {"conditions": NUMBERED}}
+a = assess(ENT)
+check("assess tracks every condition", len(a["conditions"]) == 5, len(a["conditions"]))
+check("  the vague one is counted as unparsed", a["unparsed_count"] == 1, a["counts"])
+check("  and the report says an unread condition is not a met one",
+      "out of compliance" in a["note"], a["note"])
+check("  nothing is fully discharged out of the box", a["fully_discharged"] is False)
+
+d = assess(ENT, discharged_seqs={1, 2, 3, 4})
+check("a person CAN discharge a parsed condition — the twin of the refusal",
+      d["discharged_count"] == 4, d["counts"])
+check("  but an UNPARSED condition cannot be discharged even when named",
+      assess(ENT, discharged_seqs={1, 2, 3, 4, 5})["counts"].get(STATUS_UNPARSED) == 1,
+      assess(ENT, discharged_seqs={1, 2, 3, 4, 5})["counts"])
+check("  so an approval with an unreadable condition is never fully discharged",
+      assess(ENT, discharged_seqs={1, 2, 3, 4, 5})["fully_discharged"] is False)
+
+allp = {"id": "e2", "ref": "ENT-002", "workflow_state": "approved",
+        "data": {"conditions": "1. Maximum height 30 ft.\n2. Provide 10 parking spaces."}}
+check("an approval whose every condition IS discharged reports fully_discharged",
+      assess(allp, discharged_seqs={1, 2})["fully_discharged"] is True,
+      assess(allp, discharged_seqs={1, 2}))
+
+# --- 3. APPROVED WITH NO CONDITIONS RECORDED IS `unrecorded`, NOT CLEAN ---------------------------------
+blank = assess({"id": "e3", "ref": "ENT-003", "workflow_state": "approved",
+                "data": {"conditions": ""}})
+check("an APPROVED entitlement with no conditions text is UNRECORDED",
+      blank["status"] == STATUS_UNRECORDED, blank["status"])
+check("  and says a blank field usually means nobody typed them",
+      "nobody typed them" in blank["note"], blank["note"])
+check("  it is NOT reported as having no conditions",
+      blank["status"] != "no_conditions", blank["status"])
+draft = assess({"id": "e4", "workflow_state": "draft", "data": {"conditions": ""}})
+check("a DRAFT with no conditions is not flagged — nothing has been imposed yet",
+      draft["status"] == "no_conditions", draft["status"])
+
+print()
+if FAILED:
+    print(f"approval_conditions: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("approval_conditions: all checks passed")


### PR DESCRIPTION
### The premise-check found the entry substantially stale

The roadmap says *"today there is a hole between acquisition and construction… nothing spans approval."* That's no longer true — there are **four registers and five engines** in that space, and three of the entry's four clauses are built:

| clause | state |
|---|---|
| jurisdiction submittal packages | `jurisdiction_packs.validate()` ✅ |
| review cycles | `entitlement` workflow (draft→submitted→hearing→approved/denied/appealed) + `permit_timeline` ✅ |
| comment responses | `submittals.py` ✅ |
| **conditions of approval carried into the model as constraints** | **missing** ❌ |

*(The ⚠️ name-collision warning is also richer than documented: `entitlements.py` is subscription tiers, `entitlement_risk.py` scores risk, and there is also an `entitlement` **register** that is the real land-use one.)*

### The gap starts a step earlier than the entry assumes

`entitlement.conditions` is a single **textarea**. An approval carrying fourteen conditions is one paragraph — nobody can say which have been discharged, and no constraint can be derived from prose nobody has separated.

This splits it into tracked conditions. It does **not** check them against the model; that's the next slice, and claiming it here would be the overreach this ring exists to prevent.

### Three refusals

- **An uninterpretable condition is `unparsed`, never satisfied** — and an `unparsed` condition **cannot be discharged even when a caller names it**. Signing off text nobody read is the same failure wearing a signature. A condition silently treated as met is a building put up out of compliance while the report said it was fine.
- **An extracted quantity carries the sentence it came from.** Extraction requires number and unit to be **adjacent**, so `"45 dwelling units"` yields *nothing* rather than a `45` that could be filed as a height limit. A missed quantity becomes a condition a person reads; an invented one becomes a constraint nobody chose.
- **An APPROVED entitlement with an empty conditions field is `unrecorded`, not unconditioned** — same distinction as `no_data` vs `not_captured` in `provenance_report`.

Splitting honours enumerators (`1.` / `2)` / `(3)` / bullets) and falls back to paragraphs. A blob with neither stays **one** condition rather than being cut on full stops — which would split a condition containing "Fig. 3" in two.

### Verified

**32 checks.** Letting an `unparsed` condition be discharged is caught by **2**, no traceback.

Two defects my own tests caught:

1. **Topic matching was substring-based** — `"shall be inSTALLed"` tagged a *landscape* condition as **parking**. Whole-word matching now. A loose keyword list doesn't mis-tag rarely; it mis-tags exactly the conditions whose wording is most ordinary.
2. A heredoc turned `\b` into a **literal 0x08 byte** in the source. It read as correct in plain output and only showed under `cat -A`.

Route: `GET /projects/{pid}/entitlements/conditions`, under the already-protected `/projects` prefix. `test_reachable`, `test_global_authz`, `test_route_authz`, `test_protected_prefix_coverage` green; ruff clean over `src/` and `../data/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval-condition tracking for entitlements, including condition status, topics, quantities, and source text.
  * Added support for recording human-confirmed condition discharges.
  * Added project-level entitlement condition reporting through a new API endpoint.
  * Reports open, unparsed, discharged, and unrecorded conditions.

* **Tests**
  * Added coverage for condition parsing, assessment, discharge handling, and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->