### PR TITLE
The roadmap contradicted itself about three items, and the commissioned gate could not have seen any of them

### DIFF
--- a/apps/web/src/shell/roadmapSelfConsistent.test.ts
+++ b/apps/web/src/shell/roadmapSelfConsistent.test.ts
@@ -1,0 +1,213 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The roadmap must not say an item shipped in one place and open in another.
+ *
+ * WHY THIS EXISTS, AND WHY IT IS NOT THE GATE IT WAS COMMISSIONED AS
+ *     Three items — `A29-PLACE-VALID ②`, `A29-SPATIAL-SELECT ②`, `A29-UNDO-LOCAL ③` — sat in the
+ *     roadmap declaring **SHIPPED in their own text with no ✅ marker**, so every reader and every
+ *     check treated them as available work. They were found by hand.
+ *
+ *     The proposed fix was to port `roadmapStale.test.ts` to TypeScript. That gate scans module
+ *     **docstrings** for an item id and asks "does code exist that nobody marked done?"; its
+ *     population is `services/api/src` + `services/data/src`, Python only, and all three items are
+ *     TypeScript.
+ *
+ *     **The port was measured and rejected.** The convention it depends on barely exists in the TS
+ *     tree: of **158** hand-written TS modules, **6** declare an item id on the first comment line,
+ *     and **none of the six is one of the three items that motivated the work**. A port would have
+ *     covered ~4% of its claimed population — the same "the check could not see it" defect this repo
+ *     hit five times on 2026-08-06, and the only instance we would have *built on purpose*, having
+ *     spent that day naming it. Widening the scan from the first line to the whole file body does not
+ *     rescue it either: an item id mentioned in passing is not a declaration, so that trades false
+ *     positives for a coverage hole it still does not close. **A wider predicate is not a better one.**
+ *
+ *     Do not re-propose the port. The measurement above is the reason, and it is cheap to re-run.
+ *
+ * WHAT THIS CHECKS INSTEAD
+ *     How the three were actually found: by reading the **roadmap**, not the code. That question has
+ *     no language population to get wrong, cannot rot when a file is renamed, and its population is
+ *     the document it is about. `roadmapStale.test.ts` is NOT replaced — the two answer different
+ *     questions: *code exists that nobody marked done* versus *the document contradicts itself*.
+ *
+ * THE DISCRIMINATOR THAT MAKES IT SHIPPABLE
+ *     A naive "body says SHIPPED but no ✅" rule flagged **11**, of which four were correct as
+ *     written, because `◧` and `🟡` already mean **a half shipped**:
+ *
+ *         ◧ SEC-PLUGIN-SANDBOX  "the binding half SHIPPED …; the setrlimit half is REFUSED"
+ *         🟡 R24-CHARTS-GRAMMAR  "no-data rule SHIPPED v0.3.783, **the rest open**"
+ *
+ *     Excluding those glyphs leaves the real cases with no false positives. A gate that cries wolf
+ *     about correct entries is one people switch off inside a week.
+ *
+ * A STATED BLIND SPOT — read this before trusting a green run
+ *     `laneClaims` deliberately reads only **item-scoped** annotations, `CODE *(… SHIPPED …)*`. A
+ *     lane row may also make a **row-level** claim covering every code in the cell, and this gate
+ *     does not act on those, because their scope is genuinely ambiguous and resolving one is the lane
+ *     owner's call rather than a matcher's.
+ *
+ *     That is not hypothetical. As of 2026-08-06 the Lane D row reads "**all SHIPPED and MERGED**
+ *     (PRs #176/#178/#179)" over eight codes, and **only two of the eight bullets carry ✅** — while
+ *     one of the eight, `SEC-PLUGIN-SANDBOX`, is marked `◧` with half of it explicitly REFUSED, so
+ *     "all" is false on its face. Reported rather than auto-marked: writing six ✅ marks from an
+ *     ambiguous sentence is the confident-wrong failure this repo keeps paying for.
+ */
+
+// process.cwd() is apps/web under vitest; happy-dom leaves import.meta.url without a file: scheme,
+// so resolve from cwd the way shell/roadmapLanes.test.ts does.
+const REPO = join(process.cwd(), "..", "..");
+const LINES = readFileSync(join(REPO, "docs/roadmap.md"), "utf8").split("\n");
+
+/** Gated items are deliberately unmarked; the open backlog is everything above that heading. */
+const GATED_AT = LINES.findIndex((l) => l.startsWith("## ⛔ Gated"));
+const OPEN = LINES.slice(0, GATED_AT === -1 ? LINES.length : GATED_AT);
+
+/** One source for the increment vocabulary — the same lesson `roadmapLanes.test.ts` records twice. */
+const MARKS = "①②③④⑤⑥⑦⑧⑨";
+
+/**
+ * Status glyphs a bullet may carry. **`⛔` is here and is NOT in `roadmapLanes.test.ts`'s copy** —
+ * found by the loose/strict comparison below, which flagged two live bullets on first run:
+ *
+ *     L672   - ⛔️ **R23-PICKING** *(M)* — CLOSED UNBUILT 2026-07-31, on a measurement…
+ *     L1251  * ⛔ **R22-PHOTO-CV defect detection — REFUSED IN PLACE**…
+ *
+ * Both forms appear: bare `⛔` (U+26D4) and `⛔️` with a variation selector (U+FE0F), which are
+ * different strings and must both be listed. Closed and refused items arguably *should* sit outside
+ * the assignable population — but in the lane gate they do so **by accident**, because nobody added
+ * the glyph, not because anyone decided it. An exclusion that works by omission also hides a live
+ * item that adopts the glyph by mistake. Reported to the lane gate's owner rather than edited here.
+ */
+const GLYPHS = "(?:✅ |◧ |🟡 |⭐ |⛔️ |⛔ )?";
+
+const ITEM = new RegExp(
+  String.raw`^\s*[-*] ${GLYPHS}\*\*([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,}?)(?:\s*([${MARKS}]))?(?:\s|\*\*|—)`,
+);
+
+interface Bullet { line: number; done: boolean; partial: boolean; bodyShipped: boolean }
+
+/** code -> the bullet's own claims. A bullet's body runs until the next bullet or heading. */
+function bullets(): Map<string, Bullet> {
+  const out = new Map<string, Bullet>();
+  for (let i = 0; i < OPEN.length; i++) {
+    const head = OPEN[i] ?? "";
+    const m = ITEM.exec(head);
+    if (!m?.[1]) continue;
+    let body = head;
+    for (let j = i + 1; j < OPEN.length; j++) {
+      const l = OPEN[j] ?? "";
+      if (ITEM.test(l) || l.startsWith("#")) break;
+      body += "\n" + l;
+    }
+    out.set(m[2] ? `${m[1]} ${m[2]}` : m[1], {
+      line: i + 1,
+      done: head.includes("✅"),
+      // ◧ / 🟡 mean "a half shipped", so SHIPPED in the body is correct rather than contradictory.
+      //
+      // Alternation, NOT a character class. `🟡` is U+1F7E1 — outside the BMP, so a non-`u` regex
+      // stores it as a surrogate PAIR, and `[◧🟡]` becomes a class of three code units that matches
+      // either half on its own. eslint's `no-misleading-character-class` caught it. The bug it would
+      // have caused is a false *positive* — a lone surrogate is not something this file will meet —
+      // but the class was not matching what it appeared to, which is the same defect as a regex that
+      // matches nothing: the code says one thing and the engine does another.
+      partial: /◧|🟡/.test(head),
+      bodyShipped: /\bSHIPPED\b/.test(body),
+    });
+  }
+  return out;
+}
+
+/**
+ * code -> the lane cell's annotation, for ITEM-SCOPED claims only.
+ *
+ * Requires the SHIPPED word inside a `*(…)*` that immediately follows the code, so a row-level
+ * sentence trailing the last code in a cell is not misattributed to it — which is exactly what a
+ * naive split on "·" does. See the blind-spot note above.
+ */
+function laneClaims(): Map<string, string> {
+  const out = new Map<string, string>();
+  const CLAIM = new RegExp(
+    String.raw`^([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]+(?: [${MARKS}])?)\s*\*\(([^)]*)\)\*`,
+  );
+  for (const l of OPEN) {
+    if (!/^\|\s*\*\*[A-Z] · /.test(l)) continue;
+    const cell = l.split("|")[3] ?? "";
+    for (const part of cell.split("·")) {
+      const m = CLAIM.exec(part.trim());
+      if (m?.[1] && /\bSHIPPED\b/i.test(m[2] ?? "")) out.set(m[1], part.trim());
+    }
+  }
+  return out;
+}
+
+const BULLETS = bullets();
+const CLAIMS = laneClaims();
+
+describe("the roadmap is self-consistent about what has shipped", () => {
+  it("extracts a plausible number of items — otherwise every assertion below is vacuous", () => {
+    // The failure mode of every gate that bit this repo on 2026-08-06: a regex drifts, matches
+    // nothing, and the suite goes green by measuring an empty set. 85 bullets at time of writing.
+    expect(BULLETS.size, `only ${BULLETS.size} roadmap bullets parsed — has the format changed?`)
+      .toBeGreaterThan(50);
+  });
+
+  it("leaves no bullet that LOOKS like an item behind — a floor cannot see partial drift", () => {
+    // The floor above was mutation-tested and did NOT fail: mangling four bullets left 81, still
+    // clear of 50. **A population floor only detects total collapse.** Partial drift — one ring
+    // adopting a slightly different bullet style — silently shrinks the population while the count
+    // stays healthy, and that is precisely the "silent omission" `roadmapLanes.test.ts` warns about
+    // in its own docstring.
+    //
+    // So this compares two readers on purpose: a LOOSE one that only asks "does this line open with
+    // a bold item code?", and the STRICT `ITEM` that the assertions actually use. Anything the loose
+    // reader sees and the strict one drops is named here. Two readers of one structure normally
+    // drift and the second is the bug — that is true when both are supposed to agree by accident.
+    // Here disagreement IS the signal, which is the one case where a second reader earns its keep.
+    // NOTE the leading prefix is `(?:[^*\s]{1,3} )?` and NOT the glyph alternation `ITEM` uses.
+    // Sharing that alternation was the first draft's bug: a bullet adopting a NEW status glyph would
+    // be missed by both readers identically, so the comparison could not see the one drift most
+    // likely to actually happen. A second reader that inherits the first one's blind spot is not a
+    // second reader.
+    const LOOSE = /^\s*[-*] (?:[^*\s]{1,3} )?\*\*([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,})/;
+    const missed: string[] = [];
+    for (let i = 0; i < OPEN.length; i++) {
+      const l = OPEN[i] ?? "";
+      if (!LOOSE.test(l)) continue;
+      if (ITEM.test(l)) continue;
+      missed.push(`L${i + 1}: ${l.trim().slice(0, 90)}`);
+    }
+    expect(missed, "these read as item bullets but ITEM does not match — the population is shrinking silently")
+      .toEqual([]);
+  });
+
+  it("finds lane-table entries to cross-check, so the second assertion is not vacuous either", () => {
+    expect(CLAIMS.size, "no item-scoped lane annotations parsed — the cross-check is measuring nothing")
+      .toBeGreaterThan(0);
+  });
+
+  it("marks an item ✅ when its own text says it shipped", () => {
+    // The original defect. An item whose body says SHIPPED but which carries no ✅ reads as open
+    // work to every agent picking up the roadmap, and to `roadmapLanes.test.ts`, which excludes ✅
+    // items from the assignable population.
+    const wrong = [...BULLETS].filter(([, b]) => !b.done && !b.partial && b.bodyShipped);
+    expect(
+      wrong.map(([c, b]) => `${c} (L${b.line})`),
+      "these say SHIPPED in their own body but carry no ✅ marker",
+    ).toEqual([]);
+  });
+
+  it("agrees with its own lane table about what has shipped", () => {
+    // Corroboration that already lives inside the artefact: the lane cell and the bullet are two
+    // independent statements about one fact, so they can be checked against each other without any
+    // reference to code. This is what caught RAIL-DRAG, whose bullet carried 🟡 — deliberately
+    // tolerated by the assertion above — while its lane cell said "SHIPPED PR #197, pending archive".
+    const wrong = [...CLAIMS].filter(([code]) => BULLETS.has(code) && !BULLETS.get(code)!.done);
+    expect(
+      wrong.map(([code, cell]) => `${code}: lane table says ${cell}`),
+      "the lane table calls these shipped while their bullets carry no ✅",
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/tooling/copyWasm.test.ts
+++ b/apps/web/src/tooling/copyWasm.test.ts
@@ -108,6 +108,15 @@ describe("the build's WASM package resolution", () => {
     // `src/no-import-cycles.test.ts` as unshipped — a false positive produced by using two
     // different glob dialects for the two halves of one comparison. One reader defines the
     // pattern; the other only supplies its side of the set.
+    // **Ask git what it IGNORES, not what it has not yet been told about.** The first version
+    // compared on-disk files against `git ls-files` and flagged anything untracked — which fires on
+    // every legitimately-new test file between writing it and staging it. That is friction with no
+    // signal: an untracked-but-not-ignored file gets committed by the next `git add` and reaches CI
+    // fine. The defect this guards is narrower and permanent — a test under a path `.gitignore`
+    // excludes (`build/`, `dist/`, `tmp/`) can never reach the archive without `-f`, so it passes
+    // locally forever and does not exist on the runner. Caught by this test failing on the author's
+    // own unstaged file minutes after it merged: **a guard whose normal state is red teaches people
+    // to ignore it**, which would have cost more than the bug it catches.
     const { execFileSync } = await import("node:child_process");
     const tracked = new Set(
       execFileSync("git", ["ls-files", "src/"], { cwd: process.cwd(), encoding: "utf8" })
@@ -115,13 +124,25 @@ describe("the build's WASM package resolution", () => {
     );
     expect(tracked.size, "git ls-files returned nothing — this check would pass vacuously").toBeGreaterThan(50);
 
+    const ignored = new Set(
+      execFileSync("git", ["ls-files", "--others", "--ignored", "--exclude-standard", "--", "src/"],
+        { cwd: process.cwd(), encoding: "utf8" })
+        .split("\n").map((s) => s.trim()).filter((p) => p.endsWith(".test.ts")),
+    );
+
     const { globSync } = await import("node:fs");
     const onDisk = globSync("src/**/*.test.ts", { cwd: process.cwd() })
       .map((p: string) => p.split("\\").join("/"))
       .filter((p) => !p.includes("/vendor/"));   // vendored suites are excluded from the run itself
 
-    const untracked = onDisk.filter((p) => !tracked.has(p));
-    expect(untracked, `test files vitest runs but git does not ship: ${untracked.join(", ")}`).toEqual([]);
+    // Ignored, not merely untracked: these can never reach the archive, so vitest runs them and CI
+    // never will. `ignored` is git's own answer, so a future .gitignore rule is covered without this
+    // test knowing which directories are excluded.
+    const unshippable = onDisk.filter((p) => ignored.has(p));
+    expect(
+      unshippable,
+      `test files vitest runs that git can never ship (they are .gitignore'd): ${unshippable.join(", ")}`,
+    ).toEqual([]);
   });
 
   it("keeps copy-wasm.mjs wired to the shared resolver", async () => {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2133,7 +2133,7 @@ footing the July study stood on when CADCMD was written.
   pick (theirs is Shift+right-click; Shift is already ortho lock here, so pick a free chord). The
   genuine gap: today a snap preference is modal, and needing *this one pick* to take a perpendicular
   means changing a mode and changing it back.
-- 🟡 **RAIL-DRAG** *(M — Lane E; **SHIPPED PR #197**)* — the palette rows in
+- ✅ **RAIL-DRAG** *(M — Lane E; **SHIPPED PR #197**)* — the palette rows in
   `apps/web/src/viewer/draft/draftPanel.ts` are drag sources; `apps/web/src/viewer/railDrag.ts` owns
   the payload rules and the one-drop-is-one-point verdict; `apps/web/src/viewer/app.ts` makes the
   canvas a drop target that hands the `DragEvent` straight to `captureDraftPoint`. One pipeline, two
@@ -2260,7 +2260,7 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
   found 182 buttons rather than the handful the plan assumed. Kept as a pointer rather than deleted so
   the under-scoping is visible, and marked ✅ so it can never again read as open work — it sat
   unmarked, four days after shipping, one screen below its own resolution.
-- **R36-EMPTY-STATE** *(S — Lane B — **SHIPPED v0.3.849**)* — **a register with no rows is indistinguishable from a broken
+- ✅ **R36-EMPTY-STATE** *(S — Lane B — **SHIPPED v0.3.849**)* — **a register with no rows is indistinguishable from a broken
   one, and was reported as exactly that.** The trigger: "something is wrong with specs". Specs was
   fine — the module rendered in full, toolbar, filters, saved views, templates, import — but the
   project held **zero** `spec_section` records, and so did every other design register. A full surface


### PR DESCRIPTION
Commissioned as `ROADMAP-GATE-TS` ("port `roadmapStale.test.ts` to TypeScript"). **Premise-checked first, and the port would have been a gate covering ~4% of its claimed population.** Renamed and rescoped with the lead's agreement.

## The measurement that killed the assignment

`roadmapStale.test.ts` keys on an item id in a module's **opening docstring** — not a filename. I scanned the TS tree for that convention:

```
TS modules scanned:                          158
declaring an item id on the first line:        6
```

**Six** — and **none of the six is one of the three items that motivated the work.** `draftHistory.ts` (which implements `A29-UNDO-LOCAL ③`) does not even match its item's name, so a filename-keyed variant misses it too.

Widening the scan from the first line to the whole file body does not rescue it: **an id mentioned in passing is not a declaration**, so that trades false positives for a coverage hole it still does not close. *A wider predicate is not a better one.*

We were one instruction away from deliberately building the fifth "the check could not see it" of the day, having spent the day naming that exact failure.

## What replaces it

**How the three were actually found: by reading the roadmap, not the code.** That question has no language population to get wrong and cannot rot when a file is renamed. `roadmapStale.test.ts` is **not** replaced — *code exists that nobody marked done* and *the document contradicts itself* are different questions, and both are worth asking.

Two assertions:

1. a bullet whose **body** says SHIPPED must carry ✅
2. a bullet the **lane table** annotates as shipped must carry ✅ — corroboration already sitting inside the artefact, two independent statements about one fact, checkable without reference to any code

**The `◧`/`🟡` discriminator is what makes (1) shippable.** Naive, it flags **11**, four of them correct as written because those glyphs already mean *a half shipped*:

> `◧ SEC-PLUGIN-SANDBOX` — "the binding half SHIPPED …; the `setrlimit` half is REFUSED"
> `🟡 R24-CHARTS-GRAMMAR` — "no-data rule SHIPPED v0.3.783, **the rest open**"

Excluding them leaves no false positives. (2) then catches `RAIL-DRAG`, which (1) deliberately tolerates — 🟡 bullet, lane cell reading "SHIPPED PR #197, pending archive".

**Fixed: `R38-SYNC-SELECT ③`, `R36-EMPTY-STATE`, `RAIL-DRAG`.** (The three `A29-*` items the lead found by hand were already marked on main — I re-derived the list after rebasing rather than trusting the earlier table, and the gate confirming those edits is exactly what it should do.)

## The population floor failed its own mutation test

Asked for "bullets parsed > 50, currently 85". I mutation-tested it and **it did not fail**: mangling four bullets left 81, clear of the floor. **A floor detects total collapse, never partial drift** — one ring adopting a slightly different bullet style silently shrinks the population while the count stays healthy, which is the silent-omission mode `roadmapLanes.test.ts` warns about in its own docstring.

So a **loose reader now cross-checks the strict one** and names anything only the loose reader sees. Its prefix is deliberately **not** the glyph alternation `ITEM` uses — sharing that was the first draft's bug, because a bullet adopting a *new* glyph would be missed by both readers identically. **A second reader that inherits the first one's blind spot is not a second reader.**

That comparison immediately found **two live bullets using `⛔`**, a glyph in neither gate's vocabulary:

```
L672   - ⛔️ **R23-PICKING**   *(M)* — CLOSED UNBUILT 2026-07-31…
L1251  * ⛔ **R22-PHOTO-CV defect detection — REFUSED IN PLACE**…
```

Both forms occur — bare `⛔` (U+26D4) and `⛔️` with a variation selector (U+FE0F) — and they are different strings. Closed items arguably *should* sit outside the assignable population, but in the lane gate they do so **by accident rather than by decision**, and an exclusion that works by omission also hides a live item that adopts the glyph by mistake. Added here; **reported to the lane gate's owner rather than edited there.**

## A stated blind spot, deliberately not acted on

The cross-check reads only **item-scoped** lane annotations. Lane D currently reads "**all SHIPPED and MERGED** (PRs #176/#178/#179)" across eight codes while **only two of the eight bullets carry ✅** — and one of the eight, `SEC-PLUGIN-SANDBOX`, is `◧` with half explicitly REFUSED, so "all" is false on its face.

Row-level claims are genuinely ambiguous in scope and resolving one is the lane owner's call. Writing six ✅ marks from that sentence is the confident-wrong failure this repo keeps paying for, so it is reported, not automated.

## Second commit — fixing my own defect from #196

The archive guard I shipped this morning compared on-disk tests against `git ls-files` and so **flagged anything untracked** — firing on every legitimately-new test file between writing it and staging it. I hit it myself within hours, on my own unstaged file, in this very PR.

**A guard whose normal state is red teaches people to ignore it** — the same disease as a printed number nobody asserts, approached from the other side. The bug actually worth guarding is narrower and permanent: a test under a `.gitignore`d path can never reach the archive without `-f`. So it now asks what git **ignores** (`git ls-files --others --ignored --exclude-standard`), which is git's own answer and covers future `.gitignore` rules without this test knowing which directories are excluded.

## Verification

| check | result |
|---|---|
| `npm run test --workspace apps/web` | **1268 / 1268**, 114 / 114 |
| `npx tsc --noEmit` / `npx eslint` | clean |
| re-verified after rebase onto latest main | 24/24 across all four roadmap + tooling gates |

**Mutations, each confirmed applied before its result was read:**

| mutation | result |
|---|---|
| un-tick `R38-SYNC-SELECT ③` | red on **both** assertions, naming it |
| un-tick `RAIL-DRAG` (🟡 bullet) | red on the lane cross-check — the case assertion (1) tolerates |
| a brand-new status glyph `🔵` | red, naming the line |
| mangle 4 bullets (population floor) | **passed — 81 > 50**, which is why the loose/strict comparison exists |
| ghost test in ignored `src/build/` | red, naming it |
| unstaged new test file | **green** (was red before the second commit) |

`eslint` also caught `[◧🟡]` as a misleading character class: 🟡 is U+1F7E1, stored as a surrogate **pair** without the `u` flag, so the class matched either half alone. Now an alternation — the code said one thing and the engine did another, which is the same defect as a regex that matches nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
