### PR TITLE
roadmap sweep: UX-VIEWED is one call short, not a pipeline

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1978,11 +1978,32 @@ removed. Remaining, in priority order:
   precisely the "tell me what to do next" surface a builder/developer/architect/engineer wants on
   opening a project, and it is reachable from exactly ONE destination inside ONE workspace (Design).
   Promote the readiness strip to every workspace dashboard, scoped per persona.
-- **UX-DUP-DESTINATIONS** *(S)* — `Model Health`, `Model Analysis` and `BIM KPIs` are three
+  `Model Health` (8 references), `Model Analysis` (5) and `BIM KPIs` (5) are three
   destinations whose names do not tell a user which answers their question; all three now sit together
   under `Analyse & check`, which makes the overlap visible and worth resolving rather than hiding it.
 - **UX-GANTT** *(M)* — weekly Gantt/calendar hybrid with inline % + crew coloring + a metric strip.
-- **UX-VIEWED** *(S)* — ShareToken page view-timestamps → Sent/Viewed/Paid chips, self-hosted.
+- ◧ **UX-VIEWED** *(S — **checked 2026-08-06: the pipeline is built end to end and the CHIP is the
+  only thing missing**)* — ShareToken page view-timestamps → Sent/Viewed/Paid chips, self-hosted.
+
+  Every layer this needs already exists. `services/api/src/aec_api/models.py` stores `view_count` and
+  `last_viewed_at` on `ShareToken`; `services/api/src/aec_api/client_portal.py` **increments both on
+  every view** and serves them from `_public_row`; `apps/web/src/api/client.ts` types them; and
+  `apps/web/src/ui/chips.ts` is the chip vocabulary itself — its opening line names *"Sent → Viewed →
+  Paid"* as the exact phrasing it exists to standardise, with 7 tests.
+
+  **What is missing is one call.** `apps/web/src/portal/panels/masterBuilder.ts` renders the share
+  row as a link plus a revoke button and inlines the count as plain text — `(3 views)`. It never
+  calls `statusChip`, and it **never uses `last_viewed_at` at all**, so the timestamp is gathered on
+  every view, stored, serialised, sent over the wire, typed in the client, and then dropped on the
+  floor.
+
+  So this is not "build a view-tracking pipeline" (S); it is *use the chip vocabulary that exists on
+  the data that is already on the wire*. The remaining work is in one file. **Nothing needed
+  building; something needed calling** — the same reach-not-capability shape as the `snapEngine`
+  resolver with zero callers.
+
+- **UX-DUP-DESTINATIONS** *(S — **checked 2026-08-06 and still genuinely OPEN**; recorded so the next
+  reader does not re-check)* — all three destinations are still present and distinct in the tree:
 - ✅ **UX-AR** *(S — **checked 2026-08-06: ALREADY BUILT, and built better than this asked**)* —
   Sent→Approved→Paid manual status pipeline on invoices/bills (no payment rails).
   `services/api/modules/owner_invoice/module.json` and


### PR DESCRIPTION
**Docs only.** One commit, off current main. Continuing the sweep, per your "back to sweeping" call.

## `UX-VIEWED` → ◧ — every layer exists; the chip is the only thing missing

| layer | status |
|---|---|
| `models.py` — `view_count`, `last_viewed_at` on `ShareToken` | ✅ stored |
| `client_portal.py` — increments **both** on every view | ✅ written |
| `_public_row` — serialises both | ✅ served |
| `client.ts` — types both | ✅ on the wire |
| `chips.ts` — the chip vocabulary, opening line names **"Sent → Viewed → Paid"**, 7 tests | ✅ built |
| `masterBuilder.ts` — renders the share row | ❌ **never calls `statusChip`; never uses `last_viewed_at`** |

**The timestamp is gathered on every view, stored, serialised, sent over the wire, typed in the client — and dropped on the floor.** The count survives only as plain text: `(3 views)`.

So the entry is not *"build a view-tracking pipeline"* (S). It is *use the chip vocabulary that already exists, on data already on the wire*, and the work is in **one file**. **Nothing needed building; something needed calling** — the same reach-not-capability shape as the `snapEngine` resolver with zero callers.

## I nearly reported the exact opposite

My first check grepped `routers/` for the field names, found nothing, and I was one step from recording *"stored, never served"* — which would have sent someone to build a serialiser that exists.

The serving code is in **`aec_api/client_portal.py`**, not **`aec_api/routers/client_portal.py`** — two files one directory apart with the same name. **The population I searched was narrower than the claim I was about to make**, which is the day's theme arriving through a filename collision rather than a language boundary. Widening to the package found the write, the increment and the serialiser in seconds.

## `UX-DUP-DESTINATIONS` — checked, still genuinely open

Recorded so the next reader doesn't re-check: `Model Health` (8 refs), `Model Analysis` (5), `BIM KPIs` (5) are all still present and distinct. The overlap is unresolved, not stale.

## Verification, and its limit

**Verified by hand, not by suite.** A backend `run_tests.py` was executing in another worktree, and a suite started under that contention tells you nothing either way — which is the trap the announce rule exists to prevent.

Marker properties checked by regex instead: **87 ids, zero conflicted**, `UX-VIEWED` marked, `UX-DUP-DESTINATIONS` open. **CI is the authoritative gate here**, and I would rather say that than claim a local green I did not earn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
