### PR TITLE
SCALE-SEAM ⑦ — /auth out of client.ts, and three gates that had gone quiet

### DIFF
--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,0 +1,131 @@
+/** Authentication, MFA, sessions and admin user management.
+ *
+ *  SCALE-SEAM ⑦. Route-group `/auth`, 20 methods / 96 lines, taken out of `client.ts` by the
+ *  route each method calls — the recipe ⑥ established. They sat in **four** separate regions
+ *  (`authProviders` at the top of the class, `stepUp` down among the sealing methods, the login/MFA
+ *  run, and the user-admin run), which is again the concrete form of "the `// --- section ---`
+ *  comments no longer delimit anything".
+ *
+ *  **The group the roadmap flagged as needing care, and the care turned out to be already taken.**
+ *  SCALE-SEAM ⑥ predicted `/auth` would be awkward because it "owns token state rather than just
+ *  calling routes". It does mutate token state — `changePassword` and `logoutAll` both adopt the
+ *  fresh token the server returns — but the state itself has lived on `HttpCore` since the T2
+ *  transport extraction, behind a **public** `setToken`. A mixin is a BASE of `ApiClient`, so it
+ *  cannot see `ApiClient`'s privates; it can see its own base's public and protected members. The
+ *  blocker that stopped the SSE methods travelling in ③ (`liveStream` was private on `ApiClient`)
+ *  has no analogue here. `token` itself stays `private` on `HttpCore` and is not touched.
+ *
+ *  **What deliberately did NOT move.** `auditLog`, `errorLog`, `clearErrorLog` and
+ *  `reportClientError` sit inside the `// --- admin: user management ---` run and read as part of
+ *  this group, but they route to `/audit`, `/admin/errors` and `/client-errors`. Grouping by the
+ *  section comment rather than by the route would have dragged three unrelated domains across the
+ *  seam — which is the whole reason the recipe is "locate by route".
+ *
+ *  A mixin, so every call site resolves unchanged. `api/surface.test.ts` is what proves it: moving
+ *  a method is invisible to it, losing one fails it by number.
+ */
+import { HttpCore } from "./httpCore";
+import type { AccountUser } from "./types";
+
+type Ctor<T> = new (...args: any[]) => T;
+
+export function withAuth<TBase extends Ctor<HttpCore>>(Base: TBase) {
+  return class Auth extends Base {
+  /** Enabled SSO providers (Google/Microsoft/Procore) for the login UI. */
+  authProviders() {
+    return this.json<{ providers: { id: string; label: string }[] }>("/auth/providers");
+  }
+  /** Re-prove the account password for ONE action, yielding a short-lived assertion.
+   *
+   *  Sealing needs this because a bearer token identifies a session, not a person: anything holding
+   *  the token could otherwise emit documents under the licensee's seal. The returned value is NOT a
+   *  session token — the server refuses it as one — so it is safe to pass straight to pdfSeal. */
+  stepUp(password: string, act = "pdf.seal") {
+    return this.json<{ token: string; act: string; expires_in: number }>(
+      "/auth/step-up", { method: "POST", body: JSON.stringify({ password, act }) });
+  }
+  /** Password login. If the account has MFA on, the reply is `{ mfa_required, mfa_token }` instead
+   *  of a token — complete it with `mfaVerify(mfa_token, code)`. */
+  login(username: string, password: string) {
+    return this.json<{ token?: string; username: string; role?: string;
+      mfa_required?: boolean; mfa_token?: string }>(
+      "/auth/login", { method: "POST", body: JSON.stringify({ username, password }) });
+  }
+  /** Login step 2: exchange the challenge ticket + a TOTP or recovery code for a session. */
+  mfaVerify(mfaToken: string, code: string) {
+    return this.json<{ token: string; username: string; role: string }>(
+      "/auth/mfa/verify", { method: "POST", body: JSON.stringify({ mfa_token: mfaToken, code }) });
+  }
+  mfaStatus() {
+    return this.json<{ enabled: boolean; pending: boolean; recovery_remaining: number }>("/auth/mfa/status");
+  }
+  mfaSetup() {
+    return this.json<{ secret: string; otpauth_uri: string }>("/auth/mfa/setup", { method: "POST" });
+  }
+  mfaEnable(code: string) {
+    return this.json<{ enabled: boolean; recovery_codes: string[] }>(
+      "/auth/mfa/enable", { method: "POST", body: JSON.stringify({ code }) });
+  }
+  mfaDisable(password: string, code: string) {
+    return this.json<{ enabled: boolean }>(
+      "/auth/mfa/disable", { method: "POST", body: JSON.stringify({ password, code }) });
+  }
+  register(username: string, password: string) {
+    return this.json<{ username: string; role: string }>(
+      "/auth/register", { method: "POST", body: JSON.stringify({ username, password }) });
+  }
+  me() {
+    return this.json<{ username: string; role: string | null; authenticated: boolean;
+      tier?: string; features?: Record<string, boolean>; platform_admin?: boolean }>("/auth/me");
+  }
+  logout() {
+    return this.json<{ ok: boolean }>("/auth/logout", { method: "POST" }).catch(() => ({ ok: false }));
+  }
+  /** Change your own password (requires the current one). The server revokes all other sessions
+   *  and returns a fresh token for this tab; adopt it so the current session keeps working. */
+  async changePassword(current: string, next: string) {
+    const r = await this.json<{ ok: boolean; token?: string }>(
+      "/auth/password", { method: "POST", body: JSON.stringify({ current, new: next }) });
+    if (r.token) this.setToken(r.token);
+    return r;
+  }
+  /** Sign out of every other session (revoke all outstanding tokens); keeps this tab signed in
+   *  via the fresh token the server returns. Use after a suspected token leak. */
+  async logoutAll() {
+    const r = await this.json<{ ok: boolean; token?: string }>("/auth/logout-all", { method: "POST" });
+    if (r.token) this.setToken(r.token);
+    return r;
+  }
+  /** Admin: force-revoke all of a user's outstanding sessions (offboarding / lost device). */
+  revokeUserSessions(username: string) {
+    return this.json<{ ok: boolean }>(
+      `/auth/users/${encodeURIComponent(username)}/revoke-sessions`, { method: "POST" });
+  }
+  listUsers() {
+    return this.json<AccountUser[]>("/auth/users");
+  }
+  createUser(username: string, password: string, role: "admin" | "user" = "user", email?: string) {
+    return this.json<AccountUser>(
+      "/auth/users", { method: "POST", body: JSON.stringify({ username, password, role, email }) });
+  }
+  updateUser(username: string, patch: { role?: "admin" | "user"; active?: boolean; email?: string }) {
+    return this.json<AccountUser>(
+      `/auth/users/${encodeURIComponent(username)}`, { method: "PATCH", body: JSON.stringify(patch) });
+  }
+  resetUserPassword(username: string, password: string) {
+    return this.json<{ ok: boolean }>(
+      `/auth/users/${encodeURIComponent(username)}/password`,
+      { method: "POST", body: JSON.stringify({ password }) });
+  }
+  /** Admin: mint a single-use reset token for a user to set their own password. */
+  issueResetToken(username: string) {
+    return this.json<{ username: string; reset_token: string; expires_in: number }>(
+      `/auth/users/${encodeURIComponent(username)}/reset-token`, { method: "POST" });
+  }
+  /** Unauthenticated: set a new password using a reset token (the token is the credential). */
+  resetWithToken(token: string, next: string) {
+    return this.json<{ ok: boolean; username: string }>(
+      `/auth/reset`, { method: "POST", body: JSON.stringify({ token, new: next }) });
+  }
+  };
+}

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,5 +1,6 @@
 /** Typed client for the backend API (guide §7). Geometry comes from .frag; all element
  *  metadata and work artifacts (pins/RFIs/viewpoints) come from here. */
