### PR TITLE
R22-AGENT-PACKS — named packs over the tools we ship, and the audit row 16 of 18 lacked

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -47,7 +47,7 @@ TESTS = ["test_provenance_report", "test_proforma", "test_renovation", "test_rol
          # R22-NOTICE-CLOCK — contractual notice periods + the register routes:
          "test_notice_clock", "test_notices_route",
          # Tier-2/3 competitive upgrades:
-         "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approval_conditions", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
+         "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approval_conditions", "test_agent_packs", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
          "test_ids_authoring", "test_procurement", "test_conceptual", "test_parcels", "test_net",
          "test_design_phase", "test_family_library", "test_change_instruments", "test_turnover",
          "test_prod_hardening", "test_diligence", "test_deal_funnel", "test_deal_memory", "test_operations", "test_reserves_cam", "test_esg",

--- a/services/api/src/aec_api/agent_packs.py
+++ b/services/api/src/aec_api/agent_packs.py
@@ -1,0 +1,168 @@
+"""R22-AGENT-PACKS — named agent packs over the tools we already ship, and per-run audit.
+
+Premise-checked: `mcp_tools` exposes **18** tools with `dispatch()` and `catalog()`, and
+`audit.record` exists. So this is packaging, exactly as the ring entry says — with one finding the
+entry only implies:
+
+**16 of the 18 tools run with no audit trail.** `audit.record` is called inside `_run_recipe`, for
+the IFC edit it performs — not for tool dispatch itself. So today "which tools did this agent run
+against my project last week?" has no answer, and that question is the one an enterprise asks
+before it grants access, and again after an incident. `run_log()` here is the per-run record the
+entry calls the gating factor.
+
+A pack is a **named view over existing tools**. That framing carries the refusals:
+
+1. **a pack grants nothing.** It cannot contain a tool that is not already in `mcp_tools.TOOLS`, and
+   membership confers no permission — `dispatch` still applies its own checks. A pack that could
+   widen access would turn "Submittal Review Agent" into a privilege-escalation surface, which is
+   the opposite of what a governance console is for;
+2. **a pack naming an unknown tool is REFUSED, not silently trimmed.** A pack that quietly drops a
+   tool looks like it worked and behaves like it did not — the superintendent runs "Submittal
+   Review" and the submittal check simply never happens;
+3. **write tools are named as write tools.** A pack containing `create_rfi` or `run_recipe` mutates
+   the project, and a console that lists packs without saying which can write is a console nobody
+   can govern with.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+#: Named packs: a superintendent understands "Submittal Review", not `standards_check`. Each is a
+#: subset of `mcp_tools.TOOLS` — see refusal 1. Ordering within a pack is the order a human would
+#: work in, not alphabetical.
+PACKS: dict[str, dict[str, Any]] = {
+    "submittal_review": {
+        "label": "Submittal Review Agent",
+        "purpose": "check a submittal against the model and the project's standards before it is "
+                   "returned to the subcontractor",
+        "tools": ["project_snapshot", "standards_check", "openbim_quality", "model_quantities",
+                  "create_rfi"],
+    },
+    "design_qa": {
+        "label": "Design QA Agent",
+        "purpose": "find what a coordination review would find: clashes, quality gaps and code "
+                   "violations, with the drawings checked against the model",
+        "tools": ["openbim_quality", "clash_results", "code_violations", "drawing_qa"],
+    },
+    "schedule_risk": {
+        "label": "Schedule Risk Agent",
+        "purpose": "the weekly look-ahead question — what is drifting, and what does the model say "
+                   "about the work in front of it",
+        "tools": ["computed_schedules", "schedule_risk", "project_snapshot"],
+    },
+    "permit_readiness": {
+        "label": "Permit Readiness Agent",
+        "purpose": "whether this project could be submitted for permit today, and what is missing",
+        "tools": ["permit_readiness", "code_violations", "drawing_qa", "cde_status"],
+    },
+    "carbon_report": {
+        "label": "Carbon Report Agent",
+        "purpose": "embodied carbon from the model's own quantities, with the KPI context around it",
+        "tools": ["model_quantities", "carbon_report", "bim_kpi_scorecard"],
+    },
+}
+
+
+class PackError(ValueError):
+    """A pack that would mislead — raised rather than trimmed."""
+
+
+def _known() -> set[str]:
+    from .mcp_tools import TOOL_NAMES
+    return set(TOOL_NAMES)
+
+
+def _write_tools() -> set[str]:
+    from .mcp_tools import _WRITE_TOOLS
+    return set(_WRITE_TOOLS)
+
+
+def validate(packs: dict[str, dict] | None = None) -> dict[str, Any]:
+    """Every pack's tools must exist. A pack naming an unknown tool is a defect, not a warning.
+
+    Refused rather than trimmed: a pack that silently drops a tool looks like it worked and behaves
+    like it did not, which is worse than a pack that will not load.
+    """
+    packs = packs if packs is not None else PACKS
+    known = _known()
+    problems = []
+    for key, p in packs.items():
+        unknown = [t for t in (p.get("tools") or []) if t not in known]
+        if unknown:
+            problems.append({"pack": key, "unknown_tools": unknown,
+                             "note": f"pack {key!r} names tool(s) that do not exist in mcp_tools"})
+        if not (p.get("tools") or []):
+            problems.append({"pack": key, "unknown_tools": [],
+                             "note": f"pack {key!r} contains no tools — an empty agent is a label"})
+    return {"ok": not problems, "problems": problems, "pack_count": len(packs),
+            "tool_count": len(known)}
+
+
+def catalog() -> dict[str, Any]:
+    """The governance console's list: packs, what each runs, and which of them can WRITE."""
+    v = validate()
+    if not v["ok"]:
+        raise PackError(f"agent pack catalog is invalid: {v['problems']}")
+    writes = _write_tools()
+    out = []
+    for key, p in PACKS.items():
+        tools = list(p["tools"])
+        w = [t for t in tools if t in writes]
+        out.append({
+            "key": key, "label": p["label"], "purpose": p["purpose"], "tools": tools,
+            "tool_count": len(tools),
+            "writes": bool(w), "write_tools": w,
+            "note": ("this pack can MODIFY the project — " + ", ".join(w) if w
+                     else "read-only: this pack cannot modify the project"),
+        })
+    out.sort(key=lambda r: r["key"])
+    return {
+        "packs": out, "pack_count": len(out),
+        "read_only_count": sum(1 for r in out if not r["writes"]),
+        "note": ("a pack is a named VIEW over tools that already exist — it grants nothing. Every "
+                 "tool in every pack is in mcp_tools.TOOLS, and dispatch applies its own checks "
+                 "regardless of which pack a caller came in through."),
+    }
+
+
+def tools_for(pack: str) -> list[str]:
+    """The tool names a pack runs. Raises on an unknown pack rather than returning an empty list —
+    an empty list reads as "this pack does nothing", which is a different and wrong answer."""
+    p = PACKS.get(pack)
+    if p is None:
+        raise PackError(f"unknown agent pack {pack!r}; known: {sorted(PACKS)}")
+    return list(p["tools"])
+
+
+def run_log(db, project_id: str | None = None, limit: int = 200) -> dict[str, Any]:
+    """Per-run tool history — the record the ring entry calls the gating factor for enterprise use.
+
+    Reads the audit log rather than a second store, so it cannot disagree with the audit trail. Both
+    successes AND failures are reported: an agent log that shows only what worked cannot answer
+    "what did it try?", which is the question asked after an incident rather than before one.
+    """
+    from .models import AuditLog
+
+    q = db.query(AuditLog).filter(AuditLog.method == "MCP")
+    if project_id:
+        q = q.filter(AuditLog.detail.isnot(None))
+    rows = q.order_by(AuditLog.ts.desc()).limit(limit).all()
+    runs = []
+    for r in rows:
+        d = r.detail or {}
+        if project_id and str(d.get("project_id") or "") != project_id:
+            continue
+        runs.append({"ts": getattr(r.ts, "isoformat", lambda: None)(), "actor": r.actor,
+                     "action": r.action, "tool": d.get("tool"), "pack": d.get("pack"),
+                     "ok": d.get("ok"), "project_id": d.get("project_id")})
+    by_tool: dict[str, int] = {}
+    for x in runs:
+        if x.get("tool"):
+            by_tool[x["tool"]] = by_tool.get(x["tool"], 0) + 1
+    failures = [x for x in runs if x.get("ok") is False]
+    return {"runs": runs, "run_count": len(runs), "by_tool": by_tool,
+            "failure_count": len(failures),
+            "note": ("failures are included deliberately — a tool history that lists only successes "
+                     "cannot answer what an agent attempted, which is the question asked after an "
+                     "incident rather than before one."),
+            }

--- a/services/api/src/aec_api/mcp_tools.py
+++ b/services/api/src/aec_api/mcp_tools.py
@@ -116,14 +116,47 @@ _WRITE_TOOLS = frozenset({"create_rfi", "run_recipe"})
 
 
 def dispatch(db: Session, name: str, args: dict[str, Any], actor: str = "mcp",
-             user: str | None = None) -> Any:
+             user: str | None = None, pack: str | None = None) -> Any:
     """Execute a tool by name against the DB session. Raises ValueError on an unknown tool.
 
     Defense-in-depth authorization: the MCP server is local/stdio today, but dispatch must not be the
     layer that trusts everyone if that ever changes. The effective identity is `user`, else the
     `AEC_MCP_USER` env var, else the admin api-key (the historical stdio behaviour). Under RBAC a
     non-admin identity is membership-scoped: `list_projects` returns only member projects, and any tool
-    addressing a `project_id` outside the membership raises PermissionError."""
+    addressing a `project_id` outside the membership raises PermissionError.
+
+    R22-AGENT-PACKS: **every dispatch is audited, success or failure.** Until this existed only
+    `run_recipe` wrote an audit row (for the IFC edit it performed), so 16 of 18 tools ran with no
+    trail and "which tools did this agent run against my project?" had no answer. A log of successes
+    alone cannot answer what an agent *attempted*, which is the question asked after an incident, so
+    the failure path records too and then re-raises. `pack` is recorded when the caller came in
+    through a named pack — it is provenance, never permission."""
+    from . import audit as _audit
+
+    _t0_detail = {"tool": name, "pack": pack,
+                  "project_id": args.get("project_id") or args.get("pid")}
+    try:
+        _out = _dispatch_inner(db, name, args, actor=actor, user=user)
+    except Exception as exc:
+        try:
+            _audit.record(db, action=f"mcp.{name}", actor=user or actor, method="MCP",
+                          detail={**_t0_detail, "ok": False, "error": type(exc).__name__})
+            db.commit()
+        except Exception:                        # noqa: BLE001 — auditing must never mask the error
+            db.rollback()
+        raise
+    try:
+        _audit.record(db, action=f"mcp.{name}", actor=user or actor, method="MCP",
+                      detail={**_t0_detail, "ok": True})
+        db.commit()
+    except Exception:                            # noqa: BLE001 — a tool result is not lost to an audit write
+        db.rollback()
+    return _out
+
+
+def _dispatch_inner(db: Session, name: str, args: dict[str, Any], actor: str = "mcp",
+                    user: str | None = None) -> Any:
+    """The tool body. Split out so `dispatch` can audit every run without touching any decision."""
     import os as _os
 
     from . import bim_kpi, cde, standards_expert

--- a/services/api/src/aec_api/routers/assistant.py
+++ b/services/api/src/aec_api/routers/assistant.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from .. import assistant, routines
+from .. import agent_packs, assistant, routines
 from ..db import get_db
+from ..models import Project
 from ..rbac import require_identified, require_role
 
 router = APIRouter()
@@ -80,3 +81,28 @@ def project_routines_due(pid: str, db: Session = Depends(get_db),
     refused rather than defaulted, and skips come back with their reasons.
     """
     return routines.from_project(db, pid)
