### PR TITLE
R41-LICENCE-GATE — read the LICENSE file, because a declaration cannot catch a lying declaration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,18 @@ jobs:
       - name: Bundle-size budget (app shell)
         run: npm run budget --workspace apps/web
 
+      # R41-LICENCE-GATE. Runs HERE and not in the API gate on purpose: this job is the one that
+      # runs `npm ci`, so `node_modules` exists. The API job does not install it, and a licence scan
+      # over an absent tree passes by finding nothing — the vacuous-population failure this repo has
+      # hit repeatedly. Where a check runs is part of its claim.
+      #
+      # `services/api/test_license_gate.py` already fails on a GPL/AGPL **Python** distribution, from
+      # its **declared metadata**. This covers the 638-package **npm** tree, which that gate never
+      # saw, and reads each package's **LICENSE file** rather than its badge — because the item this
+      # implements exists precisely because declarations and licence files disagree.
+      - name: Licence allowlist (npm tree, reads LICENSE files)
+        run: npm run licences --workspace apps/web
+
   # Container supply chain: build the deployable images, scan them, and (on main) publish to ghcr
   # with an immutable :sha tag so production can pin digests instead of pulling a mutable :latest.
   containers:

--- a/LICENSE-NOTES.md
+++ b/LICENSE-NOTES.md
@@ -8,11 +8,18 @@ This platform composes components under different licenses. The key rule: keep t
 desktop editor a separate process you *use*, not code you statically link into a proprietary
 product.
 
+> **This table is now checked, not just written.** `apps/web/scripts/check-licences.mjs` reads every
+> npm package's **LICENSE file** — not its badge or its `package.json` field — and fails the build on
+> a forbidden licence or on a package whose file disagrees with its declaration. That gate exists
+> because this very table was wrong: it grouped `web-ifc` with the MIT `@thatopen/*` packages as
+> "MIT-style", and `web-ifc` is **MPL-2.0**. A summary of a licence is not the licence.
+
 | Component | License | Implication |
 |---|---|---|
 | Blender + Bonsai (desktop editor) | **GPL** | Run as a separate process/tool. Do not link its code into a closed product. Bonsai-MCP drives it over a socket — that boundary keeps it separate. |
 | IfcOpenShell core | **LGPL** | Dynamic linking OK; keep it replaceable. Used in `services/data` and `apps/editor-bridge` recipes. |
-| That Open Engine (`@thatopen/*`, web-ifc) | MIT-style | Permissive; fine in the web viewer and converter. |
+| That Open Engine (`@thatopen/components`, `-front`, `fragments`, `ui`) | MIT | Permissive; fine in the web viewer and converter. Verified from each package's declared licence — none ships a LICENSE file. |
+| **web-ifc** | **MPL-2.0** | **Weak (file-level) copyleft, NOT "MIT-style".** Using it unmodified — which is what we do, it is a vendored WASM build — carries no obligation beyond attribution. **Modifying an MPL file obliges you to publish that file's source.** So keep local patches out of it: fix upstream or wrap it. |
 | Bonsai-MCP | MIT | Permissive. |
 | xeokit SDK (if you switch viewers) | Custom | Check its own terms before use. |
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "budget": "node scripts/bundle-budget.mjs",
+    "licences": "node scripts/check-licences.mjs",
     "copy-wasm": "node scripts/copy-wasm.mjs",
     "tauri": "tauri",
     "prebuild:mobile": "node scripts/copy-wasm.mjs",

