### PR TITLE
SCALE-SEAM ⑧ — /proforma out of client.ts, plus three endpoints nothing could call

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -7,6 +7,7 @@ import { HttpCore, type LiveStream } from "./httpCore";
 import { withModel } from "./model";
 import { withEstimate } from "./estimate";
 import { withProcurement } from "./procurement";
+import { withProforma } from "./proforma";
 import { withModules } from "./modules";
 import { withSchedule } from "./schedule";
 
@@ -25,9 +26,8 @@ export * from "./authoring";
 export * from "./library";
 import type {
   Appraisal, AuditEntry, ConnectionItem, Dashboard, DocFile,
-  DisciplineTree, DocFolderNode, DrawingMarkupItem, DueFeed, EditMacro, EscalationScan, EscalationRun, ElementProps, EnergyResult, FinancialStatements,
-  IntegrationGroup, Job, LifecycleStrip, ModelCiReport, WorkQueue, ModulePin, ModuleRecord, MonteCarloMetric, MonteCarloResult, RoomAllocation,
-  LogisticsResource, NotifItem, OpendataPermit, ProformaForecast, ProformaResult, ProjectMember, ProjectRole, PropLayer, PropMapRule,
+  DisciplineTree, DocFolderNode, DrawingMarkupItem, DueFeed, EditMacro, EscalationScan, EscalationRun, ElementProps, EnergyResult, IntegrationGroup, Job, LifecycleStrip, ModelCiReport, WorkQueue, ModulePin, ModuleRecord, MonteCarloMetric, RoomAllocation,
+  LogisticsResource, NotifItem, OpendataPermit, ProjectMember, ProjectRole, PropLayer, PropMapRule,
   PreflightGate, PreflightSummary, ProfessionalLicense,
   ResolveAction, ResponsibilityMatrix, SheetMarkupIn, SmartView, StampTemplate, SyncScheduleItem,
   Topic, Vec3, Viewpoint, WorkItem, VitalsPayload } from "./types";