+
+
+@router.get("/projects/{pid}/agent-packs")
+def project_agent_packs(pid: str, db: Session = Depends(get_db),
+                        _: str = Depends(require_role("viewer"))):
+    """R22-AGENT-PACKS — the governance console: which named agents exist, what each runs, which can
+    write, and what has actually been run against this project.
+
+    A pack is a **named view over tools that already exist** — "Submittal Review Agent" rather than
+    `standards_check`. It grants nothing: every tool in every pack is already in `mcp_tools.TOOLS`,
+    and `dispatch` applies its own membership and role checks regardless of which pack a caller came
+    through. A pack that could widen access would be a privilege-escalation surface wearing the name
+    of a governance feature.
+
+    **Packs that can modify the project say so**, naming the write tools — a console that lists
+    agents without distinguishing read from write is not one anybody can govern with.
+
+    `runs` is the per-run history the ring entry calls the gating factor for enterprise adoption.
+    Until R22-AGENT-PACKS only `run_recipe` wrote an audit row, so 16 of 18 tools ran with no trail.
+    Every dispatch now records one — **including failures**, because a history of successes cannot
+    answer what an agent *attempted*, which is the question asked after an incident.
+    """
+    if not db.get(Project, pid):
+        raise HTTPException(404, "project not found")
+    return {**agent_packs.catalog(), **agent_packs.run_log(db, project_id=pid)}

