### PR TITLE
requirements: networkx is load-bearing for section drawings, not dead weight

### DIFF
--- a/services/api/requirements.in
+++ b/services/api/requirements.in
@@ -25,6 +25,21 @@ ifctester>=0.8
 trimesh>=4.0
 manifold3d>=2.0
 scipy>=1.18.0
+# DO NOT REMOVE — it looks unused and is not. Nothing under `services/` writes `import networkx`,
+# so a grep for import sites says "zero" and the line reads like dead weight. It is the ONLY thing
+# installing networkx: both consumers declare it as an *optional extra* (`trimesh[easy]`,
+# `ifcopenshell[advanced]`) and we install neither extra, so dropping this line drops the package.
+#
+# It is load-bearing for plan/section drawings. `aec_data/drawings.py` cuts geometry with
+# `mesh.section(...)` and then reads `sec.discrete`, and that attribute walks the path graph through
+# networkx. Verified by blocking the import: `.section()` still returns a Path3D, and `.discrete`
+# raises ImportError.
+#
+# The failure would also have been quiet. `drawings.py` wraps the cut in
+# `except Exception  # noqa: BLE001 — one unsectionable mesh must not kill the cut`, so the
+# ImportError is swallowed once per mesh and every plan and section renders BLANK rather than
+# erroring. `test_sections.py` is what actually catches it — it asserts the SVG contains drawn
+# geometry, so it goes red instead of the drawings going empty.
 networkx>=3.6.1
 shapely>=2.0
 reportlab>=5.0.0


### PR DESCRIPTION
## The short version

**I was about to delete this dependency. It would have silently blanked every plan and section drawing.** This PR is the comment that stops the next person (or the next me) from repeating the reasoning.

No version change, no lock regeneration — comment only.

## How the wrong conclusion was reached

The planned item was "remove networkx: zero import sites, so the image installs it for nothing." The grep behind that is accurate — nothing under `services/` writes `import networkx`. The inference from it is wrong, in two steps:

1. **Both consumers declare it as an optional extra**, not a dependency: `trimesh` has `Requires-Dist: networkx; extra == "easy"` and `ifcopenshell` has `extra == "advanced"`. We install neither extra. The lock agrees — `networkx==3.6.1` is annotated `# via -r services/api/requirements.in`, nothing else. So this line isn't redundant with a transitive pull; it *is* the pull.

2. **`drawings.py` reaches it through trimesh, not through an import.** The section cut does `mesh.section(...)` then reads `sec.discrete`, and that attribute walks the path graph via networkx.

Verified by blocking the import rather than reasoning about it:

```
section() ok -> Path3D
RESULT: .discrete FAILED without networkx -> ImportError No module named 'networkx'
```

## Why this one deserved a comment rather than a shrug

The failure mode is silent. `drawings.py` wraps the cut in

```python
except Exception as exc:   # noqa: BLE001 — one unsectionable mesh must not kill the cut
```

which is the right call for a genuinely unsectionable mesh — but it means a missing networkx is swallowed **once per mesh**, and the result is not a crash. It's every plan and section rendering **blank**, with a debug line per mesh and a warning about linework.

`test_sections.py:48` is what actually catches it: it asserts the SVG contains `<polyline` / `<path` / `<line`, so the suite goes red instead of the drawings going empty. That test is in the `run_tests.py` manifest and passes today. The comment names it, so the next person to question this line finds the gate instead of just my prose.

## Checks

- `test_lock_satisfies_requirements.py` — **48 requirement lines = 48 floors, unchanged** by the added comment (the parser strips `#`). 48 floors against 109 pins, green.
- `test_sections.py` — green.
- Comment-only diff; no floor moved, so no lock regeneration needed.

## Note on the source I read

The main clone's working tree shows `networkx>=3.0` and `reportlab>=4.0`; `origin/main` has `>=3.6.1` and `>=5.0.0`. That tree is stale — this branch is cut from `a13d8612` and the numbers above are from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)