@@ -35,7 +35,7 @@ import type {
 
 // Transport (baseUrl, token, json/_pdfPost/url/health) lives in HttpCore; ApiClient adds the typed
 // domain methods below. Every `api.method()` call site is unchanged by the split.
-export class ApiClient extends withAuth(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore)))))))) {
+export class ApiClient extends withAuth(withProforma(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore))))))))) {
   /** Admin: integration settings (AI / email / SSO). Secret values are never returned. */
   integrations() {
     return this.json<{ groups: IntegrationGroup[] }>("/settings/integrations");
@@ -2151,53 +2151,6 @@ export class ApiClient extends withAuth(withProcurement(withEstimate(withModules
   }
 
   // real-estate development finance (Proforma)
-  solveProforma(assumptions: unknown) {
-    return this.json<ProformaResult>(`/proforma/solve`, { method: "POST", body: JSON.stringify(assumptions) });
-  }
-  /** Same solve, but the guardrails also validate the exit cap against the project's sale comps (U3). */
-  solveProformaForProject(pid: string, assumptions: unknown) {
-    return this.json<ProformaResult>(`/projects/${pid}/proforma/solve`,
-      { method: "POST", body: JSON.stringify(assumptions) });
-  }
-  /** Three financial statements + tax for the current deal (income/balance/cash-flow + two-sided budget). */
-  financials(assumptions: unknown) {
-    return this.json<FinancialStatements>(`/proforma/financials`, { method: "POST", body: JSON.stringify(assumptions) });
-  }
-  sensitivity(body: unknown) {
-    return this.json<{ metric: string; x_values: number[]; y_values: number[]; matrix: (number | null)[][] }>(
-      `/proforma/sensitivity`, { method: "POST", body: JSON.stringify(body) });
-  }
-  monteCarlo(body: unknown) {
-    return this.json<MonteCarloResult>(
-      `/proforma/monte-carlo`, { method: "POST", body: JSON.stringify(body) });
-  }
-  forecast(assumptions: unknown, actuals: unknown[], asOfMonth: number) {
-    return this.json<ProformaForecast>(`/proforma/forecast`, {
-      method: "POST", body: JSON.stringify({ assumptions, actuals, as_of_month: asOfMonth }) });
-  }
-  portfolio() {
-    return this.json<{ deal_count: number; totals: Record<string, number | null>; deals: { id: string; name: string; total_uses: number; equity: number; loan: number; equity_irr: number | null; equity_multiple: number | null }[] }>(`/proforma/portfolio`);
-  }
-  createScenario(name: string, projectId: string | null, assumptions: unknown) {
-    return this.json<{ id: string }>(`/proforma/scenarios`, {
-      method: "POST", body: JSON.stringify({ name, project_id: projectId, assumptions }) });
-  }
-  /** Saved proforma scenarios for a project (with their solved returns), oldest→newest. */
-  listScenarios(projectId: string) {
-    return this.json<{ id: string; name: string; project_id: string | null;
-      returns: { equity_irr?: number | null; equity_multiple?: number | null; project_irr?: number | null;
-        yield_on_cost?: number | null; npv?: number | null } | null }[]>(
-      `/proforma/scenarios?project_id=${encodeURIComponent(projectId)}`);
-  }
-  drawPackage(sid: string, body: unknown) {
-    return this.json<{ sov_lines_created: number; g702: Record<string, number>; g702_pdf: string }>(
-      `/proforma/scenarios/${sid}/draw-package`, { method: "POST", body: JSON.stringify(body) });
-  }
-  /** FIN-GOV — move a scenario through draft → in_review → approved → published (reject/reopen → draft). */
-  reviewScenario(sid: string, action: "submit" | "approve" | "reject" | "publish" | "reopen", note?: string) {
-    return this.json<{ id: string; review_status: string; reviewed_by: string; note: string }>(
-      `/proforma/scenarios/${sid}/review`, { method: "POST", body: JSON.stringify({ action, note: note ?? "" }) });
-  }
   /** FIN-GOV — the project's locked reporting period (books closed through lock_date, or null). */
   financeLock(pid: string) {
     return this.json<{ lock_date: string | null; set_by?: string; set_at?: string; note?: string }>(
@@ -2207,14 +2160,6 @@ export class ApiClient extends withAuth(withProcurement(withEstimate(withModules
     return this.json<{ lock_date: string | null; set_by: string; note: string }>(
       `/projects/${pid}/finance/lock`,
       { method: "PUT", body: JSON.stringify({ lock_date: lockDate, note: note ?? "" }) });
-  }
-  /** FIN-CALC — residual land value: the land price that hits a target return (bisection over the solve). */
-  residualLand(assumptions: unknown, target: string, targetValue: number, maxLand?: number) {
-    return this.json<{ land_value: number | null; achieved: number | null; target: string;
-      target_value: number; iterations: number; converged: boolean; at_zero_land: number | null;
-      note?: string }>(
-      `/proforma/residual-land`, { method: "POST",
-        body: JSON.stringify({ assumptions, target, target_value: targetValue, max_land: maxLand ?? null }) });
   }
   /** FIN-INGEST — budget ↔ actuals two-way reconciliation on the cost-code spine. */
   financeReconcile(pid: string) {
@@ -2394,14 +2339,6 @@ export class ApiClient extends withAuth(withProcurement(withEstimate(withModules
   saveSharedParams(pid: string, params: unknown[]) {
     return this.json<{ params: unknown[] }>(`/projects/${pid}/shared-params`,
       { method: "PUT", body: JSON.stringify({ params }) });
-  }
-  portfolioCompare() {
-    return this.json<{ project_count: number; rows: { project_id: string; project_name: string;
-      scenario_id: string; scenario_name: string; review_status: string;
-      equity_irr: number | null; equity_multiple: number | null; yield_on_cost: number | null;
-      total_uses: number | null }[];
-      spread: Record<string, { best: string | null; worst: string | null;
-        min: number | null; max: number | null }> }>(`/proforma/portfolio/compare`);
   }
 
   rooms() {
@@ -3587,13 +3524,6 @@ export class ApiClient extends withAuth(withProcurement(withEstimate(withModules
     return this.json<{ applied: { styled: number; materialed: number; materials: number; classes: number }; publish: string }>(
       `/projects/${pid}/materials/apply`, { method: "POST" });
   }
-  /** Import a Primavera P6 export (.xer or .xml/PMXML — auto-detected) so the 4D scrub reports
-   *  real calendar dates and the tasks become editable schedule_activity records. */
-  proformaLive(pid: string) {
-    return this.json<{ model_version: string; est_construction_cost: number; gfa_m2: number;
-      cost_per_m2: number | null; budget_hard_cost: number | null;
-      delta_vs_budget: number | null; note: string }>(`/projects/${pid}/proforma/live`);
-  }
   /** RISK-BOARD: one ranked register unifying every computed risk signal (deep-linked per item). */
   riskBoard(pid: string) {
     return this.json<{ items: { source: string; severity: "high" | "medium" | "low"; title: string;
@@ -3731,11 +3661,6 @@ export class ApiClient extends withAuth(withProcurement(withEstimate(withModules
   }) {
     return this.json<{ iterations: number; metrics: Record<string, MonteCarloMetric> }>(
       `/projects/${pid}/specialty/monte-carlo`, { method: "POST", body: JSON.stringify(body) });
-  }
-  /** Proforma seed metrics derived from the project's source IFC (areas / space + storey counts). */
-  proformaModelMetrics(pid: string) {
-    return this.json<{ space_count: number; spaces_with_area: number; storey_count: number; net_floor_area_m2: number; net_floor_area_sf: number }>(
-      `/projects/${pid}/proforma/model-metrics`);
   }
   /** Upload an IFC as the project's source model (sets source_ifc + publishes) — what lights up
    *  drawings, clash/IDS, energy, exports, and authoring for the project. */

--- a/apps/web/src/api/proforma.ts
+++ b/apps/web/src/api/proforma.ts
@@ -1,0 +1,141 @@
+/** Development pro-forma: solve, scenarios, sensitivity, portfolio and the model-linked metrics.
+ *
+ *  SCALE-SEAM ⑧. Route-group `/proforma`, taken out of `client.ts` by the route each method calls.
+ *
+ *  **The group was four times the size the hand-off estimated.** It was scoped as "~3 methods
+ *  (`solve`, `live`, `model-metrics`)"; locating by route rather than by eye found **15**, sitting in
+ *  four separate regions — a run of twelve, then `portfolioCompare`, `proformaLive` and
+ *  `proformaModelMetrics` each alone, ~1,200 and ~1,500 lines further down. That is the same finding
+ *  ⑥ and ⑦ recorded in their own words: the `// --- section ---` comments label where a run *starts*
+ *  and stop meaning anything after it.
+ *
+ *  **Three methods here are new, not moved**, and they exist because the endpoints were unreachable:
+ *  `/proforma/renovation`, `/proforma/rollover` and `/proforma/income-basis` are built, tested and
+ *  had no client caller at all — `test_reachable` passes on them because the *route* exists, which is
+ *  the gap `test_route_reachability` now ratchets. `renovation` carries the load-bearing negative:
+ *  `nothing_renovated` says a pace renovates NOTHING across the whole hold, and a finding like that
+ *  should be loud rather than a `false` in a payload nobody fetches.
+ *
+ *  A mixin, so every call site resolves unchanged. `api/surface.test.ts` is what proves it: moving a
+ *  method is invisible to it, losing one fails it by number. The floor moves 699 -> 702 because of
+ *  the three NEW methods, not because anything moved.
+ */
+import { HttpCore } from "./httpCore";
+import type { FinancialStatements, MonteCarloResult, ProformaForecast, ProformaResult } from "./types";
+
+type Ctor<T> = new (...args: any[]) => T;
+
+export function withProforma<TBase extends Ctor<HttpCore>>(Base: TBase) {
+  return class Proforma extends Base {
+  solveProforma(assumptions: unknown) {
+    return this.json<ProformaResult>(`/proforma/solve`, { method: "POST", body: JSON.stringify(assumptions) });
+  }
+
+  /** Same solve, but the guardrails also validate the exit cap against the project's sale comps (U3). */
+  solveProformaForProject(pid: string, assumptions: unknown) {
+    return this.json<ProformaResult>(`/projects/${pid}/proforma/solve`,
+      { method: "POST", body: JSON.stringify(assumptions) });
+  }
+
+  /** Three financial statements + tax for the current deal (income/balance/cash-flow + two-sided budget). */
+  financials(assumptions: unknown) {
+    return this.json<FinancialStatements>(`/proforma/financials`, { method: "POST", body: JSON.stringify(assumptions) });
+  }
+
+  sensitivity(body: unknown) {
+    return this.json<{ metric: string; x_values: number[]; y_values: number[]; matrix: (number | null)[][] }>(
+      `/proforma/sensitivity`, { method: "POST", body: JSON.stringify(body) });
+  }
+
+  monteCarlo(body: unknown) {
+    return this.json<MonteCarloResult>(
+      `/proforma/monte-carlo`, { method: "POST", body: JSON.stringify(body) });
+  }
+
+  forecast(assumptions: unknown, actuals: unknown[], asOfMonth: number) {
+    return this.json<ProformaForecast>(`/proforma/forecast`, {
+      method: "POST", body: JSON.stringify({ assumptions, actuals, as_of_month: asOfMonth }) });
+  }
+
+  portfolio() {
+    return this.json<{ deal_count: number; totals: Record<string, number | null>; deals: { id: string; name: string; total_uses: number; equity: number; loan: number; equity_irr: number | null; equity_multiple: number | null }[] }>(`/proforma/portfolio`);
+  }
+
+  createScenario(name: string, projectId: string | null, assumptions: unknown) {
+    return this.json<{ id: string }>(`/proforma/scenarios`, {
+      method: "POST", body: JSON.stringify({ name, project_id: projectId, assumptions }) });
+  }
+
+  /** Saved proforma scenarios for a project (with their solved returns), oldest→newest. */
+  listScenarios(projectId: string) {
+    return this.json<{ id: string; name: string; project_id: string | null;
+      returns: { equity_irr?: number | null; equity_multiple?: number | null; project_irr?: number | null;
+        yield_on_cost?: number | null; npv?: number | null } | null }[]>(
+      `/proforma/scenarios?project_id=${encodeURIComponent(projectId)}`);
+  }
+
+  drawPackage(sid: string, body: unknown) {
+    return this.json<{ sov_lines_created: number; g702: Record<string, number>; g702_pdf: string }>(
+      `/proforma/scenarios/${sid}/draw-package`, { method: "POST", body: JSON.stringify(body) });
+  }
+
+  /** FIN-GOV — move a scenario through draft → in_review → approved → published (reject/reopen → draft). */
+  reviewScenario(sid: string, action: "submit" | "approve" | "reject" | "publish" | "reopen", note?: string) {
+    return this.json<{ id: string; review_status: string; reviewed_by: string; note: string }>(
+      `/proforma/scenarios/${sid}/review`, { method: "POST", body: JSON.stringify({ action, note: note ?? "" }) });
+  }
+
+  /** FIN-CALC — residual land value: the land price that hits a target return (bisection over the solve). */
+  residualLand(assumptions: unknown, target: string, targetValue: number, maxLand?: number) {
+    return this.json<{ land_value: number | null; achieved: number | null; target: string;
+      target_value: number; iterations: number; converged: boolean; at_zero_land: number | null;
+      note?: string }>(
+      `/proforma/residual-land`, { method: "POST",
+        body: JSON.stringify({ assumptions, target, target_value: targetValue, max_land: maxLand ?? null }) });
+  }
+
+  portfolioCompare() {
+    return this.json<{ project_count: number; rows: { project_id: string; project_name: string;
+      scenario_id: string; scenario_name: string; review_status: string;
+      equity_irr: number | null; equity_multiple: number | null; yield_on_cost: number | null;
+      total_uses: number | null }[];
+      spread: Record<string, { best: string | null; worst: string | null;
+        min: number | null; max: number | null }> }>(`/proforma/portfolio/compare`);
+  }
+
+  /** Import a Primavera P6 export (.xer or .xml/PMXML — auto-detected) so the 4D scrub reports
+   *  real calendar dates and the tasks become editable schedule_activity records. */
+  proformaLive(pid: string) {
+    return this.json<{ model_version: string; est_construction_cost: number; gfa_m2: number;
+      cost_per_m2: number | null; budget_hard_cost: number | null;
+      delta_vs_budget: number | null; note: string }>(`/projects/${pid}/proforma/live`);
+  }
+
+  /** Proforma seed metrics derived from the project's source IFC (areas / space + storey counts). */
+  proformaModelMetrics(pid: string) {
+    return this.json<{ space_count: number; spaces_with_area: number; storey_count: number; net_floor_area_m2: number; net_floor_area_sf: number }>(
+      `/projects/${pid}/proforma/model-metrics`);
+  }
+
+  /** RENOVATION schedule over the hold — pace, spend and what it renovates.
+   *
+   *  Reads `nothing_renovated` / `nothing_renovated_why`: the schedule says explicitly when a chosen
+   *  pace renovates NOTHING across the entire hold. That is a load-bearing negative and callers
+   *  should surface it prominently rather than treating a `false` as "fine".
+   */
+  proformaRenovation(pid: string) {
+    return this.json<{ nothing_renovated?: boolean; nothing_renovated_why?: string;
+      [k: string]: unknown }>(`/projects/${pid}/proforma/renovation`);
+  }
+
+  /** Lease ROLLOVER exposure across the hold — expiries, downtime and re-let assumptions. */
+  proformaRollover(pid: string) {
+    return this.json<Record<string, unknown>>(`/projects/${pid}/proforma/rollover`);
+  }
+
+  /** INCOME BASIS — which income line each figure is derived from, so a reader can trace it. */
+  proformaIncomeBasis(pid: string) {
+    return this.json<Record<string, unknown>>(`/projects/${pid}/proforma/income-basis`);
+  }
+  };
+}

--- a/apps/web/src/api/surface.test.ts
+++ b/apps/web/src/api/surface.test.ts
@@ -86,7 +86,12 @@ describe("the API client's public surface", () => {
     // plainly: **an extraction is the occasion to re-read this number, never the cause of it moving.**
     // Anyone raising this line because their own change grew the surface should say so here; anyone
     // raising it to make a red test go green has inverted the gate.
-    expect(surface.size, `only ${surface.size} methods reachable`).toBeGreaterThanOrEqual(699);
+    // 2026-08-06 (SCALE-SEAM ⑧): raised 699 -> 702, and the +3 is NEW SURFACE, not a moved one.
+    // The /proforma extraction moved 15 methods and this reader counted **699 both before and after
+    // the move** — that is the evidence nothing was dropped. The three added methods
+    // (proformaRenovation / proformaRollover / proformaIncomeBasis) are client callers for endpoints
+    // that had none, which is why the floor legitimately rises.
+    expect(surface.size, `only ${surface.size} methods reachable`).toBeGreaterThanOrEqual(702);
   });
 
   it("keeps the transport primitives the domain methods are built on", () => {
@@ -104,6 +109,8 @@ describe("the API client's public surface", () => {
       "modules", "moduleRecords", "createModuleRecord", "updateModuleRecord",  // CRUD — used everywhere
       "topicsBoard", "createTopic", "viewpoints",                   // BCF coordination
       "elementEffectiveProps", "elementCosts", "costSummary",       // model + 5D
+      "solveProforma", "proformaLive", "portfolioCompare",           // ⑧ moved — spread over 4 regions
+      "proformaRenovation", "proformaRollover", "proformaIncomeBasis",  // ⑧ new — were unreachable
       "schedule4d", "scheduleCpm", "evm",                           // 4D + earned value
       "estimateFromModel", "qtoByFloor", "sovFromBudget",           // estimating
       "drawingMarkup", "promoteDrawingMarkup",                      // 2D markup -> RFI

--- a/services/api/test_file_sizes.py
+++ b/services/api/test_file_sizes.py
@@ -58,7 +58,7 @@ CEILING = 5_200
 #: post-⑦ the answer is usually yes. Raising an entry is therefore a deliberate act that should be
 #: argued for in the commit message — the direction of travel is down.
 PER_FILE = {
-    "apps/web/src/api/client.ts": 3_871,   # SCALE-SEAM ⑦ (/auth out); was 3,967 before
+    "apps/web/src/api/client.ts": 3_796,   # SCALE-SEAM ⑧ (/proforma out); ⑦ 3,871; before ⑦ 3,967
 }
 
 #: Exempt because a human never reads them top-to-bottom. Name them, never infer them.


### PR DESCRIPTION
`client.ts` **3,871 → 3,796**. Fifteen methods moved to `apps/web/src/api/proforma.ts` behind a `withProforma` mixin, composed into the chain, so every call site resolves unchanged.

### The group was five times the size the hand-off estimated

Scoped as *"~3 methods (`solve`, `live`, `model-metrics`)"*. Locating by **route** rather than by eye found **15**, in **four separate regions** — a run of twelve, then `portfolioCompare`, `proformaLive` and `proformaModelMetrics` each alone, ~1,200 and ~1,500 lines further down.

That's ⑥ and ⑦'s finding again: the `// --- section ---` comments label where a run *starts* and stop meaning anything after it. Grouping by comment would have moved 12 and missed 3.

### Three methods are new, not moved

`/proforma/renovation`, `/proforma/rollover`, `/proforma/income-basis` are built, tested, and had **no client caller at all**. `test_reachable` passes on them because the *route* exists — precisely the gap #193's ratchet catches.

`renovation` carries the load-bearing negative: **`nothing_renovated` says a pace renovates nothing across the entire hold**, and the client type surfaces it explicitly rather than leaving it a `false` in a payload nobody fetches.

### The surface count is the evidence — read *before*, not after

```
699  unmodified tree          <- read first, on purpose
699  what a pure move would give
702  actual, = 699 + 3 new methods
```

Without the before-number, "the test passes" is indistinguishable from raising the floor to hide a loss. The floor moves 699 → 702 with that reasoning written at the assertion, and **six method names are added to the spot-check list** — a count is a weak assertion about a set, so losing one would clear the floor while losing all six fails loudly.

The per-file ratchet moves **down**, 3,871 → 3,796, which is the direction that map exists for.

### Traps hit — all three called in advance by ⑦'s author

1. **The file is CRLF.** A multi-line regex silently matches nothing and reports success.
2. **Doc comments claimed backwards with an ENDS-WITH `*/` test** — a block comment can close mid-line, and a "starts with" test silently drops the doc.
3. **Four type imports orphaned** in `client.ts` by the move (`FinancialStatements`, `MonteCarloResult`, `ProformaForecast`, `ProformaResult`) — would have failed lint.

tsc clean. **Full web suite 1223/1223.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)