--- a/apps/web/scripts/check-licences.mjs
+++ b/apps/web/scripts/check-licences.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * R41-LICENCE-GATE — enforce the licence allowlist over the npm tree in CI instead of by reading.
+ *
+ * Runs in the WEB job, deliberately. `node_modules` exists there because that job runs `npm ci`;
+ * the API test gate does not, so a Python-side npm scan would have found nothing and passed
+ * vacuously — the failure mode this repo keeps paying for. Where a check runs is part of its claim.
+ *
+ * Policy and the reasoning behind the classifier live in `licencePolicy.mjs`. Read the note there
+ * about MPL-2.0 naming the GPL in its own definitions before changing anything.
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { verdict } from "./licencePolicy.mjs";
+import { findPackageDir } from "./wasmSources.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Locate `node_modules` by RESOLVING a package, never by counting `..` segments.
+ *
+ * The first draft used `join(here, "..", "..", "..")` — "the repo root, three levels up from
+ * `apps/web/scripts`". That is true in the main clone and **false in every git worktree**, where the
+ * hoisted `node_modules` lives in the main clone several levels away and at no fixed depth. It
+ * printed "node_modules not found" from a worktree.
+ *
+ * This is the identical bug fixed in `copy-wasm.mjs` earlier the same day, reintroduced here by the
+ * same reflex a few hours later — which is the argument for the shared resolver existing at all.
+ * `findPackageDir` walks the way Node does; the parent of any resolved package is its `node_modules`.
+ */
+function locateNodeModules() {
+  const webRoot = join(here, "..");
+  for (const probe of ["vite", "three", "typescript"]) {
+    const dir = findPackageDir(probe, webRoot);
+    // A scoped package resolves two levels deep; none of the probes is scoped, so one parent is right.
+    if (dir) return dirname(dir);
+  }
+  return null;
+}
+
+/** A licence file, whatever the extension: LICENSE, LICENCE, COPYING, LICENSE.md, LICENSE-MIT… */
+const LICENCE_FILE = /^(LICENSE|LICENCE|COPYING)([.-].*)?$/i;
+
+/** Directories that are not packages. `.bin` is symlinks; the rest are caches. */
+const NOT_A_PACKAGE = new Set([".bin", ".vite", ".cache", ".package-lock.json"]);
+
+export function scan(nodeModules, maxDepth = 3) {
+  const found = [];
+  const walk = (dir, depth) => {
+    if (depth > maxDepth) return;
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      if (NOT_A_PACKAGE.has(e.name)) continue;
+      const p = join(dir, e.name);
+      // A scope directory (@thatopen) is a container, not a package — descend at the same depth.
+      if (e.name.startsWith("@")) { walk(p, depth); continue; }
+      const manifest = join(p, "package.json");
+      if (existsSync(manifest)) {
+        try {
+          const j = JSON.parse(readFileSync(manifest, "utf8"));
+          const declared = typeof j.license === "string"
+            ? j.license
+            : (j.license?.type ?? (Array.isArray(j.licenses) ? j.licenses.map((x) => x.type).join(" OR ") : null));
+          const licenceFile = readdirSync(p).find((f) => LICENCE_FILE.test(f)) ?? null;
+          found.push(verdict({
+            name: j.name ?? e.name,
+            declared,
+            licenceFile,
+            licenceText: licenceFile ? readFileSync(join(p, licenceFile), "utf8") : null,
+          }));
+        } catch { /* an unreadable manifest is not a licence finding; npm ci would have failed */ }
+      }
+      if (existsSync(join(p, "node_modules"))) walk(join(p, "node_modules"), depth + 1);
+    }
+  };
+  walk(nodeModules, 0);
+  return found;
+}
+
+/**
+ * Unclassified packages are a RATCHET, not a pass. Eight licence files match no known title today
+ * (two Tauri `.spdx` stubs, `type-fest`'s CC0, and five bespoke or terse texts). Letting that number
+ * grow unremarked is how a classifier quietly stops classifying; it only ever moves down.
+ *
+ * Set at the EXACT current count, not comfortably above it. The first draft said 19 — the count from
+ * an earlier, coarser classifier — which would have sat green through eleven new unreadable licences.
+ * A threshold taken from a superseded measurement is a threshold for a different question.
+ */
+const UNCLASSIFIED_CEILING = Number(process.env.LICENCE_UNCLASSIFIED_CEILING || 8);
+
+/** Below this the scan found nothing meaningful and every verdict below would be vacuous. */
+const MIN_PACKAGES = 400;
+
+if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, "/") || process.argv[1]?.endsWith("check-licences.mjs")) {
+  const root = locateNodeModules();
+  if (!root || !existsSync(root)) {
+    console.error("[licences] could not resolve node_modules from any known package — run `npm ci` at the repo root.");
+    process.exit(2);
+  }
+  const all = scan(root);
+  const by = (s) => all.filter((v) => v.status === s);
+
+  console.log(`[licences] scanned ${all.length} npm packages under ${root.replace(/\\/g, "/")}`);
+  if (all.length < MIN_PACKAGES) {
+    console.error(`[licences] FAIL — only ${all.length} packages scanned (< ${MIN_PACKAGES}); this gate would be vacuous.`);
+    process.exit(1);
+  }
+
+  const report = by("REPORT");
+  if (report.length) {
+    console.log(`[licences] weak copyleft, accepted for our distribution model (${report.length}):`);
+    for (const v of report) console.log(`    ${v.name} — ${v.reason}`);
+  }
+
+  const unclassified = by("UNCLASSIFIED");
+  console.log(`[licences] unclassified licence texts: ${unclassified.length} (ceiling ${UNCLASSIFIED_CEILING})`);
+
+  const bad = [...by("FORBIDDEN"), ...by("CONTRADICTION")];
+  if (bad.length) {
+    console.error(`\n[licences] FAIL — ${bad.length} package(s) violate the MIT/BSD/Apache-only rule:\n`);
+    for (const v of bad) console.error(`    ${v.status.padEnd(14)} ${v.name}\n                   ${v.reason}`);
+    console.error(
+      "\n  A CONTRADICTION means the package's own LICENSE file disagrees with what it declares.\n" +
+      "  Trust the file. Remove the dependency or get the licence confirmed in writing.\n",
+    );
+    process.exit(1);
+  }
+
+  if (unclassified.length > UNCLASSIFIED_CEILING) {
+    console.error(
+      `\n[licences] FAIL — ${unclassified.length} unclassified licence texts exceeds the ceiling of ${UNCLASSIFIED_CEILING}.\n` +
+      "  Either the classifier needs a new title, or a dependency ships a bespoke licence that wants reading:\n",
+    );
+    for (const v of unclassified) console.error(`    ${v.name} (${v.licenceFile})`);
+    process.exit(1);
+  }
+
+  console.log(`[licences] OK — ${by("OK").length} permissive, ${report.length} weak-copyleft reported, 0 forbidden.`);
+}

--- a/apps/web/scripts/check-licences.mjs
+++ b/apps/web/scripts/check-licences.mjs
@@ -19,25 +19,59 @@ import { findPackageDir } from "./wasmSources.mjs";
 const here = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Locate `node_modules` by RESOLVING a package, never by counting `..` segments.
+ * Every `node_modules` this workspace can see — plural, because in an npm workspace the tree is SPLIT.
  *
- * The first draft used `join(here, "..", "..", "..")` — "the repo root, three levels up from
- * `apps/web/scripts`". That is true in the main clone and **false in every git worktree**, where the
- * hoisted `node_modules` lives in the main clone several levels away and at no fixed depth. It
- * printed "node_modules not found" from a worktree.
+ * TWO WRONG VERSIONS, BOTH FROM ASSUMING THE TREE HAS ONE ROOT
  *
