### PR TITLE
The lock gate's population excluded the file that moved — #229 was a false upgrade

### DIFF
--- a/services/api/test_lock_satisfies_requirements.py
+++ b/services/api/test_lock_satisfies_requirements.py
@@ -28,10 +28,26 @@ WHY THE EXISTING WORKFLOW DID NOT CATCH IT
     but it can compare what the lock PINS against what the input REQUIRES, in the normal suite,
     on every run. The workflow stays the authority on resolution; this stays the tripwire.
 
+IT HAPPENED AGAIN ON 2026-08-07, THROUGH THE HALF THIS SCOPE PARAGRAPH LEFT OUT
+    The paragraph below used to end "only the direct constraints in `requirements.in` are checked".
+    That was a deliberate, reasonable scope — and it was **not the whole population**.
+    `services/data/requirements.txt` declares floors too, and the API image runs that code: the
+    Dockerfile copies `services/data/src` in and puts it on `PYTHONPATH`, and 59 files under
+    `services/api/src` import `aec_data`. But pip installs only `services/api/requirements.lock`.
+
+    So when Dependabot raised `trimesh>=4.12.2` to `>=5.0.0` there (#229), this test **passed** —
+    `requirements.in` still said `trimesh>=4.0`, which the pinned 4.12.2 satisfies. The image kept
+    shipping 4.12.2 while a manifest in the repo said 5.0.0 was required. Same failure as
+    2026-08-01, one file to the left, four days later, past a gate written for exactly it.
+
+    **A gate's population is part of its claim, and a second input file inherits none of the
+    protection the first one has.** `SOURCES` below is now the population, and a missing entry fails
+    loudly rather than shrinking the checked set in silence.
+
 WHAT IS DELIBERATELY NOT ASSERTED
     That the lock is a *complete* or *minimal* resolution — that needs a real resolver. Only the
-    direct constraints in `requirements.in` are checked, because those are the ones a human wrote
-    on purpose and the ones Dependabot edits.
+    direct constraints in the files listed in `SOURCES` are checked, because those are the ones a
+    human wrote on purpose and the ones Dependabot edits.
 
 Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_lock_satisfies_requirements.py
 """
@@ -92,8 +108,40 @@ for path in (IN_PATH, LOCK_PATH):
         print(f"FAIL  missing {path}")
         sys.exit(1)
 
-with open(IN_PATH, encoding="utf-8") as fh:
-    in_lines = fh.read().splitlines()
+#: Every file whose floors the API lock must satisfy, tagged with the name used in failure messages.
+#:
+#: **`services/data/requirements.txt` is here because the API image RUNS that code.** The Dockerfile
+#: copies `services/data/src` into the image and puts it on `PYTHONPATH`, and 59 files under
+#: `services/api/src` import `aec_data` — but the only thing pip installs is
+#: `services/api/requirements.lock`. So a floor raised in the data service's requirements is a
+#: promise the container never keeps.
+#:
+#: That is not hypothetical. Dependabot raised `trimesh>=4.12.2` to `>=5.0.0` there on 2026-08-07
+#: (#229) and this test **passed**, because its population was `requirements.in` alone and
+#: `requirements.in` still said `trimesh>=4.0`, which the pinned 4.12.2 satisfies. The image kept
+#: shipping 4.12.2 while the manifest said 5.0.0 was required — *truthfully and ineffectively*, which
+#: is the sentence this file's own docstring already uses about the 2026-08-01 incident.
+#:
+#: **The gate was correct and its claim was narrower than it read.** The 2026-08-01 lesson was
+#: "compare what the lock pins against what the input requires"; what went unstated was *which*
+#: inputs. A second requirements file appeared later and inherited none of the protection.
+SOURCES = [
+    (IN_PATH, "requirements.in"),
+    (os.path.join(HERE, "..", "data", "requirements.txt"), "services/data/requirements.txt"),
+]
+
+in_lines: list[tuple[str, str]] = []          # (line, source-label) so a failure names its file
+for _path, _label in SOURCES:
+    if not os.path.exists(_path):
+        # Loud rather than skipped: a renamed or moved requirements file must not silently shrink
+        # this test's population back to where it was when #229 slipped through. Verified by
+        # mutation — pointing this at a missing file drops the floors from 48 to 35 and FAILS,
+        # rather than passing on the smaller set.
+        print(f"FAIL  requirements source missing: {_label} ({_path})")
+        FAILED.append("requirements source missing")
+        continue
+    with open(_path, encoding="utf-8") as fh:
+        in_lines += [(ln, _label) for ln in fh.read().splitlines()]
 with open(LOCK_PATH, encoding="utf-8") as fh:
     lock_text = fh.read()
 
@@ -122,11 +170,14 @@ check("the lock parses and pins a realistic number of packages", len(pinned) > 5
 REQ = re.compile(r"^([A-Za-z0-9._-]+)\s*(?:\[[^\]]*\])?\s*(>=|==|~=|>)\s*([0-9][^\s,;#]*)")
 NAME_ONLY = re.compile(r"^([A-Za-z0-9._-]+)\s*(?:\[[^\]]*\])?\s*(?:[;#].*)?$")
 
-floors: list[tuple[str, str, int]] = []
+floors: list[tuple[str, str, str]] = []   # (name, floor, "<file>:<line>")
 unversioned: list[str] = []
 unparsed: list[str] = []
 requirement_lines = 0
-for i, raw in enumerate(in_lines, 1):
+_line_no: dict[str, int] = {}                 # per-source numbering, so citations stay honest
+for raw, _src in in_lines:
+    _line_no[_src] = _line_no.get(_src, 0) + 1
+    i = f"{_src}:{_line_no[_src]}"
     line = raw.split("#")[0].strip()
     if not line or line.startswith("-"):
         continue
@@ -138,9 +189,9 @@ for i, raw in enumerate(in_lines, 1):
         # because nothing in the file uses `>`, and inventing the rule now would be untested.
         floors.append((_norm(m.group(1)), m.group(3), i))
     elif NAME_ONLY.match(line):
-        unversioned.append(f"{line} (line {i})")     # legitimately unconstrained — nothing to check
+        unversioned.append(f"{line} ({i})")     # legitimately unconstrained — nothing to check
     else:
-        unparsed.append(f"{line} (line {i})")
+        unparsed.append(f"{line} ({i})")
 
 check("every requirement line is either checked or explicitly accounted for",
       not unparsed,
@@ -148,7 +199,7 @@ check("every requirement line is either checked or explicitly accounted for",
       f"{requirement_lines} requirement lines = {len(floors)} with a version floor "
       f"+ {len(unversioned)} deliberately unconstrained")
 
-check("requirements.in declares floors this test can check", len(floors) >= 5,
+check("the requirements sources declare floors this test can check", len(floors) >= 5,
       f"{len(floors)} version constraints found")
 
 # --- every floor must be satisfied by the pin ---------------------------------------------------
@@ -158,15 +209,15 @@ for name, floor, lineno in floors:
     got = pinned.get(name)
     if got is None:
         # A required package absent from the lock would not install at all.
-        unpinned.append(f"{name} (requirements.in:{lineno})")
+        unpinned.append(f"{name} ({lineno})")
         continue
     if _version_key(got) < _version_key(floor):
-        violations.append(f"{name}: lock pins {got}, requirements.in:{lineno} requires >={floor}")
+        violations.append(f"{name}: lock pins {got}, {lineno} requires >={floor}")
 
-check("every package required by requirements.in is present in the lock",
+check("every package the requirements sources require is present in the lock",
       not unpinned, "; ".join(unpinned[:5]))
 
-check("the lock satisfies every floor requirements.in declares",
+check("the lock satisfies every floor the requirements sources declare",
       not violations,
       "\n        " + "\n        ".join(violations)
       + "\n        -> regenerate: run the 'Lockfile (pip-compile)' workflow, download the"

--- a/services/data/requirements.txt
+++ b/services/data/requirements.txt
@@ -3,7 +3,15 @@ ifcopenshell>=0.8.5,<0.9
 openpyxl>=3.1          # XLSX export
 numpy>=2.5.1           # geometry-derived quantities, AABB clash
 ifctester>=0.8        # IDS / openBIM model validation
-trimesh>=5.0.0          # clash narrow phase (mesh booleans) + 2D section cuts
+# Held at 4.12.2, which is what `services/api/requirements.lock` pins and therefore what the
+# container actually runs — this file is NOT installed anywhere (the API image installs only that
+# lock, and CI installs it too). Dependabot raised this to >=5.0.0 in #229 and every check went
+# green, because nothing had ever compared this file against the lock; the image kept shipping
+# 4.12.2 while this line claimed 5.0.0 was required. Raising it again means regenerating the lock
+# AND validating trimesh 5 against the paths below — it drives mesh booleans (with manifold3d, at
+# 3.5.2) and 2D section cuts, so a major move there is not free. `test_lock_satisfies_requirements.py`
+# now reads this file, so the two can no longer disagree silently.
+trimesh>=4.12.2         # clash narrow phase (mesh booleans) + 2D section cuts
 manifold3d>=2.0       # boolean intersection engine for trimesh
 scipy>=1.18.0           # trimesh path assembly (section drawings)
 networkx>=3.6.1         # trimesh path traversal (section drawings)


### PR DESCRIPTION
Two things: revert a dependency floor that never reached production, and widen the gate that should have caught it. **I merged #229, so this is mine to fix.** Caught by Massing Core on review.

## #229 raised a floor in a file nothing installs

`#229` raised `trimesh>=4.12.2` → `>=5.0.0` in **`services/data/requirements.txt`**.

The API image installs `services/api/requirements.lock` and **only** that (`--require-hashes`, `Dockerfile:33`). CI installs the same lock. The lock pins `trimesh==4.12.2`.

| | data floor | api.in floor | lock (what ships) |
|---|---|---|---|
| **trimesh** | **>=5.0.0** | >=4.0 | **==4.12.2** |
| rdflib | >=7.6.0 | >=7.1 | ==7.6.0 |
| shapely | >=2.1.2 | >=2.0 | ==2.1.2 |
| scipy | >=1.18.0 | >=1.18.0 | ==1.18.0 |
| networkx | >=3.6.1 | >=3.6.1 | ==3.6.1 |

Every other package lines up. trimesh is the one that doesn't — so the container keeps running **4.12.2** while a manifest in the repo says 5.0.0 is required. *Truthfully and ineffectively*, which is the phrase this test's own docstring already uses about the 2026-08-01 incident. **Same failure, one file to the left, four days later, past a gate written for exactly it.**

**The green tick on #229 never touched trimesh 5.** CI installs the lock, so the API test gate ran on 4.12.2 throughout — the check that passed *could not have exercised the change*.

## Reverted, not raised

Shipping trimesh 5 means regenerating the lock **and** validating it against the paths that floor exists for — mesh booleans (with `manifold3d` at 3.5.2) and 2D section cuts. That is deliberate work, not a dependabot merge, and **nothing has run against 5.0.0 yet**.

## The durable half: `SOURCES` is now the population

The gate read `requirements.in` alone — a reasonable scope, stated plainly in its docstring, and **not the whole set**. `services/data/requirements.txt` declares floors too, and **the API image runs that code**: the Dockerfile copies `services/data/src` in and puts it on `PYTHONPATH`, and **59 files** under `services/api/src` import `aec_data`.

Floors checked go **35 → 48**. A missing source now **fails loudly** rather than shrinking the checked set in silence.

Failure messages now name the file: `trimesh: lock pins 4.12.2, services/data/requirements.txt:14 requires >=5.0.0`. With two sources a bare line number is ambiguous.

> **A gate's population is part of its claim, and a second input file inherits none of the protection the first one has.**

## Verification

| mutation (each confirmed applied) | result |
|---|---|
| re-raise the data floor — the #229 defect | **EXIT=1**, names the file and line |
| point `SOURCES` at a missing path | **EXIT=1** "requirements source missing", and the count visibly drops **48 → 35** |
| baseline | EXIT=0, 48 floors against 109 pins |

The second mutation matters: the shrink is *evidence*, not a silent pass on a smaller set.

`ruff` clean. `test_lock_satisfies_requirements`, `test_manifest`, `test_supply_chain`, `test_license_gate`, `test_claude_md_gates` all exit 0, zero tracebacks.

## Also confirmed, for the release holder

- **DracoPy (#241) is consistent** — it lives in `requirements-dev.txt` at `==2.0.0` and deliberately **not** in `requirements.in`, so the runtime image never carries the native wheel and `gltf_export` imports it lazily. **There is no runtime pin for it to disagree with, by design.**
- **reportlab (#240) is consistent** — `api.in >=5.0.0`, `lock ==5.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)