### PR TITLE
fix(viewer): the mis-click guard was defeated by a ground plane

### DIFF
--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -47,6 +47,7 @@ import { TransformGizmo } from "./draft/transformGizmo";
 import { PushPullGizmo, stretchTransform } from "./draft/pushPull";
 import { PlanPane } from "./planPane";
 import { type PlanBounds, validatePlacement } from "./placeValid";
+import { planBoundsFromModels } from "./modelBounds";
 import { type SpatialElement, type SpatialScope, nextScope, scopeSelection } from "./spatialSelect";
 import { DraftPointHistory } from "./draftHistory";
 import { DEFAULT_RISE_M, runReadout } from "./draft/stairLive";
@@ -1097,11 +1098,12 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   /** A29-PLACE-VALID: the loaded model's plan extent, from the same mesh traversal fitToModels
    *  uses. Null when nothing is loaded — a blank model must never refuse its first element. */
   function modelPlanBounds(): PlanBounds | null {
-    const box = new THREE.Box3();
-    viewer.world.scene.three.traverse((o) => { if ((o as THREE.Mesh).isMesh) box.expandByObject(o); });
-    if (box.isEmpty()) return null;
-    // plan coords are E = world x, N = -world z, so the N range is the NEGATED world-z range.
-    return { minX: box.min.x, maxX: box.max.x, minZ: -box.max.z, maxZ: -box.min.z };
+    // The MODEL, not the scene. Walking the scene expanded over the 2000x2000 shadow-catcher plane
+    // `world.ts` adds in presentation mode, so the "model extent" became +/-1000 m and the mis-click
+    // refusal it feeds stopped refusing anything. See `modelBounds.ts` for why this is an allowlist.
+    return planBoundsFromModels(
+      [...loader.fragments.list].map(([, m]) => m as unknown as { object: THREE.Object3D }),
+    );
   }
 
   async function finishDraft() {

--- a/apps/web/src/viewer/modelBounds.test.ts
+++ b/apps/web/src/viewer/modelBounds.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as THREE from "three";
+import { planBoundsFromModels, type BoundedModel } from "./modelBounds";
+import { BOUNDS_MARGIN_M, checkBounds } from "./placeValid";
+
+/** A box mesh centred at (cx, 0, cz) with the given plan size, as a loaded model would appear. */
+function model(cx: number, cz: number, sizeX = 10, sizeZ = 6): BoundedModel {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(sizeX, 3, sizeZ));
+  mesh.position.set(cx, 0, cz);
+  mesh.updateMatrixWorld(true);
+  return { object: mesh };
+}
+
+/** The `2000 × 2000` shadow-catcher `world.ts` adds in presentation mode. */
+function shadowGround(): THREE.Object3D {
+  const g = new THREE.Mesh(new THREE.PlaneGeometry(2000, 2000));
+  g.name = "aec-shadow-ground";
+  g.rotation.x = -Math.PI / 2;
+  g.position.y = -0.01;
+  g.updateMatrixWorld(true);
+  return g;
+}
+
+describe("planBoundsFromModels — the extent comes from the model", () => {
+  it("measures a single model", () => {
+    const b = planBoundsFromModels([model(0, 0, 10, 6)])!;
+    expect(b.minX).toBeCloseTo(-5, 6);
+    expect(b.maxX).toBeCloseTo(5, 6);
+  });
+
+  it("unions several models", () => {
+    const b = planBoundsFromModels([model(0, 0, 10, 6), model(100, 0, 10, 6)])!;
+    expect(b.minX).toBeCloseTo(-5, 6);
+    expect(b.maxX).toBeCloseTo(105, 6);
+  });
+
+  // Plan is E = x, N = -z. A sign error here yields a box of the right size and shape, mirrored —
+  // plausible enough to survive review, so it is asserted rather than assumed.
+  it("negates the world-z range into plan N, swapping min and max", () => {
+    const m = model(0, 20, 10, 6);                 // world z spans 17..23
+    const b = planBoundsFromModels([m])!;
+    expect(b.minZ).toBeCloseTo(-23, 6);            // N min is the NEGATED world-z MAX
+    expect(b.maxZ).toBeCloseTo(-17, 6);
+  });
+
+  it("returns null with nothing loaded — a blank model must not be refused by this check", () => {
+    expect(planBoundsFromModels([])).toBeNull();
+    // and null really does mean "allow", which is the half that makes the null safe
+    expect(checkBounds([[9999, 9999]], null).ok).toBe(true);
+  });
+
+  it("skips a model with no scene object rather than throwing mid-placement", () => {
+    const models = [model(0, 0), { object: undefined } as unknown as BoundedModel];
+    expect(planBoundsFromModels(models)).not.toBeNull();
+    expect(planBoundsFromModels([{ object: undefined } as unknown as BoundedModel])).toBeNull();
+  });
+});
+
+/**
+ * The regression itself.
+ *
+ * These do not assert "the ground plane is excluded by name" — they assert the property that makes
+ * that unnecessary: only loaded models are ever passed in, so a `2000 × 2000` shadow catcher sitting
+ * in the same scene cannot reach the calculation at all.
+ */
+describe("the shadow ground plane cannot widen the model extent", () => {
+  const ground = shadowGround();
+
+  it("a scene-wide walk WOULD have blown the extent out to ±1000 m", () => {
+    // Reproducing the old behaviour to prove the fixture is real: this is what expanding over every
+    // mesh in the scene produced, and it is the number that made the check useless.
+    const box = new THREE.Box3();
+    for (const o of [model(0, 0).object, ground]) box.expandByObject(o);
+    expect(box.min.x).toBeCloseTo(-1000, 3);
+    expect(box.max.x).toBeCloseTo(1000, 3);
+  });
+
+  it("the model-scoped bounds stay at the building", () => {
+    const b = planBoundsFromModels([model(0, 0, 10, 6)])!;
+    expect(b.maxX).toBeCloseTo(5, 6);
+    expect(b.minX).toBeCloseTo(-5, 6);
+  });
+
+  // The consequence, stated in the units the user experiences: a click 400 m out.
+  it("a mis-click 400 m from the building is REFUSED with model bounds and ACCEPTED with scene bounds", () => {
+    const misClick: [number, number][] = [[400, 0]];
+
+    const modelBounds = planBoundsFromModels([model(0, 0, 10, 6)])!;
+    expect(checkBounds(misClick, modelBounds).ok).toBe(false);
+
+    // what the scene-wide walk yielded, expressed as PlanBounds
+    const box = new THREE.Box3();
+    for (const o of [model(0, 0).object, ground]) box.expandByObject(o);
+    const sceneBounds = { minX: box.min.x, maxX: box.max.x, minZ: -box.max.z, maxZ: -box.min.z };
+    expect(checkBounds(misClick, sceneBounds).ok).toBe(true);   // the bug, demonstrated
+  });
+
+  it("the refusal names a distance, so the message is not generic", () => {
+    const b = planBoundsFromModels([model(0, 0, 10, 6)])!;
+    const v = checkBounds([[400, 0]], b);
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toMatch(/\d+ m outside the model/);
+  });
+
+  it("legitimate site work just past the building still passes — the margin is intact", () => {
+    const b = planBoundsFromModels([model(0, 0, 10, 6)])!;
+    // 5 m (half-width) + 40 m is inside the 50 m margin
+    expect(checkBounds([[45, 0]], b).ok).toBe(true);
+    expect(BOUNDS_MARGIN_M).toBe(50);
+  });
+});
+
+/**
+ * The call site, asserted against source.
+ *
+ * Everything above tests a pure function that can only see what it is handed. None of it would
+ * notice `app.ts` going back to walking the scene — which is the form the bug actually took, and the
+ * form a later edit would most naturally reintroduce (a scene walk reads as the obvious way to get
+ * "everything"). `modelPlanBounds` is a closure inside a 5k-line module that needs a WebGL renderer
+ * and a Fragments worker to instantiate, so source text is the only reader available.
+ *
+ * Resolved from `process.cwd()` (= `apps/web`) — under happy-dom `import.meta.url` has no `file:`
+ * scheme, the same constraint `shell/roadmapLanes.test.ts` works around.
+ */
+describe("app.ts asks the models, not the scene", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/viewer/app.ts"), "utf8");
+  const fn = src.slice(src.indexOf("function modelPlanBounds"),
+                       src.indexOf("async function finishDraft"));
+
+  it("found the function to check — not vacuously green", () => {
+    expect(fn.length).toBeGreaterThan(50);
+    expect(fn).toContain("modelPlanBounds");
+  });
+
+  it("uses the model-scoped helper", () => {
+    expect(fn).toContain("planBoundsFromModels");
+  });
+
+  it("does not traverse the scene for bounds", () => {
+    expect(fn, "modelPlanBounds walks the scene again — the shadow ground plane is back in the extent")
+      .not.toMatch(/scene\.three\.traverse/);
+  });
+});

