### PR TITLE
Worktree builds: fix the depth guess, then assert the thing it was hiding

### DIFF
--- a/apps/web/scripts/bundle-budget.mjs
+++ b/apps/web/scripts/bundle-budget.mjs
@@ -69,6 +69,40 @@ console.log(`  ${kb(total).padStart(7)} KB  total  (budget ${BUDGET_KB} KB)`);
 const lazy = files.filter((f) => LAZY.test(f) && /\.js$/.test(f));
 console.log(`Lazy chunks kept out of the shell: ${lazy.length}`);
 
+// ...and ASSERT it, because printing a number is not a check.
+//
+// `vite.config.ts` says of the vendor split: "A vendor split that silently stops splitting is the
+// worst kind of build regression: the bundle still works, so nothing fails" — and then "Verify by
+// grepping the OUTPUT, never by reading the config and believing it." Nobody was verifying the
+// output. The line above computed `lazy` and printed it, and a build with the split gone printed
+// a smaller number and exited 0.
+//
+// It is not hypothetical. Measured 2026-08-06, same commit, same command, two checkouts:
+//
+//     main clone   exit 0   three-*.js + thatopen-*.js present   app shell    334 KB
+//     git worktree exit 1   NEITHER chunk emitted                app shell  6,581 KB   (19.7x)
+//
+// In a worktree the hoisted `node_modules` sits outside the workspace root, the deps fall back to
+// CommonJS interop (a `_commonjsHelpers` chunk appears; 638 modules transformed vs 585), and the
+// `advancedChunks` rules never match — so three.js and the That Open stack are folded into the
+// eager shell. The only thing that turned that into a visible failure was the PWA precache size
+// limit, which is absent from `VITE_PAGES=1` builds. Without this assertion, that configuration
+// ships a 20x shell in silence.
+const VENDOR_CHUNKS = [
+  ["three", /^three-.*\.js$/],
+  ["thatopen", /^thatopen-.*\.js$/],
+];
+const missingVendor = VENDOR_CHUNKS.filter(([, re]) => !files.some((f) => re.test(f))).map(([n]) => n);
+if (missingVendor.length) {
+  console.error(
+    `\nbundle-budget: FAIL — vendor chunk(s) not emitted: ${missingVendor.join(", ")}.\n` +
+    "The advancedChunks split did not match, so these libs are inside the eager shell and are no\n" +
+    "longer separately cacheable. If you are building from a git worktree this is expected and the\n" +
+    "build output is WRONG — build from the main clone. Otherwise the chunking config has regressed.",
+  );
+  process.exit(1);
+}
+
 if (total / 1024 > BUDGET_KB) {
   console.error(`\nbundle-budget: FAIL — shell ${kb(total)} KB exceeds ${BUDGET_KB} KB.`);
   console.error("Trim the eager path (lazy-load it) or bump BUNDLE_BUDGET_KB deliberately with a note.");

--- a/apps/web/scripts/copy-wasm.mjs
+++ b/apps/web/scripts/copy-wasm.mjs
@@ -3,22 +3,24 @@
 import { mkdirSync, copyFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { createRequire } from "node:module";
+
+import { findPackageDir } from "./wasmSources.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const webRoot = join(here, "..");
 const dest = join(webRoot, "public", "wasm");
 
-// resolve the web-ifc package dir — handles npm-workspace hoisting (root node_modules)
-// or a local install. web-ifc blocks ./package.json in its exports map, so probe paths.
-createRequire(import.meta.url); // (kept for potential future resolve use)
-const candidates = [
-  join(webRoot, "node_modules", "web-ifc"),
-  join(webRoot, "..", "..", "node_modules", "web-ifc"),
-];
-const wasmSource = candidates.find((c) => existsSync(join(c, "web-ifc.wasm")));
-if (!wasmSource) {
-  console.error("[copy-wasm] could not find web-ifc package. Looked in:\n  " + candidates.join("\n  "));
+// Resolve the package rather than guessing how far up `node_modules` is: the old two-candidate
+// probe assumed the repo root was exactly two levels above `apps/web`, which is false in every
+// git worktree and made `npm run build` fail there. See scripts/wasmSources.mjs.
+const wasmSource = findPackageDir("web-ifc", webRoot);
+if (!wasmSource || !existsSync(join(wasmSource, "web-ifc.wasm"))) {
+  console.error(
+    "[copy-wasm] could not find the web-ifc package.\n" +
+    `  resolved to: ${wasmSource ?? "(unresolved)"}\n` +
+    "  Run `npm install` at the repo root. From a git worktree this resolves the MAIN clone's\n" +
+    "  node_modules by upward lookup, which is expected — worktrees do not get their own.",
+  );
   process.exit(1);
 }
 
@@ -36,10 +38,8 @@ for (const f of files) {
 }
 
 // laz-perf WASM (LAZ point-cloud decoding) — same offline-vendoring rule; loaded via locateFile.
-const lazSrc = [
-  join(webRoot, "node_modules", "laz-perf", "lib", "laz-perf.wasm"),
-  join(webRoot, "..", "..", "node_modules", "laz-perf", "lib", "laz-perf.wasm"),
-].find((p) => existsSync(p));
+const lazDir = findPackageDir("laz-perf", webRoot);
+const lazSrc = lazDir ? [join(lazDir, "lib", "laz-perf.wasm")].find((p) => existsSync(p)) : undefined;
 if (lazSrc) {
   copyFileSync(lazSrc, join(dest, "laz-perf.wasm"));
   console.log("[copy-wasm] laz-perf.wasm -> public/wasm/");

--- a/apps/web/scripts/wasmSources.mjs
+++ b/apps/web/scripts/wasmSources.mjs
@@ -1,0 +1,75 @@
+/**
+ * Locate an installed package directory, without assuming how deep `node_modules` sits.
+ *
+ * WHY THIS EXISTS
+ *     `copy-wasm.mjs` found `web-ifc` by trying two hard-coded relative paths:
+ *
+ *         <webRoot>/node_modules/web-ifc
+ *         <webRoot>/../../node_modules/web-ifc      <- "the repo root", assumed two levels up
+ *
+ *     That second assumption is true in the main clone and **false in every git worktree**. A
+ *     worktree at `.claude/worktrees/<lane>` puts the repo root FOUR levels above `apps/web`, and a
+ *     worktree has no `node_modules` of its own — it resolves the main clone's by Node's upward
+ *     lookup. So both candidates miss, and `npm run build` dies in `prebuild` with
+ *     "could not find web-ifc package". Measured: exit 1 from a worktree's own `apps/web`.
+ *     (That sentence originally cited the path as a glob, whose "star-slash" closed this very
+ *     comment and made the file a syntax error — the build script's own docs breaking the build.)
+ *
+ *     That matters more than a broken build script, because `docs/roadmap-directions.md` §3 tells
+ *     every agent to work in a worktree and states the marginal cost is "a source checkout". The
+ *     build was an unlisted part of that cost.
+ *
+ * THE FIX WAS ALREADY IN THIS REPO, ONE DIRECTORY AWAY
+ *     `apps/web/vitest.config.ts` hit the identical problem — a worktree resolving `node_modules`
+ *     up into the main clone — and solved it by asking Node instead of guessing:
+ *
+ *         path.dirname(createRequire(import.meta.url).resolve("pdfjs-dist/package.json"))
+ *
+ *     Same cause, same fix, written for the test config and never carried across to the build
+ *     script. **Depth is the thing you must not hard-code**; `createRequire` walks upward exactly
+ *     the way the runtime does, so it is correct at any depth and in any checkout.
+ *
+ * WHY NOT JUST `resolve(name + "/package.json")`
+ *     Because `web-ifc` blocks `./package.json` in its exports map — that resolve throws
+ *     `ERR_PACKAGE_PATH_NOT_EXPORTED`. (`laz-perf` allows it; the two packages genuinely differ,
+ *     which is why this tries both and then truncates a resolved entry point instead.) The original
+ *     script's comment already recorded this hazard, and it even imported `createRequire` on the
+ *     line above — then left it unused with the note "kept for potential future resolve use". The
+ *     tool that would have fixed this was sitting in the file the whole time.
+ */
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { dirname, join, sep } from "node:path";
+
+/**
+ * Absolute path to an installed package's root directory, or `null`.
+ *
+ * `webRoot` is consulted only as a LAST resort, for layouts Node cannot resolve (a package vendored
+ * somewhere that is not on the resolution path). It is a parameter rather than a constant so a test
+ * can hand this function a directory where the old relative candidates could not possibly succeed —
+ * which is the only way to assert the depth assumption is really gone. See `src/build/copyWasm.test.ts`.
+ */
+export function findPackageDir(name, webRoot, requireFrom = import.meta.url) {
+  const req = createRequire(requireFrom);
+
+  // 1. The package's own manifest, when its exports map permits it.
+  try {
+    return dirname(req.resolve(`${name}/package.json`));
+  } catch { /* exports map may block it (web-ifc does) — try the entry point instead */ }
+
+  // 2. The entry point, truncated back to the package root. `lastIndexOf` rather than `indexOf`
+  //    because a nested `node_modules` (a transitive copy) is the one actually being used.
+  try {
+    const entry = req.resolve(name);
+    const marker = `node_modules${sep}${name.split("/").join(sep)}`;
+    const at = entry.lastIndexOf(marker);
+    if (at >= 0) return entry.slice(0, at + marker.length);
+  } catch { /* not resolvable at all — fall through to the explicit candidates */ }
+
+  // 3. Explicit layouts, kept so a non-node_modules checkout still works. NOT the primary path:
+  //    these are the assumptions that broke, and they must never be the only mechanism again.
+  for (const candidate of [join(webRoot, "node_modules", name), join(webRoot, "..", "..", "node_modules", name)]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}

--- a/apps/web/src/tooling/copyWasm.test.ts
+++ b/apps/web/src/tooling/copyWasm.test.ts
@@ -1,0 +1,140 @@
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The build's WASM copy step must not assume how deep `node_modules` is.
+ *
+ * WHAT BROKE
+ *     `scripts/copy-wasm.mjs` located `web-ifc` with two hard-coded relative candidates, the second
+ *     being `<webRoot>/../../node_modules` — "the repo root, two levels above apps/web". True in the
+ *     main clone, false in every git worktree, where the root is four levels up and the worktree has
+ *     no `node_modules` of its own. `npm run build` therefore exited 1 in `prebuild` from any
+ *     worktree, taking `build`, `build:desktop` and `build:mobile` with it.
+ *
+ * WHY THIS TEST IS SHAPED THE WAY IT IS — the important part
+ *     The obvious test ("run the build script, assert exit 0") **cannot fail in CI**, because CI runs
+ *     in the main clone where the broken assumption happens to hold. It would have been green
+ *     throughout the entire period the bug existed. A check that is structurally unable to reach the
+ *     failure is not a check, and this repo has shipped that shape before.
+ *
+ *     So the depth assumption is attacked directly instead: `findPackageDir` takes `webRoot` as a
+ *     PARAMETER, and this test hands it a temp directory that has no `node_modules` anywhere above
+ *     it. Under the old implementation both candidates miss and the answer is null — in the main
+ *     clone, on CI, everywhere. Under the fixed one, `createRequire` resolves upward from the
+ *     script's own location and finds the real package regardless of what `webRoot` says.
+ *
+ *     That is what makes this fail on a regression rather than on a checkout.
+ *
+ * WHY THIS FILE IS IN `src/tooling/` AND NOT `src/build/`
+ *     It was written in `src/build/` first. `.gitignore` line 9 is `build/`, which matches a
+ *     directory of that name **at any depth**, so the file was ignored. Vitest collected it off disk
+ *     and reported 110 passing files locally; `git status` never mentioned it, and CI — which only
+ *     ever sees the archive — would have run 109. A test that passes on your machine and does not
+ *     exist on the runner is worse than no test, because the green is real and the coverage is not.
+ *     The repo has been bitten by the archive-vs-disk distinction before, with `samples/*.ifc`.
+ *     `git check-ignore -v <path>` answers this in one command; `ls` never will.
+ */
+
+// process.cwd() is apps/web under vitest (see roadmap-directions §5). Resolved from cwd rather than
+// import.meta.url because the suite runs under happy-dom, where import.meta.url has no file: scheme.
+const SCRIPTS = join(process.cwd(), "scripts");
+
+type WasmSources = {
+  findPackageDir: (name: string, webRoot: string, requireFrom?: string) => string | null;
+};
+
+/** Dynamic import so TypeScript does not need a declaration for the .mjs build script. */
+async function load(): Promise<WasmSources> {
+  return (await import(
+    /* @vite-ignore */ pathToFileURL(join(SCRIPTS, "wasmSources.mjs")).href
+  )) as WasmSources;
+}
+
+describe("the build's WASM package resolution", () => {
+  it("finds web-ifc and laz-perf at all — otherwise every assertion below is vacuous", async () => {
+    const { findPackageDir } = await load();
+    for (const name of ["web-ifc", "laz-perf"]) {
+      const dir = findPackageDir(name, process.cwd());
+      expect(dir, `${name} did not resolve; the viewer cannot be built offline without it`).toBeTruthy();
+      expect(existsSync(dir as string)).toBe(true);
+    }
+  });
+
+  it("copies the exact files the offline viewer needs", async () => {
+    // Named, not counted. The non-negotiable is that the viewer runs fully offline with local WASM,
+    // so a missing binary here is a runtime CDN fetch or a dead viewer, not a slow build.
+    const { findPackageDir } = await load();
+    const webIfc = findPackageDir("web-ifc", process.cwd()) as string;
+    expect(existsSync(join(webIfc, "web-ifc.wasm")), "web-ifc.wasm missing").toBe(true);
+
+    const laz = findPackageDir("laz-perf", process.cwd()) as string;
+    expect(existsSync(join(laz, "lib", "laz-perf.wasm")), "laz-perf.wasm missing").toBe(true);
+  });
+
+  it("resolves without depending on where node_modules sits relative to webRoot", async () => {
+    // THE REGRESSION GUARD. This temp path has no node_modules at any ancestor, so both of the old
+    // relative candidates are guaranteed to miss. Passing here means resolution is anchored to the
+    // module's own location (upward lookup) rather than to a counted number of `..` segments.
+    const { findPackageDir } = await load();
+    const nowhere = join(tmpdir(), "massing-wasm-resolve-probe");
+    expect(existsSync(join(nowhere, "node_modules"))).toBe(false);
+
+    for (const name of ["web-ifc", "laz-perf"]) {
+      const dir = findPackageDir(name, nowhere);
+      expect(
+        dir,
+        `${name} resolved only via a webRoot-relative guess — the worktree build is broken again`,
+      ).toBeTruthy();
+      // And it must be a real directory, not a plausible string assembled from the fake root.
+      expect(existsSync(dir as string)).toBe(true);
+      expect(dir as string).not.toContain(nowhere);
+    }
+  });
+
+  it("is itself in the archive CI runs from, not merely on this disk", async () => {
+    // The generalisation of why this file moved out of src/build/. Vitest collects from DISK; CI
+    // collects from the ARCHIVE. A test in an ignored directory passes locally and does not exist on
+    // the runner. This asserts the whole suite is tracked, so the next person who adds a test under
+    // a conveniently-named folder (`build/`, `dist/`, `tmp/` — all in .gitignore) is told at once
+    // rather than believing a green that never ran.
+    // Ask git for the whole of src/ and filter HERE, rather than handing git a `**` pathspec.
+    // Git's default pathspec is not the same glob as Node's: `*` matches `/` too, so
+    // `src/**/*.test.ts` requires an intermediate directory and silently misses a test sitting
+    // directly in `src/`. The first draft did exactly that and reported the tracked, unmodified
+    // `src/no-import-cycles.test.ts` as unshipped — a false positive produced by using two
+    // different glob dialects for the two halves of one comparison. One reader defines the
+    // pattern; the other only supplies its side of the set.
+    const { execFileSync } = await import("node:child_process");
+    const tracked = new Set(
+      execFileSync("git", ["ls-files", "src/"], { cwd: process.cwd(), encoding: "utf8" })
+        .split("\n").map((s) => s.trim()).filter((p) => p.endsWith(".test.ts")),
+    );
+    expect(tracked.size, "git ls-files returned nothing — this check would pass vacuously").toBeGreaterThan(50);
+
+    const { globSync } = await import("node:fs");
+    const onDisk = globSync("src/**/*.test.ts", { cwd: process.cwd() })
+      .map((p: string) => p.split("\\").join("/"))
+      .filter((p) => !p.includes("/vendor/"));   // vendored suites are excluded from the run itself
+
+    const untracked = onDisk.filter((p) => !tracked.has(p));
+    expect(untracked, `test files vitest runs but git does not ship: ${untracked.join(", ")}`).toEqual([]);
+  });
+
+  it("keeps copy-wasm.mjs wired to the shared resolver", async () => {
+    // The resolver is only load-bearing if the build script actually calls it. Without this, someone
+    // could reintroduce the inline candidates and every assertion above would still pass — the same
+    // "engine exists, nothing calls it" gap the directions warn about.
+    const src = await import("node:fs").then((fs) =>
+      fs.readFileSync(join(SCRIPTS, "copy-wasm.mjs"), "utf8"),
+    );
+    expect(src).toContain("findPackageDir");
+    expect(
+      src.includes(`"..", "..", "node_modules"`),
+      "copy-wasm.mjs has a hard-coded ../../node_modules candidate again",
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Unowned tooling item (`apps/web/scripts/`, `apps/web/src/tooling/`) — no lane owns these paths. **No version files, no `CHANGELOG.md`.**

The assigned item was "`npm run build` fails in a worktree". It does. **Fixing only that would have been the wrong move, because the failure was the only thing preventing a silently wrong bundle.**

## 1 · `copy-wasm.mjs` guessed how deep `node_modules` was

It probed two hard-coded paths, the second being `<webRoot>/../../node_modules` — "the repo root, two levels above `apps/web`". True in the main clone; **false in every worktree**, where the root is four levels up and a worktree has no `node_modules` of its own (it resolves the main clone's by upward lookup). `prebuild` exited 1, taking `build`, `build:desktop` and `build:mobile` with it.

**The fix already existed one directory away.** `vitest.config.ts` hit the identical worktree cause and solved it with `createRequire(...).resolve(...)`. `copy-wasm.mjs` even *imported* `createRequire` — then left it unused, commented *"kept for potential future resolve use"*. The tool that fixes this was in the file the whole time.

Extracted to `scripts/wasmSources.mjs` so a test can drive it with an arbitrary `webRoot`. (`web-ifc` blocks `./package.json` in its exports map, so resolution falls back to truncating the resolved entry point; `laz-perf` permits it. The two genuinely differ — hence both paths.)

## 2 · And then the worktree build produces a WRONG bundle

Same commit, same command (`vite build`), two checkouts, measured:

| | main clone | git worktree |
|---|---|---|
| exit | 0 | 1 |
| `three-*.js` chunk | present | **absent** |
| `thatopen-*.js` chunk | present | **absent** |
| eager app shell | **334 KB** | **6,581 KB** — 19.7× |
| modules transformed | 585 | 638 (`_commonjsHelpers` appears) |

In a worktree the hoisted `node_modules` sits outside the workspace root (`searchForWorkspaceRoot` returns the *worktree* root), deps fall back to CommonJS interop, and the `advancedChunks` rules never match — so three.js and the That Open stack are folded into the eager shell.

**Package resolution is not the cause.** I verified `three` and `@thatopen/components` resolve to identical absolute paths in both checkouts. This is workspace-root scoping, not resolution.

`vite.config.ts` predicted this precisely:

> *"A vendor split that silently stops splitting is the worst kind of build regression: the bundle still works, so nothing fails"* … *"Verify by grepping the OUTPUT, never by reading the config and believing it."*

**Nobody was verifying the output.** `bundle-budget.mjs` computed the lazy-chunk count and *printed* it without ever asserting it — on the broken build it printed `Lazy chunks kept out of the shell: 1` and that line exited 0. The only thing that made this visible at all was the PWA precache size limit, and **`VitePWA` is excluded entirely when `VITE_PAGES=1`** — the Pages build path. In that configuration a worktree build ships a 20× shell in silence.

So `bundle-budget.mjs` now **asserts** the vendor chunks exist. It already runs in CI as `npm run budget`; no workflow change.

## 3 · The new test was invisible to CI — a third bug

I wrote it in `src/build/`. **`.gitignore` line 9 is `build/`, which matches a directory of that name at any depth.** Vitest collected it off disk and reported 110 green files; `git status` never mentioned it; CI, which sees only the archive, would have run 109. A test that passes on your machine and does not exist on the runner is worse than no test — the green is real and the coverage is not.

Moved to `src/tooling/`, and generalised into an assertion that **every `src/**/*.test.ts` on disk is tracked**, so the next test dropped into `build/`, `dist/` or `tmp/` is named immediately.

That guard's own first draft was wrong in the way this repo keeps re-learning: it passed `src/**/*.test.ts` to `git ls-files`, whose default pathspec lets `*` match `/`, so it required an intermediate directory and reported the tracked, unmodified `src/no-import-cycles.test.ts` as unshipped. **Two glob dialects for the two halves of one comparison.** Git now supplies only its side of the set; the pattern is applied in one place.

## Why the resolution test is shaped oddly

The obvious test — "run the build, assert exit 0" — **cannot fail in CI**, because CI runs in the main clone where the broken assumption happens to hold. It would have been green for the entire life of the bug. So `findPackageDir` takes `webRoot` as a *parameter* and the test hands it a temp directory with no `node_modules` above it: the old implementation returns `null` there, on any machine.

## Verification

| check | result |
|---|---|
| `npm run test --workspace apps/web` | **1228 / 1228**, 110 / 110 |
| `npx tsc --noEmit` | clean |
| `npx eslint` (changed files) | 0 errors (`scripts/` is eslint-ignored) |
| `npm run build` from a worktree, before | exit 1 at `prebuild` |
| `copy-wasm` from a worktree, after | exit 0 — all three WASM binaries copied |

**Mutation checks — each verified to have applied before its result was read:**

| mutation | result |
|---|---|
| resolver reverted to depth-guessing only | 3 of 4 fail, incl. *"the worktree build is broken again"* (mutant proven: fake root → `null`) |
| vendor-split assertion vs worktree build | exit 1, names `three, thatopen` |
| vendor-split assertion vs main-clone build | exit 0, shell 185 KB, 3 lazy chunks |
| ghost test file in ignored `src/build/` | exit 1, names `src/build/ghost.test.ts` |

My *first* mutation of the resolver was malformed — an `else` that disabled only one of two resolution paths, so the test passed correctly and the mutation proved nothing. Caught by checking what the mutant actually did (`findPackageDir("web-ifc", "/nope/nowhere")`) rather than trusting the edit.

## Deliberately not attempted

**Making worktree builds correct.** That is workspace-root scoping in a shared `vite.config.ts` with blast radius across every lane, and it deserves to be picked as a roadmap item rather than smuggled into a tooling fix. The interim position is exactly what the gate now states: **build from the main clone or CI; a worktree is for typecheck and tests.** `docs/roadmap-directions.md` §3 currently sells worktrees as costing "a source checkout" — that claim needs this caveat, which I have left for the lead since the directions are shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
