### PR TITLE
R41-FDD-INGEST — consume fault findings, and say whose system said so

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1463,7 +1463,7 @@ requiring a manual read** — filed below as R41-LICENCE-GATE.
 
 ### Capability items
 
-- **R41-FDD-INGEST** *(M — Lane C)* — **consume fault findings; do not build a historian.** The operate
+- ✅ **R41-FDD-INGEST** *(M — Lane C/H; `fault_finding` register shipped 2026-08-07)* — **consume fault findings; do not build a historian.** The operate
   phase has a real hole: FCA/FCI, work orders, PM schedules, asset registers and warranties all exist,
   but **nothing consumes time-series building-automation telemetry**, so condition is surveyed by a
   person rather than measured continuously. The tempting answer — build fault detection ourselves —
@@ -1472,6 +1472,26 @@ requiring a manual read** — filed below as R41-LICENCE-GATE.
   `fault_finding` register keyed to IFC GlobalId, populated from an external system's MCP or REST
   surface**, feeding the FCI and work-order modules we already have. Public ASHRAE Guideline 36 fault
   identifiers are a stable vocabulary to key against.
+
+  **Premise held — genuinely unbuilt**, unlike most of this ring: `asset_register`, `fca_element`,
+  `work_order` and `warranty` all existed and nothing consumed telemetry findings.
+  `fault_finding` (FDD, 16 fields, four contiguous fieldsets: Fault / Provenance / Asset /
+  Consequence) takes the cheap path the entry prescribes and **does not** build a historian.
+  The design point is that we CONSUME rather than detect, so provenance is a fieldset rather than a
+  footnote: `source_system` + `external_id` + `first_seen`/`last_seen`/`occurrences`. A finding with
+  no source is not ours to assert, and a telemetry fault is an interval that recurs, not an instant —
+  which is why `cleared → reported` ("recurred") is a real transition: **a fault that stops reporting
+  is not necessarily fixed, and one that returns is not new.** `dismissed` is separate from `cleared`
+  for the same reason.
+  G36 identifiers FC1–FC15 are the `g36_id` vocabulary, plus an explicit "Other (not a G36 fault)" so
+  an unmapped fault is recorded as unmapped instead of forced into the nearest code.
+  **No defaults at all** — `test_field_attrs.py` caps them and requires each to be a fact about the
+  record rather than a policy, and on a register fed by someone else's system every default would be
+  an assertion about *their* data.
+  Verified over HTTP with startup actually running: `GET /modules` → **137** (was 136), key-shape
+  identical to `pm_contract`, room derived as `operate`, `POST` → 201 `FDD-001`.
+  *The registry validator earned its keep*: the first draft wrote reference fields as `ref:` when the
+  schema wants `module:`, and it named all four rather than failing silently.
 
   **CHECKED 2026-08-06 — the premise HOLDS, which is worth recording because most have not.** The
   modules the entry says exist do: `fca_element` + `services/api/src/aec_api/fca.py`, `work_order`,

