### PR TITLE
R22-PM-CONTRACTS — the register that was missing was the agreement, not the maintenance

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -222,7 +222,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-PLACE-VALID ② · A29-SPATIAL-SELECT ② · A29-UNDO-LOCAL ③ *(all three SHIPPED v0.3.831–833, pending archive)* · A29-GUIDE-UNDERLAY ③ · AUTH-SNAP-OVERRIDE *(SHIPPED PR #192, pending archive)* · RAIL-DRAG *(SHIPPED PR #197, pending archive)* · R28-VIEWER ④ · R22-PUBLIC-VIEWER · UX-AR · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R36-AUTHOR-MENU *(SHIPPED v0.3.836–843: the More menu is gone, not reorganised)* · R38-NODE-SLIDERS ③ *(ALREADY BUILT — checked 2026-08-06)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
-| **H · Registers** | `services/api/modules/*/module.json` | R22-PM-CONTRACTS |
+| **H · Registers** | `services/api/modules/*/module.json` | R22-PM-CONTRACTS *(SHIPPED 2026-08-06 — `pm_contract`; pending archive)* — lane now empty |
 | **I · API client** | `apps/web/src/api/` | SCALE-SEAM ⑧ |
 | **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | BUILD-WORKTREE-CHUNKS *(lane added 2026-08-06 — **three sessions in one day flagged a path belonging to no lane**: `services/api/test_file_sizes.py`, `apps/web/src/style.css`, and the build scripts. Each flagged it correctly and then had to edit it anyway. An unowned shared path is not neutral ground; it is a collision nobody is watching for)* |
 
@@ -615,9 +615,49 @@ stakes we are missing.
   is a funnel, not a project.
 - ◧ **R22-ROUTINES** *(S — `routines.py` + migration shipped)* — **scheduled agent runs** (monthly progress report, weekly schedule-risk
   scan) rather than on-demand only. Turns AI from a tool you remember to use into infrastructure.
-- **R22-PM-CONTRACTS** *(M)* — **preventative-maintenance contracts from turnover data.** The COBie
-  asset register, warranties and service intervals become billable recurring PM contracts. Extends
-  past turnover without breaking the mission; nobody in the scanned set does it from model data.
+- ✅ **R22-PM-CONTRACTS** *(M — Lane H, SHIPPED 2026-08-06)* — **preventative-maintenance contracts
+  from turnover data.** The COBie asset register, warranties and service intervals become billable
+  recurring PM contracts. Extends past turnover without breaking the mission.
+
+  **Premise-checked first, and the entry was half wrong — in the direction that wastes work rather
+  than causing a defect.** Read as written, this item sounds like PM capability is missing. It is
+  not: `pm_schedule`, `warranty`, `asset_register`, `work_order`, `equipment_log` and `cmms.py` were
+  all already here, and `pm_schedule` even carries `frequency_days`/`next_due` and a
+  "Generate PM work orders" tool. What did **not** exist is the item's actual noun — a *billable
+  recurring service agreement*. The four contract-shaped registers are all **construction** contracts
+  (`prime_contract`, `subcontract`, `owner_invoice`, `sub_invoice`); not one models a term, a billing
+  frequency, an escalation, a renewal notice or a response SLA. So the gap was real and much narrower
+  than an M implies: one register, not a subsystem. *Recorded rather than deleted, because "checked,
+  and here is what was actually missing" is what stops the next agent re-running the check.*
+
+  **Shipped:** `services/api/modules/pm_contract/module.json` — 18 fields in four contiguous
+  fieldsets (Agreement / Coverage / Term / Commercial), referencing `company`, `asset_register`,
+  `pm_schedule` and `warranty`, with a six-state workflow carrying the renewal path
+  (`draft → active → expiring → renewed → active`, plus lapse and terminate). `PMC` prefix verified
+  free against all 135 pre-existing registers. Alembic revision `a7e3b9c04d15` chained to head,
+  **including the Postgres FTS GIN tail** — the part that reads as boilerplate and is the reason a
+  post-baseline module silently loses full-text search on Postgres while passing every SQLite test.
+
+  **A gate caught me writing a commercial term nobody agreed to.** The first draft defaulted
+  `billing_frequency` to "Quarterly" and `coverage` to "Labour only" — helpful-looking, and exactly
+  what `test_field_attrs.py` forbids: it caps defaults across every register at eight and requires
+  each to be a fact about the **record** (a daily report is filed today), never a **policy**. On a
+  contract register that rule is at its sharpest: a defaulted billing frequency is a *term*, and it
+  would have been recorded as though someone had chosen it, invisibly, because a default looks
+  deliberate. Both removed. Worth noting that this is a **ceiling, not a floor** — the only such
+  assertion in the module gates, because here the risk runs toward adding rather than omitting.
+
+  **The `starts_after_warranty` flag is the join the item was actually asking for.** A PM contract
+  that begins while the equipment warranty still runs is money paid twice for the same obligation;
+  the field, plus the `warranty` reference, is what lets turnover data drive the contract start date
+  rather than a guess.
+
+  **Reachability measured over HTTP, not inferred:** `GET /modules` returns **136 (was 135)** with
+  `pm_contract` present and a key-shape identical to `pm_schedule`, including the derived `room`.
+  Worth recording how the first probe lied: it reported `/modules` → 200 with **0 modules**, which
+  reads as an empty registry and was the instrument — `TestClient(app)` outside a `with` block never
+  runs startup, so the registry never loaded. The route had been answering 200 the whole time.
+  (`/modules/{key}` 404s for `pm_schedule` too; that route shape does not exist.)
 - **R22-PUBLIC-VIEWER** — *(sized **M**, not S; see the Band 2 entry, which is the live one.)* This
   line is the original scan's one-sentence estimate. It called the item S because it counted the
   viewer, which exists; the Band 2 entry counted the **scoped revocable token and a route that

--- a/services/api/migrations/versions/2026_08_06_1200-a7e3b9c04d15_mod_pm_contract_r22_pm_contracts_.py
+++ b/services/api/migrations/versions/2026_08_06_1200-a7e3b9c04d15_mod_pm_contract_r22_pm_contracts_.py
@@ -1,0 +1,64 @@
+"""mod_pm_contract (R22-PM-CONTRACTS persistence)
+
+Revision ID: a7e3b9c04d15
+Revises: c81f5ad3e074
+Create Date: 2026-08-06 12:00:00.000000
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7e3b9c04d15'
+down_revision: str | None = 'c81f5ad3e074'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table('mod_pm_contract',
+    sa.Column('id', sa.String(), nullable=False),
+    sa.Column('project_id', sa.String(), nullable=True),
+    sa.Column('ref', sa.String(), nullable=True),
+    sa.Column('title', sa.String(), nullable=True),
+    sa.Column('workflow_state', sa.String(), nullable=True),
+    sa.Column('party_owner', sa.String(), nullable=True),
+    sa.Column('assignee', sa.String(), nullable=True),
+    sa.Column('created_by', sa.String(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('modified_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('anchor', sa.JSON(), nullable=True),
+    sa.Column('element_guids', sa.JSON(), nullable=True),
+    sa.Column('links', sa.JSON(), nullable=True),
+    sa.Column('data', sa.JSON(), nullable=True),
+    sa.PrimaryKeyConstraint('id')
+    )
+    with op.batch_alter_table('mod_pm_contract', schema=None) as batch_op:
+        batch_op.create_index('ix_mod_pm_contract_proj_assignee', ['project_id', 'assignee'], unique=False)
+        batch_op.create_index('ix_mod_pm_contract_proj_created', ['project_id', 'created_at'], unique=False)
+        batch_op.create_index('ix_mod_pm_contract_proj_state', ['project_id', 'workflow_state'], unique=False)
+        batch_op.create_index(batch_op.f('ix_mod_pm_contract_project_id'), ['project_id'], unique=False)
+        batch_op.create_index(batch_op.f('ix_mod_pm_contract_workflow_state'), ['workflow_state'], unique=False)
+
+    # Postgres-only FTS GIN index — every module table gets one at runtime; a post-baseline module
+    # migration must create its own (the baseline only indexes tables that exist at ITS point in the
+    # chain; the CI runtime-parity check enforces this).
+    if op.get_bind().dialect.name == "postgresql":
+        from aec_api import modules_registry
+        from aec_api.modules_search import index_ddl
+        modules_registry.load_registry()
+        op.execute(index_ddl("pm_contract", modules_registry.TABLES["pm_contract"]))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('mod_pm_contract', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_mod_pm_contract_workflow_state'))
+        batch_op.drop_index(batch_op.f('ix_mod_pm_contract_project_id'))
+        batch_op.drop_index('ix_mod_pm_contract_proj_state')
+        batch_op.drop_index('ix_mod_pm_contract_proj_created')
+        batch_op.drop_index('ix_mod_pm_contract_proj_assignee')
+
+    op.drop_table('mod_pm_contract')

--- a/services/api/modules/pm_contract/module.json
+++ b/services/api/modules/pm_contract/module.json
@@ -1,0 +1,231 @@
+{
+  "key": "pm_contract",
+  "name": "PM Contracts",
+  "section": "Maintenance",
+  "icon": "📋",
+  "ref_prefix": "PMC",
+  "title_field": "subject",
+  "pinnable": false,
+  "fields": [
+    {
+      "name": "subject",
+      "label": "Contract",
+      "type": "text",
+      "required": true,
+      "fieldset": "Agreement"
+    },
+    {
+      "name": "vendor",
+      "label": "Service Provider",
+      "type": "reference",
+      "module": "company",
+      "required": true,
+      "fieldset": "Agreement"
+    },
+    {
+      "name": "scope",
+      "label": "Scope of Service",
+      "type": "textarea",
+      "fieldset": "Agreement",
+      "placeholder": "What the provider is obliged to do, and what is expressly excluded."
+    },
+    {
+      "name": "coverage",
+      "label": "Coverage",
+      "type": "select",
+      "options": [
+        "Labour only",
+        "Parts and labour",
+        "Full service (incl. replacement)",
+        "Inspection only"
+      ],
+      "fieldset": "Agreement"
+    },
+    {
+      "name": "asset",
+      "label": "Covered Asset",
+      "type": "reference",
+      "module": "asset_register",
+      "fieldset": "Coverage"
+    },
+    {
+      "name": "pm_schedule",
+      "label": "PM Schedule",
+      "type": "reference",
+      "module": "pm_schedule",
+      "fieldset": "Coverage"
+    },
+    {
+      "name": "warranty",
+      "label": "Superseded Warranty",
+      "type": "reference",
+      "module": "warranty",
+      "fieldset": "Coverage"
+    },
+    {
+      "name": "starts_after_warranty",
+      "label": "Starts at warranty expiry",
+      "type": "checkbox",
+      "fieldset": "Coverage"
+    },
+    {
+      "name": "response_hours",
+      "label": "Emergency Response",
+      "type": "number",
+      "unit": "hr",
+      "min": 0,
+      "fieldset": "Coverage"
+    },
+    {
+      "name": "term_start",
+      "label": "Term Start",
+      "type": "date",
+      "required": true,
+      "fieldset": "Term"
+    },
+    {
+      "name": "term_end",
+      "label": "Term End",
+      "type": "date",
+      "required": true,
+      "fieldset": "Term"
+    },
+    {
+      "name": "auto_renew",
+      "label": "Auto-renews",
+      "type": "checkbox",
+      "fieldset": "Term"
+    },
+    {
+      "name": "notice_days",
+      "label": "Non-renewal Notice",
+      "type": "number",
+      "unit": "days",
+      "min": 0,
+      "fieldset": "Term",
+      "placeholder": "Days before term end that notice must be served."
+    },
+    {
+      "name": "billing_frequency",
+      "label": "Billing Frequency",
+      "type": "select",
+      "options": [
+        "Monthly",
+        "Quarterly",
+        "Semi-annual",
+        "Annual",
+        "Per visit"
+      ],
+      "required": true,
+      "fieldset": "Commercial"
+    },
+    {
+      "name": "billing_amount",
+      "label": "Amount per Period",
+      "type": "currency",
+      "min": 0,
+      "fieldset": "Commercial"
+    },
+    {
+      "name": "annual_value",
+      "label": "Annual Value",
+      "type": "currency",
+      "min": 0,
+      "fieldset": "Commercial"
+    },
+    {
+      "name": "escalation_pct",
+      "label": "Annual Escalation",
+      "type": "percent",
+      "min": 0,
+      "fieldset": "Commercial"
+    },
+    {
+      "name": "po_number",
+      "label": "PO / Cost Code",
+      "type": "text",
+      "fieldset": "Commercial"
+    }
+  ],
+  "workflow": {
+    "initial": "draft",
+    "states": [
+      "draft",
+      "active",
+      "expiring",
+      "renewed",
+      "expired",
+      "terminated"
+    ],
+    "transitions": [
+      {
+        "from": "draft",
+        "to": "active",
+        "action": "execute",
+        "party": [
+          "Owner",
+          "PM"
+        ]
+      },
+      {
+        "from": "active",
+        "to": "expiring",
+        "action": "flag renewal",
+        "party": [
+          "Owner",
+          "PM",
+          "GC"
+        ]
+      },
+      {
+        "from": "expiring",
+        "to": "renewed",
+        "action": "renew",
+        "party": [
+          "Owner",
+          "PM"
+        ]
+      },
+      {
+        "from": "renewed",
+        "to": "active",
+        "action": "start new term",
+        "party": [
+          "Owner",
+          "PM"
+        ]
+      },
+      {
+        "from": "expiring",
+        "to": "expired",
+        "action": "let lapse",
+        "party": [
+          "Owner",
+          "PM"
+        ]
+      },
+      {
+        "from": "active",
+        "to": "terminated",
+        "action": "terminate",
+        "party": [
+          "Owner"
+        ]
+      }
+    ]
+  },
+  "list_columns": [
+    "vendor",
+    "term_end",
+    "billing_frequency",
+    "annual_value",
+    "asset"
+  ],
+  "workspace": "construction",
+  "tools": [
+    {
+      "dest": "__operations__",
+      "label": "Review PM contract renewals"
+    }
+  ]
+}


### PR DESCRIPTION
Lane **H · Registers** (`services/api/modules/*/module.json`) — the lane's only item, unclaimed. **No version files, no `CHANGELOG.md`, no `run_tests.py`.**

## The premise was half wrong, in the direction that wastes work

Read as written, this item sounds like preventative-maintenance capability is missing. **It is not.** `pm_schedule`, `warranty`, `asset_register`, `work_order`, `equipment_log` and `cmms.py` were all already here — `pm_schedule` even carries `frequency_days`/`next_due` and a "Generate PM work orders" tool.

What did **not** exist is the item's actual noun: a **billable recurring service agreement**. The four contract-shaped registers are all *construction* contracts (`prime_contract`, `subcontract`, `owner_invoice`, `sub_invoice`), and not one models a term, a billing frequency, an escalation, a renewal notice or a response SLA.

So the gap was real but far narrower than the `M` implies — **one register, not a subsystem**. Filed as a correction in the roadmap rather than deleted, because "checked, and here is what was actually missing" is what stops the next agent re-running the check.

## What shipped

**`services/api/modules/pm_contract/module.json`** — 18 fields in four contiguous fieldsets (Agreement / Coverage / Term / Commercial), referencing `company`, `asset_register`, `pm_schedule` and `warranty`. Six-state workflow carrying the renewal path proper: `draft → active → expiring → renewed → active`, plus lapse and terminate. `PMC` prefix verified free against all 135 pre-existing registers.

**`starts_after_warranty` is the join the item was actually asking for.** A PM contract that begins while the equipment warranty still runs is money paid twice for the same obligation. That flag, plus the `warranty` reference, is what lets turnover data drive the contract start date instead of a guess — which is the "from turnover data" half of the item title.

**Alembic revision `a7e3b9c04d15`**, chained to head, **including the Postgres FTS GIN tail**. That tail reads as boilerplate and is not: the baseline migration only indexes tables existing at *its* point in the chain, so a post-baseline module that skips it silently loses full-text search on Postgres while passing every SQLite test.

## A gate caught me writing a commercial term nobody agreed to

The first draft defaulted `billing_frequency` to "Quarterly" and `coverage` to "Labour only". Helpful-looking, and exactly what `test_field_attrs.py` forbids — it caps defaults across every register at eight and requires each to be a fact about the **record** ("a daily report is filed today"), never a **policy**.

On a contract register that rule is at its sharpest: **a defaulted billing frequency is a commercial term**, and it would have been recorded as though someone had chosen it — invisible precisely because a default looks deliberate. Both removed.

Worth noting the gate is a **ceiling, not a floor** — the only such assertion in the module gates, because here the risk runs toward adding rather than omitting.

## Reachability measured, not inferred

`GET /modules` returns **136 (was 135)** with `pm_contract` present and a key-shape identical to `pm_schedule`, including the derived `room`.

**How the first probe lied:** it reported `/modules` → 200 with **0 modules** — including the 135 that already existed. That reads as an empty registry and it was the instrument: `TestClient(app)` outside a `with` block never runs startup, so the registry never loaded. The route had been answering 200 the whole time. (`/modules/{key}` 404s for `pm_schedule` too — that route shape does not exist, so it is not a defect here.)

## Verification

| check | result |
|---|---|
| `run_tests.py` (full backend) | see below |
| `test_module_schema.py` | exit 0 |
| `test_field_attrs.py` | exit 0 (after removing both defaults) |
| `test_alembic_migrations.py` | exit 0 — "No new upgrade operations detected", 167 tables |
| `test_claude_md_gates.py` | exit 0 — 177 citations |
| `roadmapLanes.test.ts` + `roadmapStale.test.ts` | 14/14 |
| `GET /modules` | 136, `pm_contract` present, shape matches sibling |

**On the suite result, stated with its grade.** My first run showed 8 FAILs with **one traceback between them** and tests taking 47–58s that now take 0.5s — that was CPU contention with another session's web suite, not code. Exactly one of those was real (`test_field_attrs`, with a traceback naming my field), and it is fixed. I then **discarded a second run** because I had edited `module.json` mid-run to apply that fix, which invalidates a suite whose tests read that file from disk. The result quoted here is a third, clean run started after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Suite result: `527/528 suites passed` (15 parallel, 1447s wall).**

The one failure is `test_ifcpatch_transforms`, and it is environmental: `sqlite3.OperationalError: disk I/O error` while creating an index on `mod_decision` — **an unrelated module** — with the disk at **2.6% free** and two other sessions' backend suites running concurrently. It passes standalone **twice**, exit 0, zero tracebacks.

**Rebased onto latest main** (which added Lane J and moved Lane I to SCALE-SEAM ⑧). The lane-table conflict was additive on both sides; resolved keeping all three rows, then **compiled rather than merely grepped for markers** — `roadmapLanes.test.ts` + `roadmapStale.test.ts` 14/14, and all five backend gates re-run green on the merged tree (`test_alembic_migrations`, `test_module_schema`, `test_field_attrs`, `test_module_config`, `test_claude_md_gates`). My revision is still chained to the current head `c81f5ad3e074`.
