### PR TITLE
The public build had no size or chunking check at all — give the gate the population it claims

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,6 +47,36 @@ jobs:
           VITE_PAGES: "1"
           VITE_BASE: "/app/"
 
+      # The PUBLIC build had no size or chunking check of any kind, which is the worst place for that
+      # to be true. `ci.yml` runs this step; `pages.yml` never did — and `VITE_PAGES=1` also excludes
+      # `VitePWA`, whose precache limit was the only thing that ever objected to a bloated shell (it is
+      # what caught a 19.7x eager bundle, by accident, on a different build). So the one configuration
+      # facing the public was guarded by neither.
+      #
+      # This measures the same dist the "Assemble site" step is about to publish, so it gates the
+      # artefact rather than a proxy for it.
+      - name: Bundle-size budget + vendor split (public build)
+        run: npm run budget --workspace apps/web
+        env:
+          # A SEPARATE budget, because this is a different artefact — not a relaxation of the other.
+          #
+          # Measured 2026-08-06, same commit, both builds, Brotli:
+          #
+          #     default (ci.yml)   index 89.9 KB + app 85.8 + css 9.3  =  185.0 KB   (budget 220)
+          #     pages   (here)     index 189.4   + app 85.8 + css 9.3  =  284.5 KB
+          #
+          # `app-*` and the CSS are byte-identical; the whole 99.5 KB sits in the ENTRY chunk, which
+          # is 1.38 MB raw here against 396 KB by default. The static demo has no API to fetch from,
+          # so `VITE_PAGES=1` inlines the demo corpus and the module registry — grepping the entry
+          # chunk finds "PM Schedules" 11x and "IfcWall" 8x, both absent from the default build.
+          # That is the demo working as designed, not a regression, so holding it to 220 would fail
+          # honestly-different content and teach everyone to ignore the step.
+          #
+          # 300 is a RATCHET on today's real number (284.5), not a comfortable ceiling: ~5% headroom
+          # against the default build's ~19%. It only ever moves down. **Every register added to the
+          # registry grows this**, so it is the number to re-read when the demo corpus changes.
+          BUNDLE_BUDGET_KB: "300"
+
       # assemble the Pages site: landing page at the root, viewer demo under /app/
       #
       # `docs/` doubles as the web root, so a plain `cp -r docs/.` publishes everything in it. That is

--- a/apps/web/scripts/bundle-budget.mjs
+++ b/apps/web/scripts/bundle-budget.mjs
@@ -40,10 +40,18 @@ try {
   console.error(`bundle-budget: ${join(DIST_ROOT, "index.html")} not found — run \`vite build\` first.`);
   process.exit(2);
 }
-// only the entry assets index.html actually references (under /assets/), not registerSW.js etc.
+// only the entry assets index.html actually references (under <base>assets/), not registerSW.js etc.
+//
+// The `[^"]*` before `/assets/` is load-bearing and was not there originally: `vite.config.ts` sets
+// `base: process.env.VITE_BASE || "/"`, and the Pages build (`pages.yml`) sets `VITE_BASE=/app/`, so
+// Vite emits `src="/app/assets/…"` there and `src="/assets/…"` by default. Anchoring the match at
+// `/assets/` meant this script found no entry on a Pages build and exited 2 — which reads as "the
+// build output changed", not as "this configuration is unmeasured". It never surfaced because
+// `npm run budget` was not in `pages.yml` at all. Matching the segment rather than the prefix is
+// what lets one script measure both builds.
 const htmlEntry = (re) => [...html.matchAll(re)].map((m) => m[1]);
