### PR TITLE
AUTH-SNAP-OVERRIDE — a one-shot object snap, and the resolver nothing was calling

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1738,8 +1738,15 @@ window.addEventListener("keydown", (e) => {
   // The draw codes are only offered once the viewer is in memory: importing them eagerly would pull
   // viewer code into the startup bundle to populate a list that cannot be used yet anyway.
   if (k === "?") {
+    // AUTH-SNAP-OVERRIDE — the one-shot snap codes ride along with the draw codes, and for the same
+    // reason they must: `keysDyn` installs its OWN `?` listener once the viewer is loaded, so both
+    // handlers answer this key. While they published the same list that was invisible; the moment one
+    // of them knows about a section the other does not, `?` gives two different answers again — which
+    // is the precise defect `ui/keys.ts` was written to end. Gated on `viewerApp` like the draw codes,
+    // because neither does anything without an armed tool.
     void import("./viewer/keysDyn")
-      .then(({ KEY_SHORTCUTS }) => showKeyHelp(viewerApp ? KEY_SHORTCUTS : []))
+      .then(({ KEY_SHORTCUTS, SNAP_HELP }) =>
+        showKeyHelp(viewerApp ? KEY_SHORTCUTS : [], viewerApp ? SNAP_HELP : []))
       .catch(() => showKeyHelp());
     return;
   }

--- a/apps/web/src/ui/keys.test.ts
+++ b/apps/web/src/ui/keys.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
-import { KEY_SHORTCUTS } from "../viewer/keysDyn";
+import { KEY_SHORTCUTS, SNAP_HELP } from "../viewer/keysDyn";
+import { OVERRIDE_CODES } from "../viewer/snapOverride";
 import { GLOBAL_KEYS, VIEWER_KEYS, keyContract, keysIn } from "./keys";
 
 /**
@@ -53,11 +56,65 @@ describe("the draw codes are not a second copy", () => {
   });
 });
 
+describe("AUTH-SNAP-OVERRIDE — the one-shot snap codes are not a second copy either", () => {
+  it("agrees with viewer/snapOverride in BOTH directions", () => {
+    const contract = keysIn(keyContract(KEY_SHORTCUTS, SNAP_HELP), "Snap for one pick");
+    expect([...contract].sort()).toEqual(Object.keys(OVERRIDE_CODES).sort());
+  });
+
+  it("publishes a human label per code, not the internal kind", () => {
+    const sect = keyContract(KEY_SHORTCUTS, SNAP_HELP).find((s) => s.title === "Snap for one pick")!;
+    expect(sect.entries.find((e) => e.keys === "PE")?.does).toBe("Perpendicular");
+    expect(sect.entries.find((e) => e.keys === "NO")?.does).toBe("No snap");
+  });
+
+  // The one thing a reader of this section most needs to know, because it is what makes it usable
+  // mid-draw and is the whole difference from a mode.
+  it("says it applies to one click and that Esc leaves the tool armed", () => {
+    const sect = keyContract(KEY_SHORTCUTS, SNAP_HELP).find((s) => s.title === "Snap for one pick")!;
+    expect(sect.note).toMatch(/that click only/i);
+    expect(sect.note).toMatch(/not a mode/i);
+    expect(sect.note).toMatch(/leaves the tool armed/i);
+  });
+});
+
+/**
+ * Both `?` handlers must publish the same sections.
+ *
+ * `main.ts` answers `?` globally and `viewer/keysDyn.ts` installs a second `?` listener once the 3D
+ * bundle is in memory, so with the viewer loaded BOTH run. That was harmless only while they passed
+ * identical arguments. This module's whole origin story is `?` giving two different answers depending
+ * on load state, and the cheapest way for it to come back is a new section added to one call site.
+ *
+ * Asserted against source text because the two call sites are in module top-level key handlers that
+ * cannot be invoked without standing up the shell and the viewer. Resolved from `process.cwd()`
+ * (= `apps/web`) — under happy-dom `import.meta.url` has no `file:` scheme.
+ */
+describe("the two `?` call sites publish the same sections", () => {
+  const read = (rel: string) => readFileSync(resolve(process.cwd(), rel), "utf8");
+
+  it("main.ts passes the snap codes, not just the draw codes", () => {
+    const src = read("src/main.ts");
+    expect(src).toMatch(/SNAP_HELP/);
+    // and imports it from the same module it already takes KEY_SHORTCUTS from, rather than keeping
+    // a second copy of the table
+    expect(src).toMatch(/KEY_SHORTCUTS,\s*SNAP_HELP/);
+  });
+
+  it("keysDyn.ts passes both as well", () => {
+    expect(read("src/viewer/keysDyn.ts")).toMatch(/showKeyHelp\(KEY_SHORTCUTS,\s*SNAP_HELP\)/);
+  });
+});
+
 describe("the contract degrades honestly", () => {
   it("omits the Draw tools section entirely when the viewer has not loaded", () => {
     // Rather than showing fourteen codes that would do nothing if pressed.
     const titles = keyContract([]).map((s) => s.title);
     expect(titles).toEqual(["Anywhere", "In the 3D view"]);
+  });
+
+  it("omits the snap codes too — they need an armed draw tool, which needs the viewer", () => {
+    expect(keyContract(KEY_SHORTCUTS, []).map((s) => s.title)).not.toContain("Snap for one pick");
   });
 
   it("says the 3D keys need a model rather than letting the user find out", () => {

--- a/apps/web/src/ui/keys.ts
+++ b/apps/web/src/ui/keys.ts
@@ -63,7 +63,10 @@ export const VIEWER_KEYS: KeyEntry[] = [
  * screen must be openable before the 3D bundle has loaded, which is exactly the moment the old toast
  * was the only thing available.
  */
-export function keyContract(drawCodes: readonly (readonly [string, string, string])[] = []): KeySection[] {
+export function keyContract(
+  drawCodes: readonly (readonly [string, string, string])[] = [],
+  snapCodes: readonly (readonly [string, string])[] = [],
+): KeySection[] {
   const sections: KeySection[] = [
     { title: "Anywhere", entries: GLOBAL_KEYS },
     {
@@ -78,6 +81,18 @@ export function keyContract(drawCodes: readonly (readonly [string, string, strin
       note: "Type the two letters with no modifier to arm a tool, then click in the model to place it. "
         + "Esc disarms. While a tool is armed you can type a distance or angle — 6, <30, or 6<30.",
       entries: drawCodes.map(([code, , label]) => ({ keys: code, does: label })),
+    });
+  }
+  // AUTH-SNAP-OVERRIDE. Same rule as the draw codes: passed in, never imported, so `?` still works
+  // before the 3D bundle has loaded — and omitted entirely rather than printed as an aspiration.
+  if (snapCodes.length) {
+    sections.push({
+      title: "Snap for one pick",
+      note: "While a draw tool is armed, type one of these to aim the NEXT click at a particular snap "
+        + "— it applies to that click only and is not a mode. Esc cancels it and leaves the tool armed. "
+        + "If the picked element has no such snap the click takes the raw cursor and the glyph says so, "
+        + "rather than quietly using a different one.",
+      entries: snapCodes.map(([code, label]) => ({ keys: code, does: label })),
     });
   }
   return sections;
@@ -95,9 +110,12 @@ export function keysIn(sections: readonly KeySection[], title: string): string[]
  * unlike the toast it replaces, it stays on screen until dismissed. A help surface with a six-second
  * timeout is a help surface you have to read faster than you can try.
  */
-export function showKeyHelp(drawCodes: readonly (readonly [string, string, string])[] = []): void {
+export function showKeyHelp(
+  drawCodes: readonly (readonly [string, string, string])[] = [],
+  snapCodes: readonly (readonly [string, string])[] = [],
+): void {
   showResult("⌨ Keyboard", (body) => {
-    for (const section of keyContract(drawCodes)) {
+    for (const section of keyContract(drawCodes, snapCodes)) {
       const h = document.createElement("div");
       h.className = "section-title";
       h.style.marginTop = "10px";

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -9,7 +9,10 @@ import { installCollabPresence } from "./collabPresence";
 import { installKeysDyn } from "./keysDyn";
 import { installEnvTools } from "./envTools";
 import { inferDirection } from "./inference";
-import { applyDynamicInput, polarConstrain } from "./snapEngine";
+import { applyDynamicInput, polarConstrain, resolveSnap } from "./snapEngine";
+import {
+  OVERRIDE_LABEL, createSnapOverride, overrideCandidates, type OverrideKind,
+} from "./snapOverride";
 import { parseDynConstraint } from "./dynInput";
 import { parseCadCommand } from "./cadCommands";
 import { ModelLoader } from "./loader";
@@ -774,14 +777,17 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   // REL-4 leaf: the KEYS 2-letter shortcuts, the typed distance/angle constraint (dynamic input),
   // and the snap-glyph feedback live in keysDyn.ts; the handle exposes the dyn buffer for the draft
   // flow and Escape routes back through disarmDraft.
+  // AUTH-SNAP-OVERRIDE — one-shot osnap, armed by a two-letter code and spent by the next pick.
+  const snapOverride = createSnapOverride();
   const keysDyn = installKeysDyn({
     container, notify,
     isArmed: () => !!armed, armedPoints: () => armPts.length,
     draftHandle: () => draftHandle, onEscape: () => disarmDraft(),
+    snapOverride,
   });
   const setDynBuf = keysDyn.setDynBuf;
   const flashSnapGlyph = keysDyn.flashSnapGlyph;
-  function disarmDraft() { armed = null; armPts.length = 0; draftHistory.clear(); setDynBuf(""); draftHandle?.onArmCleared(); }
+  function disarmDraft() { armed = null; armPts.length = 0; draftHistory.clear(); setDynBuf(""); snapOverride.clear(); draftHandle?.onArmCleared(); }
   // A29-UNDO-LOCAL — Ctrl+Z pops the last clicked point of the IN-PROGRESS draft (Ctrl+Shift+Z
   // restores it); the server's versioned history stays the record for committed work. Registered on
   // window because the canvas never holds focus; consumed ONLY while a draft is armed, so committed-
@@ -954,14 +960,50 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     } catch { return null; }
   }
 
+  /** AUTH-SNAP-OVERRIDE — resolve ONE named snap kind against the picked element's plan footprint.
+   *
+   *  Null when the model has nothing of that kind to offer; the caller then keeps the raw cursor and
+   *  says so on the glyph. It deliberately does **not** fall back to another kind — the drafter named
+   *  one, and a point silently placed on a midpoint while the HUD said "perpendicular" carries a
+   *  GlobalId into the schedules.
+   *
+   *  No aperture. The automatic path uses a 0.4 m tolerance because it is guessing which of six kinds
+   *  the drafter meant; here the kind is stated and the candidates are the ≤4 points of the element
+   *  the drafter explicitly picked, so a distance cut would only make a stated intent fail. */
+  async function snapByOverride(raw: THREE.Vector3, hit: Hit | null, kind: OverrideKind,
+                                from: THREE.Vector3 | null): Promise<THREE.Vector3 | null> {
+    if (kind === "none" || !hit) return null;
+    try {
+      const boxes = await loader.fragments.getBBoxes({ [hit.fragments.modelId]: new Set([hit.localId]) });
+      const bx = boxes[0];
+      if (!bx) return null;
+      const cur = { x: raw.x, z: raw.z };
+      const cands = overrideCandidates(kind, { minX: bx.min.x, maxX: bx.max.x, minZ: bx.min.z, maxZ: bx.max.z },
+                                       cur, from ? { x: from.x, z: from.z } : null);
+      const r = resolveSnap(cur, cands, Number.POSITIVE_INFINITY, kind);
+      return r ? new THREE.Vector3(r.x, raw.y, r.z) : null;
+    } catch { return null; }
+  }
+
   // --- P0 Draft placement: parameter-driven (params baked into `armed.build`), no prompt() --------
   async function captureDraftPoint(e: MouseEvent, hit: Hit | null) {
     const spec = armed;
     if (!spec) return;
     const raw = hit?.point ?? screenToGround(e);
-    const geoSnap = raw ? await snapToGeometry(raw, hit) : null;   // hard endpoint/edge/vertex snap
-    let p = raw ? (geoSnap ?? snapPoint(raw)) : null;
-    if (geoSnap) flashSnapGlyph(e, "◻ snap");
+    // AUTH-SNAP-OVERRIDE — spent by THIS pick whether or not it resolves, so a miss never steers the
+    // click after it. While armed it replaces the automatic geometry snap and suppresses every
+    // automatic stage below (grid increment, grid overlay, axis inference, polar, Shift ortho): a
+    // stated "this pick, perpendicular" that then got re-snapped to a grid line is not an override.
+    // A TYPED constraint still wins, because exact numbers are the more specific statement of the two.
+    const ovr = snapOverride.consume();
+    const ovrFrom = armPts.length >= 1 ? armPts[armPts.length - 1]! : null;
+    const geoSnap = raw
+      ? (ovr ? await snapByOverride(raw, hit, ovr, ovrFrom) : await snapToGeometry(raw, hit))
+      : null;                                                      // hard endpoint/edge/vertex snap
+    let p = raw ? (geoSnap ?? (ovr ? raw.clone() : snapPoint(raw))) : null;
+    if (ovr === "none") flashSnapGlyph(e, "⊾ no snap");
+    else if (ovr) flashSnapGlyph(e, geoSnap ? `⊾ ${OVERRIDE_LABEL[ovr]}` : `⊾ no ${OVERRIDE_LABEL[ovr]} here`);
+    else if (geoSnap) flashSnapGlyph(e, "◻ snap");
     // SNAP-KIT phase 2 — a TYPED constraint beats every automatic snap: the drafter said exactly
     // what they want. Plan angles are CCW-from-east with North "up" = -z, while the snap engine's
     // +z axis points south — so the typed angle's sign flips on the way in.
@@ -974,11 +1016,11 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
       showCoords(p);
       flashSnapGlyph(e, `⌨ ${keysDyn.dynBuf()}`);
       setDynBuf("");
-    } else if (p && e.shiftKey && armPts.length >= 1) {   // ortho lock from the previous point
+    } else if (p && e.shiftKey && armPts.length >= 1 && !ovr) {   // ortho lock from the previous point
       const a = armPts[armPts.length - 1]!; // safe: armPts.length >= 1 checked above
       if (Math.abs(p.x - a.x) >= Math.abs(p.z - a.z)) p = new THREE.Vector3(p.x, p.y, a.z);
       else p = new THREE.Vector3(a.x, p.y, p.z);
-    } else if (p && !geoSnap && armPts.length >= 1) {
+    } else if (p && !geoSnap && armPts.length >= 1 && !ovr) {
       // E1 — automatic on-axis / parallel inference (SketchUp-style): snap the point onto a world axis
       // or the previous edge's direction/perpendicular when the cursor is within ~6° of it. A hard
       // geometry-vertex snap (above) always wins; Shift is the manual hard ortho-lock.
@@ -998,7 +1040,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     if (!p) { notify("couldn't pick a point — click the floor or grid", "error"); return; }
     // snap to the nearest grid intersection when the grid overlay is loaded (plan E=x, N=-z) —
     // unless a TYPED constraint placed this point (explicit intent must not be re-snapped away)
-    if (gridOverlay.hasData && !dynC) {
+    if (gridOverlay.hasData && !dynC && !ovr) {
       const gs = gridOverlay.nearestSnap(p.x, -p.z, 0.6);
       if (gs) p = new THREE.Vector3(gs[0], p.y, -gs[1]);
     }

--- a/apps/web/src/viewer/keysDyn.test.ts
+++ b/apps/web/src/viewer/keysDyn.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { installKeysDyn } from "./keysDyn";
+import { createSnapOverride, type SnapOverrideHandle } from "./snapOverride";
+
+/**
+ * AUTH-SNAP-OVERRIDE — the *reachability* half.
+ *
+ * `snapOverride.test.ts` proves the state machine and the geometry. Neither would notice if the chord
+ * never arrived: the override is armed from a two-letter buffer that already belongs to the draw-tool
+ * shortcuts, and "an engine with nothing calling it" is this repo's most-repeated defect. So these
+ * tests press keys at the real installed handler.
+ */
+
+function install(opts: { armed?: boolean; points?: number } = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const s = {
+    container,
+    notify: vi.fn((_msg: string, _kind: "info" | "success" | "error") => {}),
+    onEscape: vi.fn(() => {}),
+    override: createSnapOverride() as SnapOverrideHandle,
+    armed: opts.armed ?? true,
+    points: opts.points ?? 1,
+  };
+  installKeysDyn({
+    container: s.container,
+    notify: s.notify,
+    isArmed: () => s.armed,
+    armedPoints: () => s.points,
+    draftHandle: () => null,
+    onEscape: s.onEscape,
+    snapOverride: s.override,
+  });
+  return s;
+}
+
+const press = (key: string) => window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+const type = (code: string) => { for (const ch of code) press(ch); };
+
+beforeEach(() => { document.body.innerHTML = ""; });
+
+describe("the one-shot code reaches the override through the real key handler", () => {
+  it("PE while a tool is armed arms the perpendicular override", () => {
+    const s = install({ armed: true });
+    type("pe");
+    expect(s.override.peek()).toBe("perpendicular");
+  });
+
+  it("all six codes arm, so none is published-but-dead", () => {
+    for (const [code, kind] of [["EN", "endpoint"], ["MI", "midpoint"], ["CE", "center"],
+      ["PE", "perpendicular"], ["NE", "nearest"], ["NO", "none"]] as const) {
+      const s = install({ armed: true });
+      type(code);
+      expect(s.override.peek(), `code ${code}`).toBe(kind);
+    }
+  });
+
+  // With no tool armed there is no "next pick", so the code must stay inert exactly as it was before
+  // this feature existed — not arm an override that then steers an unrelated click.
+  it("does nothing when no draw tool is armed", () => {
+    const s = install({ armed: false });
+    type("pe");
+    expect(s.override.peek()).toBeNull();
+  });
+
+  it("a draw-tool code does not arm a snap override", () => {
+    const s = install({ armed: true });
+    type("wa");
+    expect(s.override.peek()).toBeNull();
+  });
+
+  it("an unknown two-letter code arms nothing at all", () => {
+    const s = install({ armed: true });
+    type("zq");
+    expect(s.override.peek()).toBeNull();
+    expect(s.notify).not.toHaveBeenCalled();
+  });
+
+  it("tells the user what the next pick will do", () => {
+    const s = install({ armed: true });
+    type("ce");
+    expect(s.notify).toHaveBeenCalledWith(expect.stringMatching(/next pick: centre/i), "info");
+  });
+
+  it("ignores keys typed into a text field", () => {
+    const s = install({ armed: true });
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    for (const ch of "pe") input.dispatchEvent(new KeyboardEvent("keydown", { key: ch, bubbles: true }));
+    expect(s.override.peek()).toBeNull();
+  });
+});
+
+describe("Escape cancels the pending override before it cancels the tool", () => {
+  it("first Escape clears the override and leaves the draw tool alone", () => {
+    const s = install({ armed: true });
+    type("pe");
+    press("Escape");
+    expect(s.override.peek()).toBeNull();
+    expect(s.onEscape).not.toHaveBeenCalled();       // the points already placed survive
+  });
+
+  it("Escape with nothing armed still disarms the tool, as it always did", () => {
+    const s = install({ armed: true });
+    press("Escape");
+    expect(s.onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it("a second Escape disarms the tool", () => {
+    const s = install({ armed: true });
+    type("pe");
+    press("Escape");
+    press("Escape");
+    expect(s.onEscape).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the HUD says what is armed and stops saying it when nothing is", () => {
+  const hud = (s: ReturnType<typeof install>) => s.container.querySelector<HTMLElement>(".snap-override-hud")!;
+
+  it("is hidden until something is armed", () => {
+    const s = install({ armed: true });
+    expect(hud(s).style.display).toBe("none");
+  });
+
+  it("names the armed kind", () => {
+    const s = install({ armed: true });
+    type("pe");
+    expect(hud(s).style.display).toBe("block");
+    expect(hud(s).textContent).toMatch(/perpendicular/i);
+  });
+
+  // A HUD still promising "perpendicular" after the pick that spent it is a statement about the next
+  // click that is no longer true.
+  it("clears when the override is consumed by a pick", () => {
+    const s = install({ armed: true });
+    type("pe");
+    s.override.consume();
+    expect(hud(s).style.display).toBe("none");
+  });
+
+  it("clears on Escape", () => {
+    const s = install({ armed: true });
+    type("ne");
+    press("Escape");
+    expect(hud(s).style.display).toBe("none");
+  });
+});
+
+describe("the typed distance/angle buffer still works beside the codes", () => {
+  it("digits build the dyn constraint rather than the two-letter buffer", () => {
+    const s = install({ armed: true, points: 1 });
+    press("6");
+    const dyn = s.container.querySelector<HTMLElement>(".dyn-hud")!;
+    expect(dyn.textContent).toContain("6");
+  });
+});

--- a/apps/web/src/viewer/keysDyn.ts
+++ b/apps/web/src/viewer/keysDyn.ts
@@ -1,5 +1,6 @@
 import { dynKeystroke, formatDynConstraint, isDynKey, parseDynConstraint } from "./dynInput";
 import { showKeyHelp } from "../ui/keys";
+import { OVERRIDE_CODES, OVERRIDE_LABEL, type SnapOverrideHandle } from "./snapOverride";
 import type { DraftPanelHandle } from "./draft/draftPanel";
 
 /** REL-4 leaf — the KEYS shortcut layer + SNAP-KIT dynamic input.
@@ -18,6 +19,10 @@ export interface KeysDynDeps {
   draftHandle: () => DraftPanelHandle | null;
   /** Escape pressed → disarm the draft tool (the host also clears the dyn buffer via setDynBuf). */
   onEscape: () => void;
+  /** AUTH-SNAP-OVERRIDE — the one-shot osnap override, armed from the SAME two-letter buffer as the
+   *  draw tools (the two code sets are asserted disjoint in `snapOverride.test.ts`). Owned by the
+   *  host because the host's pick handler is what consumes it. */
+  snapOverride: SnapOverrideHandle;
 }
 
 export interface KeysDynHandle {
@@ -48,7 +53,20 @@ const KEY_MAP: Record<string, string> = Object.fromEntries(KEY_SHORTCUTS.map(([c
 // mentioned each other and one global key that produced a different answer depending on whether the
 // 3D bundle had finished loading. Both now open the single contract in `ui/keys.ts`, which reads the
 // table above rather than keeping a copy of it.
-const showKeysHelp = () => showKeyHelp(KEY_SHORTCUTS);
+// AUTH-SNAP-OVERRIDE — the published form of the one-shot snap codes, **derived** from the table the
+// handler dispatches rather than retyped beside it. `ui/keys.test.ts` asserts set-equality with the
+// source in both directions, the same way the draw codes are held.
+// The `?? kind` is not defensive noise: without it an unlabelled kind throws at MODULE LOAD, which
+// takes the whole test file down before a single assertion runs — the partition test written to catch
+// exactly that mistake would never get to report it. Degrade to the raw kind name and let the
+// assertion in `snapOverride.test.ts` be the thing that fails.
+export const SNAP_HELP: [string, string][] = Object.entries(OVERRIDE_CODES)
+  .map(([code, kind]) => {
+    const label = OVERRIDE_LABEL[kind] ?? kind;
+    return [code, label.charAt(0).toUpperCase() + label.slice(1)];
+  });
+
+const showKeysHelp = () => showKeyHelp(KEY_SHORTCUTS, SNAP_HELP);
 
 export function installKeysDyn(d: KeysDynDeps): KeysDynHandle {
   const { container, notify } = d;
@@ -96,6 +114,20 @@ export function installKeysDyn(d: KeysDynDeps): KeysDynHandle {
     setTimeout(() => g.remove(), 1100);
   }
 
+  // AUTH-SNAP-OVERRIDE — the armed-override HUD. It sits above the dyn HUD and is deliberately a
+  // DIFFERENT colour: a one-shot that looks like the persistent typed-constraint box would be read as
+  // a mode, which is the exact thing this feature exists to avoid.
+  const snapHud = document.createElement("div");
+  snapHud.className = "snap-override-hud";
+  snapHud.style.cssText = "position:absolute;bottom:74px;left:50%;transform:translateX(-50%);z-index:38;"
+    + "display:none;background:var(--panel,#0f172a);color:var(--warn,#f59e0b);border:1px solid "
+    + "var(--warn,#f59e0b);border-radius:6px;padding:3px 10px;font-size:13px;font-family:var(--mono)";
+  container.appendChild(snapHud);
+  d.snapOverride.subscribe((k) => {
+    snapHud.style.display = k ? "block" : "none";
+    snapHud.textContent = k ? `⊾ next pick: ${OVERRIDE_LABEL[k]} — Esc to cancel` : "";
+  });
+
   // KEYS — the 2-letter shortcut listener + its HUD
   let buf = "";
   let bufTimer = 0;
@@ -111,7 +143,13 @@ export function installKeysDyn(d: KeysDynDeps): KeysDynHandle {
     const t = e.target as HTMLElement | null;
     if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.tagName === "SELECT" || t.isContentEditable)) return;
     if (e.ctrlKey || e.metaKey || e.altKey) return;
-    if (e.key === "Escape") { d.onEscape(); clearBuf(); return; }
+    if (e.key === "Escape") {
+      // AUTH-SNAP-OVERRIDE — Escape cancels the PENDING override first and leaves the tool armed.
+      // Disarming the whole draw tool because the drafter changed their mind about one snap would
+      // throw away the points already placed; a second Escape still disarms.
+      if (d.snapOverride.peek()) { d.snapOverride.clear(); clearBuf(); return; }
+      d.onEscape(); clearBuf(); return;
+    }
     if (e.key === "?") { e.preventDefault(); showKeysHelp(); return; }
     // SNAP-KIT phase 2: while a draw tool is armed with a previous point, digits/./</- build the
     // typed distance/angle constraint (Backspace edits it) — it wins over every automatic snap.
@@ -132,6 +170,13 @@ export function installKeysDyn(d: KeysDynDeps): KeysDynHandle {
         const label = handle?.armByKey(key);
         if (label) notify(`${label} armed — click in the model to place`, "info");
         else if (handle) notify(`“${buf}” → ${key}: not available (needs a source IFC)`, "info");
+      } else if (d.isArmed()) {
+        // AUTH-SNAP-OVERRIDE — an osnap code, but only while a draw tool is armed: with nothing
+        // armed there is no "next pick" for a one-shot to attach to, so "NE" stays inert exactly as
+        // it is today rather than arming an override that would sit there waiting for a click that
+        // means something else.
+        const k = d.snapOverride.arm(buf);
+        if (k) notify(`next pick: ${OVERRIDE_LABEL[k]} — Esc to cancel`, "info");
       }
       clearBuf();
     }

--- a/apps/web/src/viewer/snapEngine.test.ts
+++ b/apps/web/src/viewer/snapEngine.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { applyDynamicInput, polarConstrain, resolveSnap, segmentSnaps } from "./snapEngine";
+import {
+  applyDynamicInput, nearestSnaps, perpendicularSnaps, polarConstrain, resolveSnap, segmentSnaps,
+} from "./snapEngine";
 
 describe("SNAP-KIT resolveSnap", () => {
   const cands = [
@@ -102,5 +104,47 @@ describe("SNAP-KIT applyDynamicInput", () => {
   it("passes the raw cursor through when nothing (or invalid) is typed", () => {
     expect(applyDynamicInput(O, { x: 2, z: 3 }, {})).toEqual({ x: 2, z: 3 });
     expect(applyDynamicInput(O, { x: 2, z: 3 }, { distance: -1 })).toEqual({ x: 2, z: 3 });
+  });
+});
+
+describe("SNAP-KIT perpendicularSnaps", () => {
+  const line = [{ x: 0, z: 0 }, { x: 10, z: 0 }];
+
+  it("drops the foot at 90° onto the segment", () => {
+    const s = perpendicularSnaps(line, { x: 3, z: 7 });
+    expect(s).toEqual([{ x: 3, z: 0, kind: "perpendicular" }]);
+  });
+
+  it("emits nothing when the foot falls outside the segment", () => {
+    expect(perpendicularSnaps(line, { x: -5, z: 7 })).toEqual([]);
+    expect(perpendicularSnaps(line, { x: 15, z: 7 })).toEqual([]);
+  });
+
+  it("includes the closing edge only when closed", () => {
+    const tri = [{ x: 0, z: 0 }, { x: 10, z: 0 }, { x: 10, z: 10 }];
+    expect(perpendicularSnaps(tri, { x: 5, z: 5 }, false)).toHaveLength(2);
+    expect(perpendicularSnaps(tri, { x: 5, z: 5 }, true)).toHaveLength(3);
+  });
+
+  it("skips a degenerate (zero-length) segment instead of dividing by zero", () => {
+    const s = perpendicularSnaps([{ x: 2, z: 2 }, { x: 2, z: 2 }], { x: 0, z: 0 });
+    expect(s).toEqual([]);
+  });
+
+  it("a foot exactly on an endpoint is kept — it IS on the segment", () => {
+    expect(perpendicularSnaps(line, { x: 0, z: 4 })).toEqual([{ x: 0, z: 0, kind: "perpendicular" }]);
+  });
+});
+
+describe("SNAP-KIT nearestSnaps", () => {
+  const line = [{ x: 0, z: 0 }, { x: 10, z: 0 }];
+
+  it("projects onto the segment", () => {
+    expect(nearestSnaps(line, { x: 4, z: 3 })).toEqual([{ x: 4, z: 0, kind: "nearest" }]);
+  });
+
+  it("CLAMPS past the end, where perpendicular drops — the two differ on purpose", () => {
+    expect(nearestSnaps(line, { x: 99, z: 3 })).toEqual([{ x: 10, z: 0, kind: "nearest" }]);
+    expect(perpendicularSnaps(line, { x: 99, z: 3 })).toEqual([]);
   });
 });

--- a/apps/web/src/viewer/snapEngine.ts
+++ b/apps/web/src/viewer/snapEngine.ts
@@ -25,10 +25,19 @@ const PRIORITY: Record<SnapKind, number> = {
 /**
  * The best object-snap for `cursor` among `candidates`, or null if none is within `tol` (world units).
  * Ties on distance break by snap priority (a vertex beats a midpoint at the same range).
+ *
+ * `only` restricts the search to one snap kind — this is what a **one-shot override** is made of
+ * (AUTH-SNAP-OVERRIDE). It is a filter and never a preference: when nothing of that kind is in range
+ * the answer is `null`, *not* the nearest point of some other kind. Falling back would hand the
+ * drafter a midpoint while the HUD said "perpendicular", and a snap that lies about its kind is worse
+ * than no snap at all — the placed point carries a GlobalId and feeds schedules.
  */
-export function resolveSnap(cursor: Vec2, candidates: SnapCandidate[], tol: number): SnapResult | null {
+export function resolveSnap(
+  cursor: Vec2, candidates: SnapCandidate[], tol: number, only?: SnapKind | null,
+): SnapResult | null {
   let best: SnapResult | null = null;
   for (const c of candidates) {
+    if (only && c.kind !== only) continue;
     const d = Math.hypot(c.x - cursor.x, c.z - cursor.z);
     if (d > tol) continue;
     if (!best) { best = { x: c.x, z: c.z, kind: c.kind, dist: d }; continue; }
@@ -38,6 +47,56 @@ export function resolveSnap(cursor: Vec2, candidates: SnapCandidate[], tol: numb
     }
   }
   return best;
+}
+
+/** Parameter of the projection of `p` onto segment a→b, unclamped. Null for a degenerate segment. */
+function projectT(a: Vec2, b: Vec2, p: Vec2): number | null {
+  const dx = b.x - a.x, dz = b.z - a.z;
+  const len2 = dx * dx + dz * dz;
+  if (len2 < 1e-12) return null;
+  return ((p.x - a.x) * dx + (p.z - a.z) * dz) / len2;
+}
+
+/**
+ * Foot-of-perpendicular candidates: for each segment of `points`, the point where a line from `from`
+ * meets that segment at 90°. **Emitted only when the foot lies ON the segment** — a perpendicular
+ * that lands past the end of an edge is a perpendicular to that edge's *infinite line*, which is not
+ * a place on the model, so it is dropped rather than clamped. (Clamping would silently return the
+ * endpoint and label it "perpendicular".)
+ *
+ * `from` is the point being drawn *from* — the previous point of the run. Perpendicular is the one
+ * osnap that is meaningless without it, which is why it takes an argument the others do not.
+ */
+export function perpendicularSnaps(points: Vec2[], from: Vec2, closed = false): SnapCandidate[] {
+  const out: SnapCandidate[] = [];
+  const n = points.length;
+  for (let i = 0; i < n; i++) {
+    const j = i + 1;
+    if (j >= n && !closed) break;
+    const a = points[i]!, b = points[j % n]!;
+    const t = projectT(a, b, from);
+    if (t === null || t < -1e-9 || t > 1 + 1e-9) continue;
+    out.push({ x: a.x + t * (b.x - a.x), z: a.z + t * (b.z - a.z), kind: "perpendicular" });
+  }
+  return out;
+}
+
+/** Nearest-point-on-edge candidates ("nearest" osnap) — the projection of `cursor` onto each
+ *  segment, clamped to the segment's ends. Unlike perpendicular this always yields a point per
+ *  segment, because "nearest" makes no claim about the angle. */
+export function nearestSnaps(points: Vec2[], cursor: Vec2, closed = false): SnapCandidate[] {
+  const out: SnapCandidate[] = [];
+  const n = points.length;
+  for (let i = 0; i < n; i++) {
+    const j = i + 1;
+    if (j >= n && !closed) break;
+    const a = points[i]!, b = points[j % n]!;
+    const t = projectT(a, b, cursor);
+    if (t === null) continue;
+    const c = Math.min(1, Math.max(0, t));
+    out.push({ x: a.x + c * (b.x - a.x), z: a.z + c * (b.z - a.z), kind: "nearest" });
+  }
+  return out;
 }
 
 /** Endpoint + midpoint snap candidates for a polyline (open or closed). Used by the viewer to feed

--- a/apps/web/src/viewer/snapOverride.test.ts
+++ b/apps/web/src/viewer/snapOverride.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import { KEY_SHORTCUTS } from "./keysDyn";
+import { resolveSnap, type SnapKind } from "./snapEngine";
+import {
+  ALL_OVERRIDE_KINDS, OVERRIDE_CODES, OVERRIDE_LABEL, createSnapOverride, overrideCandidates,
+  type OverrideKind, type PlanBox,
+} from "./snapOverride";
+
+// A 4 x 2 footprint, axis-aligned: x 0..4, z 0..2.
+const BOX: PlanBox = { minX: 0, maxX: 4, minZ: 0, maxZ: 2 };
+
+describe("AUTH-SNAP-OVERRIDE — the code table is a partition, not a list", () => {
+  // The override codes share the two-letter buffer with the draw-tool shortcuts. If they ever
+  // overlap, one of the two features silently stops working for that code and nothing says so.
+  it("no override code is also a draw-tool code", () => {
+    const tools = new Set(KEY_SHORTCUTS.map(([code]) => code));
+    const clashes = Object.keys(OVERRIDE_CODES).filter((c) => tools.has(c));
+    expect(clashes).toEqual([]);
+  });
+
+  it("every override code is exactly two upper-case letters, like the tool codes it shares a buffer with", () => {
+    for (const code of Object.keys(OVERRIDE_CODES)) expect(code).toMatch(/^[A-Z]{2}$/);
+  });
+
+  // The reason there is no `IN` (intersection) or grid code: nothing can produce one, so the override
+  // would resolve to nothing 100% of the time. This asserts the two sets are the SAME set, in both
+  // directions — a code with no producer and a producer with no code both fail here.
+  it("the kinds a code can name are exactly the kinds a producer can emit", () => {
+    expect([...new Set(Object.values(OVERRIDE_CODES))].sort()).toEqual([...ALL_OVERRIDE_KINDS].sort());
+  });
+
+  it("every override kind has a human label", () => {
+    for (const k of ALL_OVERRIDE_KINDS) expect(OVERRIDE_LABEL[k]).toBeTruthy();
+  });
+
+  // Iterates the CODES rather than ALL_OVERRIDE_KINDS on purpose. A code added without extending
+  // the kind list is invisible to the loop above — which is precisely the mistake this catches.
+  it("every kind a code names has a label, reached from the code side", () => {
+    for (const [code, kind] of Object.entries(OVERRIDE_CODES)) {
+      expect(OVERRIDE_LABEL[kind], `code ${code} → ${kind}`).toBeTruthy();
+    }
+  });
+
+  it("`intersection` and `grid` are deliberately absent — a control that can never resolve is worse than none", () => {
+    const named: string[] = Object.values(OVERRIDE_CODES);
+    expect(named).not.toContain("intersection");
+    expect(named).not.toContain("grid");
+  });
+});
+
+describe("AUTH-SNAP-OVERRIDE — overrideCandidates emits the asked-for kind and nothing else", () => {
+  const from = { x: 2, z: 8 };      // well off the box, so a perpendicular foot lands on the far edge
+  const cursor = { x: 2, z: 1 };
+
+  // The producer half of the partition above: every kind except `none` must actually yield points.
+  for (const kind of ALL_OVERRIDE_KINDS.filter((k) => k !== "none")) {
+    it(`${kind}: yields candidates, all of that kind`, () => {
+      const c = overrideCandidates(kind, BOX, cursor, from);
+      expect(c.length).toBeGreaterThan(0);
+      expect(new Set(c.map((p) => p.kind))).toEqual(new Set([kind as SnapKind]));
+    });
+  }
+
+  it("none: yields nothing — its meaning is 'do not snap', not 'search harder'", () => {
+    expect(overrideCandidates("none", BOX, cursor, from)).toEqual([]);
+  });
+
+  it("endpoint: the four footprint corners", () => {
+    const c = overrideCandidates("endpoint", BOX, cursor, from);
+    expect(c).toHaveLength(4);
+    expect(c.map((p) => [p.x, p.z]).sort()).toEqual([[0, 0], [0, 2], [4, 0], [4, 2]].sort());
+  });
+
+  it("center: the single footprint centre", () => {
+    expect(overrideCandidates("center", BOX, cursor, from))
+      .toEqual([{ x: 2, z: 1, kind: "center" }]);
+  });
+
+  it("midpoint: one per edge, and none of them is a corner", () => {
+    const c = overrideCandidates("midpoint", BOX, cursor, from);
+    expect(c).toHaveLength(4);
+    expect(c.map((p) => [p.x, p.z]).sort()).toEqual([[0, 1], [2, 0], [2, 2], [4, 1]].sort());
+  });
+
+  it("perpendicular: returns nothing without a previous point, rather than guessing one", () => {
+    expect(overrideCandidates("perpendicular", BOX, cursor, null)).toEqual([]);
+  });
+
+  it("perpendicular: the foot from a point due north of the box is on the near and far edges", () => {
+    const c = overrideCandidates("perpendicular", BOX, { x: 2, z: 1 }, { x: 2, z: 8 });
+    // from (2,8): feet on z=0 and z=2 at x=2. The x=0 and x=4 edges take the foot at z=8, off-segment.
+    expect(c.map((p) => [p.x, p.z]).sort()).toEqual([[2, 0], [2, 2]].sort());
+  });
+
+  it("perpendicular: an off-segment foot is DROPPED, never clamped to the endpoint", () => {
+    // from (99, 1) — the foot on the z=0 edge would be x=99, way past the corner at x=4.
+    const c = overrideCandidates("perpendicular", BOX, { x: 2, z: 1 }, { x: 99, z: 1 });
+    for (const p of c) expect(p.x).toBeLessThanOrEqual(4 + 1e-9);
+    // a clamped implementation would return the corner (4,0) and call it a perpendicular
+    expect(c.map((p) => [p.x, p.z])).not.toContainEqual([4, 0]);
+  });
+
+  it("nearest: projects the cursor onto each edge, clamped", () => {
+    const c = overrideCandidates("nearest", BOX, { x: 1, z: 0.25 }, from);
+    expect(c).toHaveLength(4);
+    expect(c.map((p) => [p.x, p.z])).toContainEqual([1, 0]);   // straight down onto the z=0 edge
+  });
+});
+
+describe("AUTH-SNAP-OVERRIDE — resolveSnap honours the filter without falling back", () => {
+  const cands = [
+    { x: 0, z: 0, kind: "endpoint" as const },
+    { x: 0.05, z: 0, kind: "midpoint" as const },
+  ];
+
+  it("returns the filtered kind even when a nearer candidate of another kind exists", () => {
+    const r = resolveSnap({ x: 0.05, z: 0 }, cands, 1, "endpoint");
+    expect(r!.kind).toBe("endpoint");
+    expect(r!.x).toBe(0);
+  });
+
+  // The whole point of the item: a snap that lies about its kind is worse than no snap.
+  it("returns NULL when nothing of the asked-for kind is in range — it does not substitute", () => {
+    expect(resolveSnap({ x: 0, z: 0 }, cands, 1, "perpendicular")).toBeNull();
+  });
+
+  it("without a filter it behaves exactly as before", () => {
+    const r = resolveSnap({ x: 0.05, z: 0 }, cands, 1);
+    expect(r!.kind).toBe("midpoint");
+  });
+});
+
+describe("AUTH-SNAP-OVERRIDE — one shot means one shot", () => {
+  it("arms from a code, case-insensitively", () => {
+    const o = createSnapOverride();
+    expect(o.arm("pe")).toBe("perpendicular");
+    expect(o.peek()).toBe("perpendicular");
+  });
+
+  it("ignores a code that is not an override, and leaves any armed state alone", () => {
+    const o = createSnapOverride();
+    o.arm("PE");
+    expect(o.arm("WA")).toBeNull();          // a draw-tool code, handled elsewhere
+    expect(o.peek()).toBe("perpendicular");
+  });
+
+  it("consume returns the kind and disarms", () => {
+    const o = createSnapOverride();
+    o.arm("MI");
+    expect(o.consume()).toBe("midpoint");
+    expect(o.peek()).toBeNull();
+    expect(o.consume()).toBeNull();
+  });
+
+  // A one-shot that survived a failed pick would silently steer the NEXT click too — the user would
+  // have to notice a snap they never asked for on a click they thought was ordinary.
+  it("is spent by the pick that reads it even when that pick found no such snap", () => {
+    const o = createSnapOverride();
+    o.arm("PE");
+    const kind = o.consume();                                       // the pick reads it…
+    expect(overrideCandidates(kind!, BOX, { x: 2, z: 1 }, null)).toEqual([]);   // …and finds nothing
+    expect(o.peek()).toBeNull();                                    // still spent
+  });
+
+  it("clear disarms, and Escape can call it safely when nothing is armed", () => {
+    const o = createSnapOverride();
+    o.clear();
+    expect(o.peek()).toBeNull();
+    o.arm("NO");
+    o.clear();
+    expect(o.peek()).toBeNull();
+  });
+
+  it("notifies a subscriber on arm, consume and clear — the HUD cannot go stale", () => {
+    const seen: (OverrideKind | null)[] = [];
+    const o = createSnapOverride();
+    o.subscribe((k) => seen.push(k));
+    o.arm("CE");
+    o.consume();
+    o.arm("NE");
+    o.clear();
+    expect(seen).toEqual(["center", null, "nearest", null]);
+  });
+
+  it("does not fire the subscriber for a no-op clear", () => {
+    const seen: (OverrideKind | null)[] = [];
+    const o = createSnapOverride();
+    o.subscribe((k) => seen.push(k));
+    o.clear();
+    expect(seen).toEqual([]);
+  });
+});

--- a/apps/web/src/viewer/snapOverride.ts
+++ b/apps/web/src/viewer/snapOverride.ts
@@ -1,0 +1,142 @@
+import { nearestSnaps, perpendicularSnaps, type SnapCandidate, type SnapKind, type Vec2 } from "./snapEngine";
+
+/** AUTH-SNAP-OVERRIDE — a one-shot object-snap override: "**this one pick**, take a perpendicular".
+ *
+ *  ## What was actually missing (premise-checked 2026-08-06, and the roadmap entry was understated)
+ *
+ *  The entry said "today a snap preference is modal, and needing this one pick to take a perpendicular
+ *  means changing a mode and changing it back". There is **no such mode to change**. The only snap
+ *  setting in the app is `getSettings().snap`, a *grid increment* (a number). Object-snap in the
+ *  viewer is entirely automatic with a fixed precedence — typed constraint > Shift ortho > geometry
+ *  snap > axis inference > polar > grid — and no part of it can be aimed. So the gap is not "the mode
+ *  is inconvenient to flip"; it is that a drafter **cannot ask for a snap kind at all, ever**.
+ *
+ *  Second premise correction, same check: `resolveSnap` and `segmentSnaps` in `snapEngine.ts` — the
+ *  priority-ordered resolver, the half that knows what a snap *kind* is — had **no callers**. Only
+ *  `polarConstrain` and `applyDynamicInput` were wired. `perpendicular` has been a member of
+ *  `SnapKind` all along with nothing anywhere able to produce one.
+ *
+ *  ## The chord
+ *
+ *  The roadmap suggested Shift+right-click (Shift is taken here by ortho lock, so it flagged the need
+ *  to pick something else). This uses the app's **own existing grammar instead of a new chord**: the
+ *  two-letter buffer that arms draw tools (`WA` wall, `CL` column …) also accepts an override code
+ *  while a tool is armed. `EN` `MI` `CE` `PE` `NE` `NO`. Nothing to learn beyond the codes, no
+ *  modifier to fight the browser over, and the two code sets are asserted **disjoint** by
+ *  `snapOverride.test.ts` — so an ambiguous code fails a build rather than arming the wrong thing.
+ *
+ *  ## Only kinds that can actually be produced
+ *
+ *  `SnapKind` also contains `intersection` and `grid`, and there is **no override code for either**.
+ *  Nothing in the pipeline emits an intersection candidate, so an `IN` override could never resolve —
+ *  it would be a control that is always "no intersection here", which reads as a broken feature
+ *  rather than an absent one. `ALL_OVERRIDE_KINDS` is asserted to be exactly what
+ *  `overrideCandidates` can emit, so adding a code without a producer fails the same build.
+ */
+
+export type OverrideKind = "endpoint" | "midpoint" | "center" | "perpendicular" | "nearest" | "none";
+
+/** Two-letter codes, typed into the same buffer as the draw-tool shortcuts. Disjoint from
+ *  `KEY_SHORTCUTS` by test, not by inspection. */
+export const OVERRIDE_CODES: Record<string, OverrideKind> = {
+  EN: "endpoint",
+  MI: "midpoint",
+  CE: "center",
+  PE: "perpendicular",
+  NE: "nearest",
+  NO: "none",        // suppress every snap for one pick — the raw cursor, untouched
+};
+
+export const OVERRIDE_LABEL: Record<OverrideKind, string> = {
+  endpoint: "endpoint", midpoint: "midpoint", center: "centre",
+  perpendicular: "perpendicular", nearest: "nearest on edge", none: "no snap",
+};
+
+/** Every kind an override can name. Kept beside the producer so the two cannot drift. */
+export const ALL_OVERRIDE_KINDS: OverrideKind[] =
+  ["endpoint", "midpoint", "center", "perpendicular", "nearest", "none"];
+
+/** A plan-projected bounding footprint (world x / z), which is what the viewer can cheaply get for a
+ *  picked element without re-reading its mesh. */
+export type PlanBox = { minX: number; maxX: number; minZ: number; maxZ: number };
+
+/** The footprint as a closed 4-point ring, in a fixed winding so tests can name an edge. */
+function ring(b: PlanBox): Vec2[] {
+  return [
+    { x: b.minX, z: b.minZ }, { x: b.maxX, z: b.minZ },
+    { x: b.maxX, z: b.maxZ }, { x: b.minX, z: b.maxZ },
+  ];
+}
+
+/**
+ * Candidates of **one kind only** for a picked element's footprint.
+ *
+ * Deliberately narrow: an override asks for one kind, so building the other five would only create
+ * opportunities for the resolver to return something the drafter did not ask for. `none` yields no
+ * candidates at all — its meaning is "do not snap", which the caller honours by keeping the raw
+ * point, not by searching for one.
+ *
+ * `from` is the previous point of the run; `perpendicular` returns nothing without it (there is no
+ * perpendicular to something from nowhere), and that is a refusal rather than a fallback.
+ */
+export function overrideCandidates(
+  kind: OverrideKind, box: PlanBox, cursor: Vec2, from: Vec2 | null,
+): SnapCandidate[] {
+  const r = ring(box);
+  const midX = (box.minX + box.maxX) / 2, midZ = (box.minZ + box.maxZ) / 2;
+  switch (kind) {
+    case "none":
+      return [];
+    case "endpoint":
+      return r.map((p) => ({ x: p.x, z: p.z, kind: "endpoint" as SnapKind }));
+    case "midpoint":
+      return [
+        { x: midX, z: box.minZ, kind: "midpoint" }, { x: box.maxX, z: midZ, kind: "midpoint" },
+        { x: midX, z: box.maxZ, kind: "midpoint" }, { x: box.minX, z: midZ, kind: "midpoint" },
+      ];
+    case "center":
+      return [{ x: midX, z: midZ, kind: "center" }];
+    case "perpendicular":
+      return from ? perpendicularSnaps(r, from, true) : [];
+    case "nearest":
+      return nearestSnaps(r, cursor, true);
+  }
+}
+
+export interface SnapOverrideHandle {
+  /** Arm from a two-letter code. Returns the kind armed, or null if the code is not an override. */
+  arm(code: string): OverrideKind | null;
+  /** What is armed, without consuming it (for the HUD). */
+  peek(): OverrideKind | null;
+  /** Take the armed override and clear it — a one-shot is spent by the pick that reads it, whether
+   *  or not that pick found anything of the kind. Otherwise a failed override would silently apply
+   *  to the *next* click too. */
+  consume(): OverrideKind | null;
+  clear(): void;
+  /** Watch the armed kind. The key layer draws the HUD from this rather than polling, so the HUD
+   *  cannot outlive the override it describes — a stale "next pick: perpendicular" is a lie about
+   *  what the next click will do. */
+  subscribe(fn: (k: OverrideKind | null) => void): void;
+}
+
+export function createSnapOverride(): SnapOverrideHandle {
+  let armedKind: OverrideKind | null = null;
+  const subs: ((k: OverrideKind | null) => void)[] = [];
+  const set = (k: OverrideKind | null) => { armedKind = k; for (const fn of subs) fn(k); };
+  return {
+    arm(code) {
+      const k = OVERRIDE_CODES[code.toUpperCase()];
+      if (!k) return null;
+      set(k);
+      return k;
+    },
+    peek: () => armedKind,
+    consume() {
+      const k = armedKind;
+      if (k) set(null);
+      return k;
+    },
+    clear: () => { if (armedKind) set(null); },
+    subscribe: (fn) => { subs.push(fn); },
+  };
+}


### PR DESCRIPTION
**Lane E · Authoring feel & viewer.** Branched from `origin/main` @ `4fcd2fbb` (v0.3.872), developed in an isolated in-repo worktree. **No version files, no `CHANGELOG.md`, no `docs/roadmap.md` edit** — those belong to whoever holds the release.

## The premise check changed the item

The roadmap says AUTH-SNAP-OVERRIDE is about a modal preference: *"today a snap preference is modal, and needing this one pick to take a perpendicular means changing a mode and changing it back."*

**There is no such mode.** The only snap setting in the app is `getSettings().snap` — a grid *increment*, a number. Object-snap in the viewer is entirely automatic with a fixed precedence (typed constraint → Shift ortho → geometry snap → axis inference → polar → grid) and no part of it can be aimed. The gap is not that a mode is inconvenient to flip; **a drafter cannot ask for a snap kind at all, ever.**

The same check turned up a second thing: this is also a **Band-2 "built but unreachable"** item. `resolveSnap` and `segmentSnaps` in `apps/web/src/viewer/snapEngine.ts` — the priority-ordered resolver, the half that knows what a snap *kind* is — had **zero callers**. Only `polarConstrain` and `applyDynamicInput` were wired. `perpendicular` has been a member of `SnapKind` all along with nothing anywhere able to produce one.

Suggest the roadmap entry be corrected in place rather than just ticked, per §8 of the directions.

## What lands

| | |
|---|---|
| `viewer/snapEngine.ts` | `perpendicularSnaps`, `nearestSnaps`, and an optional kind filter on `resolveSnap` |
| `viewer/snapOverride.ts` **(new)** | code table, one-shot state machine, single-kind candidate producer |
| `viewer/keysDyn.ts` | dispatches the codes, owns the HUD, Escape precedence |
| `viewer/app.ts` | `snapByOverride` + consumption in `captureDraftPoint` (**+42 lines**; the file is 5106 of the 5200 ceiling, so the logic deliberately lives elsewhere) |
| `ui/keys.ts`, `main.ts` | publish the codes in the one keyboard contract |

**The chord reuses the app's own grammar** instead of adding a modifier. The two-letter buffer that arms draw tools also takes `EN` `MI` `CE` `PE` `NE` `NO` while a tool is armed. The two code sets are asserted **disjoint**, so an ambiguous code fails a build rather than arming the wrong thing. With no tool armed the codes stay inert — there is no "next pick" for a one-shot to attach to.

### Three decisions that are the point of the item

- **The filter never falls back.** Asked for a perpendicular with none in range, `resolveSnap` returns `null` — not the nearest midpoint. The caller keeps the raw cursor and the glyph says so. A snap that lies about its kind is worse than no snap, because the point carries a GlobalId into the schedules.
- **`perpendicularSnaps` drops an off-segment foot rather than clamping it.** Clamping returns the corner and labels it "perpendicular".
- **No `IN` (intersection) code.** Nothing produces an intersection candidate, so it could only ever resolve to nothing, and a control that is permanently "none here" reads as broken rather than absent. A test asserts the codeable kinds and the producible kinds are the *same set*, both directions.

Escape cancels a pending override and **leaves the tool armed**; a second Escape disarms as before. Discarding the points already placed because someone changed their mind about one snap is the wrong trade.

## `main.ts` — a lane crossing, and why it isn't optional

`main.ts` (Lane A) installs a global `?` handler and `keysDyn` installs a second one, so **with the viewer loaded both answer that key**. That was harmless only while they passed identical arguments. A section known to one and not the other makes `?` give two different answers again — the precise defect `ui/keys.ts` was written to end. Both now publish both lists, and a test reads the two call sites.

`ui/keys.ts` is likewise outside Lane E. Both changes are additive (new optional 2nd parameter, defaulted; existing call sites unchanged). **Happy to split them out if you'd rather** — but shipping the feature without them makes it undiscoverable and makes `?` inconsistent.

## Verification, with its grade

- `npx tsc --noEmit` clean · `eslint` clean
- **1223/1223 web green** (109 files) on the committed tree, `origin/main` @ `4fcd2fbb`
- `test_file_sizes.py` passes — `app.ts` 5106 / 5200
- **Seven mutations checked red through named assertions**: resolver falls back · perpendicular clamps · a code collides with a draw code · a code with no producer · the chord never dispatched · the one-shot goes sticky · `main.ts` left one-sided

The no-producer mutation first went red via a **module-load crash that took every assertion down with it** — a fail, but not the gate I wrote firing. `SNAP_HELP` now degrades to the raw kind name so the assertion is what fails.

### Not verified in a real browser — worth flagging beyond this PR

`preview_start` resolves `.claude/launch.json` against the **session's primary working directory**, so a dev server started for this branch serves the **main clone, not the worktree**. Proved rather than assumed: `/src/viewer/snapOverride.ts` returned Vite's SPA fallback, and `snapEngine.ts` came back with no `perpendicularSnaps`. Had I screenshotted a working app it would have been someone else's code.

So the 3D pick path — `snapByOverride` against a real Fragments bbox, and the glyph — is covered by unit tests driving the **real installed key handler** under happy-dom, not by a live model. **This undercuts the worktree convention for any UI change and probably deserves its own item.**

A bare `vite build` exits 1 on the workbox precache limit (`app-*.js` 6.58 MB). **Pristine `origin/main` fails identically, with the asset 36 bytes _larger_** — pre-existing, not from this branch. `npm run build` cannot run in a worktree at all: `scripts/copy-wasm.mjs` looks in exactly two paths and neither is the repo-root `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
