### PR TITLE
R22-OPTION-OBJECT — the record had no front door, and neither did the three routes it joins

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -2,6 +2,7 @@
  *  metadata and work artifacts (pins/RFIs/viewpoints) come from here. */
 import { withAuth } from "./auth";
 import { withAuthoring } from "./authoring";
+import { withDesignOptions } from "./designOptions";
 import { withLibrary } from "./library";
 import { HttpCore, type LiveStream } from "./httpCore";
 import { withModel } from "./model";
@@ -27,15 +28,14 @@ export * from "./library";
 import type {
   Appraisal, AuditEntry, ConnectionItem, Dashboard, DocFile,
   DisciplineTree, DocFolderNode, DrawingMarkupItem, DueFeed, EditMacro, EscalationScan, EscalationRun, ElementProps, EnergyResult, IntegrationGroup, Job, LifecycleStrip, ModelCiReport, WorkQueue, ModulePin, ModuleRecord, MonteCarloMetric, RoomAllocation,
-  LogisticsResource, NotifItem, OpendataPermit, ProjectMember, ProjectRole, PropLayer, PropMapRule,
-  PreflightGate, PreflightSummary, ProfessionalLicense,
+  LogisticsResource, NotifItem, OpendataPermit, ProjectMember, ProjectRole, PropLayer, PropMapRule, PreflightGate, PreflightSummary, ProfessionalLicense,
   ResolveAction, ResponsibilityMatrix, SheetMarkupIn, SmartView, StampTemplate, SyncScheduleItem,
   Topic, Vec3, Viewpoint, WorkItem, VitalsPayload } from "./types";
 
 
 // Transport (baseUrl, token, json/_pdfPost/url/health) lives in HttpCore; ApiClient adds the typed
 // domain methods below. Every `api.method()` call site is unchanged by the split.
