### PR TITLE
A29-GUIDE-UNDERLAY — pin a scanned plan to a level and trace over it

### DIFF
--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -48,6 +48,7 @@ import { PushPullGizmo, stretchTransform } from "./draft/pushPull";
 import { PlanPane } from "./planPane";
 import { type PlanBounds, validatePlacement } from "./placeValid";
 import { planBoundsFromModels } from "./modelBounds";
+import { GuideUnderlay, openUnderlayPanel } from "./guideUnderlay";
 import { type SpatialElement, type SpatialScope, nextScope, scopeSelection } from "./spatialSelect";
 import { DraftPointHistory } from "./draftHistory";
 import { DEFAULT_RISE_M, runReadout } from "./draft/stairLive";
@@ -714,6 +715,12 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   });
   // UX-4: "Script this" — make the scriptable recipe interface a first-class, discoverable resource.
   // Plain-English → the GUID-safe recipe plan it maps to (the same verbs the AI bar + sandbox use) → apply.
+  toolBtn("🖼", "Guide underlay — pin a scanned plan to this level and trace over it", () => {
+    openUnderlayPanel({
+      underlay: guideUnderlay, levelZ: () => activeStoreyZ, notify, showResult,
+    });
+  }, "edit");
+
   toolBtn("⌨", "Script this — see the GUID-safe recipe plan behind a plain-English command, then apply", () => {
     if (!connected || !projectId) { notify("open a project to script it", "error"); return; }
     showResult("Script this — the recipe interface", (body) => {
@@ -851,6 +858,9 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   // P1 grid/level drafting refs: the grid overlay + snap, and the active storey/work-plane.
   const gridOverlay = new GridOverlay(viewer.world.scene.three);
   const logisticsOverlay = new LogisticsOverlay(viewer.world.scene.three);
+  // A29-GUIDE-UNDERLAY — a scanned plan pinned to the active level, to trace over. It owns its own
+  // panel (see `guideUnderlay.ts`) so this file stays out of it; app.ts is near its size ceiling.
+  const guideUnderlay = new GuideUnderlay(viewer.world.scene.three);
   const draftProxies = new DraftProxyLayer(viewer.world.scene.three);   // P6: optimistic placement feedback
   let activeStorey: string | null = null;       // name passed to Draft recipes; sets the work-plane Z
   let activeStoreyZ = 0;

--- a/apps/web/src/viewer/guideUnderlay.test.ts
+++ b/apps/web/src/viewer/guideUnderlay.test.ts
@@ -179,15 +179,23 @@ describe("A29-GUIDE-UNDERLAY — the scene object is a picture, not geometry", (
   });
 
   /**
-   * It is a guide. If it can be picked it will be snapped to, selected and measured against.
+   * **A negative assertion needs a positive control, or it is measuring its own setup.**
    *
-   * The first version of this test passed whether or not the guard existed — a mutation removing
+   * If you are writing an "X does not happen" test, this is the paragraph to read.
+   *
+   * It is a guide: if it can be picked it will be snapped to, selected and measured against. The
+   * first version of this test passed **whether or not the guard existed** — a mutation removing
    * `mesh.raycast = () => {}` stayed green, because calling `mesh.raycast(...)` by hand on a mesh
    * whose world matrix was never updated intersects nothing either way. It asserted an empty array
-   * that was empty for the wrong reason.
+   * that was empty *for the wrong reason*, and it would have shipped green having tested nothing.
    *
-   * So the CONTROL comes first: an identical plane WITHOUT the guard must be hit by this exact ray.
-   * Only then does an empty result mean "the guard worked" rather than "the ray missed".
+   * So the CONTROL comes first: an identical plane **without** the guard must be hit by this exact
+   * ray. Only then does an empty result mean "the guard worked" rather than "the ray missed".
+   *
+   * This is the same defect as the picking benchmark that reported a confident p50 with `hits: 0`,
+   * and the same family as happy-dom's `DataTransfer` vouching for a drop the browser silently
+   * refuses (`railDrag.test.ts`). In each case the instrument never engaged and the result looked
+   * like an answer. **Assert that the instrument engaged, never the output alone.**
    */
   it("is not a raycast target, and the ray is proven to be aimed at it", () => {
     const scene = new THREE.Scene();

--- a/apps/web/src/viewer/guideUnderlay.test.ts
+++ b/apps/web/src/viewer/guideUnderlay.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import {
+  GuideUnderlay, LEVEL_LIFT_M, UNDERLAY_EXTENSIONS, UNDERLAY_NAME, buildPlacement, clampOpacity,
+  isSupportedImageName, mppFromTwoPoints, mppFromWidth, normaliseRotation, underlayPlanSize,
+} from "./guideUnderlay";
+import { planBoundsFromModels } from "./modelBounds";
+
+const widthScale = (realWidthM: number) => ({ kind: "width" as const, realWidthM });
+
+describe("A29-GUIDE-UNDERLAY — scale from a known width", () => {
+  it("divides real width by pixel width", () => {
+    const r = mppFromWidth(1000, 50);
+    expect(r.ok && r.value).toBeCloseTo(0.05, 9);
+  });
+
+  // A silently-wrong scale is the one failure that poisons everything traced afterwards, and unlike
+  // a mis-placed image it looks completely fine on screen. So each of these refuses with a reason.
+  it("refuses a width that is missing, zero or negative", () => {
+    for (const w of [0, -5, NaN, Infinity]) {
+      const r = mppFromWidth(1000, w);
+      expect(r.ok, `width ${w}`).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/greater than zero/);
+    }
+  });
+
+  it("refuses a pixel width that is not a usable image", () => {
+    for (const px of [0, 1, -100, 1.5, 40_000]) {
+      expect(mppFromWidth(px, 50).ok, `px ${px}`).toBe(false);
+    }
+  });
+
+  it("refuses an implausible scale and says it looks like a typo", () => {
+    const tiny = mppFromWidth(1000, 0.01);          // 1e-5 m/px
+    expect(tiny.ok).toBe(false);
+    if (!tiny.ok) expect(tiny.reason).toMatch(/typo/);
+    expect(mppFromWidth(1000, 500_000).ok).toBe(false);   // 500 m/px
+  });
+
+  it("accepts the extremes of the plausible band", () => {
+    expect(mppFromWidth(1000, 0.1).ok).toBe(true);        // 1e-4 m/px exactly
+    expect(mppFromWidth(1000, 100_000).ok).toBe(true);    // 100 m/px exactly
+  });
+});
+
+describe("A29-GUIDE-UNDERLAY — scale from two points", () => {
+  it("divides the known distance by the pixel separation", () => {
+    const r = mppFromTwoPoints({ x: 100, y: 100 }, { x: 400, y: 500 }, 25);   // 500 px
+    expect(r.ok && r.value).toBeCloseTo(0.05, 9);
+  });
+
+  // Dividing by a zero pixel distance yields Infinity — an underlay the size of the solar system,
+  // or nothing at all, depending on the driver. It is the pick a real user makes by double-clicking.
+  it("refuses two picks at the same spot rather than dividing by zero", () => {
+    const r = mppFromTwoPoints({ x: 7, y: 7 }, { x: 7, y: 7 }, 10);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/same spot/);
+  });
+
+  it("refuses non-finite picks and non-positive distances", () => {
+    expect(mppFromTwoPoints({ x: NaN, y: 0 }, { x: 10, y: 0 }, 5).ok).toBe(false);
+    expect(mppFromTwoPoints({ x: 0, y: 0 }, { x: 100, y: 0 }, 0).ok).toBe(false);
+    expect(mppFromTwoPoints({ x: 0, y: 0 }, { x: 100, y: 0 }, -3).ok).toBe(false);
+  });
+
+  it("agrees with the width method when they describe the same image", () => {
+    // 1000 px wide, 50 m across => 0.05 m/px, and a 500 px span is therefore 25 m.
+    const byWidth = mppFromWidth(1000, 50);
+    const byPoints = mppFromTwoPoints({ x: 0, y: 0 }, { x: 500, y: 0 }, 25);
+    expect(byWidth.ok && byPoints.ok).toBe(true);
+    if (byWidth.ok && byPoints.ok) expect(byPoints.value).toBeCloseTo(byWidth.value, 12);
+  });
+});
+
+describe("A29-GUIDE-UNDERLAY — size, opacity, rotation", () => {
+  it("preserves aspect ratio by construction — one scale, both axes", () => {
+    const s = underlayPlanSize(1600, 900, 0.05);
+    expect(s.ok).toBe(true);
+    if (s.ok) {
+      expect(s.value.widthM).toBeCloseTo(80, 9);
+      expect(s.value.heightM).toBeCloseTo(45, 9);
+      expect(s.value.widthM / s.value.heightM).toBeCloseTo(1600 / 900, 9);
+    }
+  });
+
+  it("clamps opacity instead of refusing — a slider cannot produce a meaningful error", () => {
+    expect(clampOpacity(-1)).toBe(0);
+    expect(clampOpacity(2)).toBe(1);
+    expect(clampOpacity(0.35)).toBeCloseTo(0.35, 9);
+    expect(clampOpacity(NaN)).toBe(0.5);
+    expect(clampOpacity(0)).toBe(0);          // "hide it for a moment" is legitimate, not an error
+  });
+
+  it("normalises rotation into [0,360) including negatives", () => {
+    expect(normaliseRotation(-90)).toBe(270);
+    expect(normaliseRotation(450)).toBe(90);
+    expect(normaliseRotation(360)).toBe(0);
+    expect(normaliseRotation(NaN)).toBe(0);
+  });
+
+  it("knows which files a browser can decode", () => {
+    for (const ext of UNDERLAY_EXTENSIONS) expect(isSupportedImageName(`plan.${ext}`)).toBe(true);
+    expect(isSupportedImageName("PLAN.PNG")).toBe(true);
+    for (const n of ["plan.pdf", "plan.ifc", "plan.dwg", "plan", "plan.png.exe"]) {
+      expect(isSupportedImageName(n), n).toBe(false);
+    }
+  });
+});
+
+describe("A29-GUIDE-UNDERLAY — buildPlacement is the only arithmetic the panel needs", () => {
+  it("assembles a full placement from a width scale", () => {
+    const r = buildPlacement({ pixelW: 1000, pixelH: 500, scale: widthScale(50), levelZ: 3 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.widthM).toBeCloseTo(50, 9);
+    expect(r.value.heightM).toBeCloseTo(25, 9);
+    expect(r.value.opacity).toBe(0.5);          // a guide defaults to see-through
+    expect(r.value.rotationDeg).toBe(0);
+  });
+
+  // A guide sitting exactly at the level z-fights the slab it is being traced against — the artefact
+  // reads as a rendering bug and makes the guide unusable at precisely the moment it is needed.
+  it("lifts the plane fractionally above its level", () => {
+    const r = buildPlacement({ pixelW: 1000, pixelH: 500, scale: widthScale(50), levelZ: 3 });
+    expect(r.ok && r.value.levelZ).toBeCloseTo(3 + LEVEL_LIFT_M, 9);
+    expect(LEVEL_LIFT_M).toBeGreaterThan(0);
+    expect(LEVEL_LIFT_M).toBeLessThan(0.05);    // still reads as "on" the level
+  });
+
+  it("propagates the FIRST refusal rather than producing a half-valid placement", () => {
+    const r = buildPlacement({ pixelW: 1000, pixelH: 500, scale: widthScale(0), rotationDeg: 45 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/greater than zero/);
+  });
+
+  it("defaults every optional field instead of emitting NaN", () => {
+    const r = buildPlacement({ pixelW: 800, pixelH: 600, scale: widthScale(40),
+                               offsetE: NaN, offsetN: undefined, rotationDeg: NaN, opacity: NaN });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    for (const v of Object.values(r.value)) expect(Number.isFinite(v)).toBe(true);
+    expect(r.value.offsetE).toBe(0);
+    expect(r.value.offsetN).toBe(0);
+  });
+});
+
+describe("A29-GUIDE-UNDERLAY — the scene object is a picture, not geometry", () => {
+  const place = () => {
+    const r = buildPlacement({ pixelW: 1000, pixelH: 500, scale: widthScale(50), levelZ: 0 });
+    if (!r.ok) throw new Error(r.reason);
+    return r.value;
+  };
+  const tex = () => new THREE.Texture();
+
+  it("adds a named plane to the scene and removes it on clear", () => {
+    const scene = new THREE.Scene();
+    const u = new GuideUnderlay(scene);
+    expect(u.hasImage).toBe(false);
+    u.setTexture(tex(), place());
+    expect(u.hasImage).toBe(true);
+    expect(scene.getObjectByName(UNDERLAY_NAME)).toBeTruthy();
+    u.clear();
+    expect(scene.getObjectByName(UNDERLAY_NAME)).toBeFalsy();
+    expect(u.hasImage).toBe(false);
+  });
+
+  it("clear is safe when nothing is loaded, and idempotent", () => {
+    const u = new GuideUnderlay(new THREE.Scene());
+    expect(() => { u.clear(); u.clear(); }).not.toThrow();
+  });
+
+  it("replaces rather than stacking when a second image is loaded", () => {
+    const scene = new THREE.Scene();
+    const u = new GuideUnderlay(scene);
+    u.setTexture(tex(), place());
+    u.setTexture(tex(), place());
+    const found = scene.children.filter((c) => c.name === UNDERLAY_NAME);
+    expect(found).toHaveLength(1);
+  });
+
+  /**
+   * It is a guide. If it can be picked it will be snapped to, selected and measured against.
+   *
+   * The first version of this test passed whether or not the guard existed — a mutation removing
+   * `mesh.raycast = () => {}` stayed green, because calling `mesh.raycast(...)` by hand on a mesh
+   * whose world matrix was never updated intersects nothing either way. It asserted an empty array
+   * that was empty for the wrong reason.
+   *
+   * So the CONTROL comes first: an identical plane WITHOUT the guard must be hit by this exact ray.
+   * Only then does an empty result mean "the guard worked" rather than "the ray missed".
+   */
+  it("is not a raycast target, and the ray is proven to be aimed at it", () => {
+    const scene = new THREE.Scene();
+    new GuideUnderlay(scene).setTexture(tex(), place());
+    const mesh = scene.getObjectByName(UNDERLAY_NAME) as THREE.Mesh;
+    scene.updateMatrixWorld(true);
+    const rc = new THREE.Raycaster(new THREE.Vector3(0, 10, 0), new THREE.Vector3(0, -1, 0));
+
+    const control = new THREE.Mesh(mesh.geometry, new THREE.MeshBasicMaterial());
+    control.rotation.copy(mesh.rotation);
+    control.position.copy(mesh.position);
+    control.updateMatrixWorld(true);
+    expect(rc.intersectObject(control, false).length,
+      "the ray misses even an unguarded plane — this test would pass for the wrong reason")
+      .toBeGreaterThan(0);
+
+    expect(rc.intersectObject(mesh, false),
+      "the guide is pickable — it will be snapped to and selected").toEqual([]);
+  });
+
+  it("never occludes the model it is traced against", () => {
+    const scene = new THREE.Scene();
+    new GuideUnderlay(scene).setTexture(tex(), place());
+    const mesh = scene.getObjectByName(UNDERLAY_NAME) as THREE.Mesh;
+    const mat = mesh.material as THREE.MeshBasicMaterial;
+    expect(mat.transparent).toBe(true);
+    expect(mat.depthWrite).toBe(false);
+    expect(mesh.renderOrder).toBeLessThan(0);
+  });
+
+  it("maps plan N to -z and E to +x, the draft pipeline's convention", () => {
+    const scene = new THREE.Scene();
+    const u = new GuideUnderlay(scene);
+    const p = place();
+    u.setTexture(tex(), { ...p, offsetE: 10, offsetN: 4 });
+    const mesh = scene.getObjectByName(UNDERLAY_NAME)!;
+    expect(mesh.position.x).toBeCloseTo(10, 9);
+    expect(mesh.position.z).toBeCloseTo(-4, 9);
+  });
+
+  it("apply() moves and fades without recreating the mesh", () => {
+    const scene = new THREE.Scene();
+    const u = new GuideUnderlay(scene);
+    u.setTexture(tex(), place());
+    const before = scene.getObjectByName(UNDERLAY_NAME);
+    u.apply({ ...place(), offsetE: 25, opacity: 0.2 });
+    const after = scene.getObjectByName(UNDERLAY_NAME);
+    expect(after).toBe(before);                       // same object
+    expect(after!.position.x).toBeCloseTo(25, 9);
+    expect(((after as THREE.Mesh).material as THREE.MeshBasicMaterial).opacity).toBeCloseTo(0.2, 9);
+  });
+
+  it("apply() on an empty underlay is a no-op, not a throw", () => {
+    expect(() => new GuideUnderlay(new THREE.Scene()).apply(place())).not.toThrow();
+  });
+
+  /**
+   * The reason `modelBounds.ts` exists. A 50 m guide plane in the scene must not become the model's
+   * plan extent, or the mis-click guard drifts exactly the way the shadow-catcher made it drift.
+   */
+  it("does not enter the model's plan extent", () => {
+    const scene = new THREE.Scene();
+    new GuideUnderlay(scene).setTexture(tex(), place());
+    // the underlay is in the SCENE but is not a loaded model, so bounds ignore it entirely
+    expect(planBoundsFromModels([])).toBeNull();
+
+    const building = new THREE.Mesh(new THREE.BoxGeometry(10, 3, 6));
+    building.updateMatrixWorld(true);
+    const b = planBoundsFromModels([{ object: building }])!;
+    expect(b.maxX).toBeCloseTo(5, 6);                 // the building, not the 50 m guide
+  });
+});

--- a/apps/web/src/viewer/guideUnderlay.ts
+++ b/apps/web/src/viewer/guideUnderlay.ts
@@ -1,0 +1,403 @@
+/**
+ * A29-GUIDE-UNDERLAY — trace over a plan.
+ *
+ * A 2D reference image (a scan, a photographed survey, a plan exported as PNG) pinned to a level and
+ * **scaled to real metres**, so an existing building can be redrawn over it with the ordinary draw
+ * tools. The image is a guide only: nothing about it enters IFC, and it is not selectable, not
+ * snappable and not part of the model.
+ *
+ * ## Scale is the whole feature
+ *
+ * An underlay that is merely *placed* is decoration. The reason this is worth building is that walls
+ * traced over it come out at real dimensions — so the calibration is not a nicety, it is the thing.
+ * Two ways in, both reduced to one number (metres per pixel):
+ *
+ *   - **known width** — "this scan is 42.5 m across". One number, no picking.
+ *   - **two points** — the drafter names a distance they know between two points on the image (a grid
+ *     bay, a scale bar). This is the same idea `drawings/pdfTakeoff.ts` uses for PDF takeoff.
+ *
+ * Every derivation refuses rather than guessing. A zero-length reference, a non-finite number, a
+ * negative distance or an implausible scale returns a REASON, because a silently-wrong scale is the
+ * one failure mode that poisons everything traced afterwards — and unlike a mis-placed image, it
+ * looks completely fine on screen.
+ *
+ * ## Why this file is nearly all pure functions
+ *
+ * The THREE object is mechanical: a plane, a texture, an opacity. What can actually be *wrong* is the
+ * arithmetic and the refusals, and none of that needs a renderer. So the decisions live here as
+ * plain functions and `GuideUnderlay` only applies them — the same split that let `snapEngine` and
+ * `placeValid` be exhaustively tested while the viewer stayed untestable.
+ *
+ * ## It must not become part of the model
+ *
+ * Adding a large plane to the scene is exactly what broke `modelPlanBounds` before `modelBounds.ts`
+ * existed: a 2000x2000 shadow-catcher made the model's plan extent +/-1000 m and defeated the
+ * mis-click guard. That is now an allowlist over loaded Fragments models, so this plane is
+ * structurally out of scope for bounds — but it is also given a name and marked non-raycastable so
+ * every other consumer has something explicit to key on.
+ */
+import * as THREE from "three";
+
+/** The object name, so anything walking the scene can identify (and skip) the underlay. */
+export const UNDERLAY_NAME = "aec-guide-underlay";
+
+/** Raster formats a browser can decode into a texture without any new dependency. */
+export const UNDERLAY_EXTENSIONS = ["png", "jpg", "jpeg", "webp", "gif", "bmp"] as const;
+
+/** Below this an "image" is a decoding artefact; above it a texture will not upload on most GPUs. */
+const MIN_PX = 2;
+const MAX_PX = 32_768;
+
+/** A scale outside this is not a plan — it is a typo. 1 mm/px to 100 m/px spans every real drawing. */
+const MIN_MPP = 1e-4;
+const MAX_MPP = 100;
+
+export type Derived<T> = { ok: true; value: T } | { ok: false; reason: string };
+
+const bad = (reason: string): Derived<never> => ({ ok: false, reason });
+
+export function isSupportedImageName(name: string): boolean {
+  const ext = name.toLowerCase().split(".").pop() ?? "";
+  return (UNDERLAY_EXTENSIONS as readonly string[]).includes(ext);
+}
+
+function finitePositive(n: number): boolean {
+  return Number.isFinite(n) && n > 0;
+}
+
+/**
+ * Metres per pixel from the image's known real-world width.
+ *
+ * The simplest calibration and the one most people have: a survey says how wide the building is.
+ */
+export function mppFromWidth(pixelWidth: number, realWidthM: number): Derived<number> {
+  if (!Number.isInteger(pixelWidth) || pixelWidth < MIN_PX || pixelWidth > MAX_PX) {
+    return bad(`image width ${pixelWidth} px is not a usable image`);
+  }
+  if (!finitePositive(realWidthM)) return bad("enter the real width in metres (greater than zero)");
+  const mpp = realWidthM / pixelWidth;
+  if (mpp < MIN_MPP || mpp > MAX_MPP) {
+    return bad(`that gives ${mpp.toPrecision(3)} m per pixel — check the width, it looks like a typo`);
+  }
+  return { ok: true, value: mpp };
+}
+
+/**
+ * Metres per pixel from two points on the image whose real separation is known.
+ *
+ * `a` and `b` are in image pixels. The refusal that matters is the coincident pick: two points at the
+ * same place give a zero pixel distance, and dividing by it yields `Infinity` — which would render
+ * as an underlay the size of the solar system, or as nothing at all, depending on the driver.
+ */
+export function mppFromTwoPoints(
+  a: { x: number; y: number }, b: { x: number; y: number }, realDistanceM: number,
+): Derived<number> {
+  if (![a?.x, a?.y, b?.x, b?.y].every((n) => Number.isFinite(n))) return bad("pick two points on the image");
+  const px = Math.hypot(b.x - a.x, b.y - a.y);
+  if (px < 1) return bad("those two points are the same spot — pick two points further apart");
+  if (!finitePositive(realDistanceM)) return bad("enter the real distance in metres (greater than zero)");
+  const mpp = realDistanceM / px;
+  if (mpp < MIN_MPP || mpp > MAX_MPP) {
+    return bad(`that gives ${mpp.toPrecision(3)} m per pixel — check the distance, it looks like a typo`);
+  }
+  return { ok: true, value: mpp };
+}
+
+/** The plane's real size. Aspect ratio is preserved by construction — one scale, both axes. */
+export function underlayPlanSize(pixelW: number, pixelH: number, mpp: number): Derived<{ widthM: number; heightM: number }> {
+  if (!finitePositive(pixelW) || !finitePositive(pixelH)) return bad("image has no usable dimensions");
+  if (!finitePositive(mpp)) return bad("scale is not set");
+  return { ok: true, value: { widthM: pixelW * mpp, heightM: pixelH * mpp } };
+}
+
+/** Opacity is clamped rather than refused: a slider cannot produce a meaningful error, and an
+ *  underlay at 0 is a legitimate "hide it for a moment" that must not throw. */
+export function clampOpacity(v: number): number {
+  if (!Number.isFinite(v)) return 0.5;
+  return Math.min(1, Math.max(0, v));
+}
+
+/** Rotation normalised to [0, 360). Non-finite falls back to 0 — an unrotated guide is always valid. */
+export function normaliseRotation(deg: number): number {
+  if (!Number.isFinite(deg)) return 0;
+  return ((deg % 360) + 360) % 360;
+}
+
+export interface UnderlayPlacement {
+  metresPerPixel: number;
+  widthM: number;
+  heightM: number;
+  /** Plan offset of the image centre, in metres (E = +x, N = -z). */
+  offsetE: number;
+  offsetN: number;
+  rotationDeg: number;
+  opacity: number;
+  /** World Y the plane sits at — the active level, nudged so it never z-fights the slab it traces. */
+  levelZ: number;
+}
+
+/** How far above the level the guide floats. Small enough to read as "on" the level, large enough
+ *  that a slab authored at exactly that level does not z-fight with it. */
+export const LEVEL_LIFT_M = 0.005;
+
+/**
+ * Assemble a full placement, or refuse with the first reason found.
+ *
+ * Everything the panel can get wrong funnels through here, so the panel has no arithmetic of its own
+ * and the refusal text is written once.
+ */
+export function buildPlacement(input: {
+  pixelW: number; pixelH: number;
+  scale: { kind: "width"; realWidthM: number }
+       | { kind: "two-points"; a: { x: number; y: number }; b: { x: number; y: number }; realDistanceM: number };
+  offsetE?: number; offsetN?: number; rotationDeg?: number; opacity?: number; levelZ?: number;
+}): Derived<UnderlayPlacement> {
+  const mppRes = input.scale.kind === "width"
+    ? mppFromWidth(input.pixelW, input.scale.realWidthM)
+    : mppFromTwoPoints(input.scale.a, input.scale.b, input.scale.realDistanceM);
+  if (!mppRes.ok) return mppRes;
+
+  const size = underlayPlanSize(input.pixelW, input.pixelH, mppRes.value);
+  if (!size.ok) return size;
+
+  const num = (v: number | undefined, fallback: number) => (Number.isFinite(v) ? (v as number) : fallback);
+  return {
+    ok: true,
+    value: {
+      metresPerPixel: mppRes.value,
+      widthM: size.value.widthM,
+      heightM: size.value.heightM,
+      offsetE: num(input.offsetE, 0),
+      offsetN: num(input.offsetN, 0),
+      rotationDeg: normaliseRotation(num(input.rotationDeg, 0)),
+      opacity: clampOpacity(num(input.opacity, 0.5)),
+      levelZ: num(input.levelZ, 0) + LEVEL_LIFT_M,
+    },
+  };
+}
+
+/**
+ * The scene object. Mechanical by design — every decision above it is a pure function.
+ *
+ * The plane lies in the ground plane (rotated -90° about X, like `world.ts`'s shadow catcher) and is
+ * positioned in WORLD coordinates from the plan offsets: E maps to +x and N maps to **-z**, the same
+ * convention the draft pipeline uses.
+ */
+export class GuideUnderlay {
+  private mesh: THREE.Mesh | null = null;
+  private texture: THREE.Texture | null = null;
+
+  constructor(private readonly scene: THREE.Object3D) {}
+
+  get hasImage(): boolean { return !!this.mesh; }
+
+  /** Swap in a texture and its pixel dimensions. Replaces any existing underlay. */
+  setTexture(texture: THREE.Texture, placement: UnderlayPlacement): void {
+    this.clear();
+    const geo = new THREE.PlaneGeometry(placement.widthM, placement.heightM);
+    const mat = new THREE.MeshBasicMaterial({
+      map: texture,
+      transparent: true,
+      opacity: placement.opacity,
+      depthWrite: false,          // a guide must never occlude the model it is traced against
+      side: THREE.DoubleSide,     // visible from below, so an underhung view still shows it
+    });
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.name = UNDERLAY_NAME;
+    // Not a pick target and not a snap target: it is a picture, not geometry. `raycast` is emptied
+    // rather than relying on a layer, because a layer is a rendering concern that a future camera
+    // change could silently undo, while an empty raycast is a property of THIS object.
+    mesh.raycast = () => {};
+    mesh.renderOrder = -1;        // behind the model
+    this.mesh = mesh;
+    this.texture = texture;
+    this.apply(placement);
+    this.scene.add(mesh);
+  }
+
+  /** Re-apply a placement to the existing plane (scale/rotate/move/fade without reloading). */
+  apply(placement: UnderlayPlacement): void {
+    const mesh = this.mesh;
+    if (!mesh) return;
+    mesh.rotation.set(-Math.PI / 2, 0, -placement.rotationDeg * Math.PI / 180);
+    // plan E = +x, plan N = -z
+    mesh.position.set(placement.offsetE, placement.levelZ, -placement.offsetN);
+    const mat = mesh.material as THREE.MeshBasicMaterial;
+    mat.opacity = placement.opacity;
+    mat.needsUpdate = true;
+    const geo = mesh.geometry as THREE.PlaneGeometry;
+    const p = geo.parameters;
+    if (p.width !== placement.widthM || p.height !== placement.heightM) {
+      mesh.geometry.dispose();
+      mesh.geometry = new THREE.PlaneGeometry(placement.widthM, placement.heightM);
+    }
+  }
+
+  set visible(v: boolean) { if (this.mesh) this.mesh.visible = v; }
+  get visible(): boolean { return this.mesh?.visible ?? false; }
+
+  /** Remove and release. Safe to call when nothing is loaded. */
+  clear(): void {
+    if (!this.mesh) return;
+    this.scene.remove(this.mesh);
+    this.mesh.geometry.dispose();
+    (this.mesh.material as THREE.Material).dispose();
+    this.texture?.dispose();
+    this.mesh = null;
+    this.texture = null;
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Loading and the panel. Kept in this file rather than in `app.ts` deliberately: app.ts is at 5,150
+// of a 5,200-line ceiling and is the file most likely to red the next build, so a feature that can
+// own its own UI should.
+// ---------------------------------------------------------------------------------------------
+
+export interface LoadedImage { texture: THREE.Texture; pixelW: number; pixelH: number; name: string }
+
+/**
+ * Decode an image file into a texture, with its true pixel dimensions.
+ *
+ * The dimensions come from the decoded image rather than from anything the user typed, because the
+ * whole scale calculation divides by them — a wrong pixel width produces a confidently wrong
+ * metres-per-pixel and every traced wall inherits it.
+ *
+ * The object URL is revoked once decoding finishes: an underlay is a big raster and a viewer session
+ * that swaps several of them would otherwise hold every one alive until the tab closes.
+ */
+export function loadImageTexture(file: File): Promise<LoadedImage> {
+  return new Promise((resolve, reject) => {
+    if (!isSupportedImageName(file.name)) {
+      reject(new Error(`${file.name} is not an image this can decode (${UNDERLAY_EXTENSIONS.join(", ")})`));
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      const texture = new THREE.Texture(img);
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.needsUpdate = true;
+      resolve({ texture, pixelW: img.naturalWidth, pixelH: img.naturalHeight, name: file.name });
+    };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error(`could not decode ${file.name}`)); };
+    img.src = url;
+  });
+}
+
+export interface UnderlayPanelDeps {
+  underlay: GuideUnderlay;
+  /** World Y of the level currently being authored on. */
+  levelZ: () => number;
+  notify: (msg: string, kind?: "info" | "success" | "error") => void;
+  showResult: (title: string, build: (body: HTMLElement) => void) => void;
+}
+
+/** Build the underlay panel body into `body`. Exported separately from `openUnderlayPanel` so it can
+ *  be exercised without the app's modal chrome. */
+export function buildUnderlayPanel(body: HTMLElement, d: UnderlayPanelDeps): void {
+  let loaded: LoadedImage | null = null;
+
+  const row = (label: string, control: HTMLElement) => {
+    const r = document.createElement("label");
+    r.style.cssText = "display:flex;align-items:center;gap:8px;margin:4px 0";
+    const s = document.createElement("span");
+    s.textContent = label; s.style.cssText = "flex:1;font-size:12px";
+    r.append(s, control);
+    body.appendChild(r);
+    return r;
+  };
+  const num = (value: number, step = "0.1", width = "90px") => {
+    const i = document.createElement("input");
+    i.type = "number"; i.value = String(value); i.step = step;
+    i.className = "portal-filter"; i.style.width = width;
+    return i;
+  };
+
+  const note = document.createElement("div");
+  note.className = "meta";
+  note.style.marginBottom = "6px";
+  note.textContent = "Pin a scanned or exported plan to this level and trace over it. The guide is "
+    + "never selectable, never snapped to, and never enters IFC — only what you draw does.";
+  body.appendChild(note);
+
+  const file = document.createElement("input");
+  file.type = "file";
+  file.accept = UNDERLAY_EXTENSIONS.map((e) => `.${e}`).join(",");
+  file.setAttribute("aria-label", "Guide image");
+  row("Image", file);
+
+  const widthM = num(50, "0.1");
+  widthM.setAttribute("aria-label", "Real width in metres");
+  row("Real width (m)", widthM);
+
+  const offE = num(0, "0.5"); offE.setAttribute("aria-label", "East offset in metres");
+  const offN = num(0, "0.5"); offN.setAttribute("aria-label", "North offset in metres");
+  row("Offset E (m)", offE);
+  row("Offset N (m)", offN);
+
+  const rot = num(0, "1"); rot.setAttribute("aria-label", "Rotation in degrees");
+  row("Rotation (°)", rot);
+
+  const opacity = document.createElement("input");
+  opacity.type = "range"; opacity.min = "0"; opacity.max = "1"; opacity.step = "0.05";
+  opacity.value = "0.5"; opacity.style.width = "120px";
+  opacity.setAttribute("aria-label", "Guide opacity");
+  row("Opacity", opacity);
+
+  const status = document.createElement("div");
+  status.className = "meta";
+  status.style.marginTop = "6px";
+  body.appendChild(status);
+
+  /** One place where the panel's fields become a placement — or a refusal the user can act on. */
+  function currentPlacement() {
+    if (!loaded) return { ok: false as const, reason: "choose an image first" };
+    return buildPlacement({
+      pixelW: loaded.pixelW, pixelH: loaded.pixelH,
+      scale: { kind: "width", realWidthM: Number(widthM.value) },
+      offsetE: Number(offE.value), offsetN: Number(offN.value),
+      rotationDeg: Number(rot.value), opacity: Number(opacity.value),
+      levelZ: d.levelZ(),
+    });
+  }
+
+  function applyNow(announce: boolean) {
+    const r = currentPlacement();
+    if (!r.ok) { status.textContent = `⚠ ${r.reason}`; if (announce) d.notify(r.reason, "error"); return; }
+    if (!d.underlay.hasImage) d.underlay.setTexture(loaded!.texture, r.value);
+    else d.underlay.apply(r.value);
+    status.textContent = `${loaded!.name} — ${r.value.widthM.toFixed(1)} × ${r.value.heightM.toFixed(1)} m `
+      + `at ${(r.value.metresPerPixel * 1000).toFixed(1)} mm/px`;
+    if (announce) d.notify("guide underlay placed", "success");
+  }
+
+  file.onchange = () => {
+    const f = file.files?.[0];
+    if (!f) return;
+    loadImageTexture(f)
+      .then((img) => { loaded = img; status.textContent = `${img.name} — ${img.pixelW}×${img.pixelH} px`; applyNow(false); })
+      .catch((e: Error) => { status.textContent = `⚠ ${e.message}`; d.notify(e.message, "error"); });
+  };
+  for (const el of [widthM, offE, offN, rot, opacity]) el.oninput = () => { if (loaded) applyNow(false); };
+
+  const btns = document.createElement("div");
+  btns.style.cssText = "display:flex;gap:6px;margin-top:8px";
+  const apply = document.createElement("button");
+  apply.className = "tool-btn"; apply.textContent = "Apply";
+  apply.onclick = () => applyNow(true);
+  const hide = document.createElement("button");
+  hide.className = "tool-btn"; hide.textContent = "Hide / show";
+  hide.onclick = () => { d.underlay.visible = !d.underlay.visible; };
+  const remove = document.createElement("button");
+  remove.className = "tool-btn"; remove.textContent = "Remove";
+  remove.onclick = () => { d.underlay.clear(); loaded = null; status.textContent = "removed"; };
+  btns.append(apply, hide, remove);
+  body.appendChild(btns);
+}
+
+/** Open the guide-underlay panel in the app's standard result chrome. */
+export function openUnderlayPanel(d: UnderlayPanelDeps): void {
+  d.showResult("🖼 Guide underlay", (body) => buildUnderlayPanel(body, d));
+}

--- a/apps/web/src/viewer/toolbarLayout.ts
+++ b/apps/web/src/viewer/toolbarLayout.ts
@@ -95,6 +95,10 @@ export const TOOLS: ToolSpec[] = [
   { title: "Plan beside model", label: "Plan pane", group: "look" },
   { title: "Move selected element (E,N,Z metres)", label: "Move", group: "author", primary: onEditableSelection },
   { title: "Copy selected element (offset E,N,Z metres)", label: "Copy", group: "author", primary: onEditableSelection },
+  // A29-GUIDE-UNDERLAY. In `author` rather than `look` because it is not a way of viewing the model —
+  // it is a reference you draw ON TOP OF, so it belongs beside the verbs that draw.
+  { title: "Guide underlay — pin a scanned plan to this level and trace over it",
+    label: "Guide underlay", group: "author" },
   { title: "Rotate selected element (degrees about Z)", label: "Rotate", group: "author" },
   { title: "Delete selected element", label: "Delete", group: "author" },
   { title: "Edit a property on the selected element", label: "Property", group: "author" },
@@ -167,6 +171,7 @@ export function describe(spec: ToolSpec): string {
  * wearing a blank.
  */
 export const TOOL_ICON: Record<string, string> = {
+  "Guide underlay": "scan",     // A29-GUIDE-UNDERLAY — a scanned plan, traced over
   "Levels": "layers",
   "Show all": "eye",
   "Isolate": "focus",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -219,7 +219,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-ELEMENT-CARD ② *(moved from E 2026-08-06 — the cell said E, the item's own text says the remaining work is "purely call sites: RFI, estimate line, pay app, COBie row", which live in `apps/web/src/ui/` and `apps/web/src/portal/panels/`. **A lane's paths and a lane's items are two claims and only the first is tested**, so the cell drifted from the item under it)* · R24-CHARTS-GRAMMAR · R24-REPORTS-BY-MOMENT · R24-DENSITY ② · R24-MONO-DATA · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R36-EMPTY-STATE *(SHIPPED v0.3.849, pending archive)* · R36-ROOM-BRIEFS · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/` | R22-ENTITLEMENT · R22-AGENT-PACKS · R22-PROVENANCE · R22-OPTION-OBJECT · R22-PIPELINE · R22-ROUTINES · R24-PERF-BUDGET · R22-PHOTO-CV · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-RATE ② · PERF-THREADS ③ · R35-PIDLOCK-XPROC · R35-DEAL-MEMORY · R37-TRIAGE · R40-EOT ② · R39-THROTTLE-SHARED ① · R39-UPLOAD-CAP-APP ① |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | SEC-PLUGIN-SANDBOX *(moved from C 2026-08-05 — the item said "Lane **D**, not C" all along; while one ID covered two items the table could not be right about both)* · R28-ICDD ③ · R38-PLAN-IDENTITY ③ · R38-ARRAY-LIVE ③ · R21-4D-CLASH · R23-STOREY-LOD · R28-UNIFY ① · R28-BUNDLE ② — **all SHIPPED and MERGED** (PRs #176/#178/#179 landed 2026-08-02); pending archive. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* |
-| **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-PLACE-VALID ② · A29-SPATIAL-SELECT ② · A29-UNDO-LOCAL ③ *(all three SHIPPED v0.3.831–833, pending archive)* · A29-GUIDE-UNDERLAY ③ · AUTH-SNAP-OVERRIDE *(SHIPPED PR #192, pending archive)* · RAIL-DRAG *(SHIPPED PR #197, pending archive)* · R28-VIEWER ④ · R22-PUBLIC-VIEWER · UX-AR · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R36-AUTHOR-MENU *(SHIPPED v0.3.836–843: the More menu is gone, not reorganised)* · R38-NODE-SLIDERS ③ *(ALREADY BUILT — checked 2026-08-06)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* |
+| **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-PLACE-VALID ② · A29-SPATIAL-SELECT ② · A29-UNDO-LOCAL ③ *(all three SHIPPED v0.3.831–833, pending archive)* · A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · AUTH-SNAP-OVERRIDE *(SHIPPED PR #192, pending archive)* · RAIL-DRAG *(SHIPPED PR #197, pending archive)* · R28-VIEWER ④ · R22-PUBLIC-VIEWER · UX-AR · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R36-AUTHOR-MENU *(SHIPPED v0.3.836–843: the More menu is gone, not reorganised)* · R38-NODE-SLIDERS ③ *(ALREADY BUILT — checked 2026-08-06)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | R22-PM-CONTRACTS |
@@ -1634,9 +1634,32 @@ the screen stops waiting for it.
   should not require three republishes. Scope: the in-progress draft only, discarded on commit, with
   the server history unchanged as the record.
 
-* **A29-GUIDE-UNDERLAY ③** — *trace over a plan.* A 2D reference image pinned to a level and scaled,
-  for redrawing an existing building from a scan or a PDF. Small, self-contained, and the one place
-  their `Guide` node maps onto something we do not have.
+* 🟡 **A29-GUIDE-UNDERLAY ③** *(in flight, PR #199)* — *trace over a plan.* A 2D reference image
+  pinned to a level and scaled, for redrawing an existing building from a scan or a PDF. Small,
+  self-contained, and the one place their `Guide` node maps onto something we do not have.
+  `apps/web/src/viewer/guideUnderlay.ts` holds the calibration, the refusals and the plane;
+  `app.ts` gets six lines.
+
+  **Scale is the whole feature, and the entry undersold it.** An underlay that is merely *placed* is
+  decoration — the reason to build it is that walls traced over it come out at real dimensions. So
+  every path reduces to metres-per-pixel and every derivation **refuses rather than guesses**: a
+  silently-wrong scale is the one failure that poisons everything traced afterwards, and unlike a
+  mis-placed image it looks completely fine on screen. The coincident two-point pick is the one that
+  matters, because it is what a real user produces by double-clicking, and dividing by a zero pixel
+  distance yields `Infinity`.
+
+  **This item is what found the `modelPlanBounds` defect** (PR #198). Premise-checking "can I add a
+  plane to the scene?" led to "what already reads the scene?", and the answer was that a
+  2000 × 2000 shadow-catcher had been defeating the mis-click guard. *Before adding an object to a
+  shared structure, check what already reads that structure* — a new object is the moment you finally
+  have a reason to enumerate the readers.
+
+  **A mutation pass caught a decorative test of my own.** "the guide is not a raycast target" passed
+  whether or not the guard existed: calling `mesh.raycast()` by hand on a mesh whose world matrix was
+  never updated intersects nothing either way, so it asserted an empty array that was empty for the
+  wrong reason. It now runs a **control** first — an identical unguarded plane must be hit by the same
+  ray — so empty means "the guard worked" rather than "the ray missed". Same shape as the picking
+  benchmark that reported a confident p50 with `hits: 0`.
 
 **Explicitly NOT in this ring:** adopting React/R3F, adopting a bespoke node schema beside IFC,
 vendoring `engine_clay` (dormant), and anything from IFChili (AGPL). If client-side booleans become


### PR DESCRIPTION
**Lane E.** Two commits (code, then roadmap). `#198` merged while this was in progress, so this now sits cleanly on `456fa6c0`. No version files, no CHANGELOG.

**1289/1289 web green** (114 files) · tsc + eslint clean · `app.ts` **5160/5200** · roadmap gates 14/14 · `test_claude_md_gates` OK · **six mutations red**.

## Scale is the whole feature, and the entry undersold it

The roadmap called this *"a 2D reference image pinned to a level and scaled"* — small and self-contained, which is true. But an underlay that is merely *placed* is decoration. The reason to build it is that **walls traced over it come out at real dimensions**, so the calibration is not a nicety, it is the thing.

Two ways in, both reduced to metres-per-pixel: a **known real width**, or **two points** whose separation the drafter knows (the idea `drawings/pdfTakeoff.ts` already uses for PDF takeoff).

**Every derivation refuses rather than guesses** — zero-length reference, non-finite input, negative distance, implausible scale. A silently-wrong scale is the one failure that poisons everything traced afterwards, and *unlike a mis-placed image it looks completely fine on screen*. The coincident two-point pick matters most: it is what a real user produces by double-clicking, and dividing by a zero pixel distance yields `Infinity` — an underlay the size of the solar system, or nothing at all, depending on the driver.

## It is a picture, not geometry

Not raycastable · `depthWrite: false` so it never occludes the model it is traced against · `renderOrder` behind the model · lifted **5 mm** above its level so a slab authored at exactly that level does not z-fight with it.

And it cannot enter the model: bounds are an allowlist over loaded Fragments models (#198), so this plane is structurally out of scope — plus it is named and non-raycastable so any other consumer has something explicit to key on.

## This item is what found #198

Premise-checking *"can I add a plane to the scene?"* led to *"what already reads the scene?"* — and the answer was that a 2000 × 2000 shadow-catcher had been defeating the mis-click guard all along. Worth folding into the premise-check habit: **before adding an object to a shared structure, check what already reads that structure.** A new object is the moment you finally have a reason to enumerate the readers.

## A mutation pass caught a decorative test of my own

`"the guide is not a raycast target"` **passed whether or not the guard existed**. Calling `mesh.raycast()` by hand on a mesh whose world matrix was never updated intersects nothing either way — it asserted an empty array that was empty *for the wrong reason*.

It now runs a **control first**: an identical *unguarded* plane must be hit by the same ray, so an empty result means "the guard worked" rather than "the ray missed". Same shape as the picking benchmark that once reported a confident p50 with `hits: 0`.

The other five mutations: coincident-pick guard removed · implausible-scale guard removed · `depthWrite` turned on · level lift zeroed · `setTexture` stacking instead of replacing.

## Your layout gates worked, twice

Wiring the tool button failed first on *"a tool the layout table does not describe"* (it lands in the unlaid spill), then on **"a new verb cannot ship wearing a blank"** (no `TOOL_ICON` entry). Both caught real omissions before review. Icon is `scan`, group `author` — it is not a way of *viewing* the model, it is a reference you draw on top of, so it belongs beside the verbs that draw.

### Not verified in a browser

Image decoding and the rendered result need a real canvas, and a worktree branch still cannot be previewed (`preview_start` resolves `launch.json` against the session's primary cwd). Everything that can be wrong **without** a GPU — all the arithmetic, every refusal, the scene-object contract — is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Guide underlay tool for loading scanned plans into the viewer.
  * Calibrate plans using a known width or two measured points.
  * Adjust placement, opacity, rotation, visibility, and size.
  * Underlays remain non-selectable and do not interfere with model interactions.
  * Added support for replacing and removing plans with proper cleanup.

* **Documentation**
  * Updated the roadmap with guide-underlay scope and calibration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->