### PR TITLE
R22-AGENT-PACKS — the audit could only record the identity the transport never sent

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -560,11 +560,25 @@ stakes we are missing.
   never noticing `approval_risk.py`, which the eventual build should probably feed. Third
   collision found on 2026-07-31, after `report_builders/` (five hardcoded builders, not the no-code
   builder R22-REPORT-BUILDER describes).
-- ◧ **R22-AGENT-PACKS** *(M — `agent_packs.py` shipped; console scope unverified)* — **named agent packs + org "Skills" + a governance console** over the
+- ◧ **R22-AGENT-PACKS** *(M — `agent_packs.py` shipped; audit half CLOSED 2026-08-06; console is Lane A/E)* — **named agent packs + org "Skills" + a governance console** over the
   MCP layer we already ship. We expose raw capability; the market ships "Submittal Review Agent",
   which a superintendent understands. Pure packaging of existing tools, plus per-run audit logging —
   the gating factor for enterprise adoption. Our version reads the IFC, so a submittal check can test
   the submitted product against the element's *specified properties* rather than against a PDF.
+
+  **The audit half is done, and the last gap was in the caller, not the callee.** `dispatch` audits
+  every run, success and failure — but it can only record the identity it is *given*, and the stdio
+  transport (`services/api/mcp_server.py`, the one path every real agent run takes) passed none. Every
+  row read actor `mcp`, no user, no pack: the trail answered *which tools ran* and not *whose agent
+  ran them*, which is the half an enterprise actually asks for, both before granting access and after
+  an incident. `test_agent_packs.py` asserted attribution "to the effective user, not the transport"
+  and passed the whole time, because **the test supplied a user the transport never did** — a test
+  that provides a caller's arguments cannot notice the caller omitting them. The transport now reads
+  `AEC_MCP_USER` / `AEC_MCP_ACTOR` / `AEC_MCP_PACK`, warns at startup when runs will be unattributable
+  rather than recording them silently, and refuses to invent a person-shaped default (an unverified
+  name in an audit trail is worse than an honest "the transport ran this").
+  `services/api/test_mcp_attribution.py` asserts the **call site** forwards all three, mutation-checked
+  against the original defect. **What remains is the governance console itself — Lane A/E, not C.**
 
 **Tier 2 — evidence, provenance and procurement**
 

--- a/services/api/mcp_server.py
+++ b/services/api/mcp_server.py
@@ -20,6 +20,54 @@ import json
 import os
 import sys
 