- * This is the identical bug fixed in `copy-wasm.mjs` earlier the same day, reintroduced here by the
- * same reflex a few hours later — which is the argument for the shared resolver existing at all.
- * `findPackageDir` walks the way Node does; the parent of any resolved package is its `node_modules`.
+ * 1. `join(here, "..", "..", "..")` — "the repo root, three levels up". True in the main clone,
+ *    **false in every git worktree**, where the hoisted `node_modules` sits in the main clone at no
+ *    fixed depth. Printed "node_modules not found". That is the identical bug fixed in
+ *    `copy-wasm.mjs` earlier the same day, reintroduced hours later by reflex.
+ *
+ * 2. Resolving ONE package and taking its parent. This passed locally and **failed in CI on its
+ *    first real run**, with the vacuity floor firing:
+ *
+ *        [licences] scanned 1 npm packages under .../apps/web/node_modules
+ *        [licences] FAIL — only 1 packages scanned (< 400); this gate would be vacuous.
+ *
+ *    `apps/web/package.json` pins `vite`, so npm installs it NESTED at `apps/web/node_modules/vite`
+ *    while everything else hoists to the repo root — **that directory holds exactly one entry.**
+ *    Probing `vite` therefore resolves to a `node_modules` containing 1 package instead of 434.
+ *
+ *    The bitter part: that layout is the **same fact** diagnosed in BUILD-WORKTREE-CHUNKS hours
+ *    earlier ("that directory contains exactly one entry, `vite`"). One root cause, two defects, and
+ *    the second bit the tool built to prevent this class of mistake. **A fact you have already
+ *    established about the layout does not automatically transfer to the next thing you build on it.**
+ *
+ *    Note also the inversion: in a WORKTREE (no nested dir) the probe resolves to the root and the
+ *    scan is correct, so the broken configuration is the one that looks right locally. **The local
+ *    run scanned the right tree by accident.**
+ *
+ * So: walk the ancestor chain and take EVERY `node_modules`, then add whatever Node resolves, and
+ * union. The floor stays at 400 — it earned it.
  */