--- a/apps/web/src/viewer/modelBounds.ts
+++ b/apps/web/src/viewer/modelBounds.ts
@@ -1,0 +1,68 @@
+import * as THREE from "three";
+import type { PlanBounds } from "./placeValid";
+
+/**
+ * The loaded model's plan extent — measured from the **model**, not from the scene.
+ *
+ * ## The defect this exists to fix
+ *
+ * `A29-PLACE-VALID`'s second refusal is, in `placeValid.ts`'s own words, *"a click FAR OUTSIDE the
+ * model — the 3D click falls back to the infinite ground plane, so a mis-click near the horizon
+ * quietly authors a wall 400 m from the building"*. It compares the click against the model's plan
+ * extent plus a 50 m margin.
+ *
+ * That extent used to be computed by walking the **whole scene** and expanding a box over every
+ * `isMesh` object. The scene contains a `2000 × 2000` shadow-catcher plane (`aec-shadow-ground` in
+ * `world.ts`), added whenever presentation/render mode is on. So with render mode on the "model
+ * extent" became roughly **±1000 m**, and with the margin a mis-click up to ~1050 m out passed.
+ *
+ * **The check written to catch a mis-click on a ground plane was defeated by a ground plane.** It
+ * failed silently and in the permissive direction: nothing errors, placements just stop being
+ * refused, and only in one render mode — so it would pass any test that did not turn that mode on.
+ *
+ * `world.ts` already knew this. It excludes the ground mesh by name in **two** places (its shadow
+ * frustum fit and its material sweep). The bounds walk was the third site that needed to and did not
+ * — the same fact encoded correctly twice and missed once.
+ *
+ * ## Why an allowlist rather than "skip the ground plane"
+ *
+ * Excluding `aec-shadow-ground` by name would fix today's symptom and leave the shape intact: every
+ * future non-model mesh — draft proxies, the grid overlay, logistics markers, a guide underlay
+ * pinned to a level — would silently widen the model again, one at a time, each needing to be
+ * remembered. The repo's own rule is that needing an exemption list is the tell that the *population*
+ * is wrong.
+ *
+ * So the population is stated positively: **a loaded Fragments model, and nothing else.** Anything
+ * the viewer draws that is not streamed model geometry is structurally out of scope rather than
+ * remembered-to-be-excluded.
+ *
+ * Preview models are deliberately IN. They are real fragment geometry for the element being placed,
+ * they sit at the placement point, and they arrive through the same loader — so they can only widen
+ * the extent toward the very point being validated, which is not a mis-click.
+ */
+
+/** What `modelPlanBounds` needs from a loaded model: its scene object. */
+export interface BoundedModel { object: THREE.Object3D }
+
+/**
+ * Plan bounds over `models`, or null when nothing is loaded.
+ *
+ * Null is meaningful and is not an error: `checkBounds` passes everything when bounds are null,
+ * because a blank model authoring its first element must never be refused by a check that needs a
+ * model to exist.
+ *
+ * Plan coordinates are **E = world x, N = −world z**, so the N range is the *negated* world-z range
+ * and the min/max swap. Getting that backwards yields a box that is still plausible — right size,
+ * right shape, mirrored — which is why it is asserted directly rather than assumed.
+ */
+export function planBoundsFromModels(models: Iterable<BoundedModel>): PlanBounds | null {
+  const box = new THREE.Box3();
+  let any = false;
+  for (const m of models) {
+    if (!m?.object) continue;
+    box.expandByObject(m.object);
+    any = true;
+  }
+  if (!any || box.isEmpty()) return null;
+  return { minX: box.min.x, maxX: box.max.x, minZ: -box.max.z, maxZ: -box.min.z };
+}