+#: Environment the operator sets so MCP runs are attributable. `dispatch` audits every run, but it can
+#: only record the identity it is GIVEN — and until this existed the stdio transport passed none, so
+#: every row in the governance console read actor `mcp` with no user and no pack. The audit trail
+#: answered "which tools ran" and could not answer "whose agent ran them", which is the half an
+#: enterprise actually asks for, both before granting access and after an incident.
+ENV_USER = "AEC_MCP_USER"
+ENV_ACTOR = "AEC_MCP_ACTOR"
+ENV_PACK = "AEC_MCP_PACK"
+
+#: What `actor` becomes when the operator sets nothing. Deliberately not a person-shaped default: a
+#: placeholder like "local" or the OS username would put an unverified name in an audit trail, and a
+#: name nobody authenticated is worse than an honest "the transport ran this".
+TRANSPORT_ACTOR = "mcp-stdio"
+
+
+def transport_identity(env: dict[str, str] | None = None) -> dict[str, object]:
+    """The identity this transport can honestly claim, from the operator's environment.
+
+    Pure and env-injectable so it is testable without the MCP SDK — the SDK is an optional dependency,
+    so anything that can only be reached through `main()` cannot be covered by the suite at all.
+
+    `attributed` is the field a console must read before showing a name. The stdio server has no
+    authentication of its own: whoever can run the process can set these variables, so a configured
+    user is an *operator assertion*, not a verified identity, and this says which one it is rather
+    than letting a configured string pass for a login.
+    """
+    e = os.environ if env is None else env
+    user = (e.get(ENV_USER) or "").strip() or None
+    actor = (e.get(ENV_ACTOR) or "").strip() or TRANSPORT_ACTOR
+    pack = (e.get(ENV_PACK) or "").strip() or None
+    return {"actor": actor, "user": user, "pack": pack, "attributed": user is not None}
+
+
+def _warn_unattributed(ident: dict[str, object], write=None) -> bool:
+    """Say plainly, once at startup, that runs will not be attributable. Returns whether it warned.
+
+    An unattributed audit trail must announce itself. Silently recording every run against the
+    transport looks identical to recording it against a user nobody checked, and a console reading
+    those rows cannot tell the difference either.
+    """
+    if ident["attributed"]:
+        return False
+    (write or sys.stderr.write)(
+        f"massing-mcp: runs will be audited as {ident['actor']!r} with no user.\n"
+        f"  Set {ENV_USER} (and optionally {ENV_PACK}) so the governance console can answer\n"
+        f"  'whose agent ran this'. Without it the audit trail records what ran, not who ran it.\n")
+    return True
+
 
 def _fail_no_sdk() -> None:
     sys.stderr.write(
@@ -43,11 +91,18 @@ def main() -> None:
 
     server = FastMCP("massing")
 
+    ident = transport_identity()
+    _warn_unattributed(ident)
+
     def _make(tool: dict):
         def _run(**kwargs) -> str:
             db = SessionLocal()
             try:
-                result = mcp_tools.dispatch(db, tool["name"], kwargs)
+                # Attribution is passed on EVERY run, not just write tools: "which tools did this
+                # agent read from my project" is the question asked after an incident, and a read is
+                # exactly what an exfiltration looks like.
+                result = mcp_tools.dispatch(db, tool["name"], kwargs, actor=ident["actor"],
+                                            user=ident["user"], pack=ident["pack"])
                 db.commit()
                 return json.dumps(result, default=str)
             finally:

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -64,7 +64,7 @@ TESTS = ["test_provenance_report", "test_proforma", "test_renovation", "test_rol
          # R22-NOTICE-CLOCK — contractual notice periods + the register routes:
          "test_notice_clock", "test_notices_route",
          # Tier-2/3 competitive upgrades:
-         "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approval_conditions", "test_agent_packs", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
+         "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approval_conditions", "test_agent_packs", "test_mcp_attribution", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
          "test_ids_authoring", "test_procurement", "test_conceptual", "test_parcels", "test_net",
          "test_design_phase", "test_family_library", "test_change_instruments", "test_turnover",
          "test_prod_hardening", "test_diligence", "test_deal_funnel", "test_deal_memory", "test_operations", "test_reserves_cam", "test_esg",

--- a/services/api/src/aec_api/agent_packs.py
+++ b/services/api/src/aec_api/agent_packs.py
@@ -4,11 +4,20 @@ Premise-checked: `mcp_tools` exposes **18** tools with `dispatch()` and `catalog
 `audit.record` exists. So this is packaging, exactly as the ring entry says — with one finding the
 entry only implies:
 
-**16 of the 18 tools run with no audit trail.** `audit.record` is called inside `_run_recipe`, for
-the IFC edit it performs — not for tool dispatch itself. So today "which tools did this agent run
-against my project last week?" has no answer, and that question is the one an enterprise asks
-before it grants access, and again after an incident. `run_log()` here is the per-run record the
-entry calls the gating factor.
+**Originally 16 of the 18 tools ran with no audit trail** — `audit.record` was called inside
+`_run_recipe`, for the IFC edit it performs, not for tool dispatch itself. `dispatch` now audits
+every run, success and failure, so "which tools did this agent run against my project last week?"
+has an answer. `run_log()` here reads that trail and is the per-run record the entry calls the
+gating factor.
+
+The second half took longer to see, because it was not in the callee. `dispatch` can only record the
+identity it is **given**, and the stdio transport — the one path every real agent run takes — passed
+none, so each row read actor `mcp` with no user and no pack. `test_agent_packs.py` asserted runs are
+attributed "to the effective user, not the transport" and passed, because the test supplied a user
+the transport never did. The trail answered *which tools ran* and not *whose agent ran them*, which
+is the half an enterprise asks for. Fixed at the call site; `test_mcp_attribution.py` asserts the
+call site forwards all three, since a test that supplies a caller's arguments cannot notice the
+caller omitting them.
 
 A pack is a **named view over existing tools**. That framing carries the refusals:
 

--- a/services/api/test_mcp_attribution.py
+++ b/services/api/test_mcp_attribution.py
@@ -1,0 +1,87 @@
+"""R22-AGENT-PACKS — the transport must pass the identity, not just the audit accept one.
+
+`test_agent_packs.py` proves `dispatch` audits every run and attributes it "to the effective user,
+not the transport". That check passes because **the test supplies `user=` and `pack=`**. The only
+production caller — the stdio MCP server, the single path any real agent run takes — supplied
+neither, so every row in the governance console read actor `mcp`, user empty, pack empty. The audit
+answered "which tools ran" and could not answer "whose agent ran them".
+
+That is the defect a test supplying the inputs cannot see: it exercises the callee with arguments the
+caller never sends. So these checks are about the **call site**, and the two halves are asserted
+separately:
+
+1. `transport_identity()` — what the transport can honestly claim from the operator's environment,
+   including the case where it can claim nothing;
+2. **the wiring** — that `main()`'s dispatch call actually forwards all three. A perfect
+   `transport_identity` that nothing passes to `dispatch` is the same bug in a new place.
+
+And one refusal: an unconfigured server must **say so**. Recording every run against the transport
+silently is indistinguishable from recording it against a user nobody verified.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_mcp_attribution.py
+"""
+import ast
+import sys
+
+sys.path.insert(0, "src")
+
+import mcp_server  # noqa: E402
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+# --- 1. what the transport can honestly claim -----------------------------------------------------
+bare = mcp_server.transport_identity({})
+check("with nothing configured the run is NOT attributed", bare["attributed"] is False, bare)
+check("  and the actor names the transport rather than inventing a person",
+      bare["actor"] == mcp_server.TRANSPORT_ACTOR and bare["user"] is None, bare)
+check("  with no pack claimed", bare["pack"] is None, bare)
+
+conf = mcp_server.transport_identity({mcp_server.ENV_USER: "sam@acme.com",
+                                      mcp_server.ENV_PACK: "submittal_review"})
+check("a configured user IS carried", conf["user"] == "sam@acme.com", conf)
+check("  and marks the run attributed", conf["attributed"] is True, conf)
+check("  carrying the pack the operator configured", conf["pack"] == "submittal_review", conf)
+
+check("whitespace is not an identity — a blank value is absent, not a user named ' '",
+      mcp_server.transport_identity({mcp_server.ENV_USER: "   "})["attributed"] is False)
+check("a custom actor is honoured",
+      mcp_server.transport_identity({mcp_server.ENV_ACTOR: "ci-runner"})["actor"] == "ci-runner")
+
+# --- the refusal: an unattributed server says so --------------------------------------------------
+said: list[str] = []
+check("an UNATTRIBUTED server warns at startup", mcp_server._warn_unattributed(bare, said.append))
+check("  naming the variable that fixes it", mcp_server.ENV_USER in "".join(said), said)
+check("  and saying what the trail can and cannot answer", "not who ran it" in "".join(said), said)
+said2: list[str] = []
+check("a configured server does NOT nag", mcp_server._warn_unattributed(conf, said2.append) is False)
+check("  and stays silent", said2 == [], said2)
+
+# --- 2. THE WIRING — the half the callee's own test cannot see ------------------------------------
+# Asserted against the parsed call site, because the alternative is importing FastMCP, which is an
+# OPTIONAL dependency. A check that silently skips when the SDK is absent would pass on every
+# machine that cannot run it, which is the shape of a gate that never fails.
+tree = ast.parse(open(mcp_server.__file__, encoding="utf-8").read())
+calls = [n for n in ast.walk(tree)
+         if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+         and n.func.attr == "dispatch"]
+check("main() really calls mcp_tools.dispatch — exactly once", len(calls) == 1, len(calls))
+kw = {k.arg for k in calls[0].keywords} if calls else set()
+check("THE CALL SITE FORWARDS THE IDENTITY — actor, user AND pack",
+      {"actor", "user", "pack"} <= kw, sorted(kw))
+check("  and dispatch actually accepts all three, so the forward is not a silent no-op",
+      all(p in __import__("inspect").signature(
+          __import__("aec_api.mcp_tools", fromlist=["dispatch"]).dispatch).parameters
+          for p in ("actor", "user", "pack")))
+
+print()
+if FAILED:
+    print(f"mcp_attribution: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("mcp_attribution: all checks passed")


### PR DESCRIPTION
## The defect

`dispatch()` audits every MCP run, success and failure — and `test_agent_packs.py` asserts runs are attributed **"to the effective user, not the transport"**. That check passed the whole time because **the test supplied `user=` and `pack=`**.

The stdio MCP server — `services/api/mcp_server.py`, the one path every real agent run takes — called `dispatch(db, tool["name"], kwargs)` with none of them. Every production audit row read actor `mcp`, no user, no pack. The trail answered *which tools ran* and never *whose agent ran them*, which is the half an enterprise asks for before granting access and again after an incident — the thing the roadmap entry calls "the gating factor for enterprise adoption".

**A test that supplies a caller's arguments cannot notice the caller omitting them.** Same family as #205, one layer out.

## The fix

The transport reads `AEC_MCP_USER` / `AEC_MCP_ACTOR` / `AEC_MCP_PACK` and forwards all three. Two refusals:

1. **It warns at startup when runs will be unattributable.** Silently recording every run against the transport is indistinguishable from recording it against a user nobody verified.
2. **No person-shaped default.** A placeholder like the OS username would put an unverified name in an audit trail. The stdio server authenticates nobody, so a configured user is an *operator assertion*, and `attributed` says which it is rather than letting a configured string pass for a login.

## Verification

- `test_mcp_attribution.py` — 16 checks. It asserts the **call site**, parsed from source, because `FastMCP` is an optional dependency and a check that silently skips when the SDK is absent would pass on every machine that cannot run it.
- **Mutation-checked**: restoring the original kwargs-only call gives **1 named FAIL, 0 tracebacks**; restored file byte-identical and green.
- Full suite **529/530** — the one failure is `test_claude_md_gates`, because the new test was untracked at run time; it passes at the commit SHA.
- `ruff` clean on everything CI lints. `mcp_server.py` carries one pre-existing I001 from main; CI lints only `src/` and `../data/src/`, so it is out of scope and I left it rather than mixing unrelated churn in.

## Also

`agent_packs.py`'s docstring stated the already-closed "16 of the 18 tools run with no audit trail" in the **present tense**; corrected to say what was closed and when.

**Remaining for this ring: the governance console itself — Lane A/E, not C.**

## Sequencing

Touches `run_tests.py`, as do #193 and #205. Manifest verified by set-difference against current main: 529 → 530, nothing lost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP connections can now identify the effective user, actor, and pack for each tool operation.
  - Tool activity, including read operations and failed attempts, is consistently attributed for auditing.
- **Bug Fixes**
  - Prevented unattributed runs from receiving invented default identities.
  - Added clear startup warnings when user attribution is unavailable.
  - Improved handling and validation of custom attribution values.
- **Documentation**
  - Clarified attribution behavior, audit coverage, and remaining governance-console work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->