--- a/services/api/migrations/versions/2026_08_07_0700-b4c1f7d92e08_mod_fault_finding_r41_fdd_ingest_.py
+++ b/services/api/migrations/versions/2026_08_07_0700-b4c1f7d92e08_mod_fault_finding_r41_fdd_ingest_.py
@@ -1,0 +1,69 @@
+"""mod_fault_finding (R41-FDD-INGEST persistence)
+
+Revision ID: b4c1f7d92e08
+Revises: f4b8d2e17c93
+Create Date: 2026-08-07 07:00:00.000000
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b4c1f7d92e08'
+down_revision: str | None = 'f4b8d2e17c93'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table('mod_fault_finding',
+    sa.Column('id', sa.String(), nullable=False),
+    sa.Column('project_id', sa.String(), nullable=True),
+    sa.Column('ref', sa.String(), nullable=True),
+    sa.Column('title', sa.String(), nullable=True),
+    sa.Column('workflow_state', sa.String(), nullable=True),
+    sa.Column('party_owner', sa.String(), nullable=True),
+    sa.Column('assignee', sa.String(), nullable=True),
+    sa.Column('created_by', sa.String(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('modified_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('anchor', sa.JSON(), nullable=True),
+    sa.Column('element_guids', sa.JSON(), nullable=True),
+    sa.Column('links', sa.JSON(), nullable=True),
+    sa.Column('data', sa.JSON(), nullable=True),
+    # R41-SCHEMA-STALE added this to every mod_* table (revision e2c6f31b9a44). A register
+    # created AFTER that revision must declare it at create_table, or  reports
+    # model-vs-migration drift - which is how this was caught rather than shipping skewed.
+    sa.Column('schema_version', sa.String(), nullable=True),
+    sa.PrimaryKeyConstraint('id')
+    )
+    with op.batch_alter_table('mod_fault_finding', schema=None) as batch_op:
+        batch_op.create_index('ix_mod_fault_finding_proj_assignee', ['project_id', 'assignee'], unique=False)
+        batch_op.create_index('ix_mod_fault_finding_proj_created', ['project_id', 'created_at'], unique=False)
+        batch_op.create_index('ix_mod_fault_finding_proj_state', ['project_id', 'workflow_state'], unique=False)
+        batch_op.create_index(batch_op.f('ix_mod_fault_finding_project_id'), ['project_id'], unique=False)
+        batch_op.create_index(batch_op.f('ix_mod_fault_finding_workflow_state'), ['workflow_state'], unique=False)
+
+    # Postgres-only FTS GIN index — every module table gets one at runtime; a post-baseline module
+    # migration must create its own (the baseline only indexes tables that exist at ITS point in the
+    # chain, so skipping this silently loses full-text search on Postgres while passing every SQLite
+    # test — which is exactly what makes it look like boilerplate).
+    if op.get_bind().dialect.name == "postgresql":
+        from aec_api import modules_registry
+        from aec_api.modules_search import index_ddl
+        modules_registry.load_registry()
+        op.execute(index_ddl("fault_finding", modules_registry.TABLES["fault_finding"]))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('mod_fault_finding', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_mod_fault_finding_workflow_state'))
+        batch_op.drop_index(batch_op.f('ix_mod_fault_finding_project_id'))
+        batch_op.drop_index('ix_mod_fault_finding_proj_state')
+        batch_op.drop_index('ix_mod_fault_finding_proj_created')
+        batch_op.drop_index('ix_mod_fault_finding_proj_assignee')
+
+    op.drop_table('mod_fault_finding')

--- a/services/api/modules/fault_finding/module.json
+++ b/services/api/modules/fault_finding/module.json
@@ -1,0 +1,211 @@
+{
+  "key": "fault_finding",
+  "name": "Fault Findings",
+  "section": "Condition & Capital",
+  "icon": "📉",
+  "ref_prefix": "FDD",
+  "title_field": "fault_name",
+  "pinnable": true,
+  "fields": [
+    {
+      "name": "fault_name",
+      "label": "Fault",
+      "type": "text",
+      "fieldset": "Fault"
+    },
+    {
+      "name": "g36_id",
+      "label": "ASHRAE G36 fault",
+      "type": "select",
+      "options": [
+        "FC1 low duct static",
+        "FC2 mixed air too low",
+        "FC3 mixed air too high",
+        "FC4 excessive mode changes",
+        "FC5 supply/return temp mismatch",
+        "FC6 outside air fraction off",
+        "FC7 heating valve saturated",
+        "FC8 economizer temp mismatch",
+        "FC9 free cooling unavailable",
+        "FC10 mixed air vs outside air",
+        "FC11 outside air vs supply",
+        "FC12 mixed air above supply",
+        "FC13 cooling valve saturated",
+        "FC14 coil delta-T low",
+        "FC15 coil delta-T high",
+        "Other (not a G36 fault)"
+      ],
+      "fieldset": "Fault"
+    },
+    {
+      "name": "severity",
+      "label": "Severity",
+      "type": "select",
+      "options": [
+        "Critical",
+        "High",
+        "Medium",
+        "Low"
+      ],
+      "fieldset": "Fault"
+    },
+    {
+      "name": "description",
+      "label": "What the system reported",
+      "type": "textarea",
+      "fieldset": "Fault"
+    },
+    {
+      "name": "source_system",
+      "label": "Source system",
+      "type": "text",
+      "fieldset": "Provenance"
+    },
+    {
+      "name": "external_id",
+      "label": "Fault ID in that system",
+      "type": "text",
+      "fieldset": "Provenance"
+    },
+    {
+      "name": "first_seen",
+      "label": "First seen",
+      "type": "date",
+      "fieldset": "Provenance"
+    },
+    {
+      "name": "last_seen",
+      "label": "Last seen",
+      "type": "date",
+      "fieldset": "Provenance"
+    },
+    {
+      "name": "occurrences",
+      "label": "Occurrences",
+      "type": "number",
+      "fieldset": "Provenance"
+    },
+    {
+      "name": "asset",
+      "label": "Asset",
+      "type": "reference",
+      "module": "asset_register",
+      "fieldset": "Asset"
+    },
+    {
+      "name": "equipment_tag",
+      "label": "Equipment tag",
+      "type": "text",
+      "fieldset": "Asset"
+    },
+    {
+      "name": "location_loc",
+      "label": "Location (linked)",
+      "type": "reference",
+      "module": "location",
+      "fieldset": "Asset"
+    },
+    {
+      "name": "condition_impact",
+      "label": "Condition impact",
+      "type": "select",
+      "options": [
+        "Suspected deficiency",
+        "Confirmed deficiency",
+        "No condition impact",
+        "Not assessed"
+      ],
+      "fieldset": "Consequence"
+    },
+    {
+      "name": "fca_element",
+      "label": "Condition record",
+      "type": "reference",
+      "module": "fca_element",
+      "fieldset": "Consequence"
+    },
+    {
+      "name": "work_order",
+      "label": "Work order",
+      "type": "reference",
+      "module": "work_order",
+      "fieldset": "Consequence"
+    },
+    {
+      "name": "energy_cost_annual",
+      "label": "Est. annual energy cost",
+      "type": "currency",
+      "fieldset": "Consequence"
+    }
+  ],
+  "workflow": {
+    "initial": "reported",
+    "states": [
+      "reported",
+      "triaged",
+      "actioned",
+      "cleared",
+      "dismissed"
+    ],
+    "transitions": [
+      {
+        "from": "reported",
+        "to": "triaged",
+        "action": "triage",
+        "party": [
+          "Owner",
+          "OwnersRep",
+          "Engineer",
+          "Consultant"
+        ]
+      },
+      {
+        "from": "triaged",
+        "to": "actioned",
+        "action": "raise work order",
+        "party": [
+          "Owner",
+          "OwnersRep",
+          "GC"
+        ]
+      },
+      {
+        "from": "actioned",
+        "to": "cleared",
+        "action": "clear",
+        "party": [
+          "Owner",
+          "OwnersRep",
+          "GC"
+        ]
+      },
+      {
+        "from": "cleared",
+        "to": "reported",
+        "action": "recurred",
+        "party": [
+          "Owner",
+          "OwnersRep",
+          "Engineer"
+        ]
+      },
+      {
+        "from": "triaged",
+        "to": "dismissed",
+        "action": "dismiss",
+        "party": [
+          "Owner",
+          "OwnersRep",
+          "Engineer"
+        ]
+      }
+    ]
+  },
+  "list_columns": [
+    "g36_id",
+    "severity",
+    "source_system",
+    "last_seen"
+  ],
+  "workspace": "construction|developer"
+}


### PR DESCRIPTION
## Premise held — genuinely unbuilt

Unlike most of this ring. `asset_register`, `fca_element`, `work_order` and `warranty` all existed; **nothing consumed telemetry findings**.

`fault_finding` (FDD, 16 fields, four contiguous fieldsets: Fault / Provenance / Asset / Consequence). **No historian**, exactly as the entry insists — the cheap path is a register keyed to the model and fed from someone else's system.

## The design point

**We consume rather than detect, so provenance is a fieldset rather than a footnote:** `source_system` + `external_id` + `first_seen`/`last_seen`/`occurrences`. A finding with no source is not ours to assert.

**A telemetry fault is an interval that recurs, not an instant.** That is why `cleared → reported` ("recurred") is a real transition: *a fault that stops reporting is not necessarily fixed, and one that returns is not new.* `dismissed` is separate from `cleared` for the same reason.

G36 identifiers **FC1–FC15** are the `g36_id` vocabulary, plus an explicit "Other (not a G36 fault)" so an unmapped fault is recorded as unmapped rather than forced into the nearest code.

**No defaults at all.** `test_field_attrs.py` caps defaults and requires each to be a fact about the *record*, never a policy — and on a register fed by another system, every default would be an assertion about **their** data.

## The rebase found a real interaction — twice

This branch was held during the CI stand-down, and both problems came from that.

**1. `schema_version` drift.** R41-SCHEMA-STALE shipped meanwhile and added `schema_version` to every `mod_*` table (`e2c6f31b9a44`). A register created *after* that revision must declare the column at `create_table`. **`alembic check` caught the drift** rather than letting it ship skewed.

**2. My head computation was wrong, and confidently so.** My regex required `revision: str = '...'`; the two newest migrations use bare `revision = "..."`. It silently skipped both and reported the **superseded** head. Chaining onto that would have **forked the chain into two heads**. Re-chained onto the true head `f4b8d2e17c93`.

That is the instrument deciding the answer — the same failure this repo keeps finding, here in a new costume.

## Verified by building the schema, not by reading

```
alembic upgrade head:  f4b8d2e17c93 -> b4c1f7d92e08
mod_fault_finding present: True | 169 tables
columns include schema_version
alembic check: clean, single head
```

Over HTTP with startup actually running (a `TestClient` outside a `with` block reports **zero** modules and reads as an empty registry): `GET /modules` → **137**, key-shape identical to `pm_contract`, room derived as `operate`, `POST` → 201 `FDD-001`.

Suite was **532/532** clean pre-rebase; `alembic_migrations`, `claude_md_gates`, `field_attrs` and `modules` green at the commit SHA after.

## Note

The registry validator earned its keep: the first draft wrote reference fields as `ref:` where the schema wants `module:`, and it **named all four** rather than failing silently or accepting them.