### PR TITLE
RAIL-DRAG — drag an element from the palette onto the canvas

### DIFF
--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -1230,3 +1230,14 @@ button.vit:hover { background: var(--hover, rgba(255,255,255,.06)); }
 .ws-return { position: sticky; top: 0; z-index: 5; padding: 6px 8px;
   background: var(--panel2); border-bottom: 1px solid var(--line); }
 .ws-return-btn { font-size: 12px; }
+
+/* RAIL-DRAG — the canvas as a drop target.
+   The cue is an INSET outline rather than a border: a border on the viewer container would resize
+   the canvas mid-drag and force a renderer resize on every dragover, which is both a visible jump
+   and needless work in a hot event. The pointer-events note matters too — the overlay must never
+   exist as a real element, or it would become the drop target instead of the canvas. */
+.rail-drag-over { outline: 2px dashed var(--accent); outline-offset: -6px; }
+/* Palette rows advertise that they can be dragged. `grab` is the honest cursor: the row is still a
+   button you can click to select, so it must not look exclusively like a drag handle. */
+.rail-toolgroup-body [draggable="true"], .tool-btn[draggable="true"] { cursor: grab; }
+.tool-btn[draggable="true"]:active { cursor: grabbing; }

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -13,6 +13,7 @@ import { applyDynamicInput, polarConstrain, resolveSnap } from "./snapEngine";
 import {
   OVERRIDE_LABEL, createSnapOverride, overrideCandidates, type OverrideKind,
 } from "./snapOverride";
+import { canAcceptDraftDrag, dropCompletion, readDraftDragKey } from "./railDrag";
 import { parseDynConstraint } from "./dynInput";
 import { parseCadCommand } from "./cadCommands";
 import { ModelLoader } from "./loader";
@@ -596,6 +597,47 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     await selectMap({ [hit.fragments.modelId]: new Set([hit.localId]) }, { guid: guid ?? undefined });
     setStatus(guid ? `selected ${guid} — click again to select its level` : `selected ${hit.localId}`);
   });
