### PR TITLE
R22-PROVENANCE — the estimate leg gathered for real, and the rename that would have faked it

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -582,9 +582,26 @@ stakes we are missing.
 
 **Tier 2 — evidence, provenance and procurement**
 
-- ◧ **R22-PROVENANCE** *(L — `assumption_provenance.py`, `provenance_report.py` shipped)* — **cite to file, page and revision.** Every proforma assumption, estimate
+- ◧ **R22-PROVENANCE** *(L — assumptions + estimate legs done; ANSWERS leg is the remainder)* — **cite to file, page and revision.** Every proforma assumption, estimate
   line and agent answer traceable to a source page. Three of thirteen platforms *lead* with this; it
   is what makes AI output admissible in an IC memo or a claim.
+
+  **Estimate leg closed 2026-08-06.** `provenance_report` already said exactly what was missing, in
+  code rather than prose: the `estimate` register stored line items as code/description/qty/unit/
+  unit_cost/amount and captured no `source`, `quote_ref` or `basis_date`, so `boe_ledger` could only
+  run on lines posted in a request body. Those three columns now exist and `from_project` gathers the
+  leg from stored records.
+  *The bug that mattered was the seam, not the columns.* `boe_ledger` reads `cost_code` and `total`;
+  the register writes `code` and `amount`. Passing the rows over unmapped does not raise — `_key()`
+  falls through to `description`, so every line still gets a key, `cost_code` returns None on every
+  row, and `total` silently drops to None for any line priced as a lump sum rather than qty x unit
+  cost. That is a full, plausible, quietly-wrong ledger. The mapping is now stated in one place and
+  `services/api/test_provenance_estimate_leg.py` asserts it against `boe_ledger`'s **real output**,
+  not a fixture written to agree with it; mutation-checked by emptying the map (4 named FAILs).
+  **The ANSWERS leg stays `not_captured` and the verdict still cannot read `admissible`** — agent
+  answers are not persisted at all (`cited_answer` is an in-flight contract with no store behind it),
+  and a leg reading `no_data` because nobody filled it in is a different problem from having nowhere
+  to put it. A store of answered claims is the remaining schema change.
 
 - ✅ **R22-OPTION-OBJECT** *(S/M — done)* — option as the primary object: geometry + unit mix + cost +
   carbon + IRR as one comparable record, so no massing is ever evaluated without its returns.

--- a/services/api/modules/estimate/module.json
+++ b/services/api/modules/estimate/module.json
@@ -74,6 +74,27 @@
           "name": "amount",
           "label": "Amount",
           "type": "currency"