-function locateNodeModules() {
+function nodeModulesRoots() {
   const webRoot = join(here, "..");
-  for (const probe of ["vite", "three", "typescript"]) {
-    const dir = findPackageDir(probe, webRoot);
-    // A scoped package resolves two levels deep; none of the probes is scoped, so one parent is right.
-    if (dir) return dirname(dir);
+  const roots = new Set();
+
+  // 1. Every `node_modules` on the ancestor chain. In an npm workspace the tree is SPLIT: most
+  //    packages hoist to the repo root, and a few sit nested beside the workspace that pins them.
+  let dir = webRoot;
+  for (let i = 0; i < 8; i++) {
+    const nm = join(dir, "node_modules");
+    if (existsSync(nm)) roots.add(nm);
+    const up = dirname(dir);
+    if (up === dir) break;
+    dir = up;
   }
-  return null;
+
+  // 2. Plus wherever Node actually resolves a few packages, in case a layout the walk cannot see
+  //    (a link, a different workspace root) holds something.
+  for (const probe of ["vite", "three", "typescript"]) {
+    const d = findPackageDir(probe, webRoot);
+    if (d) roots.add(dirname(d));
+  }
+  return [...roots];
 }
 
 /** A licence file, whatever the extension: LICENSE, LICENCE, COPYING, LICENSE.md, LICENSE-MIT… */
@@ -66,12 +100,20 @@ export function scan(nodeModules, maxDepth = 3) {
             ? j.license
             : (j.license?.type ?? (Array.isArray(j.licenses) ? j.licenses.map((x) => x.type).join(" OR ") : null));
           const licenceFile = readdirSync(p).find((f) => LICENCE_FILE.test(f)) ?? null;
-          found.push(verdict({
-            name: j.name ?? e.name,
-            declared,
-            licenceFile,
-            licenceText: licenceFile ? readFileSync(join(p, licenceFile), "utf8") : null,
-          }));
+          found.push({
+            // The package's own directory, so the caller can dedupe ACROSS ROOTS by identity rather
+            // than by name. Deduping by name collapses a nested second copy of a package into the
+            // hoisted one — and a nested copy can carry a DIFFERENT licence, which is precisely what
+            // this gate exists to notice. Same directory reached twice is one package; same name at
+            // two directories is two.
+            dir: p.replace(/\\/g, "/"),
+            ...verdict({
+              name: j.name ?? e.name,
+              declared,
+              licenceFile,
+              licenceText: licenceFile ? readFileSync(join(p, licenceFile), "utf8") : null,
+            }),
+          });
         } catch { /* an unreadable manifest is not a licence finding; npm ci would have failed */ }
       }
       if (existsSync(join(p, "node_modules"))) walk(join(p, "node_modules"), depth + 1);
@@ -96,15 +138,28 @@ const UNCLASSIFIED_CEILING = Number(process.env.LICENCE_UNCLASSIFIED_CEILING || 
 const MIN_PACKAGES = 400;
 
 if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, "/") || process.argv[1]?.endsWith("check-licences.mjs")) {
-  const root = locateNodeModules();
-  if (!root || !existsSync(root)) {
-    console.error("[licences] could not resolve node_modules from any known package — run `npm ci` at the repo root.");
+  const roots = nodeModulesRoots();
+  if (!roots.length) {
+    console.error("[licences] found no node_modules on the ancestor chain — run `npm ci` at the repo root.");
     process.exit(2);
   }
-  const all = scan(root);
+  // Union across roots, deduped by DIRECTORY. The same directory can be reachable from two roots and
+  // must count once; two copies of one package at different paths are two packages and must both be
+  // judged, because a nested copy can carry a different licence.
+  const seen = new Map();
+  const perRoot = new Map();
+  for (const r of roots) {
+    const found = scan(r);
+    perRoot.set(r, found.length);
+    for (const v of found) if (!seen.has(v.dir)) seen.set(v.dir, v);
+  }
+  const all = [...seen.values()];
   const by = (s) => all.filter((v) => v.status === s);
 
-  console.log(`[licences] scanned ${all.length} npm packages under ${root.replace(/\\/g, "/")}`);
+  // Name every root AND its count. The first version scanned one root and printed one number, so a
+  // 1-package scan looked like a scan. Per-root counts make the split tree legible in the log.
+  console.log(`[licences] scanned ${all.length} npm packages across ${roots.length} node_modules root(s):`);
+  for (const r of roots) console.log(`    ${String(perRoot.get(r) ?? 0).padStart(4)}  ${r.replace(/\\/g, "/")}`);
   if (all.length < MIN_PACKAGES) {
     console.error(`[licences] FAIL — only ${all.length} packages scanned (< ${MIN_PACKAGES}); this gate would be vacuous.`);
     process.exit(1);

--- a/apps/web/scripts/licencePolicy.mjs
+++ b/apps/web/scripts/licencePolicy.mjs
@@ -1,0 +1,152 @@
+/**
+ * Licence classification and policy for the npm dependency tree.
+ *
+ * WHY THIS EXISTS, AND WHAT IT ADDS TO THE GATE WE ALREADY HAD
+ *     `services/api/test_license_gate.py` already fails the build on a GPL/AGPL dependency. It is a
+ *     real gate and this does not replace it. But its claim is narrower than it reads, in two ways:
+ *
+ *     1. **It walks Python distributions only** (`importlib.metadata`). The npm tree — 638 packages,
+ *        including `three`, `web-ifc` and the whole That Open stack — was never in its population.
+ *     2. **It reads DECLARED metadata**: Trove classifiers, the `License` field, the SPDX
+ *        expression. That is the badge. The roadmap item that commissioned this exists because a
+ *        scan found repositories whose actual LICENSE differs from their README or badge, two of
+ *        them forbidding exactly our use. **A declaration cannot catch a lying declaration.**
+ *
+ *     So this reads the LICENSE FILE and cross-checks it against the declaration. Two independent
+ *     statements about one fact; disagreement is the signal. Same shape as the roadmap
+ *     self-consistency gate, applied to a different artefact.
+ *
+ * THE FALSE POSITIVE THIS ALMOST SHIPPED WITH — read before changing `classify`
+ *     The first draft tested licence names in PRECEDENCE order, GPL before MPL. It reported three
+ *     contradictions, one of them **`web-ifc` declared MPL-2.0 but "actually GPL"** — a core
+ *     dependency named in the project's non-negotiables. That was wrong, and alarmingly so.
+ *
+ *     `web-ifc/LICENSE.md` opens with "Mozilla Public License Version 2.0". MPL-2.0's own text
+ *     **defines "Secondary License" by naming the GNU GPL, LGPL and AGPL**, so any MPL-2.0 file
+ *     contains the string "GNU General Public License". A precedence-ordered matcher fires on the
+ *     definition rather than the title.
+ *
+ *     The fix is not a longer exclusion list, it is a different rule: **the earliest title wins.**
+ *     A licence document announces itself at the top; every later mention is prose about some other
+ *     licence. `lightningcss` and its win32 binary were the same false positive.
+ *
+ *     **An alarming result should raise the bar on the instrument, not lower it** — three hits
+ *     including a core dependency was the moment to doubt the classifier, not the supply chain.
+ */
+
+/**
+ * Ordered by nothing — position in the document decides. Each entry is a phrase a licence uses to
+ * NAME ITSELF at the top of its text, not a phrase that merely mentions it.
+ */
+const TITLES = [
+  [/GNU AFFERO GENERAL PUBLIC LICENSE/i, "AGPL"],
+  [/GNU LESSER GENERAL PUBLIC LICENSE/i, "LGPL"],
+  [/GNU GENERAL PUBLIC LICENSE/i, "GPL"],
+  [/Mozilla Public License/i, "MPL"],
+  [/PolyForm/i, "PolyForm"],
+  [/Server Side Public License/i, "SSPL"],
+  [/Business Source License/i, "BUSL"],
+  [/Apache License/i, "Apache"],
+  [/Permission is hereby granted, free of charge/i, "MIT"],
+  [/Redistribution and use in source and binary forms/i, "BSD"],
+  [/Permission to use, copy, modify, and(?:\/or)? distribute/i, "ISC"],
+  [/\bThe Unlicense\b|placed .{0,40}public domain/i, "PUBLIC-DOMAIN"],
+  [/Blue Oak Model License/i, "BlueOak"],
+];
+
+/** Only the head of the file is considered — a licence titles itself before it says anything else. */
+const HEAD_CHARS = 8000;
+
+/** Family of a LICENCE DOCUMENT, by whichever recognised title appears earliest. */
+export function classify(text) {
+  const head = String(text).slice(0, HEAD_CHARS);
+  let best = null;
+  let bestAt = Infinity;
+  for (const [re, name] of TITLES) {
+    const m = re.exec(head);
+    if (m && m.index < bestAt) { bestAt = m.index; best = name; }
+  }
+  return best ?? "UNKNOWN";
+}
+
+/** Family of a DECLARED SPDX-ish string. `null`/absent is "NONE", which is not the same as UNKNOWN. */
+export function declaredFamily(declared) {
+  if (!declared) return "NONE";
+  const u = String(declared).toUpperCase();
+  if (/AGPL/.test(u)) return "AGPL";
+  if (/LGPL/.test(u)) return "LGPL";
+  if (/GPL/.test(u)) return "GPL";
+  if (/MPL/.test(u)) return "MPL";
+  if (/APACHE/.test(u)) return "Apache";
+  if (/\bMIT\b/.test(u)) return "MIT";
+  if (/BSD/.test(u)) return "BSD";
+  if (/\bISC\b/.test(u)) return "ISC";
+  if (/POLYFORM/.test(u)) return "PolyForm";
+  if (/SSPL/.test(u)) return "SSPL";
+  if (/BUSL/.test(u)) return "BUSL";
+  if (/BLUEOAK|0BSD|UNLICENSE|CC0|PYTHON-2|ZLIB|WTFPL/.test(u)) return "PERMISSIVE-OTHER";
+  return "OTHER";
+}
+
+export const PERMISSIVE = new Set(["MIT", "BSD", "ISC", "Apache", "PERMISSIVE-OTHER", "PUBLIC-DOMAIN", "BlueOak"]);
+
+/**
+ * Forbidden outright: the non-negotiable is "MIT / BSD / Apache only — no GPL, no AGPL, no
+ * PolyForm/noncommercial". LGPL and MPL are WEAK copyleft and are reported rather than failed, which
+ * matches `test_license_gate.py`'s existing policy — `ifcopenshell` and `certifi` sit there and are
+ * accepted for our distribution model. Collapsing "disallowed" into "worth a look" makes a gate
+ * either useless or permanently red, and a permanently red gate gets switched off.
+ */
+export const FORBIDDEN = new Set(["AGPL", "GPL", "SSPL", "BUSL", "PolyForm"]);
+export const WEAK_COPYLEFT = new Set(["LGPL", "MPL"]);
+
+/**
+ * A dual-licensed declaration ("(MIT OR GPL-3.0-or-later)") offers a choice, and we take the
+ * permissive one. Without this, `jszip` reads as a GPL dependency — it is not; its LICENSE file is
+ * the MIT text, which is exactly the choice being exercised.
+ */
+export function isDualWithPermissive(declared) {
+  if (!declared) return false;
+  const parts = String(declared).split(/\s+OR\s+/i).map((p) => p.replace(/[()]/g, "").trim());
+  return parts.length > 1 && parts.some((p) => PERMISSIVE.has(declaredFamily(p)));
+}
+
+/**
+ * The verdict for one package.
+ *
+ * `reason` is always populated so a failure names *why*, not merely *that*. A gate that says
+ * "licence violation" without naming the file it read and what it found reproduces the class of
+ * defect it exists to catch.
+ */
+export function verdict({ name, declared, licenceText, licenceFile }) {
+  const decl = declaredFamily(declared);
+  const text = licenceText == null ? null : classify(licenceText);
+  const dual = isDualWithPermissive(declared);
+
+  // The text is the authority when we have it; the declaration is all we have when we do not.
+  const effective = text && text !== "UNKNOWN" ? text : decl;
+
+  // MOST SPECIFIC FIRST. Declared permissive, file says strong copyleft — the badge-vs-reality case
+  // this gate exists for. It is a subset of FORBIDDEN and both fail the build, so ordering changes
+  // nothing about the verdict and everything about the message: "declares MIT but LICENSE is GPL"
+  // tells you the dependency lied, while a bare "GPL — forbidden" reads as our own bookkeeping error
+  // and sends you to the wrong place. The generic branch ran first in the first draft.
+  if (text && FORBIDDEN.has(text) && PERMISSIVE.has(decl) && !dual) {
+    return { name, status: "CONTRADICTION", effective: text, declared, licenceFile,
+      reason: `declares ${declared} but ${licenceFile} is ${text}` };
+  }
+  if (FORBIDDEN.has(effective) && !dual) {
+    return { name, status: "FORBIDDEN", effective, declared, licenceFile,
+      reason: `${effective} — forbidden by the MIT/BSD/Apache-only rule` +
+              (text ? ` (from the text of ${licenceFile})` : " (declared; no LICENSE file found)") };
+  }
+  if (WEAK_COPYLEFT.has(effective)) {
+    return { name, status: "REPORT", effective, declared, licenceFile,
+      reason: `${effective} — weak copyleft, accepted for our distribution model` };
+  }
+  if (text === "UNKNOWN") {
+    return { name, status: "UNCLASSIFIED", effective: decl, declared, licenceFile,
+      reason: `${licenceFile} did not match any known licence title` };
+  }
+  return { name, status: "OK", effective, declared, licenceFile, reason: `${effective}` };
+}

--- a/apps/web/src/tooling/licencePolicy.test.ts
+++ b/apps/web/src/tooling/licencePolicy.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The licence classifier, and the false positive it almost shipped with.
+ *
+ * R41-LICENCE-GATE exists because a scan found repositories whose actual LICENSE differs from their
+ * README or badge. So the gate must read the **file**, and the classifier that reads it is the part
+ * that can be confidently wrong.
+ *
+ * **It was.** The first draft tested licence names in precedence order, GPL before MPL, and reported
+ * three contradictions — one of them `web-ifc`, a core dependency, "declared MPL-2.0 but actually
+ * GPL". That is false: `web-ifc/LICENSE.md` opens with "Mozilla Public License Version 2.0", and
+ * **MPL-2.0 defines "Secondary License" by naming the GNU GPL, LGPL and AGPL**, so every MPL-2.0
+ * file contains the string "GNU General Public License". The matcher fired on a definition.
+ *
+ * The fix is a different rule rather than a longer exclusion list: **the earliest title wins**, since
+ * a licence names itself at the top and every later mention is prose about a different licence.
+ * These tests pin that, because the next person to add a licence to the table will reach for
+ * precedence ordering — it is the obvious design, and it is wrong here.
+ */
+
+const SCRIPTS = join(process.cwd(), "scripts");
+
+type Policy = {
+  classify: (t: string) => string;
+  declaredFamily: (d: string | null) => string;
+  isDualWithPermissive: (d: string | null) => boolean;
+  verdict: (p: { name: string; declared: string | null; licenceText: string | null; licenceFile: string | null }) =>
+    { status: string; effective: string; reason: string };
+};
+
+async function policy(): Promise<Policy> {
+  return (await import(/* @vite-ignore */ pathToFileURL(join(SCRIPTS, "licencePolicy.mjs")).href)) as Policy;
+}
+
+/** The opening of the real MPL-2.0, including the clause that caused the false positive. */
+const MPL_2_0 = `Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.13. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those licenses.
+`;
+
+const GPL_3 = `                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+`;
+
+const MIT = `MIT License
+
+Copyright (c) 2024 Somebody
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+`;
+
+describe("licence classification reads the title, not any mention", () => {
+  it("classifies MPL-2.0 as MPL even though its text names the GPL three times", async () => {
+    const { classify } = await policy();
+    // The regression that matters. A precedence-ordered matcher returns "GPL" here and indicts a
+    // core dependency.
+    expect(MPL_2_0).toContain("GNU General Public License");   // the trap is really present
+    expect(classify(MPL_2_0)).toBe("MPL");
+  });
+
+  it("still classifies an actual GPL file as GPL", async () => {
+    // The other half: fixing the false positive must not blind the gate to the real thing.
+    const { classify } = await policy();
+    expect(classify(GPL_3)).toBe("GPL");
+  });
+
+  it("classifies MIT and reports UNKNOWN rather than guessing", async () => {
+    const { classify } = await policy();
+    expect(classify(MIT)).toBe("MIT");
+    expect(classify("Copyright 2020 someone. All rights reserved."))
+      .toBe("UNKNOWN");
+  });
+
+  it("matches the real web-ifc licence file on disk, not a fixture of it", async () => {
+    // Assert against the artefact the gate actually reads. A fixture can agree with the classifier
+    // while the real file differs — the same reason a round-trip through your own writer proves
+    // nothing.
+    const { classify, declaredFamily } = await policy();
+    const dir = join(process.cwd(), "..", "..", "node_modules", "web-ifc");
+    let text: string;
+    try {
+      text = readFileSync(join(dir, "LICENSE.md"), "utf8");
+    } catch {
+      return;  // hoisted elsewhere (a worktree); the fixture cases above still pin the behaviour
+    }
+    expect(classify(text), "web-ifc is MPL-2.0; classifying it GPL indicts a core dependency").toBe("MPL");
+    expect(declaredFamily("MPL-2.0")).toBe("MPL");
+  });
+});
+
+describe("licence policy", () => {
+  it("fails a forbidden licence and names why", async () => {
+    const { verdict } = await policy();
+    const v = verdict({ name: "bad-dep", declared: "AGPL-3.0", licenceText: null, licenceFile: null });
+    expect(v.status).toBe("FORBIDDEN");
+    expect(v.reason).toContain("AGPL");
+  });
+
+  it("catches the badge-vs-file case this gate exists for", async () => {
+    // Declared permissive, file says GPL. Nothing that reads only metadata can see this.
+    const { verdict } = await policy();
+    const v = verdict({ name: "liar", declared: "MIT", licenceText: GPL_3, licenceFile: "LICENSE" });
+    expect(v.status).toBe("CONTRADICTION");
+    expect(v.reason).toContain("declares MIT");
+    expect(v.reason).toContain("GPL");
+  });
+
+  it("accepts a dual licence that offers a permissive option", async () => {
+    // jszip declares "(MIT OR GPL-3.0-or-later)" and ships the MIT text. Without this it reads as a
+    // GPL dependency and the gate is permanently red on a package that is fine.
+    const { verdict, isDualWithPermissive } = await policy();
+    expect(isDualWithPermissive("(MIT OR GPL-3.0-or-later)")).toBe(true);
+    expect(verdict({ name: "jszip", declared: "(MIT OR GPL-3.0-or-later)", licenceText: MIT, licenceFile: "LICENSE" }).status)
+      .toBe("OK");
+  });
+
+  it("reports weak copyleft rather than failing it", async () => {
+    // ifcopenshell and web-ifc live here. Collapsing "disallowed" into "worth a look" makes the gate
+    // either useless or permanently red, and a permanently red gate gets switched off.
+    const { verdict } = await policy();
+    expect(verdict({ name: "web-ifc", declared: "MPL-2.0", licenceText: MPL_2_0, licenceFile: "LICENSE.md" }).status)
+      .toBe("REPORT");
+  });
+});

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -243,7 +243,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | R22-PM-CONTRACTS *(SHIPPED 2026-08-06 — `pm_contract`; pending archive)* — lane now empty |
 | **I · API client** | `apps/web/src/api/` | SCALE-SEAM ⑧ |
-| **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | BUILD-WORKTREE-CHUNKS *(lane added 2026-08-06 — **three sessions in one day flagged a path belonging to no lane**: `services/api/test_file_sizes.py`, `apps/web/src/style.css`, and the build scripts. Each flagged it correctly and then had to edit it anyway. An unowned shared path is not neutral ground; it is a collision nobody is watching for)* · R41-GATE-SUBSTANCE *(SHIPPED 2026-08-06 — `test_doc_substance.py`; pending archive)* · R41-DELETE-RATCHET · R41-LICENCE-GATE |
+| **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | BUILD-WORKTREE-CHUNKS *(lane added 2026-08-06 — **three sessions in one day flagged a path belonging to no lane**: `services/api/test_file_sizes.py`, `apps/web/src/style.css`, and the build scripts. Each flagged it correctly and then had to edit it anyway. An unowned shared path is not neutral ground; it is a collision nobody is watching for)* · R41-GATE-SUBSTANCE *(SHIPPED 2026-08-06 — `test_doc_substance.py`; pending archive)* · R41-DELETE-RATCHET · R41-LICENCE-GATE *(SHIPPED 2026-08-06 — `check-licences.mjs`; pending archive)* · R41-BUNDLER-SPLIT |
 
 **Parked — not available to pick up.** These are decisions or multi-release commitments, listed so
 nobody starts one thinking it is a sprint item: QUALITY-ROOM · R26-V-TIMING · R24-PERSONA-SHAPE ·
@@ -1687,11 +1687,69 @@ requiring a manual read** — filed below as R41-LICENCE-GATE.
   lanes ship to main at once and nothing currently stops one reintroducing a decomposed god-module or a
   re-export that reads as a dead import. A negative assertion is three lines and makes a removal stick:
   the ratchet-rather-than-allowlist principle applied to architecture instead of security.
-- **R41-LICENCE-GATE** *(S — Lane J)* — **enforce the licence allowlist in CI instead of by reading.**
-  This scan found three repositories whose actual LICENSE differs from their README or badge, two of
-  them forbidding exactly our use. A dependency and licence policy gate would have flagged them
-  mechanically. Pair it with a filesystem CVE scan and a Dockerfile linter, both of which look like
-  genuine gaps beside existing CodeQL, dependency-audit and secret-scan coverage.
+- ✅ **R41-LICENCE-GATE** *(S — Lane J, SHIPPED 2026-08-06)* — **enforce the licence allowlist in CI
+  instead of by reading.** This scan found three repositories whose actual LICENSE differs from their
+  README or badge, two of them forbidding exactly our use.
+
+  **Premise-checked, and the gate half-existed.** `services/api/test_license_gate.py` already fails
+  the build on a GPL/AGPL dependency — so the item as written ("enforce it in CI instead of by
+  reading") was already true. What was *not* true was its scope, in two ways that matter and that the
+  entry did not distinguish:
+
+  1. **It walks Python distributions only.** The npm tree — **638 packages**, including `three`,
+     `web-ifc` and the whole That Open stack — was never in its population.
+  2. **It reads DECLARED metadata** (Trove classifiers, the `License` field, the SPDX expression).
+     *That is the badge.* **A declaration cannot catch a lying declaration**, which is the exact
+     defect the item was filed about.
+
+  So `apps/web/scripts/check-licences.mjs` reads each package's **LICENSE file** and cross-checks it
+  against the declaration — two independent statements about one fact, disagreement is the signal,
+  the same shape as the roadmap self-consistency gate on a different artefact. It runs in the **web**
+  CI job, because that is the job that runs `npm ci`; in the API gate `node_modules` does not exist
+  and the scan would have passed by finding nothing.
+
+  **It found the defect in our own docs.** `LICENSE-NOTES.md` listed *"That Open Engine
+  (`@thatopen/*`, web-ifc) | MIT-style | Permissive"*. The `@thatopen/*` packages are MIT; **`web-ifc`
+  is MPL-2.0** — weak, file-level copyleft with a real obligation attached to modifying it. Corrected,
+  and the table now says it is checked rather than merely written.
+
+  **The false positive it almost shipped with is the reusable part.** The first classifier tested
+  licence names in *precedence* order, GPL before MPL, and reported three contradictions — one being
+  `web-ifc` "declared MPL-2.0 but actually GPL", a core dependency named in the non-negotiables.
+  Wrong: **MPL-2.0 defines "Secondary License" by naming the GNU GPL, LGPL and AGPL**, so every
+  MPL-2.0 file contains the string. The fix is not a longer exclusion list but a different rule —
+  **the earliest title wins**, because a licence names itself at the top and every later mention is
+  prose about a different licence. *An alarming result should raise the bar on the instrument, not
+  lower it*: three hits including a core dependency was the moment to doubt the classifier.
+
+  Current state: 638 packages, **0 forbidden**, 3 weak-copyleft reported (`web-ifc` + two
+  `lightningcss` builds, all MPL), 8 unclassified held as a down-only ratchet. Mutation-checked with a
+  planted package declaring MIT over an AGPL file → `CONTRADICTION`, and declaring AGPL outright →
+  `FORBIDDEN`.
+
+  **Still open from this entry, deliberately not done here:** the filesystem CVE scan and the
+  Dockerfile linter. Both are separate tools with their own populations; folding them into a licence
+  gate would repeat the scope confusion this item just corrected.
+
+- **R41-BUNDLER-SPLIT** *(S — Lane J)* — **the suite never exercises the bundler that ships.** The app
+  is *built* with **Vite 8 / rolldown** (pinned in `apps/web/package.json`, installed nested at
+  `apps/web/node_modules/vite`) and *tested* under **Vite 6 / rollup**, because `vitest@4.1.10`
+  depends on vite ^6 and that copy is hoisted to the repo root. Consistent between the clone and a
+  worktree, so test results are not *unstable* — but the test environment is not merely narrower than
+  production, it is **a different implementation**, and it can agree with you about code the shipping
+  bundler treats differently.
+
+  Chunking, CommonJS interop and tree-shaking are exactly where rollup and rolldown diverge, and we
+  assert about all three: `bundle-budget.mjs` asserts the vendor split, and the 19.7× shell found in
+  BUILD-WORKTREE-CHUNKS was a rollup-vs-rolldown difference. Same family as
+  `test-environment-more-permissive-than-browser`: happy-dom vouched for a drop the real browser
+  refuses. **Ask not what the test environment cannot see, but where it is a different thing wearing
+  the same name.**
+
+  Not resolvable inside BUILD-WORKTREE-CHUNKS — that item is about *which* Vite resolves, this one is
+  about the two of them being legitimately different tools. Options are to wait for a vitest that
+  tracks vite 8, to run a smoke suite against the built rolldown output, or to accept it explicitly
+  and write down why.
 
 ### Reclassified, and worth acting on separately
 


### PR DESCRIPTION
Lane **J**. Also files `R41-BUNDLER-SPLIT` as a separate item, per the lead.

## The premise was half right, and the half that was wrong is the whole item

`services/api/test_license_gate.py` **already** fails the build on a GPL/AGPL dependency — so "enforce the licence allowlist in CI instead of by reading" was already true. What was *not* true was its scope, in two ways the entry did not distinguish:

1. **It walks Python distributions only** (`importlib.metadata`). The npm tree — **638 packages**, including `three`, `web-ifc` and the whole That Open stack — was never in its population.
2. **It reads declared metadata**: Trove classifiers, the `License` field, the SPDX expression. *That is the badge.* **A declaration cannot catch a lying declaration** — which is precisely the defect this item was filed about.

So `check-licences.mjs` reads each package's **LICENSE file** and cross-checks it against the declaration. Two independent statements about one fact, disagreement is the signal — the same shape as the roadmap self-consistency gate, applied to a different artefact.

**It runs in the web job, and that is part of the claim.** That job runs `npm ci`, so `node_modules` exists. The API gate does not install it, and a licence scan over an absent tree passes by finding nothing.

## It found the defect in our own docs

`LICENSE-NOTES.md` listed:

> `That Open Engine (@thatopen/*, web-ifc) | MIT-style | Permissive; fine in the web viewer and converter.`

The `@thatopen/*` packages are genuinely MIT. **`web-ifc` is MPL-2.0** — weak, file-level copyleft, with a real obligation attached to *modifying* it. Using it unmodified (which is what we do) is fine; calling it "MIT-style permissive" misstates the obligation.

Corrected onto its own row with the actual constraint, and the table now records that it is **checked** rather than merely written.

## The false positive it almost shipped with

The first classifier tested licence names in **precedence** order, GPL before MPL. It reported three contradictions — one of them **`web-ifc` "declared MPL-2.0 but actually GPL"**, a core dependency named in the project's non-negotiables.

That is false. `web-ifc/LICENSE.md` opens with "Mozilla Public License Version 2.0", and **MPL-2.0 defines "Secondary License" by naming the GNU GPL, LGPL and AGPL** — so *every* MPL-2.0 file contains the string. The matcher fired on a definition.

The fix is not a longer exclusion list but a different rule: **the earliest title wins**, because a licence names itself at the top and every later mention is prose about a different licence. `lightningcss` and its win32 binary were the same false positive.

**An alarming result should raise the bar on the instrument, not lower it** — three hits including a core dependency was the moment to doubt the classifier, not the supply chain.

## Policy

- **Forbidden** (fails): AGPL, GPL, SSPL, BUSL, PolyForm.
- **Reported** (does not fail): LGPL, MPL — matching `test_license_gate.py`'s existing policy, where `ifcopenshell` and `certifi` already sit. Collapsing "disallowed" into "worth a look" makes a gate either useless or permanently red, and a permanently red gate gets switched off.
- **Dual licences** take the permissive option. `jszip` declares `(MIT OR GPL-3.0-or-later)` and ships the MIT text; without this the gate is permanently red on a package that is fine.
- **Contradiction beats forbidden** in the message. Both fail, but *"declares MIT but LICENSE is GPL"* tells you the dependency lied, while a bare *"GPL — forbidden"* reads as our own bookkeeping error and sends you to the wrong place. The generic branch ran first in the first draft.

## Current state

```
[licences] scanned 638 npm packages
[licences] weak copyleft, accepted for our distribution model (3):
    lightningcss — MPL      lightningcss-win32-x64-msvc — MPL      web-ifc — MPL
[licences] unclassified licence texts: 8 (ceiling 8)
[licences] OK — 627 permissive, 3 weak-copyleft reported, 0 forbidden.
```

The unclassified ceiling is the **exact** current count. The first draft said 19 — a number from the earlier, coarser classifier — which would have sat green through eleven new unreadable licences. *A threshold taken from a superseded measurement is a threshold for a different question.*

## Verification

| check | result |
|---|---|
| `npm run test --workspace apps/web` | **1316 / 1316**, 117 / 117 |
| `npx tsc --noEmit` / `npx eslint` | clean |
| `test_claude_md_gates.py` | green |
| `roadmapLanes` + `roadmapStale` + `roadmapSelfConsistent` | 24 / 24 |
| `ci.yml` | parses; licence step present |

**Mutations — packages planted in the real tree and removed after, each confirmed applied:**

| mutation | result |
|---|---|
| declares `MIT`, LICENSE file is AGPL | **CONTRADICTION** — the case the metadata-only gate cannot see |
| declares `AGPL-3.0`, no LICENSE file | **FORBIDDEN** |
| MPL-2.0 text (naming the GPL 3×) | classifies **MPL** — the regression that almost shipped |
| real `web-ifc/LICENSE.md` on disk | **MPL**, asserted against the artefact rather than a fixture |

## One note against myself

`locateNodeModules()` resolves via `findPackageDir` rather than counting `..` segments. The first draft used `join(here, "..", "..", "..")` and printed "node_modules not found" from a worktree — **reintroducing the exact bug I fixed in `copy-wasm.mjs` hours earlier**. That is the argument for the shared resolver existing at all.

## Not attempted

The filesystem CVE scan and Dockerfile linter the entry also mentions. Both are separate tools with their own populations; folding them in would repeat the scope confusion this item just corrected.

**For the release holder:** touches `apps/web/package.json` (scripts block only, **not** the version), `.github/workflows/ci.yml`, and `LICENSE-NOTES.md` (repo root, unowned by any lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated npm license verification for web application dependencies.
  - License checks now validate package declarations against included license files and flag forbidden, missing, or inconsistent licensing.
  - Weak-copyleft dependencies are identified and reported for review.

- **Documentation**
  - Updated licensing notes, including clarification of `web-ifc` and That Open Engine package licenses.
  - Updated the roadmap to reflect completed license-gate work and upcoming build-tooling tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->