### PR DESCRIPTION
**Lane E · a live wrong answer, found by premise-checking the next item.** Off `d83c0156`. 3 files, +220/−5. Independent of #197 — no version files, no CHANGELOG.

## The defect

`A29-PLACE-VALID`'s second refusal exists, in [`placeValid.ts`](apps/web/src/viewer/placeValid.ts)'s own words, to catch:

> a click FAR OUTSIDE the model — the 3D click falls back to the infinite ground plane, so a mis-click near the horizon quietly authors a wall 400 m from the building

It compares the click against the model's plan extent + a 50 m margin. That extent was computed by walking the **whole scene** and expanding a box over every `isMesh` object.

**The scene contains a 2000 × 2000 shadow-catcher plane** (`aec-shadow-ground`, added by `world.ts` whenever presentation/render mode is on). So with render mode on, the "model extent" became roughly **±1000 m**, and with the margin **a mis-click up to ~1050 m out was accepted**.

**The check written to catch a mis-click on a ground plane was defeated by a ground plane.**

It fails silently and in the *permissive* direction — nothing errors, placements simply stop being refused — and only in one render mode, so it survives any test that does not turn that mode on.

**`world.ts` already knew.** It excludes that mesh by name in **two** places: its shadow-frustum fit and its material sweep. The bounds walk was the third site that needed to and did not — the same fact encoded correctly twice and missed once.