--- a/services/api/test_agent_packs.py
+++ b/services/api/test_agent_packs.py
@@ -1,0 +1,137 @@
+"""R22-AGENT-PACKS — named packs over existing tools, and the audit row every run now writes.
+
+Premise-checked: `mcp_tools` already exposes 18 tools with `dispatch()` and `catalog()`, so this is
+packaging exactly as the ring entry says. The entry's "plus per-run audit logging" turned out to be
+a real, measurable gap: `audit.record` was called only inside `_run_recipe`, for the IFC edit it
+performs — so **16 of 18 tools ran with no trail**, and "which tools did this agent run against my
+project?" had no answer.
+
+The assertions:
+
+1. **a pack grants nothing.** Every tool in every pack is already in `mcp_tools.TOOL_NAMES`, and
+   membership confers no permission. A pack that could widen access turns "Submittal Review Agent"
+   into a privilege-escalation surface — the opposite of a governance console;
+2. **a pack naming an unknown tool is REFUSED, not trimmed.** A pack that silently drops a tool
+   looks like it worked and behaves like it did not;
+3. **every dispatch is audited, success AND failure.** A log of successes cannot answer what an
+   agent *attempted*, which is the question asked after an incident rather than before one;
+4. **the twin**: auditing must not swallow the tool's result, nor mask its exception.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_agent_packs.py
+"""
+import os
+import sys
+
+sys.path.insert(0, "src")
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_agent_packs.db"
+os.environ["STORAGE_DIR"] = "./test_storage_packs"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_agent_packs.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from aec_api import agent_packs as ap  # noqa: E402
+from aec_api import mcp_tools  # noqa: E402
+from aec_api.db import Base, SessionLocal, engine  # noqa: E402
+from aec_api.models import AuditLog, Project  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+# --- 1. A PACK GRANTS NOTHING -------------------------------------------------------------------------
+known = set(mcp_tools.TOOL_NAMES)
+every = {t for p in ap.PACKS.values() for t in p["tools"]}
+check("EVERY tool in EVERY pack already exists in mcp_tools — a pack adds no capability",
+      every <= known, sorted(every - known))
+check("  and the shipped catalogue validates", ap.validate()["ok"], ap.validate()["problems"])
+check("  packs are a strict subset — they do not expose every tool either",
+      every < known or every == known, (len(every), len(known)))
+
+# --- 2. AN UNKNOWN TOOL IS REFUSED, NOT TRIMMED --------------------------------------------------------
+bad = ap.validate({"ghost": {"label": "G", "purpose": "p", "tools": ["list_projects", "no_such"]}})
+check("a pack naming an unknown tool is INVALID", bad["ok"] is False, bad)
+check("  and the unknown tool is NAMED", bad["problems"][0]["unknown_tools"] == ["no_such"], bad)
+check("an EMPTY pack is invalid — an agent with no tools is a label",
+      ap.validate({"empty": {"label": "E", "purpose": "p", "tools": []}})["ok"] is False)
+try:
+    ap.tools_for("not_a_pack")
+    check("tools_for raises on an unknown pack", False, "no raise")
+except ap.PackError as e:
+    check("tools_for RAISES on an unknown pack rather than returning []", "unknown agent pack" in str(e))
+    check("  listing the packs that do exist", "submittal_review" in str(e))
+
+# --- 3. WRITE PACKS ARE NAMED AS SUCH -------------------------------------------------------------------
+cat = ap.catalog()
+sub = next(p for p in cat["packs"] if p["key"] == "submittal_review")
+check("a pack containing create_rfi is flagged as WRITING", sub["writes"] is True, sub)
+check("  naming which tool writes", sub["write_tools"] == ["create_rfi"], sub["write_tools"])
+check("  and saying so in words a console can show", "MODIFY" in sub["note"], sub["note"])
+ro = next(p for p in cat["packs"] if p["key"] == "design_qa")
+check("a read-only pack says it cannot modify the project",
+      ro["writes"] is False and "read-only" in ro["note"], ro)
+check("the console counts the read-only packs", cat["read_only_count"] == 4, cat["read_only_count"])
+
+# --- 4. EVERY DISPATCH IS AUDITED — success AND failure --------------------------------------------------
+Base.metadata.create_all(engine)
+with SessionLocal() as db:
+    db.add(Project(id="ap1", name="Packs"))
+    db.commit()
+
+    before = db.query(AuditLog).filter(AuditLog.method == "MCP").count()
+    out = mcp_tools.dispatch(db, "list_projects", {}, actor="test", user="u@test")
+    check("the tool still returns its result — auditing does not swallow it", out is not None, out)
+    after = db.query(AuditLog).filter(AuditLog.method == "MCP").count()
+    check("A SUCCESSFUL DISPATCH WRITES AN AUDIT ROW", after == before + 1, (before, after))
+
+    row = db.query(AuditLog).filter(AuditLog.method == "MCP").order_by(AuditLog.ts.desc()).first()
+    check("  the row names the tool", (row.detail or {}).get("tool") == "list_projects", row.detail)
+    check("  and records success", (row.detail or {}).get("ok") is True, row.detail)
+    check("  attributing it to the effective user, not the transport", row.actor == "u@test", row.actor)
+
+    # the pack is provenance, never permission
+    mcp_tools.dispatch(db, "list_projects", {}, actor="test", user="u@test", pack="design_qa")
+    r2 = db.query(AuditLog).filter(AuditLog.method == "MCP").order_by(AuditLog.ts.desc()).first()
+    check("  a run made through a pack records the PACK it came through",
+          (r2.detail or {}).get("pack") == "design_qa", r2.detail)
+
+    # THE FAILURE PATH — the question asked after an incident
+    n0 = db.query(AuditLog).filter(AuditLog.method == "MCP").count()
+    raised = False
+    try:
+        mcp_tools.dispatch(db, "no_such_tool", {}, actor="test", user="u@test")
+    except Exception:
+        raised = True
+    check("a FAILED dispatch still raises — auditing does not mask the error", raised)
+    n1 = db.query(AuditLog).filter(AuditLog.method == "MCP").count()
+    check("A FAILED DISPATCH IS AUDITED TOO — 'what did it try' is the post-incident question",
+          n1 == n0 + 1, (n0, n1))
+    fr = db.query(AuditLog).filter(AuditLog.method == "MCP").order_by(AuditLog.ts.desc()).first()
+    check("  recorded as a failure, not silently as a run", (fr.detail or {}).get("ok") is False, fr.detail)
+
+    log = ap.run_log(db)
+    check("run_log reads the audit trail rather than a second store",
+          log["run_count"] >= 3, log["run_count"])
+    check("  counting runs per tool", log["by_tool"].get("list_projects", 0) >= 2, log["by_tool"])
+    check("  and surfacing the failures", log["failure_count"] >= 1, log["failure_count"])
+    check("  saying why failures are included", "after an incident" in log["note"])
+
+engine.dispose()
+for _f in ("./test_agent_packs.db",):
+    if os.path.exists(_f):
+        try:
+            os.remove(_f)
+        except OSError:
+            pass
+
+print()
+if FAILED:
+    print(f"agent_packs: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("agent_packs: all checks passed")


### PR DESCRIPTION
Premise-checked: `mcp_tools` already exposes **18 tools** with `dispatch()` and `catalog()`, so this is packaging exactly as the entry says. But *"plus per-run audit logging"* turned out to be a **measurable gap**, not a nicety.

### The finding

`audit.record` was called **only inside `_run_recipe`** — for the IFC edit it performs. So **16 of 18 tools ran with no trail**, and *"which tools did this agent run against my project last week?"* had no answer.

That's the question an enterprise asks before granting access, and again after an incident — which is exactly why the entry calls it the gating factor.

`dispatch` now writes an audit row for **every** run. The tool body moved to `_dispatch_inner` **untouched** — this adds a record, it does not change a decision — and the wrapper records **failures too**, then re-raises.

> A history of successes cannot answer what an agent *attempted*.

Auditing never masks the tool's error nor swallows its result — both asserted.

### A pack is a named view over existing tools

That framing carries the refusals:

| refusal | why |
|---|---|
| **a pack grants nothing** | every tool is already in `TOOL_NAMES`; `dispatch` applies its own checks regardless of pack. A pack that could widen access makes "Submittal Review Agent" a privilege-escalation surface wearing the name of a governance feature. `pack` is on the audit row as **provenance, never permission** |
| **an unknown tool is REFUSED, not trimmed** | a pack that silently drops a tool looks like it worked and behaves like it didn't — the superintendent runs "Submittal Review" and the submittal check never happens. An empty pack is refused too: an agent with no tools is a label |
| **write packs are named as such** | `submittal_review` carries `create_rfi` and says so. A console that can't distinguish read from write isn't one anybody can govern with — 4 of 5 packs are read-only, and the count is reported |

Five packs: Submittal Review, Design QA, Schedule Risk, Permit Readiness, Carbon Report — names a superintendent understands rather than `standards_check`.

### Verified

**26 checks.** Suppressing the failure audit is caught by **4**, no traceback. `test_rbac`, `test_security`, `test_mcp_standards`, `test_bim_kpi`, `test_firm_standards` all stay green — the authorization path is deliberately untouched.

Route: `GET /projects/{pid}/agent-packs` (catalog + per-project run history), under the already-protected `/projects` prefix. `test_reachable`, `test_global_authz`, `test_route_authz`, `test_protected_prefix_coverage` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added named agent packs that group available tools by capability.
  * Added pack catalogs showing read-only and write capabilities.
  * Added project-level access to agent-pack information and run history.
  * Added validation for unknown or empty agent packs.
* **Auditability**
  * Tool activity now records pack attribution, outcomes, and failures for review.
* **Bug Fixes**
  * Tool errors and results are preserved even when activity logging encounters an issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->