-const entryJs = htmlEntry(/<script[^>]+src="\/assets\/([^"]+\.js)"/g);
-const entryCss = htmlEntry(/<link[^>]+href="\/assets\/([^"]+\.css)"/g);
+const entryJs = htmlEntry(/<script[^>]+src="[^"]*\/assets\/([^"/]+\.js)"/g);
+const entryCss = htmlEntry(/<link[^>]+href="[^"]*\/assets\/([^"/]+\.css)"/g);
 const shellNames = new Set([...entryJs, ...entryCss, ...files.filter((f) => APP.test(f))]);
 const shellFiles = files.filter((f) => shellNames.has(f));
 if (!entryJs.length) {


### PR DESCRIPTION
Follow-up to #196. Lane **J · Build & tooling** (`apps/web/scripts/`) — flagging the lane since it was created after I started; if `BUILD-WORKTREE-CHUNKS` is assigned, this is adjacent to it but does **not** touch `vite.config.ts`.

## The gate I shipped in #196 had the wrong population

#196 added a vendor-split assertion to `bundle-budget.mjs`. The assertion was real; **its population was the default build only.** The build that faces the public had neither half of the guard:

- **No PWA precache guard** — `pages.yml` sets `VITE_PAGES=1`, which excludes `VitePWA` entirely. That precache limit was the only thing that ever objected to a bloated shell; it is what surfaced the 19.7× eager bundle in #196, **by accident, on a different build**.
- **No bundle-budget guard** — `npm run budget` exists only in `ci.yml`. It has never run in `pages.yml`.

So the one configuration serving real users was guarded by nothing. The *worktree* cause from #196 cannot reach it — `pages.yml` uses `actions/checkout@v7` on a clean runner — but **any other cause of the split regressing ships silently**, and `vite.config.ts` names one by hand: the deprecated-`manualChunks` path, where the build succeeds and emits a chunk that turns out to be only a re-export shim.

Bounded blast radius, unbounded failure mode.

## Wiring the step in required fixing the script — verified, not predicted

`bundle-budget.mjs` located the entry by matching `src="/assets/…"`. `vite.config.ts` sets `base: process.env.VITE_BASE || "/"` and `pages.yml` sets `VITE_BASE=/app/`, so Vite emits a prefixed URL there.

I predicted this would exit 2 and then **ran it against a real `VITE_PAGES=1` build rather than shipping the prediction**:

```
old script vs Pages build:  exit 2
bundle-budget: no entry <script> found in dist/index.html — did the build output change?
```

Note the signature: that reads as **"the build output changed"**, not as "this configuration is unmeasured" — part of why it was never chased. Matching the `/assets/` *segment* instead of anchoring on the prefix lets one script measure both builds.

## Then the newly-measurable build was 29% over budget — and that is not a regression

Same commit, both builds, Brotli:

| | index | app | css | total | budget |
|---|---|---|---|---|---|
| default (`ci.yml`) | 89.9 KB | 85.8 | 9.3 | **185.0 KB** | 220 |
| pages (here) | **189.4 KB** | 85.8 | 9.3 | **284.5 KB** | 220 ❌ |

`app-*` and the CSS are **byte-identical**. All 99.5 KB of the difference is the entry chunk — 1.38 MB raw against 396 KB. The static demo has no API to fetch from, so `VITE_PAGES=1` inlines the demo corpus and the module registry: grepping the entry chunk finds `PM Schedules` ×11 and `IfcWall` ×8, **neither present in the default build**.

That is the demo working as designed. Holding it to 220 would fail honestly-different content, and **a step that fails for a reason nobody accepts is a step people learn to ignore.**

So the Pages step carries its own `BUNDLE_BUDGET_KB=300` — a ratchet on today's real 284.5, ~5% headroom against the default build's ~19%, **down-only**, and the number to re-read whenever the demo corpus changes. **Every register added to the registry grows it** — including `pm_contract` in #201.

## Verification

Each mutation confirmed applied before its result was read.

| check | result |
|---|---|
| old script vs a real Pages build | **exit 2**, "no entry `<script>` found" |
| new script vs the same build | measures — 284.5 KB |
| new script + `BUNDLE_BUDGET_KB=300` | exit 0, 3 lazy chunks |
| new script vs the **default** build | 185.0 KB, unchanged — no regression |
| `three-*`/`thatopen-*` deleted from a Pages dist | **exit 1 naming both — while the size still passed** |
| `pages.yml` | parses; both steps present with intended env |
| re-verified after rebase onto latest main | both builds still measure correctly |

That fifth row is the whole argument for the assertion existing: **the size check cannot see a lost vendor split.** A shell that is within budget and has three.js folded into it passes on size and fails here.

## Not attempted

Making worktree builds *correct* — that is workspace-root scoping in a shared `vite.config.ts`, and the lead has filed it as `BUILD-WORKTREE-CHUNKS`. The interim policy stands and is in the gate's failure message: build from the main clone or CI; a worktree is for typecheck and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