## Why an allowlist, not "skip the ground plane"

Excluding one name fixes today's symptom and leaves the shape intact: draft proxies, the grid overlay, logistics markers and a guide underlay pinned to a level would each silently widen the model again, one at a time, each needing to be remembered. **Needing an exemption list is the tell that the population is wrong.**

So the population is stated positively — **a loaded Fragments model, and nothing else**. Anything the viewer draws that is not streamed model geometry is structurally out of scope rather than remembered-to-be-excluded.

Preview models stay **in** deliberately: they are real fragment geometry at the placement point, so they can only widen the extent toward the very point being validated.

## How it was found

Premise-checking **A29-GUIDE-UNDERLAY ③**, which pins a 2D image plane to a level — i.e. adds exactly the kind of large non-model mesh that would have made this worse. I went to check whether my plane would pollute the bounds and found something already did.

## Verification

- `tsc` clean · `eslint` clean · **1263/1263 web green** (113 files) · `app.ts` **5150/5200**
- **13 tests** on the new module, including the bug **reproduced as a fixture** (the scene walk really does yield ±1000 m) and the consequence in user units: *a 400 m mis-click is REFUSED with model bounds and ACCEPTED with scene bounds*
- **Three mutations checked red**: `app.ts` reverted to the original scene walk (the actual bug) · the plan-N sign left unnegated · an empty model returning a zero box instead of `null`

The extraction to `modelBounds.ts` is what makes any of this testable — `modelPlanBounds` was a closure inside a 5k-line module that needs a WebGL renderer and a Fragments worker to instantiate. A **source-level guard** asserts `app.ts` does not go back to `scene.three.traverse`: the pure tests can only see what they are handed, and a scene walk reads as the obvious way to get "everything", so it is the form a later edit would most naturally reintroduce.

### One note on #196's new gate, which is well-aimed

`copyWasm.test.ts`'s *"is itself in the archive CI runs from"* failed on my first full run — correctly. It asserts every `*.test.ts` on disk is **tracked**, and my new test was not yet committed. Worth knowing as a workflow consequence: running the suite before staging a new test file produces a real, accurate failure rather than a false one. It caught the thing it was built to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan-bound calculations to consider only loaded model geometry.
  * Excluded presentation elements, such as the shadow-catcher plane, from placement boundaries.
  * Improved handling of empty or incomplete models and distance-specific placement messages.
  * Preserved correct coordinate conversion and margin behavior.

* **Tests**
  * Added comprehensive coverage for single and multiple models, bounds calculations, and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->