+import { withAuth } from "./auth";
 import { withAuthoring } from "./authoring";
 import { withLibrary } from "./library";
 import { HttpCore, type LiveStream } from "./httpCore";
@@ -23,7 +24,7 @@ export type { ModuleGraph, ModuleGraphEdge, ModuleGraphNode } from "./modules";
 export * from "./authoring";
 export * from "./library";
 import type {
-  AccountUser, Appraisal, AuditEntry, ConnectionItem, Dashboard, DocFile,
+  Appraisal, AuditEntry, ConnectionItem, Dashboard, DocFile,
   DisciplineTree, DocFolderNode, DrawingMarkupItem, DueFeed, EditMacro, EscalationScan, EscalationRun, ElementProps, EnergyResult, FinancialStatements,
   IntegrationGroup, Job, LifecycleStrip, ModelCiReport, WorkQueue, ModulePin, ModuleRecord, MonteCarloMetric, MonteCarloResult, RoomAllocation,
   LogisticsResource, NotifItem, OpendataPermit, ProformaForecast, ProformaResult, ProjectMember, ProjectRole, PropLayer, PropMapRule,
@@ -34,12 +35,7 @@ import type {
 
 // Transport (baseUrl, token, json/_pdfPost/url/health) lives in HttpCore; ApiClient adds the typed
 // domain methods below. Every `api.method()` call site is unchanged by the split.
-export class ApiClient extends withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore))))))) {
-  // --- auth ---------------------------------------------------------------
-  /** Enabled SSO providers (Google/Microsoft/Procore) for the login UI. */
-  authProviders() {
-    return this.json<{ providers: { id: string; label: string }[] }>("/auth/providers");
-  }
+export class ApiClient extends withAuth(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore)))))))) {
   /** Admin: integration settings (AI / email / SSO). Secret values are never returned. */
   integrations() {
     return this.json<{ groups: IntegrationGroup[] }>("/settings/integrations");
@@ -535,15 +531,6 @@ export class ApiClient extends withProcurement(withEstimate(withModules(withMode
   }
   /** The signed-in user's own verified PE/RA licences — what the seal dialog offers. */
   myLicenses() { return this.json<{ licenses: ProfessionalLicense[] }>("/licenses/mine"); }
-  /** Re-prove the account password for ONE action, yielding a short-lived assertion.
-   *
-   *  Sealing needs this because a bearer token identifies a session, not a person: anything holding
-   *  the token could otherwise emit documents under the licensee's seal. The returned value is NOT a
-   *  session token — the server refuses it as one — so it is safe to pass straight to pdfSeal. */
-  stepUp(password: string, act = "pdf.seal") {
-    return this.json<{ token: string; act: string; expires_in: number }>(
-      "/auth/step-up", { method: "POST", body: JSON.stringify({ password, act }) });
-  }
   /** Record a revision (delta) on a sheet, optionally citing the driving instrument (ASI/CCD/Addendum). */
   reviseDrawing(pid: string, drawingId: string, body: { rev: string; description?: string; date?: string; instrument_type?: string; instrument_ref?: string }) {
     return this.json<{ drawing_id: string; revision: string; delta_count: number }>(
@@ -822,68 +809,8 @@ export class ApiClient extends withProcurement(withEstimate(withModules(withMode
       total?: number; source: string; ai_enabled: boolean; message?: string }>(
       `/projects/${pid}/ai/estimate`, { method: "POST", body: JSON.stringify({ description }) });
   }
-  /** Password login. If the account has MFA on, the reply is `{ mfa_required, mfa_token }` instead
-   *  of a token — complete it with `mfaVerify(mfa_token, code)`. */
-  login(username: string, password: string) {
-    return this.json<{ token?: string; username: string; role?: string;
-      mfa_required?: boolean; mfa_token?: string }>(
-      "/auth/login", { method: "POST", body: JSON.stringify({ username, password }) });
-  }
-  /** Login step 2: exchange the challenge ticket + a TOTP or recovery code for a session. */
-  mfaVerify(mfaToken: string, code: string) {
-    return this.json<{ token: string; username: string; role: string }>(
-      "/auth/mfa/verify", { method: "POST", body: JSON.stringify({ mfa_token: mfaToken, code }) });
-  }
-  mfaStatus() {
-    return this.json<{ enabled: boolean; pending: boolean; recovery_remaining: number }>("/auth/mfa/status");
-  }
-  mfaSetup() {
-    return this.json<{ secret: string; otpauth_uri: string }>("/auth/mfa/setup", { method: "POST" });
-  }
-  mfaEnable(code: string) {
-    return this.json<{ enabled: boolean; recovery_codes: string[] }>(
-      "/auth/mfa/enable", { method: "POST", body: JSON.stringify({ code }) });
-  }
-  mfaDisable(password: string, code: string) {
-    return this.json<{ enabled: boolean }>(
-      "/auth/mfa/disable", { method: "POST", body: JSON.stringify({ password, code }) });
-  }
-  register(username: string, password: string) {
-    return this.json<{ username: string; role: string }>(
-      "/auth/register", { method: "POST", body: JSON.stringify({ username, password }) });
-  }
-  me() {
-    return this.json<{ username: string; role: string | null; authenticated: boolean;
-      tier?: string; features?: Record<string, boolean>; platform_admin?: boolean }>("/auth/me");
-  }
-  logout() {
-    return this.json<{ ok: boolean }>("/auth/logout", { method: "POST" }).catch(() => ({ ok: false }));
-  }
-  /** Change your own password (requires the current one). The server revokes all other sessions
-   *  and returns a fresh token for this tab; adopt it so the current session keeps working. */
-  async changePassword(current: string, next: string) {
-    const r = await this.json<{ ok: boolean; token?: string }>(
-      "/auth/password", { method: "POST", body: JSON.stringify({ current, new: next }) });
-    if (r.token) this.setToken(r.token);
-    return r;
-  }
-  /** Sign out of every other session (revoke all outstanding tokens); keeps this tab signed in
-   *  via the fresh token the server returns. Use after a suspected token leak. */
-  async logoutAll() {
-    const r = await this.json<{ ok: boolean; token?: string }>("/auth/logout-all", { method: "POST" });
-    if (r.token) this.setToken(r.token);
-    return r;
-  }
-  /** Admin: force-revoke all of a user's outstanding sessions (offboarding / lost device). */
-  revokeUserSessions(username: string) {
-    return this.json<{ ok: boolean }>(
-      `/auth/users/${encodeURIComponent(username)}/revoke-sessions`, { method: "POST" });
-  }
 
   // --- admin: user management --------------------------------------------
-  listUsers() {
-    return this.json<AccountUser[]>("/auth/users");
-  }
   /** Admin: read the audit trail (newest first), optionally filtered. */
   auditLog(params: { action?: string; actor?: string; since?: string; limit?: number } = {}) {
     const qs = new URLSearchParams();
@@ -912,29 +839,6 @@ export class ApiClient extends withProcurement(withEstimate(withModules(withMode
       { method: "POST", credentials: "include",
         headers: { "Content-Type": "application/json", ...this.authHeaders() },
         body: JSON.stringify(e), keepalive: true }).catch(() => { /* best-effort */ });
-  }
-  createUser(username: string, password: string, role: "admin" | "user" = "user", email?: string) {
-    return this.json<AccountUser>(
-      "/auth/users", { method: "POST", body: JSON.stringify({ username, password, role, email }) });
-  }
-  updateUser(username: string, patch: { role?: "admin" | "user"; active?: boolean; email?: string }) {
-    return this.json<AccountUser>(
-      `/auth/users/${encodeURIComponent(username)}`, { method: "PATCH", body: JSON.stringify(patch) });
-  }
-  resetUserPassword(username: string, password: string) {
-    return this.json<{ ok: boolean }>(
-      `/auth/users/${encodeURIComponent(username)}/password`,
-      { method: "POST", body: JSON.stringify({ password }) });
-  }
-  /** Admin: mint a single-use reset token for a user to set their own password. */
-  issueResetToken(username: string) {
-    return this.json<{ username: string; reset_token: string; expires_in: number }>(
-      `/auth/users/${encodeURIComponent(username)}/reset-token`, { method: "POST" });
-  }
-  /** Unauthenticated: set a new password using a reset token (the token is the credential). */
-  resetWithToken(token: string, next: string) {
-    return this.json<{ ok: boolean; username: string }>(
-      `/auth/reset`, { method: "POST", body: JSON.stringify({ token, new: next }) });
   }
 
   /** Absolute URL for a GET endpoint, e.g. an export download. */

--- a/apps/web/src/api/surface.test.ts
+++ b/apps/web/src/api/surface.test.ts
@@ -77,7 +77,16 @@ describe("the API client's public surface", () => {
     // the same drift that took it from 685 to 696 a day earlier, and it will happen again: **every
     // merge that adds an endpoint silently converts this ratchet back into a slack floor.** The
     // number must be re-read from this reader after any batch of merges, not only when extracting.
-    expect(surface.size, `only ${surface.size} methods reachable`).toBeGreaterThanOrEqual(698);
+    //
+    // 2026-08-06 (SCALE-SEAM ⑦): raised 698 -> 699, and the re-read is the point rather than the
+    // extraction. The /auth move is surface-neutral by construction — this reader counted **699 both
+    // before and after it**, which is the evidence that 20 methods changed file and none was lost.
+    // The single method of slack was therefore NOT created by this change; it had accumulated from
+    // merges since ⑥, exactly as the paragraph above predicted it would. That is worth stating
+    // plainly: **an extraction is the occasion to re-read this number, never the cause of it moving.**
+    // Anyone raising this line because their own change grew the surface should say so here; anyone
+    // raising it to make a red test go green has inverted the gate.
+    expect(surface.size, `only ${surface.size} methods reachable`).toBeGreaterThanOrEqual(699);
   });
 
   it("keeps the transport primitives the domain methods are built on", () => {
@@ -100,6 +109,15 @@ describe("the API client's public surface", () => {
       "drawingMarkup", "promoteDrawingMarkup",                      // 2D markup -> RFI
       "editIfc", "publish", "createBlankModel", "placeFamily",      // authoring
       "notificationStream", "markupStream", "pullPlanStream",       // SSE subscriptions
+      // auth (SCALE-SEAM ⑦). Named here because the count alone was a weak guard for this group:
+      // losing all 20 would have dropped the surface to 679 and failed loudly, but losing ONE — say
+      // `login` — would have left 698 and cleared the floor that stood when they moved. Every one of
+      // these has a real call site in `account/accountUI.ts`, and `stepUp` gates PDF sealing, so a
+      // silent loss here locks people out rather than breaking a screen.
+      "login", "logout", "me", "register", "changePassword",        // session lifecycle
+      "mfaVerify", "mfaStatus", "mfaEnable",                        // MFA enrolment + challenge
+      "stepUp",                                                     // per-action re-auth for seals
+      "listUsers", "createUser", "updateUser", "resetWithToken",    // admin user management
     ]) {
       expect(surface.has(k), `${k}() vanished — a call site is now broken`).toBe(true);
     }

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -35,8 +35,44 @@ const LINES = ROADMAP.split("\n");
 const GATED_AT = LINES.findIndex((l) => l.startsWith("## ⛔ Gated"));
 const OPEN = LINES.slice(0, GATED_AT === -1 ? LINES.length : GATED_AT);
 
-/** A roadmap item bullet: `- **CODE** …`, `* ⭐ **CODE ② — …**`, with or without a status glyph. */
-const ITEM = /^\s*[-*] (?:✅ |◧ |🟡 |⭐ )?\*\*([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,}?)(?:\s*([①②③④⑤⑥]))?(?:\s|\*\*|—)/;
+/**
+ * A roadmap item bullet: `- **CODE** …`, `* ⭐ **CODE ② — …**`, with or without a status glyph.
+ *
+ * **The increment marker runs ①–⑨, and it stopped at ⑥ until 2026-08-06** — the day SCALE-SEAM
+ * shipped its seventh. `⑦` was not in the class, and the interesting part is what that did rather
+ * than that it happened: the marker group is optional, so `**SCALE-SEAM ⑦ — …**` did not fail to
+ * match. It matched and returned the code as plain `SCALE-SEAM`, **silently dropping the increment
+ * number**. The item then disagreed with the lane table cell (which said `SCALE-SEAM ⑦`) and the
+ * assignment check failed — loudly, but for a reason two steps from the cause.
+ *
+ * That is the docstring's own warning arriving: "if a new item is written in a style this regex does
+ * not match, it is not in the population and the failure mode is a silent omission". Here the style
+ * was not new — only the *number* was — which is worse, because nothing about writing the eighth
+ * increment of an existing item looks like inventing a new notation. Had the table been updated to
+ * plain `SCALE-SEAM` to make the red go away, the two lists would have agreed at the cost of the
+ * roadmap no longer recording which increment was open: green, and wrong.
+ *
+ * ⑨ is not a considered limit either, just a further-off one. **A vocabulary this check defines is
+ * part of its population, so widening it is a real change and not housekeeping.**
+ */
+const MARKS = "①②③④⑤⑥⑦⑧⑨";
+
+/**
+ * One source for the marker vocabulary, because there were **two** and they had already drifted.
+ *
+ * Widening the item regex to ⑦ was not enough: `laneRows()` matched the increment on a table cell
+ * with its own separately-written `[①②③④⑤⑥]`, so the bullet parsed as `SCALE-SEAM ⑦` while the cell
+ * parsed as `SCALE-SEAM` — and the item reported as *unassigned* despite being sitting right there
+ * in the table. Two readers, one structure, opposite halves of the same comparison.
+ *
+ * This file already carries that lesson at `LANE_ROW_LINES` ("**Two readers of one structure WILL
+ * drift; the second one is the bug**"), written after a narrower row matcher let an unbolded row
+ * escape. It was true again, in the same file, about a different structure — which is the argument
+ * for making the vocabulary a value rather than restating it correctly in two places.
+ */
+const ITEM = new RegExp(
+  String.raw`^\s*[-*] (?:✅ |◧ |🟡 |⭐ )?\*\*([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,}?)(?:\s*([${MARKS}]))?(?:\s|\*\*|—)`,
+);
 
 function itemCodes(lines: string[]): Set<string> {
   const out = new Set<string>();
@@ -91,7 +127,7 @@ function laneRows(): Lane[] {
     const excludes = all.filter((p) => p.startsWith("!")).map((p) => p.slice(1));
     const items = itemCell.split("·").map((s) => s.trim())
       // Only take things shaped like a code; prose cells ("no standalone items…") contribute none.
-      .map((s) => /^([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]+(?: [①②③④⑤⑥])?)/.exec(s)?.[1])
+      .map((s) => new RegExp(String.raw`^([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]+(?: [${MARKS}])?)`).exec(s)?.[1])
       .filter((s): s is string => Boolean(s));
     rows.push({ name, paths, excludes, items });
   }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -205,7 +205,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | R22-PM-CONTRACTS |
-| **I · API client** | `apps/web/src/api/` | SCALE-SEAM ⑥ |
+| **I · API client** | `apps/web/src/api/` | SCALE-SEAM ⑦ |
 
 **Parked — not available to pick up.** These are decisions or multi-release commitments, listed so
 nobody starts one thinking it is a sprint item: QUALITY-ROOM · R26-V-TIMING · R24-PERSONA-SHAPE ·
@@ -2079,11 +2079,11 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
 
 ## 🧱 Decomposition & reliability carry-overs (interleave one per few releases)
 
-- ⭐ **SCALE-SEAM ⑥ — `client.ts` is no longer a god-file, but the split is not finished.** ②–⑤ have
+- ⭐ **SCALE-SEAM ⑦ — `client.ts` is no longer a god-file, but the split is not finished.** ②–⑦ have
   shipped: `schedule.ts` (v0.3.800, 26 methods / 207 lines) · `model.ts` (v0.3.802, 29) · `modules.ts`
-  (v0.3.803, 34) · `estimate.ts` (v0.3.804, 12). **`client.ts` went 4,956 → 4,025 lines.** ⑥ is
-  `/procurement` (89 lines, 9 methods), then `/auth` (90, 19 — which needs care, because it is the one
-  group that owns token state rather than just calling routes).
+  (v0.3.803, 34) · `estimate.ts` (v0.3.804, 12) · `procurement.ts` (9) · `auth.ts` (20).
+  **`client.ts` went 4,956 → 3,871 lines** (`wc -l`). ⑧ is the next route-group by size; pick it by
+  re-running the classification below, not by reading the section comments.
 
   **This entry read `③+` and named `/model`, `/modules` and `/estimate` as the next groups until
   2026-07-30, by which point all three had shipped.** Caught by `roadmapLanes.test.ts`, and not for the
@@ -2108,6 +2108,35 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
   in **six** separate regions of the file, which is the concrete form of "the section comments no
   longer delimit anything": they label where a run *starts*, and the file then carries on into other
   domains. Groups are located by the route each method calls, and each body by brace matching.
+
+  **⑦ shipped** — `/auth` out to `apps/web/src/api/auth.ts` (20 methods / 96 lines; `client.ts`
+  3,967 → 3,871), across **four** regions. Three things are worth carrying forward.
+
+  *The difficulty this entry predicted did not exist.* ⑥ said `/auth` "needs care, because it is the
+  one group that owns token state rather than just calling routes", and sized it at 19 methods / 90
+  lines. It does mutate token state — `changePassword` and `logoutAll` both adopt the fresh token the
+  server returns — but that state has lived on `HttpCore` behind a **public** `setToken` since the T2
+  transport extraction. A mixin cannot see `ApiClient`'s privates; its own base's public members are
+  fine. The real blocker in ③ was `liveStream` being private *on `ApiClient`*, and nothing here is
+  shaped like that. **The caution was recorded before the fix that removed it, and then outlived it** —
+  the same drift as the `③+` staleness above, in the one direction that costs work rather than
+  causing a defect: an item scoped defensively for a reason that has already been discharged.
+
+  *Four methods that read as `/auth` deliberately stayed.* `auditLog`, `errorLog`, `clearErrorLog` and
+  `reportClientError` sit inside the `// --- admin: user management ---` run but route to `/audit`,
+  `/admin/errors` and `/client-errors`. Grouping by section comment would have moved three unrelated
+  domains. The orphaned `// --- auth ---` banner was deleted rather than left labelling `integrations()`.
+
+  *The surface ratchet had gone slack again — the second consecutive increment to find this.* Floor
+  698, live count 699, raised to 699. What makes the claim usable is that the count was measured on
+  the **unmodified** tree first: 699 before and 699 after, from the gate's own reader, so the move
+  provably dropped nothing and the slack was inherited rather than caused. Mutation-checked both
+  ways (drop one method → 698 red; leave the mixin uncomposed → 679 red), with each mutation
+  confirmed to have applied before its result was read — the first attempt's regex silently matched
+  nothing under CRLF and returned a green that meant nothing. **`⑥` reported this same drift; two in
+  a row is the pattern the test predicted, not bad luck** — every merge that adds an endpoint converts
+  the ratchet back into a floor, so re-reading it is part of taking a SCALE-SEAM increment, not a
+  discretionary extra.
 
   **The remaining-groups list here was wrong, and re-measuring is the only way to keep it honest.**
   It named `/procurement`, `/auth` and `/elements` and omitted several larger ones. Measured on

--- a/services/api/test_file_sizes.py
+++ b/services/api/test_file_sizes.py
@@ -39,6 +39,28 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 #: Hand-written source we own. A file over this is a file nobody can review in one sitting.
 CEILING = 5_200
 
+#: Per-file ceilings for the files SCALE-SEAM is actively splitting. **Only ever revised DOWN.**
+#:
+#: WHY THIS EXISTS, and it is a correction to how the ratchet was understood. `CEILING` above is a
+#: single GLOBAL number, so it is pinned by whichever file is worst — today `viewer/app.ts` at 5,064.
+#: That means an extraction out of any OTHER file cannot move it: SCALE-SEAM ⑦ took 96 lines out of
+#: `client.ts` and the global ceiling was as true at 5,200 afterwards as before. The instruction
+#: "lower the ceiling as each extraction lands" is right about the intent and cannot be carried out
+#: by this number — lowering it to 5,064 would ratchet a slack belonging to `viewer/app.ts`, a file
+#: in a different lane, and leave it with zero headroom so the next edit there fails the build.
+#:
+#: **A ratchet has to be per-subject when the work is per-subject.** One global number measures the
+#: worst file and is silent about every other, which is the same shape as a gate whose scope is
+#: narrower than its claim.
+#:
+#: A new endpoint added straight to `client.ts` will fail this, and that friction is the point rather
+#: than a side effect: the question it forces is "should this live in a domain module instead?", and
+#: post-⑦ the answer is usually yes. Raising an entry is therefore a deliberate act that should be
+#: argued for in the commit message — the direction of travel is down.
+PER_FILE = {
+    "apps/web/src/api/client.ts": 3_871,   # SCALE-SEAM ⑦ (/auth out); was 3,967 before
+}
+
 #: Exempt because a human never reads them top-to-bottom. Name them, never infer them.
 EXEMPT_SUBSTRINGS = (
     "/vendor/",           # vendored upstream copies — re-synced by overwrite, never hand-edited
@@ -78,6 +100,28 @@ check(
     f"no hand-written file exceeds {CEILING} lines",
     not over,
     "; ".join(f"{rel}={n}" for rel, n in over[:5]) or "",
+)
+
+measured = dict(sizes)
+
+# A per-file ratchet keyed by PATH silently stops ratcheting the moment the path changes — a rename,
+# a move, or an exemption that starts matching would drop the entry and this check would go green by
+# measuring nothing. So assert the subjects are present BEFORE asserting their sizes, individually
+# rather than in aggregate: an aggregate non-empty check cannot see a dead entry beside a live one.
+missing = [rel for rel in PER_FILE if rel not in measured]
+check(
+    "every per-file ratchet still names a file that exists",
+    not missing,
+    "; ".join(missing) or f"{len(PER_FILE)} tracked",
+)
+
+grew = [(rel, measured[rel], cap) for rel, cap in PER_FILE.items()
+        if rel in measured and measured[rel] > cap]
+check(
+    "no file under an extraction ratchet has grown",
+    not grew,
+    "; ".join(f"{rel}={n} > {cap}" for rel, n, cap in grew)
+    or "; ".join(f"{rel}={measured[rel]}/{cap}" for rel, cap in PER_FILE.items() if rel in measured),
 )
 
 # The ratchet only ratchets if somebody can see the headroom. Print the top of the list every run so


### PR DESCRIPTION
Lane **I · API client** (`apps/web/src/api/`), confirmed clear by the lead. **No version files, no `CHANGELOG.md`, no `run_tests.py`** — for the release holder to batch.

> **Correction to my original lane justification.** I first wrote that I picked Lane I because the dirty shared clone showed lanes A–D in flight. **That reading was wrong**, as the lead caught. Releases land via temp-index `commit-tree`, so local `HEAD` never moves — it sits eleven releases stale, and `git status` was answering about that stale ref. I re-verified every dirty path against `origin/main` with line endings normalised: **all byte-identical to what is already shipped.** Nothing was in flight. The lane choice stands; the reasoning that produced it does not. Worth recording because the usual warning is "uncommitted work is invisible to git" — here the hazard was the inverse: **a git-based check that was visible and confidently wrong, reporting activity where there was none.**

## What shipped

`/auth` out of `client.ts` into [`apps/web/src/api/auth.ts`](apps/web/src/api/auth.ts) as a mixin — **20 methods / 96 lines**, `client.ts` **3,967 → 3,871**, located by the route each method calls. The 20 sat in **four** separate regions. The `client.ts` diff is **3 added lines** against 99 deletions — a pure move by construction.

## Three findings, each of which outranks the refactor

**1 · The difficulty ⑥ predicted had already been fixed — a corrected prediction, not a deleted one.** ⑥ flagged `/auth` as "the one group that owns token state rather than just calling routes", and that was reasonable when written. It does mutate token state (`changePassword` and `logoutAll` adopt the server's fresh token), but that state has lived on `HttpCore` behind a **public** `setToken` since the T2 transport extraction. The distinction that matters for scoping ⑧: what blocked the SSE methods in ③ was `liveStream` being **private on `ApiClient`** — a mixin is a *base* of `ApiClient` and cannot see its privates, but its own base's public members are always reachable. So there was never an analogue here. **The caution outlived the fix that removed it.** The roadmap entry keeps the original warning as history and records why ⑦ turned out ordinary, so the next reader can tell which future group is *genuinely* delicate.

**2 · Four methods that read as `/auth` deliberately did NOT move — the rejected option, recorded because it is the part a future extractor needs.** `auditLog`, `errorLog`, `clearErrorLog` and `reportClientError` sit inside the `// --- admin: user management ---` run and read as part of this group, but they route to `/audit`, `/admin/errors` and `/client-errors`. Grouping by **section comment** instead of **route prefix** would have dragged three unrelated domains across the seam and made ⑧ harder. The orphaned `// --- auth ---` banner is deleted rather than left labelling `integrations()`.

**3 · The surface ratchet had gone slack — second consecutive increment to find this.** Floor 698, live count 699, raised to 699. At 698 **losing a single method would have passed silently**; a ratchet with one method of slack is decorative for exactly that loss.

The claim worth checking: **I measured the count on the unmodified tree first — 699 before, 699 after**, from the gate's own reader. Without that baseline, "I raised the floor and it passes" is indistinguishable from "I raised the floor to hide what I dropped." **The slack accumulated from merges since ⑥, not from this change** — do not attribute it to the extraction when scoping ⑧.

Auth names added to the spot-check list, because a count is a weak assertion about a set: losing all 20 fails loudly at 679, losing only `login` cleared the old floor.

## Commit 2 — the lane gate could not express a seventh increment

Its marker class was `[①②③④⑤⑥]`. The failure was **not** a non-match: the group is optional, so `**SCALE-SEAM ⑦ …**` matched and returned bare `SCALE-SEAM`, *silently dropping the number*, then disagreed with the table cell. The tempting fix — retitle the cell to bare `SCALE-SEAM` — goes green while the roadmap stops recording which increment is open.

Widening it once was not enough: **`laneRows()` carried a second, independently-written `[①②③④⑤⑥]`** for the table cell. Two readers, one structure, opposite halves of the same comparison. This file already carries that lesson at `LANE_ROW_LINES` — *"Two readers of one structure WILL drift; the second one is the bug"* — written after a narrower row matcher let an unbolded row escape. True again, same file, different structure. Both now derive from one `MARKS` constant.

**Touches `apps/web/src/shell/roadmapLanes.test.ts` (Lane A) and `docs/roadmap.md`** — deliberately its own commit so it can be dropped or rebased alone.

## Commit 3 — the size ratchet had to become per-file

Asked to lower the ceiling so the extraction does not give the ratchet back. **The intent is right and `CEILING` structurally cannot carry it.** It is one global value asserted against every file, so it is pinned by the worst file — `viewer/app.ts` at 5,064. ⑦ removed 96 lines from `client.ts` and 5,200 was exactly as true afterwards. Lowering it to 5,064 would not have recorded ⑦ at all: it would ratchet slack belonging to a **Lane E** file and leave that lane zero headroom.

So `PER_FILE` pins the subjects actually being split; `client.ts` enters at 3,871 and only ever revises down. Two assertions, because a ratchet keyed by path stops ratcheting silently when the path changes — subjects asserted **present** before their sizes are asserted, per entry, since an aggregate check cannot see a dead entry beside a live one.

**Deliberate friction:** a new endpoint added straight to `client.ts` now fails, forcing the question "should this live in a domain module instead?" Post-⑦ the answer is usually yes.

## Verification

| check | result |
|---|---|
| `npm run test --workspace apps/web` (workspace cmd, not root `vitest`) | **1166 / 1166**, 107 / 107 |
| `npx tsc --noEmit` / `npx eslint` | clean |
| `test_claude_md_gates.py` | green — 173 citations, `auth.ts` resolves |
| `test_no_comparative_names.py` | green — 1619 files (1508 source) |
| `test_file_sizes.py` | green — `client.ts` 3,871/3,871 |
| surface count, **unmodified** tree | **699** |
| surface count, after extraction | **699** |

**Mutation checks — each verified to have applied before its result was read:**

| mutation | result |
|---|---|
| delete only `login()` | 698 → red, *and* names `login` |
| mixin written but never composed | 679 → red (−20) |
| table cell ⑥ vs bullet ⑦ | red, names `SCALE-SEAM ⑦` |
| `client.ts` +1 line | exit 1, `3872 > 3871` |
| size ratchet names a stale path | exit 1 — and the **size check passed with empty detail**, the silent no-op the presence assertion exists to catch |

Two near-misses stated rather than buried. The first mutation attempt used a regex that **silently matched nothing under CRLF** and reported a meaningless "6 passed" — caught only by asserting the mutation applied. And the size gate's first run **crashed on a `NameError` in its own PASS-path detail string**: the mutant failed correctly while the green path raised, so both paths are now exercised.

**One caveat needing another lane's judgement:** my first full-suite run had 1 failure — `shell/roadmapStale.test.ts` timing out at 5s under load with three sessions running. Passes standalone twice, passes in the full suite on re-run, and reads only `services/api/src` and `services/data/src`. I judged it a load flake, but it is Lane A's test and that timeout may be genuinely tight on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive authentication, MFA, session, password-reset, and user-administration API support.
  * Added token refresh handling after password changes and global sign-outs.
* **Bug Fixes**
  * Improved logout reliability by tolerating sign-out failures.
* **Documentation**
  * Updated the API roadmap to reflect completed authentication improvements.
  * Expanded roadmap marker support for additional item numbering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->