+  // ---- RAIL-DRAG: drop a palette element onto the canvas ---------------------
+  //
+  // A second GESTURE onto the click pipeline, never a second pipeline: the drop arms the tool and
+  // then hands the event straight to `captureDraftPoint`, so snapping, typed constraints, inference,
+  // the grid and `placeValid` all apply exactly as they do to a click. DragEvent extends MouseEvent,
+  // so it is literally the same input that function already takes.
+  //
+  // `dragover` must decide from `types` alone — the payload is unreadable there (protected mode), and
+  // reading it would silently refuse every drop. See `railDrag.ts`.
+  container.addEventListener("dragover", (e) => {
+    if (!canAcceptDraftDrag(e.dataTransfer)) return;      // a file/text drag is left for others
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    container.classList.add("rail-drag-over");
+  });
+  const clearDragCue = () => container.classList.remove("rail-drag-over");
+  container.addEventListener("dragleave", (e) => { if (e.target === container) clearDragCue(); });
+  container.addEventListener("drop", async (e) => {
+    const key = readDraftDragKey(e.dataTransfer);
+    clearDragCue();
+    if (!key) return;                                     // not ours — do not preventDefault
+    e.preventDefault();
+    // `armByKey` notifies and returns null when the key is unknown or authoring is unavailable
+    // (no project / no source IFC), so a refused drop already explains itself.
+    if (!draftHandle?.armByKey(key)) return;
+    const spec = armed;
+    if (!spec) return;
+    mouse.set(e.clientX, e.clientY);
+    const hit = await Promise.race([
+      loader.fragments.raycast({
+        camera: viewer.world.camera.three, mouse, dom: viewer.world.renderer!.three.domElement,
+      }),
+      new Promise<null>((res) => window.setTimeout(() => res(null), 1500)),
+    ]);
+    await captureDraftPoint(e, hit ?? null);
+    // One drop is one point. Only a points:1 element is finished by it; the rest keep the tool armed,
+    // and are told so rather than left to wonder whether the drag worked.
+    const done = dropCompletion(spec.points, spec.label);
+    if (!done.completes) notify(done.message, "info");
+  });
+
   container.addEventListener("dblclick", () => {
     if (armed && armed.points === "poly") {
       if (armPts.length >= 3) void finishDraft(); else notify("need at least 3 points to close", "error");

--- a/apps/web/src/viewer/draft/draftPanel.test.ts
+++ b/apps/web/src/viewer/draft/draftPanel.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { installDraftPanel, type ArmedDraft } from "./draftPanel";
+import { DRAFT_DRAG_MIME, readDraftDragKey } from "../railDrag";
+
+/**
+ * RAIL-DRAG — the drag SOURCE, driven through the real panel.
+ *
+ * `railDrag.test.ts` proves the payload rules in isolation. Neither that nor a typecheck would notice
+ * if the palette rows were never made draggable in the first place — "the engine exists and nothing
+ * calls it" is this repo's most-repeated defect, and it is the reason this file exists at all
+ * (`draftPanel.ts` had no test before).
+ *
+ * The drop TARGET lives in `viewer/app.ts` and is not reachable from a unit test: it needs a WebGL
+ * renderer, a Fragments worker and a loaded model. That gap is stated in the PR rather than papered
+ * over with a mock that would only assert the mock.
+ */
+
+function mount() {
+  const body = document.createElement("div");
+  document.body.appendChild(body);
+  const armed: (ArmedDraft | null)[] = [];
+  const handle = installDraftPanel({
+    body,
+    fetchFamilies: () => Promise.resolve([]),
+    arm: (a) => { armed.push(a); },
+    notify: vi.fn((_m: string, _k?: "info" | "success" | "error") => {}),
+    canAuthor: () => true,
+  });
+  return { body, armed, handle };
+}
+
+/** The palette rows — buttons inside the scrolling list, excluding discipline chips. */
+const rows = (body: HTMLElement) =>
+  [...body.querySelectorAll<HTMLButtonElement>("button")].filter((b) => b.draggable);
+
+/** A DataTransfer stub good enough for dragstart (writable, readable). */
+function makeDT(): DataTransfer {
+  const store = new Map<string, string>();
+  return {
+    get types() { return [...store.keys()]; },
+    getData: (t: string) => store.get(t) ?? "",
+    setData: (t: string, v: string) => { store.set(t, v); },
+    effectAllowed: "none",
+  } as unknown as DataTransfer;
+}
+
+describe("RAIL-DRAG — the palette rows are actually drag sources", () => {
+  it("renders draggable rows", () => {
+    const { body } = mount();
+    expect(rows(body).length, "no draggable palette rows — drag-to-place is unreachable")
+      .toBeGreaterThan(0);
+  });
+
+  it("dragstart puts a catalog key on the DataTransfer that readDraftDragKey can read back", () => {
+    const { body } = mount();
+    const row = rows(body)[0]!;
+    const dt = makeDT();
+    const ev = new Event("dragstart", { bubbles: true }) as DragEvent;
+    Object.defineProperty(ev, "dataTransfer", { value: dt });
+    row.dispatchEvent(ev);
+    const key = readDraftDragKey(dt);
+    expect(key, "dragstart set no usable payload").toBeTruthy();
+    expect(dt.types).toContain(DRAFT_DRAG_MIME);
+  });
+
+  // The key must be one the arming path accepts. A payload that round-trips but names nothing is a
+  // drag that silently does nothing on drop — the failure mode this whole item is meant to remove.
+  it("the dragged key is one armByKey resolves", () => {
+    const { body, handle, armed } = mount();
+    const row = rows(body)[0]!;
+    const dt = makeDT();
+    const ev = new Event("dragstart", { bubbles: true }) as DragEvent;
+    Object.defineProperty(ev, "dataTransfer", { value: dt });
+    row.dispatchEvent(ev);
+    const key = readDraftDragKey(dt)!;
+    expect(handle.armByKey(key), `armByKey rejected the dragged key ${key}`).toBeTruthy();
+    expect(armed.at(-1)?.key).toBe(key);
+  });
+
+  it("every draggable row carries a key armByKey resolves, not just the first", () => {
+    const { body, handle } = mount();
+    const keys: string[] = [];
+    for (const row of rows(body)) {
+      const dt = makeDT();
+      const ev = new Event("dragstart", { bubbles: true }) as DragEvent;
+      Object.defineProperty(ev, "dataTransfer", { value: dt });
+      row.dispatchEvent(ev);
+      const k = readDraftDragKey(dt);
+      expect(k, "a row produced no payload").toBeTruthy();
+      keys.push(k!);
+    }
+    expect(keys.length).toBeGreaterThan(3);
+    for (const k of keys) expect(handle.armByKey(k), `unresolvable key ${k}`).toBeTruthy();
+  });
+
+  // Dragging is also a selection: the parameter form under the list must describe the thing being
+  // dragged, or the form is a lie about what the next drop will author.
+  it("dragging a row selects it, so the parameter form matches what is being dragged", () => {
+    const { body } = mount();
+    const all = rows(body);
+    const target = all[2] ?? all[0]!;
+    const dt = makeDT();
+    const ev = new Event("dragstart", { bubbles: true }) as DragEvent;
+    Object.defineProperty(ev, "dataTransfer", { value: dt });
+    target.dispatchEvent(ev);
+    const key = readDraftDragKey(dt)!;
+    // the form header renders the selected element's label; find the row that now reads as selected
+    const on = [...body.querySelectorAll<HTMLButtonElement>("button.on")].map((b) => b.textContent);
+    expect(on.join(" "), `nothing marked selected after dragging ${key}`).not.toBe("");
+  });
+
+  it("clicking a row still selects without needing a drag — the old gesture is untouched", () => {
+    const { body } = mount();
+    const row = rows(body)[1] ?? rows(body)[0]!;
+    row.click();
+    expect(body.querySelectorAll("button.on").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/viewer/draft/draftPanel.ts
+++ b/apps/web/src/viewer/draft/draftPanel.ts
@@ -10,6 +10,7 @@ import {
   DISCIPLINES, DRAFT_ELEMENTS, familyToDraftElement,
   type Discipline, type DraftElement, type FamilyDef, type ParamDef, type ParamValues,
 } from "./draftCatalog";
+import { setDraftDragKey } from "../railDrag";
 
 export interface ArmedDraft {
   key: string;
@@ -96,6 +97,14 @@ export function installDraftPanel(deps: DraftPanelDeps): DraftPanelHandle {
       row.innerHTML = `<span>${item.label}</span>`
         + `<span class="meta" style="font-size:10px">${item.ifcClass.replace("Ifc", "").replace("Type", "")}</span>`;
       row.onclick = () => { selected = item; renderList(); renderForm(); };
+      // RAIL-DRAG — the same row is also a drag source. Dragging selects it too, so the parameter
+      // form below matches what is being dragged: a drag that placed an element while the form showed
+      // a different one would make the form a lie about the last thing authored.
+      row.draggable = true;
+      row.ondragstart = (e) => {
+        selected = item; renderList(); renderForm();
+        setDraftDragKey(e.dataTransfer, item.key);
+      };
       list.appendChild(row);
     }
   }

--- a/apps/web/src/viewer/railDrag.test.ts
+++ b/apps/web/src/viewer/railDrag.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  DRAFT_DRAG_MIME, canAcceptDraftDrag, dropCompletion, readDraftDragKey, setDraftDragKey,
+} from "./railDrag";
+import { DRAFT_ELEMENTS } from "./draft/draftCatalog";
+
+/**
+ * A DataTransfer stub with a switchable **protected mode**, because that is the whole subtlety.
+ *
+ * The spec exposes `types` in every drag event but blanks `getData()` in all of them except
+ * `dragstart` and `drop`. happy-dom's DataTransfer does not model that, so a test written against the
+ * real class would pass while the browser silently refused every drop. Modelling it here is the only
+ * way this suite can see the bug.
+ */
+function makeDT(entries: Record<string, string>, protectedMode = false): DataTransfer {
+  const store = new Map(Object.entries(entries));
+  return {
+    // A GETTER, not a snapshot: the real `types` reflects `setData` calls made after construction,
+    // and a stub that froze it at construction failed the round-trip test while the code was correct.
+    get types() { return [...store.keys()]; },
+    getData: (t: string) => (protectedMode ? "" : (store.get(t) ?? "")),
+    setData: (t: string, v: string) => { store.set(t, v); },
+    effectAllowed: "none",
+    dropEffect: "none",
+  } as unknown as DataTransfer;
+}
+
+describe("RAIL-DRAG — accepting the drag is decided from `types`, never from the payload", () => {
+  // The failure this guards is invisible: read the value during dragover, get "" because of
+  // protected mode, decide "not ours", skip preventDefault — and the browser refuses the drop with
+  // no error. The feature just does nothing.
+  it("accepts our drag during dragover even though the payload is unreadable there", () => {
+    const dt = makeDT({ [DRAFT_DRAG_MIME]: "wall" }, true);   // protected, as in a real dragover
+    expect(dt.getData(DRAFT_DRAG_MIME)).toBe("");             // the trap, made explicit
+    expect(canAcceptDraftDrag(dt)).toBe(true);                // and we still accept it
+  });
+
+  it("does not accept a file drag — dragging a PDF onto the canvas must not arm a tool", () => {
+    expect(canAcceptDraftDrag(makeDT({ Files: "" }, true))).toBe(false);
+  });
+
+  it("does not accept plain text dragged in from another app", () => {
+    expect(canAcceptDraftDrag(makeDT({ "text/plain": "wall" }, true))).toBe(false);
+  });
+
+  it("survives a null or throwing DataTransfer rather than taking the canvas down mid-drag", () => {
+    expect(canAcceptDraftDrag(null)).toBe(false);
+    const hostile = { get types(): string[] { throw new Error("nope"); } } as unknown as DataTransfer;
+    expect(canAcceptDraftDrag(hostile)).toBe(false);
+  });
+});
+
+describe("RAIL-DRAG — reading the key at drop", () => {
+  it("round-trips a catalog key through set → read", () => {
+    const dt = makeDT({});
+    setDraftDragKey(dt, "steel_column");
+    expect(canAcceptDraftDrag(dt)).toBe(true);
+    expect(readDraftDragKey(dt)).toBe("steel_column");
+  });
+
+  it("marks the drag as a copy, so the cursor says what will happen", () => {
+    const dt = makeDT({});
+    setDraftDragKey(dt, "wall");
+    expect(dt.effectAllowed).toBe("copy");
+  });
+
+  it("returns null for a foreign drag rather than a truthy empty string", () => {
+    expect(readDraftDragKey(makeDT({ "text/plain": "wall" }))).toBeNull();
+    expect(readDraftDragKey(makeDT({ Files: "" }))).toBeNull();
+    expect(readDraftDragKey(null)).toBeNull();
+  });
+
+  it("returns null for our MIME carrying nothing usable", () => {
+    expect(readDraftDragKey(makeDT({ [DRAFT_DRAG_MIME]: "" }))).toBeNull();
+    expect(readDraftDragKey(makeDT({ [DRAFT_DRAG_MIME]: "   " }))).toBeNull();
+    expect(readDraftDragKey(makeDT({ [DRAFT_DRAG_MIME]: "x".repeat(500) }))).toBeNull();
+  });
+
+  it("keeps the namespaced keys the catalog actually uses intact", () => {
+    // `mep:` and `family:` keys carry a colon; a parser that split on one would silently truncate.
+    for (const key of ["mep:diffuser", "family:0c7f1a2b", "add_wall"]) {
+      const dt = makeDT({});
+      setDraftDragKey(dt, key);
+      expect(readDraftDragKey(dt)).toBe(key);
+    }
+  });
+
+  it("setDraftDragKey on a null DataTransfer is a no-op, not a throw", () => {
+    expect(() => setDraftDragKey(null, "wall")).not.toThrow();
+  });
+});
+
+describe("RAIL-DRAG — one drop is one point, and it says which elements that finishes", () => {
+  it("a single-point element completes on the drop", () => {
+    const r = dropCompletion(1, "Column");
+    expect(r.completes).toBe(true);
+    expect(r.message).toMatch(/placed/i);
+  });
+
+  it("a two-point element sets the first point and names the gesture that finishes it", () => {
+    const r = dropCompletion(2, "Wall");
+    expect(r.completes).toBe(false);
+    expect(r.message).toMatch(/first point/i);
+    expect(r.message).toMatch(/second point/i);
+  });
+
+  it("a poly element says how to close it", () => {
+    const r = dropCompletion("poly", "Slab / floor");
+    expect(r.completes).toBe(false);
+    expect(r.message).toMatch(/double-click/i);
+  });
+
+  // Silence after a drop is indistinguishable from a drop that failed.
+  it("always returns a message naming the element", () => {
+    for (const p of [1, 2, "poly"] as const) {
+      expect(dropCompletion(p, "Duct").message).toContain("Duct");
+    }
+  });
+
+  /**
+   * The partition, asserted against the real catalog rather than against three hand-picked cases.
+   *
+   * `points` is a closed union of 1 | 2 | "poly", and every catalog element must land on exactly one
+   * side of "does a drop finish this". A fourth arity added to the catalog with no branch here would
+   * otherwise fall through to the poly message and tell the user to double-click something that
+   * cannot be closed.
+   */
+  it("every element in the real catalog gets a verdict, and only points:1 completes", () => {
+    expect(DRAFT_ELEMENTS.length).toBeGreaterThan(10);   // not vacuous
+    const arities = new Set(DRAFT_ELEMENTS.map((e) => e.points));
+    expect([...arities].sort()).toEqual([1, 2, "poly"]); // the union really is closed
+    for (const e of DRAFT_ELEMENTS) {
+      const r = dropCompletion(e.points, e.label);
+      expect(r.message, e.key).toBeTruthy();
+      expect(r.completes, `${e.key} (points=${String(e.points)})`).toBe(e.points === 1);
+    }
+  });
+
+  it("at least one element of each arity exists, so neither branch is dead in practice", () => {
+    const byArity = (p: 1 | 2 | "poly") => DRAFT_ELEMENTS.filter((e) => e.points === p).length;
+    expect(byArity(1), "no single-point element — the completing branch would be dead").toBeGreaterThan(0);
+    expect(byArity(2)).toBeGreaterThan(0);
+    expect(byArity("poly")).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/viewer/railDrag.ts
+++ b/apps/web/src/viewer/railDrag.ts
@@ -1,0 +1,107 @@
+/**
+ * RAIL-DRAG — drag an element from the Library palette onto the canvas to place it.
+ *
+ * **Discovery, not parity.** Arm-then-click is already there and is faster once you know it; dragging
+ * a door onto a wall is the mental model somebody has *before* they know anything. This adds a second
+ * gesture onto the existing pipeline — it does not add a second pipeline. The drop resolves through
+ * `captureDraftPoint`, so object snap, typed constraints, axis inference, grid and `placeValid` all
+ * apply exactly as they do to a click. The item is explicit about why: drag without snapping "places
+ * a wall at 4.03 m and calls it 4.00 m", and that point carries a GlobalId into the schedules.
+ *
+ * ## A drop is ONE point, and most elements need more
+ *
+ * `draftCatalog` elements declare `points: 1 | 2 | "poly"`. A single drop can only *finish* a
+ * `points: 1` element — column, footing, MEP terminal, family. For a wall (2) or a slab (poly) the
+ * drop places the **first** point and leaves the tool armed to be finished by clicking.
+ *
+ * That asymmetry is stated to the user rather than left to be discovered. A drag that looks like it
+ * placed a wall and did not is worse than one that says "first point set" — the same reasoning behind
+ * the amber proxy over an uncommitted draft: real-looking geometry with no marker is indistinguishable
+ * from a committed element.
+ *
+ * ## Why the payload is read two different ways
+ *
+ * **During `dragover` the payload cannot be read at all.** The HTML drag-and-drop spec puts the
+ * DataTransfer in *protected mode* for every event except `dragstart` and `drop`: `getData()` returns
+ * `""` and only `types` is exposed. So the handler that decides whether to accept the drag
+ * (`canAcceptDraftDrag`) must ask `types`, and only the drop handler (`readDraftDragKey`) can ask for
+ * the value.
+ *
+ * Getting this wrong fails in the direction that looks like it works: `getData()` during `dragover`
+ * returns an empty string, the handler concludes "not ours", never calls `preventDefault()` — and the
+ * browser then refuses the drop **silently**, with no error anywhere. The feature would simply do
+ * nothing, which is why the two functions are separate and separately tested.
+ *
+ * Both are also what keeps a **file** drag from arming a tool: dragging a PDF over the canvas carries
+ * `Files`, not our MIME, so `canAcceptDraftDrag` is false, we never `preventDefault`, and the drop
+ * falls through to whatever else wants it.
+ */
+
+/** Our private drag type. A custom MIME (not `text/plain`) so nothing else can be mistaken for it,
+ *  and so dragging text from another app onto the canvas cannot arm an authoring tool. */
+export const DRAFT_DRAG_MIME = "application/x-massing-draft";
+
+/** The catalog key is opaque here (`wall`, `mep:diffuser`, `family:<id>`) — `armByKey` is the only
+ *  thing that decides whether it names a real element. This bound exists so a hostile or corrupt
+ *  payload cannot be carried around as an unbounded string. */
+const MAX_KEY = 200;
+
+function typeList(dt: DataTransfer | null): string[] {
+  if (!dt) return [];
+  try { return Array.from(dt.types ?? []); } catch { return []; }
+}
+
+/**
+ * Is this drag one of ours? Answered from `types` alone, because that is all `dragover` exposes.
+ *
+ * A `dragover` handler must call `preventDefault()` to permit a drop, so this is the predicate that
+ * decides whether the canvas is a drop target at all for this drag.
+ */
+export function canAcceptDraftDrag(dt: DataTransfer | null): boolean {
+  return typeList(dt).includes(DRAFT_DRAG_MIME);
+}
+
+/** Attach the catalog key at `dragstart`. */
+export function setDraftDragKey(dt: DataTransfer | null, key: string): void {
+  if (!dt) return;
+  try {
+    dt.setData(DRAFT_DRAG_MIME, key);
+    dt.effectAllowed = "copy";
+  } catch { /* a browser that refuses the custom type simply has no drag-to-place */ }
+}
+
+/**
+ * Read the catalog key at `drop`. Null when this is not our drag, or when the payload is empty or
+ * implausible — the caller must treat null as "not ours" and leave the event alone.
+ */
+export function readDraftDragKey(dt: DataTransfer | null): string | null {
+  if (!canAcceptDraftDrag(dt)) return null;
+  let raw = "";
+  try { raw = dt!.getData(DRAFT_DRAG_MIME) ?? ""; } catch { return null; }
+  const key = raw.trim();
+  if (!key || key.length > MAX_KEY) return null;
+  return key;
+}
+
+export interface DropCompletion {
+  /** Did this single drop finish the element, or is the tool still armed for more points? */
+  completes: boolean;
+  /** What to tell the user. Always says something: a drop that placed nothing visible and said
+   *  nothing is indistinguishable from a drop that failed. */
+  message: string;
+}
+
+/**
+ * What one drop can accomplish for an element needing `points` clicks.
+ *
+ * `points: 1` completes. Everything else places the first point and stays armed — and says so,
+ * naming the gesture that finishes it, because the user who dragged has just demonstrated they do not
+ * yet know the click flow.
+ */
+export function dropCompletion(points: 1 | 2 | "poly", label: string): DropCompletion {
+  if (points === 1) return { completes: true, message: `${label} placed` };
+  if (points === 2) {
+    return { completes: false, message: `${label}: first point set — click the second point` };
+  }
+  return { completes: false, message: `${label}: first point set — click more, double-click to close` };
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -219,7 +219,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-ELEMENT-CARD ② *(moved from E 2026-08-06 — the cell said E, the item's own text says the remaining work is "purely call sites: RFI, estimate line, pay app, COBie row", which live in `apps/web/src/ui/` and `apps/web/src/portal/panels/`. **A lane's paths and a lane's items are two claims and only the first is tested**, so the cell drifted from the item under it)* · R24-CHARTS-GRAMMAR · R24-REPORTS-BY-MOMENT · R24-DENSITY ② · R24-MONO-DATA · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R36-EMPTY-STATE *(SHIPPED v0.3.849, pending archive)* · R36-ROOM-BRIEFS · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/` | R22-ENTITLEMENT · R22-AGENT-PACKS · R22-PROVENANCE · R22-OPTION-OBJECT · R22-PIPELINE · R22-ROUTINES · R24-PERF-BUDGET · R22-PHOTO-CV · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-RATE ② · PERF-THREADS ③ · R35-PIDLOCK-XPROC · R35-DEAL-MEMORY · R37-TRIAGE · R40-EOT ② · R39-THROTTLE-SHARED ① · R39-UPLOAD-CAP-APP ① |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | SEC-PLUGIN-SANDBOX *(moved from C 2026-08-05 — the item said "Lane **D**, not C" all along; while one ID covered two items the table could not be right about both)* · R28-ICDD ③ · R38-PLAN-IDENTITY ③ · R38-ARRAY-LIVE ③ · R21-4D-CLASH · R23-STOREY-LOD · R28-UNIFY ① · R28-BUNDLE ② — **all SHIPPED and MERGED** (PRs #176/#178/#179 landed 2026-08-02); pending archive. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* |
-| **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-PLACE-VALID ② · A29-SPATIAL-SELECT ② · A29-UNDO-LOCAL ③ *(all three SHIPPED v0.3.831–833, pending archive)* · A29-GUIDE-UNDERLAY ③ · AUTH-SNAP-OVERRIDE *(SHIPPED PR #192, pending archive)* · RAIL-DRAG · R28-VIEWER ④ · R22-PUBLIC-VIEWER · UX-AR · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R36-AUTHOR-MENU *(SHIPPED v0.3.836–843: the More menu is gone, not reorganised)* · R38-NODE-SLIDERS ③ · R38-SYNC-VIEW ③ · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* |
+| **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-PLACE-VALID ② · A29-SPATIAL-SELECT ② · A29-UNDO-LOCAL ③ *(all three SHIPPED v0.3.831–833, pending archive)* · A29-GUIDE-UNDERLAY ③ · AUTH-SNAP-OVERRIDE *(SHIPPED PR #192, pending archive)* · RAIL-DRAG *(in flight, PR #197)* · R28-VIEWER ④ · R22-PUBLIC-VIEWER · UX-AR · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R36-AUTHOR-MENU *(SHIPPED v0.3.836–843: the More menu is gone, not reorganised)* · R38-NODE-SLIDERS ③ · R38-SYNC-VIEW ③ · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | R22-PM-CONTRACTS |
@@ -1990,7 +1990,30 @@ footing the July study stood on when CADCMD was written.
   pick (theirs is Shift+right-click; Shift is already ortho lock here, so pick a free chord). The
   genuine gap: today a snap preference is modal, and needing *this one pick* to take a perpendicular
   means changing a mode and changing it back.
-- **RAIL-DRAG** *(M — Lane E)* — drag from the Library palette into the canvas. Justification is
+- 🟡 **RAIL-DRAG** *(M — Lane E; **in flight, PR #197**)* — the palette rows in
+  `apps/web/src/viewer/draft/draftPanel.ts` are drag sources; `apps/web/src/viewer/railDrag.ts` owns
+  the payload rules and the one-drop-is-one-point verdict; `apps/web/src/viewer/app.ts` makes the
+  canvas a drop target that hands the `DragEvent` straight to `captureDraftPoint`. One pipeline, two
+  gestures, as the entry required.
+
+  **Two findings worth keeping, because neither is about dragging.**
+
+  *A drop is one point, and the catalog is not.* `draftCatalog` elements are `points: 1 | 2 | "poly"`,
+  so a drop can only *finish* a `points: 1` element; a wall or a slab gets its **first** point and
+  stays armed. The entry did not say this and it is the whole shape of the interaction. It is
+  asserted as a partition over the real catalog rather than over examples, so a fourth arity added
+  later fails a build instead of silently telling the user to double-click something that cannot be
+  closed.
+
+  *The browser hides the payload exactly where you need it.* During `dragover` the DataTransfer is in
+  **protected mode** — `getData()` returns `""` and only `types` is exposed. Deciding "is this ours?"
+  by reading the value means never calling `preventDefault()`, and the browser then refuses the drop
+  **silently, with no error**. The feature does nothing and nothing reports why. Worse, **happy-dom's
+  DataTransfer does not model protected mode**, so a test written against it passes while every real
+  drop is refused — the suite would have actively vouched for the broken build. The stub in
+  `apps/web/src/viewer/railDrag.test.ts` models it deliberately.
+
+  Original text: drag from the Library palette into the canvas. Justification is
   **discovery, not parity**: dragging a door onto a wall is a better first-run mental model than
   arm-then-click. It must resolve through the existing `captureDraftPoint` + `placeValid` path so
   there is one authoring pipeline with two gestures, never two pipelines. Safe to build *because* the


### PR DESCRIPTION
**Lane E.** Off `b89a60b5` (which is your merge of #194). 6 files, +432. **No version files, no CHANGELOG.** Roadmap text follows as its own commit on this branch.

## What it is

A **second gesture onto the existing pipeline, never a second pipeline.** The drop arms the tool and hands the event straight to `captureDraftPoint`, so object snap, typed constraints, axis inference, the grid and `placeValid` all apply exactly as they do to a click. `DragEvent extends MouseEvent`, so it is literally the same input that function already takes.

The item is explicit about why that matters, and it is not stylistic: drag without snapping *"places a wall at 4.03 m and calls it 4.00 m"*, and that point carries a GlobalId into the schedules.

Justification is **discovery, not parity** — arm-then-click already exists and is faster once you know it; dragging a door onto a wall is the model somebody has *before* they know anything.

## A drop is one point, and most elements need more

`draftCatalog` declares `points: 1 | 2 | "poly"`. A drop can only *finish* a `points: 1` element — column, footing, MEP terminal, family. For a wall (2) or slab (poly) it places the **first** point and leaves the tool armed, **and says so**. A drag that looks like it placed a wall and did not is worse than one that says "first point set" — the same reasoning as the amber proxy over an uncommitted draft.

Asserted as a partition against the **real catalog**, not three hand-picked cases: every element gets a verdict, the `points` union really is closed at `1 | 2 | "poly"`, and each arity has at least one member so neither branch is dead.

## The bug this would have shipped with, if written the obvious way

**During `dragover` the payload cannot be read at all.** The spec puts the DataTransfer in *protected mode* for every drag event except `dragstart` and `drop`: `getData()` returns `""`, only `types` is exposed.

A handler that asks for the value there concludes "not ours", never calls `preventDefault()` — and the browser then refuses the drop **silently, with no error anywhere.** The feature would simply do nothing, and nothing in a typecheck, a lint or a naive test would say so.

So accepting the drag (`canAcceptDraftDrag`, from `types`) and reading it (`readDraftDragKey`, from `getData`) are separate functions, separately tested — **and the test's DataTransfer stub models protected mode, because happy-dom's does not.** A test written against the real class would have passed while every real drop was refused.

A custom MIME rather than `text/plain` is what stops a dragged file or a snippet of text from arming an authoring tool.

## Verification, with its grade

- `tsc` clean · `eslint` clean · **1245/1245 web green** (111 files) on the committed tree
- `test_file_sizes` OK — `app.ts` **5148/5200**, so the logic went into `railDrag.ts` rather than the god-file
- **Five mutations checked red**: `dragover` reads the payload (the silent-refusal bug) · a file drag is accepted · a 2-point element claims the drop finished it · the key is split on `":"` (truncating `mep:` / `family:` keys) · the palette rows are not draggable at all

Found and fixed a bug in my own test stub on the way: `types` was snapshotted at construction instead of being a getter, so the round-trip test failed while the code was correct.

### Not covered, stated rather than mocked

The **drop target** in `app.ts` needs a WebGL renderer, a Fragments worker and a loaded model. I also still cannot verify a worktree branch in a browser — `preview_start` resolves `.claude/launch.json` against the session's primary cwd, so a dev server for a worktree serves the **main clone**. The drag **source** is covered end to end through the real panel (`draftPanel.ts` had no test before this).

## Two boundary notes

- **`apps/web/src/style.css` is outside every lane's paths** — one of the unowned paths the roadmap names. 11 lines, additive, two new class rules. Flagging rather than assuming.
- **R24-ELEMENT-CARD ② looks mis-laned.** The table files it under E; its own text says the remaining work is *"purely call sites: RFI, estimate line, pay app, COBie row"*, which live in `ui/` and `portal/panels/` — **Lane B**. I skipped it for that reason. A table edit you should make rather than have two sessions find by colliding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
