### PR TITLE
R41-DELETE-RATCHET (file half) — removed documents stay removed, and docs/ is published

### DIFF
--- a/apps/web/src/tooling/deleteRatchet.test.ts
+++ b/apps/web/src/tooling/deleteRatchet.test.ts
@@ -1,0 +1,158 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * R41-DELETE-RATCHET — things removed on purpose stay removed.
+ *
+ * Several lanes ship to main at once and nothing stopped one reintroducing a document that was
+ * deliberately deleted. This is the negative assertion, over FILE PATHS.
+ *
+ * LINEAGE — the hard half was already solved next door
+ *     `portal/register/registerOwnership.test.ts` is a delete ratchet and got there first. Its
+ *     lessons are its own: *"the population is the moved code, named"*, *"a matcher that finds
+ *     nothing agrees with everything"*, and — after its first run failed on the sentence explaining
+ *     what a door is — *"a gate that forbids describing the rule it enforces teaches people to stop
+ *     writing the description"*. Read it before extending this.
+ *
+ * WHY PATHS AND NOT SYMBOLS, WHICH IS THE WHOLE REASON THIS IS TRUSTWORTHY ON DAY ONE
+ *     Every failure mode of a symbol ratchet is a string-matching problem, and all three bit on the
+ *     first attempt at this item:
+ *
+ *       · `?shell=classic` was deleted — but `"classic"` still lives in `dev/liveAudit.test.ts` as a
+ *         run label. The string has a legitimate other life.
+ *       · the More menu is gone — but `"more"` appears in `viewer/app.ts` and `railToolbox.ts` in
+ *         **prose describing the removal**. The gate would fire on the documentation of its own rule.
+ *       · the register renderer's internals — I guessed `renderRegister` and `registerBoard`.
+ *         **`git log -S` says neither ever existed at any commit.** That assertion would have passed
+ *         forever, guarded nothing, and read as coverage. It is the exact defect this ring is about,
+ *         and the only thing that caught it was checking history for a name I had invented.
+ *
+ *     A path has none of those. Prior existence is provable from history, current absence is one
+ *     `git ls-files`, and it needs no comment-stripping, no word boundaries, and no matcher that can
+ *     agree with everything. Symbols are the harder second version; deliberately not in this pass.
+ *
+ * WHY THESE EIGHT ARE LOAD-BEARING AND NOT BOOKKEEPING
+ *     **`docs/` IS the Pages web root.** `pages.yml` copies `docs/.` into the published site, so
+ *     re-adding any of these republishes a superseded planning document as a live page on the public
+ *     site. Two of them — `competitive-plan.md` and `emanager-gap-analysis.md` — are competitive
+ *     analyses, which a standing user directive keeps out of the public docs.
+ *
+ *     `services/api/test_no_comparative_names.py` already enforces that directive **by content**. It
+ *     does not assert these *files* stay gone, and this does not scan content. **Neither implies the
+ *     other**, which is a better argument for both existing than either makes alone.
+ *
+ * ENROLLMENT, SO THE NINTH ENTRY CANNOT BE INVENTED
+ *     An entry must be **absent now** and **present in some earlier commit**. The second half is what
+ *     stops this growing into a ban on future work: something that merely "does not exist yet" fails
+ *     enrollment. Enroll at deletion time; never archaeologise history for "things that were
+ *     deleted", because inference cannot tell *removed on principle* from *removed incidentally*.
+ *
+ * A STATED BLIND SPOT — the enrollment half cannot run in CI
+ *     `actions/checkout@v7` clones with `fetch-depth: 1` unless told otherwise, and `ci.yml` does not
+ *     tell it otherwise. In a shallow clone `git log --diff-filter=A` sees one commit, so the
+ *     "existed before" check would report **zero** for every entry and fail all eight — a gate that
+ *     goes red in CI for a reason that has nothing to do with the code.
+ *
+ *     So the two halves are split by what they NEED. **Absence runs everywhere and is the ratchet.**
+ *     Enrollment runs only where history exists, and when it cannot run it SAYS SO rather than
+ *     passing quietly — because a silently-skipped check is the failure this whole ring is about.
+ *     Deepening the CI clone was rejected: it would add a 2,000-commit fetch to every run to
+ *     re-verify a property that is fixed at authoring time.
+ */
+
+const REPO = join(process.cwd(), "..", "..");
+
+const git = (...args: string[]) =>
+  execFileSync("git", args, { cwd: REPO, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+
+/**
+ * Deleted on purpose. Each entry carries its reason, so **removing an entry is a decision, not a
+ * bypass** — a future author who genuinely needs one back deletes the line and says why. A ratchet
+ * with no legitimate way out gets defeated by whoever needs it out.
+ */
+const REMOVED: Record<string, string> = {
+  "docs/capability-matrix.md":
+    "competitive capability grid; superseded and off-mission for a public page",
+  "docs/competitive-plan.md":
+    "competitive analysis — standing user directive keeps these out of the public docs",
+  "docs/developer-portal-roadmap.md":
+    "superseded planning doc; the roadmap is docs/roadmap.md",
+  "docs/emanager-gap-analysis.md":
+    "competitive gap analysis against a named product — same directive as competitive-plan.md",
+  "docs/improvement-plan.md":
+    "superseded planning doc, folded into docs/roadmap.md",
+  "docs/lifecycle-roadmap.md":
+    "superseded planning doc, folded into docs/roadmap.md",
+  "docs/roadmap-modeling-tools.md":
+    "split out of the roadmap and then re-merged; a second roadmap is how the two drift",
+  "docs/roadmap-platforms.md":
+    "same as roadmap-modeling-tools.md — one roadmap, not three",
+};
+
+const TRACKED = new Set(git("ls-files").split("\n").map((s) => s.trim()).filter(Boolean));
+const SHALLOW = git("rev-parse", "--is-shallow-repository").trim() === "true";
+
+describe("deliberately removed files stay removed", () => {
+  it("has a non-empty population — an empty list passes forever", () => {
+    // The vacuity guard. Without it, emptying REMOVED turns every assertion below green.
+    expect(Object.keys(REMOVED).length, "the removed-file list is empty; this gate measures nothing")
+      .toBeGreaterThan(0);
+    expect(TRACKED.size, "git ls-files returned nothing — the tree read failed").toBeGreaterThan(100);
+  });
+
+  it("none of them is back in the tree", () => {
+    // THE RATCHET. Needs only the working tree, so it runs identically here and in a shallow CI clone.
+    const back = Object.keys(REMOVED).filter((p) => TRACKED.has(p));
+    expect(
+      back.map((p) => `${p} — removed because: ${REMOVED[p]}`),
+      "these were deleted on purpose and are back; docs/ is the published Pages root",
+    ).toEqual([]);
+  });
+
+  it("none of them reappeared under a different directory", () => {
+    // A relocation would satisfy the exact-path check while republishing the same document. Basename
+    // match, because that is what a move preserves and what `--diff-filter=D` cannot distinguish.
+    const moved: string[] = [];
+    for (const p of Object.keys(REMOVED)) {
+      const base = p.slice(p.lastIndexOf("/") + 1);
+      for (const t of TRACKED) if (t !== p && t.endsWith(`/${base}`)) moved.push(`${base} reappeared at ${t}`);
+    }
+    expect(moved, "a removed document is back under a new path").toEqual([]);
+  });
+
+  it("every entry genuinely existed once — so the ninth cannot be invented", () => {
+    if (SHALLOW) {
+      // Loud, not silent. See the blind-spot note above: this is the half that needs history, and
+      // CI has none. Failing here would be a false red; passing quietly would be the very defect
+      // this ring exists to catch, so it says which one happened.
+      console.warn(
+        "[delete-ratchet] shallow clone — enrollment (\"existed before\") NOT verified. " +
+        "The absence assertions above did run. Re-verify on a full clone before adding an entry.",
+      );
+      expect(SHALLOW).toBe(true);
+      return;
+    }
+    // ONE history walk, not one per entry. The first version ran `git log --all` eight times and
+    // **timed out at vitest's 5 s default** — 4.7 s measured, which passes alone and fails under a
+    // loaded suite. That is the same load-sensitive threshold `shell/roadmapStale.test.ts` hit today,
+    // and the fix is the one it settled on: **do the work once, do not raise the timeout.** A single
+    // walk over `docs/` measures 1.2 s, 3.8x faster and clear of the limit. Raising the timeout keeps
+    // the same eight walks and moves the cliff somewhere less predictable.
+    //
+    // `--all` so a file deleted on a branch that later merged is still found; `--diff-filter=A` lists
+    // additions; `--name-only --format=` prints just the paths.
+    const everAdded = new Set(
+      git("log", "--all", "--diff-filter=A", "--name-only", "--format=", "--", "docs/")
+        .split("\n").map((s) => s.trim().replace(/\\/g, "/")).filter(Boolean),
+    );
+    expect(everAdded.size, "the history walk returned nothing — this check would pass vacuously")
+      .toBeGreaterThan(20);
+    const never = Object.keys(REMOVED).filter((p) => !everAdded.has(p));
+    expect(
+      never,
+      "these were never added in any commit — enrolling a never-existent path is a gate that guards nothing",
+    ).toEqual([]);
+  });
+});

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1703,10 +1703,55 @@ requiring a manual read** — filed below as R41-LICENCE-GATE.
   `labor_rate` and `material_rate` are `module.json` *schemas*, not data files, and
   `module_schema.py` already rejects a malformed one — a size floor there would guard something that
   is guarded, while implying the rate *data* is covered when it lives in the database.
-- **R41-DELETE-RATCHET** *(S — Lane J)* — **assert in CI that removed things stay removed.** Several
-  lanes ship to main at once and nothing currently stops one reintroducing a decomposed god-module or a
-  re-export that reads as a dead import. A negative assertion is three lines and makes a removal stick:
-  the ratchet-rather-than-allowlist principle applied to architecture instead of security.
+- ◧ **R41-DELETE-RATCHET** *(S — Lane J; the FILE half SHIPPED 2026-08-06, the symbol half deliberately
+  not attempted)* — **assert in CI that removed things stay removed.** Shipped as
+  `apps/web/src/tooling/deleteRatchet.test.ts` over eight deleted documents.
+
+  **The entry says "a negative assertion is three lines". It is — and the population is the whole
+  problem.** Three plausible candidates were tested and all three failed, in three different ways:
+
+  * `?shell=classic` was deleted, but `"classic"` still lives in `apps/web/src/dev/liveAudit.test.ts`
+    as a run label — the string has a legitimate other life.
+  * the More menu is gone, but `"more"` appears in `apps/web/src/viewer/app.ts` and
+    `apps/web/src/viewer/railToolbox.ts` **in prose describing the removal** — the gate would fire on
+    the documentation of its own rule.
+  * the register renderer's internals — `renderRegister` and `registerBoard` were *guessed*, and
+    `git log -S` says **neither ever existed at any commit**. That assertion would have passed
+    forever, guarded nothing, and read as coverage. **It is the exact defect this ring is about, and
+    the only thing that caught it was checking history for a name somebody had invented.**
+
+  **So the first pass ratchets FILE PATHS, not symbols.** Every failure above is a string-matching
+  problem; a path has none of them — prior existence is provable from history, current absence is one
+  `git ls-files`, and it needs no comment-stripping, no word boundaries, and no matcher that can agree
+  with everything.
+
+  **The eight are load-bearing because `docs/` IS the Pages web root.** Re-adding any one republishes
+  a superseded planning document as a live public page. Two of them are competitive analyses, which a
+  standing user directive keeps out of the public docs — and `services/api/test_no_comparative_names.py`
+  enforces that **by content** while saying nothing about those *files*. **Neither check implies the
+  other**, which is a better argument for both than either makes alone.
+
+  **Enrollment stops the ninth entry being invented:** an entry must be absent now **and** present in
+  some earlier commit, so something that merely "does not exist yet" cannot be enrolled and the gate
+  cannot grow into a ban on future work. Enroll at deletion time; never archaeologise history, because
+  inference cannot separate *removed on principle* from *removed incidentally*.
+
+  **A stated blind spot, and it was proven rather than assumed.** `actions/checkout@v7` clones at
+  `fetch-depth: 1` and `.github/workflows/ci.yml` does not override it. A `git clone --depth 1` of this
+  repo reports `is_shallow=true`, **1 commit**, and the enrollment lookup finds **0** — so that half
+  would have failed all eight entries in CI for a reason unrelated to the code. The two halves are
+  therefore split by what they *need*: absence runs everywhere and is the ratchet; enrollment runs only
+  where history exists and **says so when it cannot**, rather than passing quietly. Deepening the CI
+  clone was rejected — a 2,000-commit fetch on every run to re-verify a property fixed at authoring
+  time.
+
+  Mutation-checked four ways: re-add a path → red; re-add it *relocated* → red on the basename check;
+  enroll a never-existent path → red; empty the list → red on the vacuity guard.
+
+  **Lineage:** `apps/web/src/portal/register/registerOwnership.test.ts` got there first and solved the
+  hard half — the population is the moved code *named*, the matcher is asserted to find real names,
+  comments are stripped, and the legitimate crossings are enumerated as doors. The symbol ratchet is
+  the harder second version and should extract that helper rather than re-derive it.
 - ✅ **R41-LICENCE-GATE** *(S — Lane J, SHIPPED 2026-08-06)* — **enforce the licence allowlist in CI
   instead of by reading.** This scan found three repositories whose actual LICENSE differs from their
   README or badge, two of them forbidding exactly our use.


### PR DESCRIPTION
Lane **J**. Ships the **file** half; the symbol half is deliberately not attempted, and the reason is the whole point of the PR.

## The entry says "a negative assertion is three lines"

It is. **The population is the whole problem** — and three plausible candidates all failed, in three different ways:

| candidate | why a naive assertion is wrong |
|---|---|
| `?shell=classic` (deleted) | `"classic"` still lives in `dev/liveAudit.test.ts` as a **run label**. The string has a legitimate other life. |
| the More menu ("gone, not reorganised") | `"more"` appears in `viewer/app.ts` and `railToolbox.ts` **in prose describing the removal**. The gate fires on the documentation of its own rule. |
| the register renderer's internals | I **guessed** `renderRegister` / `registerBoard`. `git log -S` says **neither ever existed at any commit.** |

The third is the one I would have shipped: **an assertion that a never-existent symbol is absent passes forever, guards nothing, and reads as coverage.** The only thing that caught it was checking history for a name I had invented.

## So this ratchets file paths, not symbols

Every failure above is a *string-matching* problem. A path has none of them: prior existence is provable from history, current absence is one `git ls-files`, and it needs no comment-stripping, no word boundaries, and no matcher that can agree with everything.

**Eight documents, all verified independently before enrolling** — absent from `origin/main`, added in some earlier commit, and basename absent everywhere else so a relocation cannot masquerade as a removal.

## Why they are load-bearing, not bookkeeping

**`docs/` IS the Pages web root.** `pages.yml` copies `docs/.` into the published site, so re-adding any one of these **republishes a superseded planning document as a live public page**.

Two are competitive analyses, which a standing user directive keeps out of the public docs. `services/api/test_no_comparative_names.py` enforces that **by content** and says nothing about those *files*; this says nothing about content. **Neither implies the other** — a better argument for both existing than either makes alone.

## Enrollment, so the ninth entry cannot be invented

An entry must be **absent now** *and* **present in some earlier commit**. Something that merely "does not exist yet" fails enrollment, so this cannot grow into a ban on future work. Each entry carries its reason, so **removing one is a decision, not a bypass**.

## A stated blind spot — proven, not assumed

`actions/checkout@v7` clones at `fetch-depth: 1` and `ci.yml` does not override it. I checked rather than reasoned:

```
$ git clone --depth 1 file:///C:/Server/modelmaker shallow
  is_shallow=true   commits=1
  enrollment lookup finds: 0 commits   (0 => would fail all eight)
```

So the halves are split by what they **need**: **absence runs everywhere and is the ratchet**; enrollment runs only where history exists and **says so when it cannot**, rather than passing quietly. Deepening the CI clone was rejected — a 2,000-commit fetch on every run to re-verify a property fixed at authoring time.

## The first version timed out, and the fix is the cause not the limit

Eight `git log --all` walks measured **4.7 s** against vitest's 5 s default — green standalone, red under a loaded suite. Same load-sensitive threshold `roadmapStale.test.ts` hit today, and the same resolution it settled on: **do the work once, do not raise the timeout.** One walk over `docs/` measures **1.2 s**; the file went from **7.77 s to 912 ms**.

## Verification

| mutation (each confirmed applied) | result |
|---|---|
| re-add a removed path | red — names the path and its reason |
| re-add it **relocated** to `docs/internal/` | red on the basename check |
| enroll a never-existent path | red — the `renderRegister` case, as a path |
| empty the list | red on the vacuity guard |
| point the history walk at an empty directory | red — "would pass vacuously" |

`npm run test --workspace apps/web` **1312 / 1312** (117/117), tsc clean, eslint clean, citation gate green.

## Lineage

`apps/web/src/portal/register/registerOwnership.test.ts` got there first and solved the hard half — the population is the moved code *named*, the matcher is asserted to find real names, comments are stripped, and legitimate crossings are enumerated as doors. **The symbol ratchet is the harder second version and should extract that helper rather than re-derive it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated safeguards to ensure eight intentionally removed documentation files do not reappear at their original or relocated paths.
  * Added validation that tracked files remain present and deleted documents existed in repository history when available.

* **Documentation**
  * Updated the roadmap to document the implemented deletion safeguards and handling for shallow repository checkouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->