-export class ApiClient extends withAuth(withProforma(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore))))))))) {
+export class ApiClient extends withAuth(withProforma(withDesignOptions(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore)))))))))) {
   /** Admin: integration settings (AI / email / SSO). Secret values are never returned. */
   integrations() {
     return this.json<{ groups: IntegrationGroup[] }>("/settings/integrations");
@@ -2976,22 +2976,6 @@ export class ApiClient extends withAuth(withProforma(withProcurement(withEstimat
     return this.url(`/projects/${pid}/contracts/completion_certificate/${certRid}/document.pdf?doc=g704`);
   }
 
-  designOptionsGenerate(pid: string, base: Record<string, unknown>, types?: string[]) {
-    return this.json<{ options: Record<string, unknown>[] }>(
-      `/projects/${pid}/design/options/generate`,
-      { method: "POST", body: JSON.stringify({ base, ...(types ? { types } : {}) }) });
-  }
-  designOptionsScore(pid: string, options: Record<string, unknown>[], weights?: Record<string, number>) {
-    return this.json<{
-      options: { label: string; building_type: string; composite: number; compliant: boolean;
-        violations: string[]; cost_total: number; cost_per_sf: number | null;
-        carbon_total_tco2e: number; carbon_intensity_kgco2e_m2: number;
-        yield_net_sellable_m2: number; scores: Record<string, number>;
-        massing: { floors: number; building_height_m: number; buildable_gfa_sf: number; units: number | null } }[];
-      weights: Record<string, number>; recommended: string | null; note: string;
-    }>(`/projects/${pid}/design/options/score`,
-      { method: "POST", body: JSON.stringify({ options, ...(weights ? { weights } : {}) }) });
-  }
   ifcClassify(pid: string) {
     return this.json<{ suggestions: { guid?: string; name: string; current_class: string;
       suggested_class: string; confidence: string; reason: string }[]; count: number;

--- a/apps/web/src/api/designOptions.ts
+++ b/apps/web/src/api/designOptions.ts
@@ -1,0 +1,59 @@
+/** Design options: generate + score envelope variants, and the stored options as ONE record.
+ *
+ *  Route-group `/projects/{pid}/design/options/*`, taken out of `client.ts` because the size ratchet
+ *  in `services/api/test_file_sizes.py` says so in as many words — "a new endpoint added straight to
+ *  `client.ts` will fail this, and that friction is the point." Adding `designOptionsRecord` there
+ *  put the file 11 lines over its pin, so the group moved instead of the pin moving.
+ *
+ *  **`designOptionsRecord` is new, and it exists because the endpoint was unreachable.** It is not
+ *  alone: `/design/options/{compare,carbon,economics}` have no client caller either, and no panel
+ *  references the `design_option` register at all — the whole stored-option family was server-only.
+ *  R22-OPTION-OBJECT's thesis is that no massing should be evaluated without its returns, which
+ *  requires a human to see it, so a record nothing can fetch does not close the ring.
+ *
+ *  It is deliberately the ONLY one of the four wired: the record IS the join over the other three,
+ *  so calling it replaces reconciling three screens by eye rather than adding a fourth.
+ *
+ *  Note `test_route_reachability` never flagged any of this. Its rule fires when a route's last
+ *  static segment appears nowhere in the web source; `record` appears everywhere (`ModuleRecord`,
+ *  `records`), so the route sits squarely in that gate's own documented false-negative class. The
+ *  gate is honest about the blind spot — this is what falling into it looks like.
+ *
+ *  A mixin, so every call site resolves unchanged.
+ */
+import { HttpCore } from "./httpCore";
+import type { OptionRecordSet } from "./types";
+
+type Ctor<T> = new (...args: any[]) => T;
+
+export function withDesignOptions<TBase extends Ctor<HttpCore>>(Base: TBase) {
+  return class DesignOptions extends Base {
+  designOptionsGenerate(pid: string, base: Record<string, unknown>, types?: string[]) {
+    return this.json<{ options: Record<string, unknown>[] }>(
+      `/projects/${pid}/design/options/generate`,
+      { method: "POST", body: JSON.stringify({ base, ...(types ? { types } : {}) }) });
+  }
+  designOptionsScore(pid: string, options: Record<string, unknown>[], weights?: Record<string, number>) {
+    return this.json<{
+      options: { label: string; building_type: string; composite: number; compliant: boolean;
+        violations: string[]; cost_total: number; cost_per_sf: number | null;
+        carbon_total_tco2e: number; carbon_intensity_kgco2e_m2: number;
+        yield_net_sellable_m2: number; scores: Record<string, number>;
+        massing: { floors: number; building_height_m: number; buildable_gfa_sf: number; units: number | null } }[];
+      weights: Record<string, number>; recommended: string | null; note: string;
+    }>(`/projects/${pid}/design/options/score`,
+      { method: "POST", body: JSON.stringify({ options, ...(weights ? { weights } : {}) }) });
+  }
+  /**
+   * The design options as one comparable record — geometry, unit mix, cost, carbon, returns.
+   *
+   * This is the join over `/design/options/{compare,carbon,economics}`, which is why the UI calls
+   * this rather than those three: reconciling three screens by eye is how a massing gets evaluated
+   * without its returns, one screen at a time. It re-derives nothing — every number comes from the
+   * engine that owns it — so it cannot disagree with a screen opened beside it.
+   */
+  designOptionsRecord(pid: string) {
+    return this.json<OptionRecordSet>(`/projects/${pid}/design/options/record`);
+  }
+  };
+}

--- a/apps/web/src/api/surface.test.ts
+++ b/apps/web/src/api/surface.test.ts
@@ -86,12 +86,17 @@ describe("the API client's public surface", () => {
     // plainly: **an extraction is the occasion to re-read this number, never the cause of it moving.**
     // Anyone raising this line because their own change grew the surface should say so here; anyone
     // raising it to make a red test go green has inverted the gate.
+    // 2026-08-06 (design/options extraction): raised 702 -> 703. The move of designOptionsGenerate
+    // and designOptionsScore into designOptions.ts is invisible to this reader, which is the point;
+    // the +1 is designOptionsRecord, a client caller for an endpoint that had none. The whole
+    // stored-option family was server-only: /design/options/{compare,carbon,economics} have no
+    // caller either and no panel touched the design_option register at all.
     // 2026-08-06 (SCALE-SEAM ⑧): raised 699 -> 702, and the +3 is NEW SURFACE, not a moved one.
     // The /proforma extraction moved 15 methods and this reader counted **699 both before and after
     // the move** — that is the evidence nothing was dropped. The three added methods
     // (proformaRenovation / proformaRollover / proformaIncomeBasis) are client callers for endpoints
     // that had none, which is why the floor legitimately rises.
-    expect(surface.size, `only ${surface.size} methods reachable`).toBeGreaterThanOrEqual(702);
+    expect(surface.size, `only ${surface.size} methods reachable`).toBeGreaterThanOrEqual(703);
   });
 
   it("keeps the transport primitives the domain methods are built on", () => {

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -613,3 +613,43 @@ export interface Job {
   started_at: string | null;
   finished_at: string | null;
 }
+
+/**
+ * R22-OPTION-OBJECT — a design option as ONE comparable record across the five axes.
+ *
+ * `axes` values are `null` when the axis is ABSENT, never 0. That distinction is the whole point of
+ * the record: `option_score` once coerced a missing `cost_per_sf` to 0.0 and, on a lower-is-better
+ * axis, scored it 100 — the best possible mark, awarded for having no data. Render an absent axis as
+ * absent; do not fall back to `?? 0`, and do not sort on an axis without checking `axis_status`.
+ *
+ * There is no rank, score or recommendation here, deliberately — `option_score` owns ranking and
+ * does it honestly. `comparable_count` below the option count means some massing is being evaluated
+ * without its returns, and `incomparable` says which.
+ */
+export type OptionAxis = "geometry" | "unit_mix" | "cost" | "carbon" | "returns";
+export type OptionAxisStatus = "present" | "absent";
+
+export interface OptionRecord {
+  id: string;
+  name: string;
+  state: string | null;
+  axes: Record<OptionAxis, number | null>;
+  axis_status: Record<OptionAxis, OptionAxisStatus>;
+  /** How each engine got its number: declared / benchmark / derived / unlinked / unavailable. */
+  carbon_basis: string | null;
+  economics_basis: string | null;
+  missing_axes: OptionAxis[];
+  comparable: boolean;
+  note: string;
+}
+
+export interface OptionRecordSet {
+  options: OptionRecord[];
+  option_count: number;
+  /** Options comparable on ALL five axes. Below `option_count` is the number worth surfacing. */
+  comparable_count: number;
+  incomparable: { id: string; name: string; missing_axes: OptionAxis[] }[];
+  axes: OptionAxis[];
+  project_id?: string;
+  note: string;
+}

--- a/apps/web/src/portal/panels/design.ts
+++ b/apps/web/src/portal/panels/design.ts
@@ -360,3 +360,82 @@ export async function renderEsg(ctx: PanelContext) {
     a.href = ctx.host.api.reportUrl(pid, "esg", "pdf"); a.target = "_blank"; a.rel = "noopener";
     rb.append(a); body.append(rb);
   }
+
+// --- R22-OPTION-OBJECT: the design options as ONE comparable record ------------------------------
+/**
+ * Geometry · unit mix · cost · carbon · returns per option, so no massing is evaluated without its
+ * returns. This is the join over /design/options/{compare,carbon,economics}; none of those three had
+ * a client caller and no panel touched the `design_option` register at all, so the whole stored
+ * option family was server-only until this.
+ *
+ * **An absent axis renders as absent, never as 0.** `option_score` once coerced a missing
+ * `cost_per_sf` to 0.0 and, on a lower-is-better axis, scored it 100 — the best possible mark for
+ * having no data. `?? 0` anywhere below would put that bug back on the screen.
+ *
+ * It shows no ranking, deliberately: `option_score` owns ranking and does it honestly.
+ */
+export async function renderOptionRecord(ctx: PanelContext) {
+  const root = ctx.root; root.innerHTML = "";
+  const el = (t: string, c = "") => { const e = document.createElement(t); if (c) e.className = c; return e; };
+  root.appendChild(ctx.bar("⚖ Option comparison", () => { ctx.activeKey = null; void ctx.renderHome(); ctx.buildNav(); }));
+  const pid = ctx.host.projectId();
+  if (!pid) { root.insertAdjacentHTML("beforeend", noProjectHtml("Option comparison")); return; }
+
+  const intro = el("div", "meta"); intro.style.marginBottom = "8px";
+  intro.textContent = "Each design option on all five axes at once — geometry, unit mix, cost, carbon "
+    + "and returns — so a scheme is never chosen on the axes that happen to be filled in. Every number "
+    + "comes from the engine that owns it, so this cannot disagree with the option screens.";
+  root.appendChild(intro);
+
+  const body = el("div"); body.textContent = "loading…"; root.appendChild(body);
+  let r;
+  try { r = await ctx.host.api.designOptionsRecord(pid); }
+  catch (e) { body.textContent = `failed: ${(e as Error).message}`; return; }
+  body.innerHTML = "";
+
+  if (!r.option_count) {
+    body.innerHTML = `<div class="meta">No design options recorded yet. Add them in the Design section.</div>`;
+    return;
+  }
+
+  // The headline: not a score, but how many options can actually be compared at all.
+  const banner = el("div", "dash-card");
+  const short = r.comparable_count < r.option_count;
+  banner.innerHTML = `<b>${r.comparable_count} of ${r.option_count}</b> option${r.option_count === 1 ? "" : "s"} `
+    + `comparable on all five axes`
+    + (short ? ` — <span style="color:var(--status-crit)">${r.option_count - r.comparable_count} cannot be `
+        + `compared on every axis, and are not zero on the ones they lack</span>` : "");
+  body.appendChild(banner);
+
+  const fmt = (axis: string, v: number | null) => {
+    if (v === null) return `<span style="color:var(--muted)" title="absent — not recorded, and NOT zero">—</span>`;
+    if (axis === "cost") return "$" + Math.round(v).toLocaleString();
+    if (axis === "returns") return v.toFixed(1) + "%";
+    return Math.round(v).toLocaleString();
+  };
+  const t = el("table", "portal-table") as HTMLTableElement;
+  t.style.cssText = "width:100%;font-size:11px;margin-top:8px";
+  t.innerHTML = `<thead><tr><th scope="col" style="text-align:left">Option</th>`
+    + r.axes.map((a) => `<th scope="col">${esc(a.replace("_", " "))}</th>`).join("")
+    + `<th scope="col" style="text-align:left">Basis</th></tr></thead><tbody>`
+    + r.options.map((o) => `<tr>`
+      + `<td>${o.comparable ? "" : `<span title="${esc(o.note)}">⚠ </span>`}${esc(o.name)}</td>`
+      + r.axes.map((a) => `<td style="text-align:right">${fmt(a, o.axes[a])}</td>`).join("")
+      + `<td class="meta">${esc([o.carbon_basis && `carbon: ${o.carbon_basis}`,
+          o.economics_basis && `economics: ${o.economics_basis}`].filter(Boolean).join(" · "))}</td>`
+      + `</tr>`).join("")
+    + `</tbody>`;
+  body.appendChild(t);
+
+  if (r.incomparable.length) {
+    const gap = el("div", "meta"); gap.style.marginTop = "8px";
+    gap.innerHTML = "<b>Not comparable on every axis:</b> " + r.incomparable
+      .map((x) => `${esc(x.name)} (missing ${esc(x.missing_axes.join(", "))})`).join("; ")
+      + " — a missing axis is absent, not zero. Fill it in rather than reading the gap as a good number.";
+    body.appendChild(gap);
+  }
+  const foot = el("div", "meta"); foot.style.marginTop = "6px";
+  foot.textContent = "No ranking is shown here on purpose — scoring lives in the option scorer, which "
+    + "excludes missing criteria from the pool rather than scoring them as zero.";
+  body.appendChild(foot);
+}

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -115,6 +115,7 @@ export class PortalUI {
       __spine__: () => this.renderSpine(),
       __land__: () => this.renderLandScreen(), __lifecycle__: () => this.renderLifecycle(),
       __diligence__: () => this.renderDiligence(), __esg__: () => this.renderEsg(),
+      __optionrecord__: () => this.renderOptionRecord(),
       __market__: () => this.renderMarket(), __conceptrender__: () => this.renderConceptRender(),
       __materials__: () => this.renderMaterials(),
       __modulegraph__: () => this.renderModuleGraph(),
@@ -635,6 +636,7 @@ export class PortalUI {
   private async renderLandScreen() { return (await import("./panels/design")).renderLandScreen(this.panelCtx()); }
   private async renderLifecycle() { return (await import("./panels/design")).renderLifecycle(this.panelCtx()); }
   private async renderDiligence() { return (await import("./panels/design")).renderDiligence(this.panelCtx()); }
+  private async renderOptionRecord() { return (await import("./panels/design")).renderOptionRecord(this.panelCtx()); }
   private async renderEsg() { return (await import("./panels/design")).renderEsg(this.panelCtx()); }
   private async renderConceptRender() { return (await import("./panels/design")).renderConceptRender(this.panelCtx()); }
   private async renderMaterials() { return (await import("./panels/materials")).renderMaterials(this.panelCtx()); }

--- a/apps/web/src/shell/destinations.ts
+++ b/apps/web/src/shell/destinations.ts
@@ -113,6 +113,7 @@ export const STAGES_BY_WS: Record<string, [string, Dest[]][]> = {
       { key: "__uw__", icon: "📊", label: "Underwriting", goto: "finance" },
       { key: "__land__", icon: "🗺️", label: "Land Screening" },
       { key: "__massingopt__", icon: "🧮", label: "Massing Optioneer" },
+      { key: "__optionrecord__", icon: "⚖", label: "Option Comparison" },
       { key: "__diligence__", icon: "📜", label: "Diligence & Entitlements" },
       { key: "__market__", icon: "💹", label: "Market Intelligence" },
     ]],

--- a/apps/web/src/shell/spine.ts
+++ b/apps/web/src/shell/spine.ts
@@ -155,7 +155,8 @@ export const DEST_ROOM: Record<string, string> = {
   // COBie chain in the first place.
   __operations__: "operate", __fca__: "operate", __assets__: "operate",
   // ── Deal: the asset as an investment ──────────────────────────────────────────────────────────
-  __uw__: "deal", __land__: "deal", __massingopt__: "deal", __diligence__: "deal",
+  __uw__: "deal", __land__: "deal", __massingopt__: "deal", __optionrecord__: "deal",
+  __diligence__: "deal",
   __market__: "deal", __lifecycle__: "deal", __portfolio__: "deal",
   __esg__: "deal",
   // ── Work: whatever is in your court ───────────────────────────────────────────────────────────

--- a/services/api/test_file_sizes.py
+++ b/services/api/test_file_sizes.py
@@ -60,7 +60,7 @@ CEILING = 5_200
 #: post-⑦ the answer is usually yes. Raising an entry is therefore a deliberate act that should be
 #: argued for in the commit message — the direction of travel is down.
 PER_FILE = {
-    "apps/web/src/api/client.ts": 3_796,   # SCALE-SEAM ⑧ (/proforma out); ⑦ 3,871; before ⑦ 3,967
+    "apps/web/src/api/client.ts": 3_780,   # design/options -> designOptions.ts; ⑧ 3,796; ⑦ 3,871;    before ⑦ 3,967
     #: R39-DECOMP-VIEWER. Pinned at its CURRENT size before any extraction, deliberately.
     #:
     #: `app.ts` had no per-file entry, so it lived under the 5,200 global — which it also *set*, being


### PR DESCRIPTION
## The gap was wider than "one route has no caller"

#205 shipped `GET /projects/{pid}/design/options/record` with no client caller. Before wiring it I checked the neighbours:

| route | client callers |
|---|---|
| `/design/options/compare` | **0** |
| `/design/options/carbon` | **0** |
| `/design/options/economics` | **0** |
| `/design/options/record` | 0 (this PR: 1) |

And **no panel references the `design_option` register at all**. The whole stored-option family was server-only. That is why shipping the route did not close the ring: R22-OPTION-OBJECT's thesis is that no massing should be evaluated without its returns, and that requires a human to see it.

**This wires exactly one of the four, deliberately.** The record *is* the join over the other three, so calling it replaces reconciling three screens by eye rather than adding a fourth call.

## A correction to my own merge-hazard warning

I told Core that `test_route_reachability` would flag this route. **It never would have.** Its rule fires only when a path's last static segment appears nowhere in the web source, and `record` appears everywhere (`ModuleRecord`, `records`, …) — squarely inside the false-negative class that gate documents about itself:

> *Any route whose distinctive segment coincides with unrelated text is invisible here.*

Verified rather than assumed: ran the gate against main's unmodified `client.ts` and it passes green either way. **The route needed a caller because it was unreachable, not because a gate demanded one** — and the gate is honest about the blind spot; this is what falling into it looks like from the inside.

## The panel

Renders an absent axis **as absent, never as 0**. `option_score` once coerced a missing `cost_per_sf` to 0.0 and, on a lower-is-better axis, scored it **100** — the best possible mark for having no data. A `?? 0` anywhere in that table would put the bug back on the screen. It shows **no ranking**, because `option_score` owns ranking and does it honestly.

The headline is `comparable_count` of `option_count`, not a score — if it is short, some massing is being evaluated without its returns and the panel names which options and which axes.

Registered at all four sites (dispatch, lazy import, nav destination, spine room), verified by **set-comparison against an existing key** rather than by assuming I'd found them all — an unmapped key is a tab that highlights and does not navigate.

## Why a new mixin instead of one more method on client.ts

The size ratchet says it in as many words:

> *A new endpoint added straight to `client.ts` will fail this, and that friction is the point.*

Adding the method put the file **11 lines over its pin**. So the group moved and **the pin moved down**: 3,796 → 3,780. Mutation-checked at the new pin — +20 lines fails by name, restored byte-identical, green.

`surface.test.ts` floor 702 → 703. The two moved methods are invisible to that reader by design (which is what proves nothing was dropped); the +1 is `designOptionsRecord`, genuinely new surface.

## Verification

- Backend gates green: `test_file_sizes`, `test_route_reachability`, `test_reachable`, `test_claude_md_gates`.
- **Typecheck and web tests are CI's here, and I am not claiming otherwise:** `node_modules` is absent in a git worktree and the web build cannot run in one. Static checks done instead — paren balance on the mixin chain counted explicitly (10/10; an imbalance in ⑧ produced 530 tsc errors), imports confirmed present, registration sites set-compared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Option Comparison workspace for reviewing design alternatives across geometry, unit mix, cost, carbon, and returns.
  * Added design-option generation, scoring, and record retrieval capabilities.
  * Displays comparison data, unavailable values, comparability details, and data sources.
  * Added navigation support for accessing Option Comparison from the Acquire stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->