### PR TITLE
R22-ENTITLEMENT ② — conditions checked against the model, and the unit it converts

### DIFF
--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 TESTS = ["test_provenance_report", "test_proforma", "test_renovation", "test_rollover", "test_income_basis", "test_cost", "test_g702_lines", "test_modules", "test_dashboard",
-         "test_rbac", "test_auth", "test_connections", "test_presence", "test_collab", "test_serving", "test_api",
+         "test_rbac", "test_auth", "test_condition_checks", "test_connections", "test_presence", "test_collab", "test_serving", "test_api",
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
          # R22-ENTITLE-RISK — approval odds + entitlement duration in the Monte Carlo:
          "test_entitlement_risk", "test_entitlement_route",

--- a/services/api/src/aec_api/approval_conditions.py
+++ b/services/api/src/aec_api/approval_conditions.py
@@ -48,11 +48,18 @@ _ENUM = re.compile(
     r"^\s*(?:\(?\d{1,3}[.)]|\(?[a-z][.)]|condition\s+\d{1,3}\s*[:.]?|[•\-–—])\s+",
     re.I)
 
-#: Quantities worth surfacing, with the unit kept as written. Deliberately narrow: a pattern that
-#: matches everything produces confident readings of sentences it did not understand.
+#: Quantities worth surfacing, with the unit kept as written. The unit list is deliberately narrow —
+#: a pattern matching everything produces confident readings of sentences it did not understand.
+#:
+#: ONE optional descriptive word is allowed between the number and its unit. Requiring strict
+#: adjacency was the first cut and it was too strict for how agencies actually write: "20 parking
+#: spaces", "45 dwelling units" and "1.5 parking spaces per unit" all extract nothing under it, so
+#: every parking condition came back unreadable. Safety does not come from refusing to read — it
+#: comes from `topic` having to agree with the unit family, and from every quantity carrying the
+#: `source_text` it was taken from, so a wrong reading is visible rather than silent.
 _QTY = re.compile(
-    r"(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>ft|feet|foot|m|metres|meters|stor(?:e|ie)ys?|stories|"
-    r"spaces?|units?|percent|%)\b", re.I)
+    r"(?P<value>\d+(?:\.\d+)?)\s*(?:[A-Za-z][A-Za-z-]{1,14}\s+)?(?P<unit>ft|feet|foot|m|metres|"
+    r"meters|stor(?:e|ie)ys?|stories|spaces?|units?|percent|%)\b", re.I)
 
 _KEYWORDS = {
     "height": ("height", "storey", "story", "stories", "storeys"),

--- a/services/api/src/aec_api/condition_checks.py
+++ b/services/api/src/aec_api/condition_checks.py
@@ -1,0 +1,166 @@
+"""R22-ENTITLEMENT ② — checking approval conditions against the model, and the unit it will not guess.
+
+Slice ① turned `entitlement.conditions` from one textarea into tracked items with topics and
+quantities. This is the clause the ring entry actually names: **conditions carried into the model as
+constraints**. It checks the two topics the model can genuinely answer today and refuses the rest.
+
+What the model answers: **height** (from `drawings.storey_elevations`) and **parking** (a count of
+parking spaces). Setback needs a property line and is not attempted — `parcel_geometry` exists but a
+setback check without a surveyed boundary is a number dressed as a compliance finding.
+
+Three refusals, and the second is the one that would otherwise cause real harm:
+
+1. **a condition this cannot check is `not_checkable`, never passing.** Same rule as slice ①'s
+   `unparsed`: a condition reported as satisfied because nobody could evaluate it is a building put
+   up out of compliance while the report said it was fine. `not_checkable` names why;
+2. **units are converted explicitly and BOTH are shown.** A condition says "45 feet"; the model is
+   in metres. Converting silently is exactly how a 45 ft height limit becomes a 45 m one — a
+   three-fold error that reads as a pass. Every comparison reports the condition value, the model
+   value, and the unit each was in;
+3. **no model is `not_checkable`, not compliant.** An absent model cannot demonstrate compliance,
+   and treating "nothing to compare against" as "nothing wrong" is the same failure as an empty
+   estimate ledger reporting 100% documented.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+M_PER_FT = 0.3048
+
+VERDICT_PASS = "within_limit"
+VERDICT_FAIL = "exceeds_limit"
+VERDICT_NOT_CHECKABLE = "not_checkable"
+
+#: Topics this can evaluate. Anything else is reported as not_checkable rather than attempted —
+#: see the module docstring on setbacks.
+CHECKABLE_TOPICS = ("height", "parking")
+
+_LENGTH_UNITS = {"ft": M_PER_FT, "feet": M_PER_FT, "foot": M_PER_FT,
+                 "m": 1.0, "metres": 1.0, "meters": 1.0}
+_STOREY_UNITS = {"storey", "storeys", "storey s", "story", "stories"}
+_COUNT_UNITS = {"spaces", "space", "units", "unit"}
+
+
+def _to_metres(value: float, unit: str) -> tuple[float | None, str]:
+    u = (unit or "").lower()
+    if u in _LENGTH_UNITS:
+        return value * _LENGTH_UNITS[u], u
+    return None, u
+
+
+def check_condition(cond: dict[str, Any], facts: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate one parsed condition (from `approval_conditions.parse`) against model facts.
+
+    `facts` is `{height_m, storeys, parking_spaces}` — any may be None, and a None fact makes the
+    condition `not_checkable` rather than passing.
+    """
+    base = {"seq": cond.get("seq"), "topic": cond.get("topic"), "text": cond.get("text")}
+    topic = cond.get("topic")
+    quantities = cond.get("quantities") or []
+
+    if topic not in CHECKABLE_TOPICS:
+        return {**base, "verdict": VERDICT_NOT_CHECKABLE,
+                "reason": (f"topic {topic!r} is not one the model can answer. Checkable topics are "
+                           f"{', '.join(CHECKABLE_TOPICS)}; a setback check without a surveyed "
+                           "property line would be a number dressed as a compliance finding")}
+    if not quantities:
+        return {**base, "verdict": VERDICT_NOT_CHECKABLE,
+                "reason": "the condition carries no quantity to compare against"}
+
+    for q in quantities:
+        unit = str(q.get("unit") or "").lower()
+        value = float(q.get("value"))
+
+        if topic == "height":
+            if unit in _STOREY_UNITS:
+                model_v, mu = facts.get("storeys"), "storeys"
+            else:
+                metres, _ = _to_metres(value, unit)
+                if metres is None:
+                    continue
+                value, model_v, mu = metres, facts.get("height_m"), "m"
+            if model_v is None:
+                return {**base, "verdict": VERDICT_NOT_CHECKABLE,
+                        "reason": f"the model reports no {mu} — an absent model fact cannot "
+                                  "demonstrate compliance, so this is unchecked, not satisfied"}
+            ok = float(model_v) <= value + 1e-9
+            return {**base, "verdict": VERDICT_PASS if ok else VERDICT_FAIL,
+                    "condition_value": round(value, 4), "condition_unit": mu,
+                    "condition_as_written": f"{q.get('value')} {q.get('unit')}",
+                    "model_value": round(float(model_v), 4), "model_unit": mu,
+                    "reason": (f"condition allows {value:.4g} {mu} (written as "
+                               f"{q.get('value')} {q.get('unit')}); the model is "
+                               f"{float(model_v):.4g} {mu}. Both values and both units are shown "
+                               "because converting silently is how a 45 ft limit becomes a 45 m one")}
+
+        if topic == "parking":
+            if unit not in _COUNT_UNITS:
+                continue
+            model_v = facts.get("parking_spaces")
+            if model_v is None:
+                return {**base, "verdict": VERDICT_NOT_CHECKABLE,
+                        "reason": "the model reports no parking space count — unchecked, not satisfied"}
+            ok = float(model_v) >= value - 1e-9      # parking conditions are minimums
+            return {**base, "verdict": VERDICT_PASS if ok else VERDICT_FAIL,
+                    "condition_value": value, "condition_unit": "spaces",
+                    "condition_as_written": f"{q.get('value')} {q.get('unit')}",
+                    "model_value": float(model_v), "model_unit": "spaces",
+                    "reason": (f"condition requires at least {value:.4g} space(s); the model has "
+                               f"{float(model_v):.4g}. Parking conditions are read as MINIMUMS — "
+                               "the opposite direction to a height limit, and reading one as the "
+                               "other inverts the finding")}
+
+    return {**base, "verdict": VERDICT_NOT_CHECKABLE,
+            "reason": (f"no quantity in this condition is in a unit the {topic} check understands "
+                       f"({[q.get('unit') for q in quantities]})")}
+
+
+def check_all(conditions: list[dict], facts: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Check parsed conditions against model facts, counting what could not be checked."""
+    facts = facts or {}
+    rows = [check_condition(c, facts) for c in conditions or []]
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    failing = [r for r in rows if r["verdict"] == VERDICT_FAIL]
+    return {
+        "checks": rows, "counts": counts,
+        "exceeds": failing, "exceeds_count": len(failing),
+        "not_checkable_count": counts.get(VERDICT_NOT_CHECKABLE, 0),
+        "checked_count": counts.get(VERDICT_PASS, 0) + len(failing),
+        "facts": dict(facts),
+        "note": ("a condition that could not be evaluated is NOT_CHECKABLE, never passing — a "
+                 "condition reported satisfied because nobody could evaluate it is a building put "
+                 "up out of compliance while the report said it was fine."),
+    }
+
+
+def model_facts(model) -> dict[str, Any]:
+    """The facts a condition check can use, read from an opened IFC model.
+
+    Returns None for anything the model does not answer rather than a zero — a zero parking count
+    and "this model has no parking information" are different claims, and only the first would make
+    a minimum-parking condition fail honestly.
+    """
+    from aec_data import drawings
+
+    facts: dict[str, Any] = {"height_m": None, "storeys": None, "parking_spaces": None}
+    try:
+        storeys = drawings.storey_elevations(model)
+    except Exception:                            # noqa: BLE001 — an unreadable model yields no facts
+        storeys = []
+    if storeys:
+        facts["storeys"] = len(storeys)
+        elevs = [float(s.get("elevation") or 0.0) for s in storeys]
+        if elevs:
+            facts["height_m"] = round(max(elevs), 4)
+    try:
+        spaces = model.by_type("IfcSpace")
+        parking = [s for s in spaces
+                   if "park" in str(getattr(s, "Name", "") or "").lower()
+                   or "park" in str(getattr(s, "LongName", "") or "").lower()]
+        if parking:
+            facts["parking_spaces"] = len(parking)
+    except Exception:                            # noqa: BLE001
+        pass
+    return facts

--- a/services/api/src/aec_api/routers/design.py
+++ b/services/api/src/aec_api/routers/design.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
-from .. import adjacency, approval_conditions, design_phase, resilience, soft_costs, spine
+from .. import adjacency, approval_conditions, condition_checks, design_phase, resilience, soft_costs, spine
 from .. import modules as me
 from ..db import get_db
 from ..models import Project
@@ -541,3 +541,47 @@ def entitlement_conditions(pid: str, db: Session = Depends(get_db),
     if not db.get(Project, pid):
         raise HTTPException(404, "project not found")
     return approval_conditions.for_project(db, pid)
+
+
+@router.get("/projects/{pid}/entitlements/condition-checks")
+def entitlement_condition_checks(pid: str, db: Session = Depends(get_db),
+                                 _: str = Depends(require_role("viewer"))):
+    """R22-ENTITLEMENT ② — the project's approval conditions checked against its model.
+
+    Slice ① made conditions individually tracked; this is the ring entry's actual clause, conditions
+    carried into the model as constraints. It checks the two topics the model can genuinely answer —
+    **height** (from the storey elevations) and **parking** (a count of parking spaces) — and refuses
+    the rest. A setback check without a surveyed property line would be a number dressed as a
+    compliance finding.
+
+    **Units are converted explicitly and both are reported.** A condition reads "45 feet"; the model
+    is metric. Comparing 45 against metres is how a 45 ft height limit silently becomes a 45 m one —
+    a three-fold error that reads as a pass. Every comparison returns the condition value as written,
+    the converted value, the model value, and the unit of each.
+
+    **A height limit is a maximum; a parking condition is a minimum.** Reading one as the other
+    inverts the finding, so the direction is stated per check.
+
+    Anything unevaluable — an unsupported topic, a missing quantity, or a model fact the file does
+    not answer — is `not_checkable`, **never a pass**. A condition reported satisfied because nobody
+    could evaluate it is a building put up out of compliance while the report said it was fine.
+    """
+    if not db.get(Project, pid):
+        raise HTTPException(404, "project not found")
+    from .. import mcp_tools
+    tracked = approval_conditions.for_project(db, pid)
+    facts = {"height_m": None, "storeys": None, "parking_spaces": None}
+    try:
+        model = mcp_tools._open_source(db, pid)
+        facts = condition_checks.model_facts(model)
+    except Exception:                            # noqa: BLE001 — no model is not_checkable, not a pass
+        pass
+    out = []
+    for ent in tracked.get("entitlements", []):
+        res = condition_checks.check_all(ent.get("conditions") or [], facts)
+        out.append({"entitlement_id": ent.get("entitlement_id"), "ref": ent.get("ref"),
+                    "workflow_state": ent.get("workflow_state"), **res})
+    return {"project_id": pid, "model_facts": facts, "entitlements": out,
+            "total_exceeds": sum(x["exceeds_count"] for x in out),
+            "total_not_checkable": sum(x["not_checkable_count"] for x in out),
+            "note": tracked.get("note", "")}

--- a/services/api/test_approval_conditions.py
+++ b/services/api/test_approval_conditions.py
@@ -72,19 +72,23 @@ check("  and the SOURCE TEXT it came from, so a person can check the reading",
 check("  the condition is topic-tagged", h["topic"] == "height", h["topic"])
 check("a parking condition is tagged parking", items[2]["topic"] == "parking", items[2]["topic"])
 check("a landscape condition is tagged landscape", items[3]["topic"] == "landscape", items[3]["topic"])
-# Extraction requires the number and unit to be ADJACENT. "45 dwelling units" yields nothing, and
-# that is the correct answer: the alternative is associating a number with a unit a word or more
-# away, which is precisely how "45" from "45 dwelling units" becomes a height limit nobody imposed.
-# A missed quantity is tracked as an unparsed condition a person reads; an invented one is a
-# constraint nobody chose.
+# Extraction allows ONE descriptive word between the number and its unit. Strict adjacency was the
+# first cut and it was too strict for how agencies actually write — "20 parking spaces", "45 dwelling
+# units" and "1.5 parking spaces per unit" all extracted NOTHING, so every parking condition came
+# back unreadable (found by R22-ENTITLEMENT ②'s checks). Safety is not "refuse to read": it is that
+# `topic` must agree with the unit family, and that every quantity carries its source_text — a wrong
+# reading is then visible rather than silent.
 _far = parse("Project limited to 45 dwelling units.")[0]
-check("a number NOT adjacent to its unit is not extracted — conservative on purpose",
-      _far["quantities"] == [], _far["quantities"])
-check("  and the condition is therefore tracked as UNPARSED for a person to read",
-      _far["status"] == STATUS_UNPARSED, _far["status"])
-check("  while an ADJACENT quantity IS extracted with its unit as written",
-      parse("Limited to 45 units.")[0]["quantities"][0]["unit"] == "units",
-      parse("Limited to 45 units.")[0]["quantities"])
+check("one descriptive word between number and unit still extracts — real agencies write this way",
+      _far["quantities"][0]["value"] == 45.0 and _far["quantities"][0]["unit"] == "units",
+      _far["quantities"])
+check("  and it is read as UNITS, not as a height — the unit is taken as written",
+      _far["quantities"][0]["unit"] == "units")
+check("  with the source text, so a wrong reading is visible rather than silent",
+      "dwelling" in _far["quantities"][0]["source_text"], _far["quantities"][0]["source_text"])
+check("'20 parking spaces' extracts 20 spaces — the phrasing that broke strict adjacency",
+      parse("Provide a minimum of 20 parking spaces.")[0]["quantities"][0]["unit"] == "spaces",
+      parse("Provide a minimum of 20 parking spaces.")[0]["quantities"])
 check("  a landscape condition containing 'installed' is NOT tagged parking (stall/installed)",
       parse("A landscape buffer shall be installed.")[0]["topic"] == "landscape",
       parse("A landscape buffer shall be installed.")[0]["topic"])

--- a/services/api/test_condition_checks.py
+++ b/services/api/test_condition_checks.py
@@ -1,0 +1,126 @@
+"""R22-ENTITLEMENT ② — checking conditions against the model, and the unit conversion it shows.
+
+Slice ① made conditions individually tracked. This is the entry's actual clause: conditions carried
+into the model as constraints. The assertions are about the ways a compliance check does harm:
+
+1. **an unevaluable condition is `not_checkable`, never passing** — a condition reported satisfied
+   because nobody could evaluate it is a building put up out of compliance while the report said it
+   was fine. Same rule as slice ①'s `unparsed`;
+2. **units are converted explicitly and BOTH are reported.** "45 feet" against a metric model is
+   how a 45 ft height limit silently becomes a 45 m one — a three-fold error that reads as a pass;
+3. **a height limit is a MAXIMUM and a parking condition is a MINIMUM.** Reading one as the other
+   inverts the finding, so both directions are asserted;
+4. **the twin**: a real violation must actually be caught. A checker that never fails is a checker
+   that never checked.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_condition_checks.py
+"""
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api.approval_conditions import parse  # noqa: E402
+from aec_api.condition_checks import (  # noqa: E402
+    M_PER_FT,
+    VERDICT_FAIL,
+    VERDICT_NOT_CHECKABLE,
+    VERDICT_PASS,
+    check_all,
+    check_condition,
+)
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+HEIGHT = parse("Maximum building height shall not exceed 45 feet.")[0]
+PARKING = parse("Provide a minimum of 20 parking spaces.")[0]
+STOREYS = parse("Building shall not exceed 3 storeys.")[0]
+VAGUE = parse("Applicant shall satisfy the Director prior to issuance.")[0]
+SETBACK = parse("Provide a minimum front setback of 20 ft.")[0]
+
+# --- 2. UNITS ARE CONVERTED EXPLICITLY, AND BOTH ARE SHOWN ----------------------------------------------
+# 45 ft = 13.716 m. A model 14 m tall EXCEEDS it — and would have "passed" against an unconverted 45.
+tall = check_condition(HEIGHT, {"height_m": 14.0})
+check("45 FEET IS CONVERTED TO METRES BEFORE COMPARISON",
+      abs(tall["condition_value"] - 45 * M_PER_FT) < 1e-6, tall.get("condition_value"))
+check("  a 14 m model EXCEEDS a 45 ft limit — the error an unconverted compare would have missed",
+      tall["verdict"] == VERDICT_FAIL, tall["verdict"])
+check("  the condition is reported AS WRITTEN as well as converted",
+      tall["condition_as_written"] == "45.0 feet", tall.get("condition_as_written"))
+check("  both units are named", tall["condition_unit"] == "m" and tall["model_unit"] == "m", tall)
+check("  and the reason says why silent conversion is the danger",
+      "45 ft limit becomes a 45 m one" in tall["reason"], tall["reason"])
+check("a 13 m model is WITHIN a 45 ft limit",
+      check_condition(HEIGHT, {"height_m": 13.0})["verdict"] == VERDICT_PASS)
+check("  and 13.716 m exactly is within it, not over",
+      check_condition(HEIGHT, {"height_m": 45 * M_PER_FT})["verdict"] == VERDICT_PASS)
+
+# --- 3. DIRECTION: height is a MAXIMUM, parking is a MINIMUM ---------------------------------------------
+check("a height limit is a maximum — over fails",
+      check_condition(HEIGHT, {"height_m": 99.0})["verdict"] == VERDICT_FAIL)
+check("PARKING IS A MINIMUM — fewer spaces than required FAILS",
+      check_condition(PARKING, {"parking_spaces": 12})["verdict"] == VERDICT_FAIL,
+      check_condition(PARKING, {"parking_spaces": 12}))
+check("  and MORE spaces than required passes — the opposite direction to height",
+      check_condition(PARKING, {"parking_spaces": 30})["verdict"] == VERDICT_PASS)
+check("  exactly the required count passes",
+      check_condition(PARKING, {"parking_spaces": 20})["verdict"] == VERDICT_PASS)
+check("  the reason names the direction, since reading it backwards inverts the finding",
+      "read as MINIMUMS" in check_condition(PARKING, {"parking_spaces": 30})["reason"])
+
+check("a storey-count condition compares against storeys, not metres",
+      check_condition(STOREYS, {"storeys": 5, "height_m": 2.0})["verdict"] == VERDICT_FAIL,
+      check_condition(STOREYS, {"storeys": 5, "height_m": 2.0}))
+check("  and passes when the model has fewer",
+      check_condition(STOREYS, {"storeys": 2})["verdict"] == VERDICT_PASS)
+
+# --- 1. WHAT CANNOT BE CHECKED NEVER PASSES ---------------------------------------------------------------
+check("a SETBACK condition is not_checkable — no surveyed property line",
+      check_condition(SETBACK, {"height_m": 10.0})["verdict"] == VERDICT_NOT_CHECKABLE,
+      check_condition(SETBACK, {"height_m": 10.0})["verdict"])
+check("  and says why rather than implying it passed",
+      "dressed as a compliance finding" in check_condition(SETBACK, {})["reason"])
+check("an untopiced condition is not_checkable",
+      check_condition(VAGUE, {"height_m": 1.0})["verdict"] == VERDICT_NOT_CHECKABLE)
+check("A MISSING MODEL FACT IS not_checkable, NOT a pass",
+      check_condition(HEIGHT, {})["verdict"] == VERDICT_NOT_CHECKABLE,
+      check_condition(HEIGHT, {})["verdict"])
+check("  saying an absent fact cannot demonstrate compliance",
+      "cannot demonstrate compliance" in check_condition(HEIGHT, {})["reason"])
+check("  and a None fact is treated the same as an absent one",
+      check_condition(HEIGHT, {"height_m": None})["verdict"] == VERDICT_NOT_CHECKABLE)
+check("a parking condition with no count in the model is not_checkable, not failed",
+      check_condition(PARKING, {"parking_spaces": None})["verdict"] == VERDICT_NOT_CHECKABLE)
+
+# --- 4. THE TWIN AND THE ROLL-UP ---------------------------------------------------------------------------
+allc = parse("""1. Maximum building height shall not exceed 45 feet.
+2. Provide a minimum of 20 parking spaces.
+3. Provide a minimum front setback of 20 ft.
+4. Applicant shall satisfy the Director prior to issuance.""")
+r = check_all(allc, {"height_m": 14.0, "parking_spaces": 12})
+check("the roll-up catches BOTH real violations", r["exceeds_count"] == 2, r["counts"])
+check("  and names them", {x["topic"] for x in r["exceeds"]} == {"height", "parking"},
+      [x["topic"] for x in r["exceeds"]])
+check("  counting what it could not check separately from what passed",
+      r["not_checkable_count"] == 2 and r["checked_count"] == 2, r["counts"])
+check("  it reports the facts it judged against, so a reader can audit the comparison",
+      r["facts"]["height_m"] == 14.0, r["facts"])
+clean = check_all(allc, {"height_m": 12.0, "parking_spaces": 25})
+check("A COMPLIANT MODEL PASSES ITS CHECKABLE CONDITIONS — not a machine for saying no",
+      clean["exceeds_count"] == 0 and clean["checked_count"] == 2, clean["counts"])
+check("  but the unchecked two are still reported, not absorbed into a clean bill",
+      clean["not_checkable_count"] == 2, clean["counts"])
+check("no conditions at all is a clean empty result, not an error",
+      check_all([], {"height_m": 1.0})["checks"] == [])
+
+print()
+if FAILED:
+    print(f"condition_checks: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("condition_checks: all checks passed")


### PR DESCRIPTION
Slice ① made `entitlement.conditions` individually tracked. This is the ring entry's **actual clause**: conditions carried into the model as constraints.

It checks the two topics the model can genuinely answer — **height** (from storey elevations) and **parking** (space count) — and refuses the rest. A setback check without a surveyed property line would be a number dressed as a compliance finding, so it isn't attempted.

### Units are converted explicitly, and both are reported

A condition reads **"45 feet"**; the model is metric. Comparing 45 against metres is how a 45 ft height limit silently becomes a **45 m** one — a three-fold error that reads as a **pass**.

The test drives exactly that case: a 14 m model correctly **exceeds** a 45 ft limit (13.716 m). Mutating away the conversion is caught by **4 checks**.

Every comparison returns the condition value *as written*, the converted value, the model value, and the unit of each.

### Direction matters

**A height limit is a maximum; a parking condition is a minimum.** Reading one as the other inverts the finding, so both directions are asserted and each reason states which it used.

### Unevaluable is never a pass

An unsupported topic, a missing quantity, or a model fact the file doesn't answer → `not_checkable`. *A condition reported satisfied because nobody could evaluate it is a building put up out of compliance while the report said it was fine.*

`model_facts` returns `None` rather than `0` for what a model doesn't say — a zero parking count and "this model has no parking information" are different claims, and only the first can honestly fail a minimum.

### Correcting slice ①'s extraction rule, with evidence

① required the number and unit to be **adjacent**, which I justified as conservative. It's too strict for how agencies actually write:

```
"20 parking spaces"            -> extracted nothing
"45 dwelling units"            -> extracted nothing
"1.5 parking spaces per unit"  -> extracted nothing
```

**Every parking condition came back unreadable** — found by these checks, not by review. One descriptive word is now allowed between number and unit.

Safety doesn't come from refusing to read: it comes from `topic` having to agree with the unit family, and from every quantity carrying its `source_text`, so a wrong reading is *visible* rather than silent. ①'s assertion is **updated to the corrected rule** rather than deleted.

### Verified

**61 checks** across the two suites (33 + 28). Route at `GET /projects/{pid}/entitlements/condition-checks`, under the already-protected `/projects` prefix. `test_reachable`, `test_global_authz`, `test_route_authz`, `test_protected_prefix_coverage` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added condition-check results for project entitlements, including height, storey, and parking compliance.
  * Results show condition values, model values, pass/fail status, and conditions that cannot be evaluated.
  * Added aggregate counts for exceeded and unevaluable conditions.
* **Improvements**
  * Approval conditions now recognize quantities with one descriptive word, such as “45 dwelling units” or “20 parking spaces.”
* **Bug Fixes**
  * Improved unit conversion and handling of missing or unavailable model information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->