+        },
+        {
+          "name": "source",
+          "label": "Source",
+          "type": "select",
+          "options": [
+            "allowance",
+            "parametric",
+            "historical",
+            "quote"
+          ]
+        },
+        {
+          "name": "quote_ref",
+          "label": "Quote ref",
+          "type": "text"
+        },
+        {
+          "name": "basis_date",
+          "label": "Basis date",
+          "type": "date"
         }
       ],
       "total_column": "amount",

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -37,7 +37,7 @@ from collections import Counter
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-TESTS = ["test_provenance_report", "test_proforma", "test_renovation", "test_rollover", "test_income_basis", "test_cost", "test_g702_lines", "test_modules", "test_dashboard",
+TESTS = ["test_provenance_report", "test_provenance_estimate_leg", "test_proforma", "test_renovation", "test_rollover", "test_income_basis", "test_cost", "test_g702_lines", "test_modules", "test_dashboard",
          "test_rbac", "test_auth", "test_condition_checks", "test_connections", "test_presence", "test_collab", "test_serving", "test_api",
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
          # R22-ENTITLE-RISK — approval odds + entitlement duration in the Monte Carlo:

--- a/services/api/src/aec_api/provenance_report.py
+++ b/services/api/src/aec_api/provenance_report.py
@@ -106,16 +106,42 @@ def _leg_answers(answers: list[dict] | None) -> dict[str, Any]:
 #: What each un-gatherable leg would need before a project-scoped verdict could include it. Named
 #: rather than described, so the follow-up is a schema change somebody can action, not a sentiment.
 NOT_CAPTURED_REASON: dict[str, str] = {
-    "estimate": ("the `estimate` register stores line_items as code/description/qty/unit/unit_cost/"
-                 "amount — it captures no `source`, `quote_ref` or `basis_date` per line, which are "
-                 "exactly the fields a basis-of-estimate ledger checks. `boe_ledger` can therefore "
-                 "only run on lines posted in a request body. Capturing those three columns is what "
-                 "would make this leg gatherable"),
     "answers": ("agent answers are not persisted at all. `cited_answer` is an in-flight contract "
                 "consumed by decision_gate / persona_answer / rfi_qa; no store keeps the answers or "
                 "their citations after the response is returned. A store of answered claims is what "
                 "would make this leg gatherable"),
 }
+
+
+#: The `estimate` register and `boe_ledger` name two of the same things differently: the register's
+#: table columns are `code` and `amount`, the ledger reads `cost_code` and `total`. Handing the rows
+#: over unmapped is not a crash — it is worse. `_key()` falls through to `description`, so every line
+#: still gets a key, `cost_code` comes back None on every row, and `total` silently drops to None for
+#: any line priced as a lump sum rather than qty x unit_cost. The result is a full, plausible,
+#: quietly-wrong ledger. So the mapping is written down in one place, and asserted in
+#: `test_provenance_estimate_leg.py` against `boe_ledger`'s real output rather than against a
+#: fixture written to match it.
+ESTIMATE_TO_BOE: dict[str, str] = {"code": "cost_code", "amount": "total"}
+
+
+def estimate_lines(records: list[dict] | None) -> list[dict[str, Any]]:
+    """Every line item across a project's estimate records, in the shape `boe_ledger` reads.
+
+    Pass-through for anything already named the ledger's way, so a record that carries `cost_code`
+    outright is not clobbered by an absent `code`.
+    """
+    out: list[dict[str, Any]] = []
+    for rec in records or []:
+        data = (rec.get("data") or rec) if isinstance(rec, dict) else {}
+        for ln in (data.get("line_items") or []):
+            if not isinstance(ln, dict):
+                continue
+            row = dict(ln)
+            for src, dst in ESTIMATE_TO_BOE.items():
+                if row.get(dst) in (None, "") and ln.get(src) not in (None, ""):
+                    row[dst] = ln[src]
+            out.append(row)
+    return out
 
 
 def from_project(db, project_id: str, scenario_id: str | None = None) -> dict[str, Any]:
@@ -141,8 +167,15 @@ def from_project(db, project_id: str, scenario_id: str | None = None) -> dict[st
         from . import assumption_provenance
         ap = assumption_provenance.scenario_provenance(scen)
 
-    out = report(ap, None, None)
-    for name in ("estimate", "answers"):
+    from . import boe_ledger
+    from . import modules as me
+
+    lines = estimate_lines(
+        me.list_records(db, "estimate", project_id, limit=100000) if "estimate" in me.TABLES else [])
+    led = boe_ledger.ledger(lines) if lines else None
+
+    out = report(ap, led, None)
+    for name in ("answers",):
         lg = next(x for x in out["legs"] if x["leg"] == name)
         lg["status"] = STATUS_NOT_CAPTURED
         lg["note"] = NOT_CAPTURED_REASON[name]
@@ -153,10 +186,14 @@ def from_project(db, project_id: str, scenario_id: str | None = None) -> dict[st
     out["scenario_id"] = getattr(scen, "id", None)
     out["verdict"] = VERDICT_INCOMPLETE if out["verdict"] == VERDICT_ADMISSIBLE else out["verdict"]
     out["note"] = (
-        "a project-scoped verdict can never read `admissible` today: two of the three legs are "
-        "NOT_CAPTURED — the system has nowhere to store their evidence — so no project can satisfy "
-        "them. That is a statement about this schema, not about the deal, and it is reported rather "
-        "than hidden by scoring only the leg that happens to work. " + out["note"])
+        "a project-scoped verdict still cannot read `admissible`: the ANSWERS leg is NOT_CAPTURED — "
+        "agent answers are not persisted, so the system has nowhere to store that evidence and no "
+        "project can satisfy it. That is a statement about this schema, not about the deal. The "
+        "estimate leg IS now gathered from the `estimate` register, whose line items carry `source`, "
+        "`quote_ref` and `basis_date`; an estimate leg reading `no_data` means nobody filled them in, "
+        "which is a different problem from having nowhere to put them, and the two are reported "
+        "differently on purpose. Nothing here is hidden by scoring only the leg that happens to "
+        "work. " + out["note"])
     return out
 
 

--- a/services/api/test_provenance_estimate_leg.py
+++ b/services/api/test_provenance_estimate_leg.py
@@ -1,0 +1,118 @@
+"""R22-PROVENANCE — the estimate leg, gathered for real, and the rename that would have faked it.
+
+`provenance_report` reported the estimate leg `not_captured` and said exactly why: the `estimate`
+register stored line items as code/description/qty/unit/unit_cost/amount and captured no `source`,
+`quote_ref` or `basis_date` — the three fields a basis-of-estimate ledger checks. Those columns now
+exist, so the leg is gathered from stored records instead of only from a request body.
+
+**The check that matters is the seam, not the columns.** `boe_ledger` reads `cost_code` and `total`;
+the register's columns are `code` and `amount`. Handing the rows over unmapped does not crash — and
+that is the danger. `_key()` falls through to `description`, so every line still gets a key,
+`cost_code` comes back None on every row, and `total` silently drops to None for any line priced as a
+lump sum rather than qty x unit_cost. The output is a full, plausible, quietly-wrong ledger.
+
+So these checks are written against `boe_ledger`'s REAL output — the module is imported and run, not
+imitated by a fixture built to agree with my mapping. A fixture that supplies both sides of a seam
+agrees with itself no matter which side is wrong.
+
+The other refusal: the ANSWERS leg must stay `not_captured`. Closing one leg is not closing the ring,
+and a verdict that quietly promoted itself to `admissible` would be the exact failure this module was
+written to prevent.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_provenance_estimate_leg.py
+"""
+import json
+import sys
+
+sys.path.insert(0, "src")
+
+from aec_api import boe_ledger  # noqa: E402
+from aec_api import provenance_report as pr
+
+FAILED: list[str] = []
+
+
+def check(label, ok, detail=""):
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{(' — ' + str(detail)) if detail and not ok else ''}")
+    if not ok:
+        FAILED.append(label)
+
+
+# --- the register really carries the three columns now --------------------------------------------
+mod = json.load(open("modules/estimate/module.json", encoding="utf-8"))
+cols = {c["name"] for f in mod["fields"] if f["name"] == "line_items" for c in f["columns"]}
+for c in ("source", "quote_ref", "basis_date"):
+    check(f"the estimate register captures {c!r}", c in cols, sorted(cols))
+check("  without dropping the columns it already had",
+      {"code", "description", "qty", "unit", "unit_cost", "amount"} <= cols, sorted(cols))
+
+# --- THE SEAM — asserted against boe_ledger's real behaviour ---------------------------------------
+REC = [{"data": {"line_items": [
+    # a lump-sum line: NO qty/unit_cost, so `total` can only come from `amount`
+    {"code": "03 30 00", "description": "Concrete", "amount": 250_000,
+     "source": "quote", "quote_ref": "Q-118", "basis_date": "2026-06-01"},
+    # a measured line, fully documented
+    {"code": "04 20 00", "description": "Masonry", "qty": 1200, "unit": "sf", "unit_cost": 32,
+     "amount": 38_400, "source": "historical", "basis_date": "2026-05-14"},
+    # undocumented: no source, no basis date
+    {"code": "09 90 00", "description": "Painting", "qty": 5000, "unit": "sf", "unit_cost": 3,
+     "amount": 15_000},
+]}}]
+
+mapped = pr.estimate_lines(REC)
+check("every line item is gathered", len(mapped) == 3, len(mapped))
+
+led = boe_ledger.ledger(mapped)
+rows = {r["description"]: r for r in led["lines"]}
+
+check("THE COST CODE SURVIVES THE SEAM — boe_ledger sees cost_code, the register wrote code",
+      rows["Concrete"]["cost_code"] == "03 30 00", rows["Concrete"])
+check("  so the ledger keys on the code, not on the description text",
+      led["lines"][0]["key"] == "03 30 00", led["lines"][0]["key"])
+check("THE LUMP-SUM AMOUNT SURVIVES — a line with no qty x unit_cost still has a total",
+      rows["Concrete"]["total"] == 250_000, rows["Concrete"]["total"])
+check("  while a measured line is still computed from qty x unit_cost",
+      rows["Masonry"]["total"] == 38_400, rows["Masonry"]["total"])
+check("the documentation fields arrive",
+      rows["Concrete"]["source"] == "quote" and rows["Concrete"]["quote_ref"] == "Q-118"
+      and rows["Concrete"]["basis_date"] == "2026-06-01", rows["Concrete"])
+
+check("the undocumented line is CAUGHT, not counted as fine",
+      [u["description"] for u in led["undocumented"]] == ["Painting"], led["undocumented"])
+check("  naming which fields it lacks", sorted(led["undocumented"][0]["missing"]) ==
+      ["basis_date", "source"], led["undocumented"][0]["missing"])
+check("two of three lines are documented", led["documented"] == 2, led["documented"])
+
+# a quote line with no quote_ref is its own failure, and the register can now express it
+q = boe_ledger.ledger(pr.estimate_lines(
+    [{"data": {"line_items": [{"code": "1", "description": "X", "amount": 1, "source": "quote",
+                               "basis_date": "2026-01-01"}]}}]))
+check("a line claiming a QUOTE with no quote ref is undocumented",
+      q["undocumented"] and "quote_ref" in q["undocumented"][0]["missing"], q["undocumented"])
+
+# --- pass-through: a row already named the ledger's way is not clobbered ---------------------------
+pt = pr.estimate_lines([{"data": {"line_items": [
+    {"cost_code": "already", "description": "D", "total": 99}]}}])
+check("a row already using the ledger's names is left alone",
+      pt[0]["cost_code"] == "already" and pt[0]["total"] == 99, pt[0])
+check("the mapping is stated in one place, not scattered",
+      pr.ESTIMATE_TO_BOE == {"code": "cost_code", "amount": "total"}, pr.ESTIMATE_TO_BOE)
+check("no records is no lines, not a crash", pr.estimate_lines(None) == [])
+
+# --- THE REFUSAL — closing one leg is not closing the ring -----------------------------------------
+check("the ANSWERS leg is still declared not-captured",
+      "answers" in pr.NOT_CAPTURED_REASON, sorted(pr.NOT_CAPTURED_REASON))
+check("  and the estimate leg is NO LONGER excused as not-captured",
+      "estimate" not in pr.NOT_CAPTURED_REASON, sorted(pr.NOT_CAPTURED_REASON))
+check("  with the answers reason naming the schema change it needs",
+      "not persisted" in pr.NOT_CAPTURED_REASON["answers"])
+
+rep = pr.report(None, led, None)
+check("a report with a real estimate ledger is NOT admissible on that alone",
+      rep["verdict"] != pr.VERDICT_ADMISSIBLE, rep["verdict"])
+
+print()
+if FAILED:
+    print(f"provenance_estimate_leg: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print("provenance_estimate_leg: all checks passed")

--- a/services/api/test_provenance_report.py
+++ b/services/api/test_provenance_report.py
@@ -159,17 +159,19 @@ with _SL() as _db:
 check("from_project finds the project's scenario", FP["scenario_id"] == "s1", FP.get("scenario_id"))
 check("  the ASSUMPTIONS leg is real — gathered, not supplied",
       leg(FP, "assumptions")["status"] in (STATUS_OK, STATUS_GAPS), leg(FP, "assumptions"))
-check("THE ESTIMATE LEG IS not_captured, NOT no_data",
-      leg(FP, "estimate")["status"] == _pr.STATUS_NOT_CAPTURED, leg(FP, "estimate")["status"])
-check("  and names the exact columns that would make it gatherable",
-      all(k in leg(FP, "estimate")["note"] for k in ("quote_ref", "basis_date")),
-      leg(FP, "estimate")["note"])
+# The estimate leg WAS not_captured; the register now carries source/quote_ref/basis_date and
+# `from_project` gathers it, so with no estimate records this project reports no_data — "nobody
+# filled it in", which is a different sentence from "there is nowhere to put it".
+check("THE ESTIMATE LEG IS NOW GATHERED — no_data, no longer not_captured",
+      leg(FP, "estimate")["status"] == STATUS_NO_DATA, leg(FP, "estimate")["status"])
+check("  and is no longer excused as un-storable",
+      "estimate" not in _pr.NOT_CAPTURED_REASON, sorted(_pr.NOT_CAPTURED_REASON))
 check("THE ANSWERS LEG IS not_captured — agent answers are never persisted",
       leg(FP, "answers")["status"] == _pr.STATUS_NOT_CAPTURED, leg(FP, "answers")["status"])
 check("  naming what would make it gatherable", "store of answered claims"
       in leg(FP, "answers")["note"], leg(FP, "answers")["note"])
-check("the two are LISTED separately from absent legs",
-      FP["legs_not_captured"] == ["estimate", "answers"], FP.get("legs_not_captured"))
+check("ONE leg remains un-storable, and is listed separately from merely-absent legs",
+      FP["legs_not_captured"] == ["answers"], FP.get("legs_not_captured"))
 
 check("A PROJECT VERDICT CANNOT READ admissible TODAY — and says why",
       FP["verdict"] != VERDICT_ADMISSIBLE, FP["verdict"])
@@ -183,7 +185,7 @@ check("a project with no scenario still answers, rather than erroring",
 check("  its assumptions leg is no_data — a source EXISTS and is empty",
       leg(EMPTY, "assumptions")["status"] == STATUS_NO_DATA, leg(EMPTY, "assumptions")["status"])
 check("  so no_data and not_captured coexist in one report, meaning different things",
-      {leg(EMPTY, "assumptions")["status"], leg(EMPTY, "estimate")["status"]}
+      {leg(EMPTY, "assumptions")["status"], leg(EMPTY, "answers")["status"]}
       == {STATUS_NO_DATA, _pr.STATUS_NOT_CAPTURED},
       [(x["leg"], x["status"]) for x in EMPTY["legs"]])
 


### PR DESCRIPTION
## What this closes

`provenance_report` already said exactly what was missing — in code, not prose. `NOT_CAPTURED_REASON["estimate"]` named it: the `estimate` register stored line items as code/description/qty/unit/unit_cost/amount and captured no `source`, `quote_ref` or `basis_date`, so `boe_ledger` could only ever run on lines posted in a request body. Those three columns now exist and `from_project` gathers the leg from stored records.

That entry was the best premise-check in the repo: an actionable schema change written next to the code that needed it, rather than a sentiment in a doc.

## The bug that mattered was the seam, not the columns

`boe_ledger` reads **`cost_code`** and **`total`**. The register writes **`code`** and **`amount`**.

Handing the rows over unmapped does not raise — and that is the danger:
- `_key()` falls through to `description`, so **every line still gets a key**;
- `cost_code` comes back `None` on every row;
- `total` silently drops to `None` for any line priced as a **lump sum** rather than qty × unit_cost.

The result is a full, plausible, quietly-wrong ledger — an estimate you'd defend line-by-line built on codes that aren't there.

The mapping is now stated in one place (`ESTIMATE_TO_BOE`) and `test_provenance_estimate_leg.py` asserts it against **`boe_ledger`'s real output** — the module is imported and run, not imitated by a fixture built to agree with my mapping. Mutation-checked by emptying the map: **4 named FAILs, 0 tracebacks**, restored byte-identical and green.

This is the seam pattern from #205 and #209 for the third time, which is why the test is written to supply *neither* side.

## What this deliberately does NOT close

**The ANSWERS leg stays `not_captured`, and a project verdict still cannot read `admissible`.** Agent answers are not persisted at all — `cited_answer` is an in-flight contract with no store behind it. A leg reading `no_data` because nobody filled it in is a different problem from having nowhere to put it, and the module reports the two differently on purpose. A store of answered claims is the remaining schema change.

## The existing contract caught this correctly

`test_provenance_report.py` failed on five assertions that encoded the old truth ("THE ESTIMATE LEG IS not_captured, NOT no_data"). Those were **updated, not deleted** — the intent worth keeping is that `no_data` and `not_captured` mean different things and must coexist in one report, so that check now pairs assumptions against *answers*. I also restored a phrase I'd dropped from the module note ("not hidden by scoring only the leg that happens to work") rather than weakening the test to match my edit.

## Verification

- `test_provenance_estimate_leg.py` — 21 checks; `test_provenance_report.py` green again.
- Full suite **529/530**; the one failure was `test_claude_md_gates` on the then-untracked test.
- Verified at the commit SHA in a clean worktree: `claude_md_gates`, `provenance_estimate_leg`, `provenance_report`, `boe_ledger`, `manifest` all green.
- `ruff` clean. Manifest re-applied by anchor onto current main (the roadmap patch conflicted after #205/#207/#209 landed, so both shared files were re-applied rather than patched); set-differenced: nothing lost, one entry gained.
