### PR TITLE
PULSE-FINDINGS: surface reserve + renovation findings on the deal card

### DIFF
--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -110,7 +110,12 @@ const uncalled = surface.filter((m) => !NOT_ENDPOINTS.has(m) && !reached(m));
 //: CEILING — only ever revised DOWN. The measured value on 2026-08-07, so the set cannot grow
 //: quietly. Wiring a method to a screen lowers it; adding an unreachable endpoint raises it and has
 //: to say so out loud in the commit message.
-const UNCALLED_CEILING = 132;
+//:
+//: 132 -> 131 when PULSE-FINDINGS wired `proformaRenovation` into the home pulse. It was expected to
+//: drop by TWO, for `reserveStudy` as well — that was wrong, and the number is why it was caught:
+//: `reserveStudy` already had a caller in `src/proforma/proforma.ts`, so it was never in this set.
+//: Measured by probing rather than derived from what the wiring touched.
+const UNCALLED_CEILING = 131;
 
 describe("client methods the application actually calls", () => {
   it("agrees with a hand-checked sample in BOTH directions", () => {
@@ -148,8 +153,22 @@ describe("client methods the application actually calls", () => {
     // `surface.test.ts` lists these under "the methods the rest of the app actually calls".
     // That was false when written. This records which of them is still true, so wiring one up
     // fails here and forces the list to be corrected rather than left to rot.
+    //
+    // It did exactly that: PULSE-FINDINGS wired `proformaRenovation` into the home pulse and this
+    // assertion went red on the same run, which is the whole reason it names them individually
+    // instead of counting them.
     const trio = ["proformaRenovation", "proformaRollover", "proformaIncomeBasis"];
     const stillUncalled = trio.filter((m) => uncalled.includes(m));
-    expect(stillUncalled.sort()).toEqual([...trio].sort());
+    expect(stillUncalled.sort()).toEqual(["proformaIncomeBasis", "proformaRollover"]);
+  });
+
+  it("proformaRenovation is reached from a SCREEN, not from another api module", () => {
+    // The pairing that makes the line above mean something. Moving a call into `src/api` would also
+    // take a method out of `uncalled` without any human ever seeing its result — so assert the thing
+    // that was actually wanted: a file outside `src/api` calls it.
+    expect(uncalled.includes("proformaRenovation")).toBe(false);
+    const callers = appFiles.filter((f) => /proformaRenovation/.test(readFileSync(f, "utf8")));
+    expect(callers.length, "no screen calls it — it left `uncalled` for the wrong reason")
+      .toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/api/surface.test.ts
+++ b/apps/web/src/api/surface.test.ts
@@ -127,7 +127,10 @@ describe("the API client's public surface", () => {
       "topicsBoard", "createTopic", "viewpoints",                   // BCF coordination
       "elementEffectiveProps", "elementCosts", "costSummary",       // model + 5D
       "solveProforma", "proformaLive", "portfolioCompare",           // ⑧ moved — spread over 4 regions
-      "proformaRenovation", "proformaRollover", "proformaIncomeBasis",  // ⑧ new — were unreachable
+      // ⑧ new — added unreachable; `proformaRenovation` now has a screen (PULSE-FINDINGS, 2026-08-07)
+      // and the other two still do not. Corrected here rather than left as "were unreachable", which
+      // had already stopped being true for one of the three.
+      "proformaRenovation", "proformaRollover", "proformaIncomeBasis",
       "schedule4d", "scheduleCpm", "evm",                           // 4D + earned value
       "estimateFromModel", "qtoByFloor", "sovFromBudget",           // estimating
       "drawingMarkup", "promoteDrawingMarkup",                      // 2D markup -> RFI

--- a/apps/web/src/portal/panels/pulse.test.ts
+++ b/apps/web/src/portal/panels/pulse.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { type ActionCandidate, buildPulse, nextBestAction } from "./pulse";
@@ -216,4 +218,95 @@ describe("the portal actually calls it", () => {
     expect(src).toMatch(/from "\.\/panels\/pulse"/);
     expect(src, "defined but never called is the orphan case").toMatch(/this\.renderPulse\(/);
   }, 15_000);
+});
+
+/**
+ * PULSE-FINDINGS — the two engine findings that ride the deal card.
+ *
+ * Both are SILENT-WRONG-ANSWER findings, which is what makes them worth a risk line rather than a
+ * footnote. A reserve suggestion that does not clear the horizon renders identically to one that
+ * does — `proforma.ts` prints "Suggested level contribution: $X/yr" in bold either way — and a
+ * renovation pace that completes no unit returns a perfectly well-formed schedule. In both cases the
+ * failure is a plausible number, not a missing one, so nothing on screen looks wrong.
+ *
+ * Read STRICTLY in `portal.ts`: `=== false` and `=== true`, never truthiness. A missing field means
+ * the engine did not answer, and inventing a risk line from an absent field is worse than showing
+ * none — one false alarm costs trust in every other line on the card.
+ */
+describe("PULSE-FINDINGS — reserve + renovation findings on the deal card", () => {
+  it("an unverified reserve suggestion turns the card to risk and says so", () => {
+    const [c] = buildPulse({ deal: { irrPct: 18.2, band: [15, 22], reserveSuggestionFails: true } });
+    expect(c!.tone, "an IRR inside its band is not good news if the funding plan does not hold")
+      .toBe("risk");
+    expect(c!.risk).toContain("does not clear the horizon");
+  });
+
+  it("the same card without the finding is good — so the assertion above is not vacuous", () => {
+    const [c] = buildPulse({ deal: { irrPct: 18.2, band: [15, 22], reserveSuggestionFails: false } });
+    expect(c!.tone).toBe("good");
+    expect(c!.risk).toBeNull();
+  });
+
+  it("carries the server's own words for a renovation that renovates nothing", () => {
+    // The reason is phrased server-side with the actual pace ("pace is 0 unit(s)/month over 60
+    // month(s)"). Re-deriving it here would produce a second, drifting explanation of one fact.
+    const why = "pace is 0 unit(s)/month over 60 month(s) — no unit completed a start";
+    const [c] = buildPulse({ deal: { irrPct: 12, nothingRenovated: why } });
+    expect(c!.tone).toBe("risk");
+    expect(c!.risk).toContain(why);
+  });
+
+  it("shows both findings at once, worst first", () => {
+    const [c] = buildPulse({ deal: {
+      irrPct: 12, staleSince: "pay app #7",
+      reserveSuggestionFails: true, nothingRenovated: "no unit completed a start",
+    } });
+    const r = c!.risk!;
+    expect(r).toContain("does not clear the horizon");
+    expect(r).toContain("renovates nothing");
+    expect(r).toContain("pay app #7");
+    // A suggestion that does not clear invalidates the funding plan; a stale forecast only ages it.
+    expect(r.indexOf("does not clear")).toBeLessThan(r.indexOf("pay app #7"));
+  });
+
+  it("KNOWN LIMIT: with no IRR there is no deal card, so the findings have nowhere to appear", () => {
+    // Asserted so it is a decision rather than something discovered later. It follows the panel's
+    // existing rule — no proforma means no deal position, and a card needs a number — but it does
+    // mean a reserve finding on a project that never had a proforma is invisible here.
+    expect(buildPulse({ deal: { irrPct: null, reserveSuggestionFails: true } })).toEqual([]);
+  });
+});
+
+/**
+ * The half the tests above cannot see.
+ *
+ * Everything above exercises `buildPulse`, which is pure and takes the findings already decoded. The
+ * DECODING lives in `portal.ts`, and that is where the strictness matters. Verified by mutation:
+ * replacing `=== false` with `!value` — which fires a false alarm on every project whose engine did
+ * not answer — passed all 77 portal tests. Nothing was guarding it.
+ *
+ * `renderPulse` needs a live api and a mounted DOM, so source is the reader available, exactly as
+ * `viewer/tools/projectPanel.test.ts` does for its own call site.
+ */
+describe("portal.ts decodes the findings strictly", () => {
+  const src = readFileSync(resolve(process.cwd(), "src/portal/portal.ts"), "utf8");
+
+  it("found the mapping — not vacuously green", () => {
+    expect(src).toContain("suggestion_clears_horizon");
+    expect(src).toContain("nothing_renovated");
+  });
+
+  it("compares against false/true, never truthiness", () => {
+    // `!clears` treats "the engine did not answer" as "the suggestion fails" — a fabricated risk
+    // line, which costs trust in every other line on the card.
+    expect(src, "a missing field must not read as a failing suggestion")
+      .toMatch(/g\(reserve, "suggestion_clears_horizon"\)\s*===\s*false/);
+    expect(src, "a missing field must not read as a stalled renovation")
+      .toMatch(/g\(renov, "nothing_renovated"\)\s*===\s*true/);
+  });
+
+  it("asks for both engines in the pulse fan-out", () => {
+    expect(src).toMatch(/"reserveStudy"/);
+    expect(src).toMatch(/"proformaRenovation"/);
+  });
 });

--- a/apps/web/src/portal/panels/pulse.ts
+++ b/apps/web/src/portal/panels/pulse.ts
@@ -39,7 +39,17 @@ export interface PulseInput {
   cost?: { variancePct?: number | null; unpricedChanges?: number | null; exposurePct?: number | null } | null;
   schedule?: { floatDays?: number | null; atRisk?: string | null } | null;
   work?: { open?: number | null; mine?: number | null; overdue?: string[] | null } | null;
-  deal?: { irrPct?: number | null; band?: [number, number] | null; staleSince?: string | null } | null;
+  deal?: {
+    irrPct?: number | null; band?: [number, number] | null; staleSince?: string | null;
+    /**
+     * `reserve.suggestion_clears_horizon === false` — the suggested level contribution was solved,
+     * re-run against the schedule, and does NOT clear it. The number is still displayed elsewhere,
+     * which is the hazard: an unverified suggestion looks exactly like a verified one.
+     */
+    reserveSuggestionFails?: boolean | null;
+    /** `renovation.nothing_renovated_why` — carried verbatim; the server phrases it with the pace. */
+    nothingRenovated?: string | null;
+  } | null;
 }
 
 const pct = (n: number, dp = 1) => `${n > 0 ? "+" : n < 0 ? "−" : ""}${Math.abs(n).toFixed(dp)}%`;
@@ -105,14 +115,38 @@ function workCard(w: NonNullable<PulseInput["work"]>): PulseCard | null {
   };
 }
 
+/**
+ * Two findings ride this card rather than getting panels of their own, and the reason is that they
+ * are **booleans**. Neither has a chart to sit in: "the pace you chose renovates nothing across the
+ * entire hold" is a sentence, not a metric. Pulse's contract is that a card says what would move the
+ * number, which is exactly the shape of both.
+ *
+ * They are also both **silent-wrong-answer** findings, which is why they are risk lines rather than
+ * anything softer. A reserve suggestion that does not clear the horizon renders identically to one
+ * that does; a renovation programme that completes no unit returns a perfectly well-formed schedule.
+ * The failure mode in each case is a plausible number, not a missing one.
+ *
+ * KNOWN LIMIT, stated rather than discovered later: both ride the deal card, so they are invisible on
+ * a project with no IRR. That follows the panel's existing rule — no proforma means no deal position,
+ * and a card with no number cannot be rendered — but it does mean a reserve finding on a project that
+ * never had a proforma has nowhere to appear. Asserted below so it is a decision, not a surprise.
+ */
 function dealCard(d: NonNullable<PulseInput["deal"]>): PulseCard | null {
   if (d.irrPct == null) return null;
   const inBand = d.band ? d.irrPct >= d.band[0] && d.irrPct <= d.band[1] : null;
+  // Ordered worst-first: a suggestion that does not clear invalidates the funding plan outright,
+  // where a stale forecast only ages it.
+  const risks = [
+    d.reserveSuggestionFails ? "Suggested reserve contribution does not clear the horizon." : null,
+    d.nothingRenovated ? `Renovation renovates nothing — ${d.nothingRenovated}.` : null,
+    d.staleSince ? `Re-forecast from ${d.staleSince} actuals.` : null,
+  ].filter((x): x is string => x !== null);
   return {
     key: "deal", label: "Deal", value: `${d.irrPct.toFixed(1)}%`,
-    tone: inBand === false ? "risk" : d.staleSince ? "watch" : "good",
+    tone: inBand === false || d.reserveSuggestionFails || d.nothingRenovated ? "risk"
+      : d.staleSince ? "watch" : "good",
     headline: inBand == null ? "IRR current." : inBand ? "IRR inside market band." : "IRR outside market band.",
-    risk: d.staleSince ? `Re-forecast from ${d.staleSince} actuals.` : null,
+    risk: risks.length ? risks.join(" ") : null,
   };
 }
 

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -825,8 +825,12 @@ export class PortalUI {
         if (typeof api[name] !== "function") return null;
         try { return await api[name]!(pid); } catch { return null; }
       };
-      const [model, cost, sched, work, deal] = await Promise.all(
-        ["modelHealth", "costSummary", "scheduleVariance", "workQueue", "proformaLive"].map(call));
+      // `reserveStudy(pid, opts = {})` and `proformaRenovation(pid)` both fit this single-argument
+      // fan-out unchanged — checked against the signatures, not the descriptions. A required second
+      // argument would have meant breaking the `.map` or changing a signature.
+      const [model, cost, sched, work, deal, reserve, renov] = await Promise.all(
+        ["modelHealth", "costSummary", "scheduleVariance", "workQueue", "proformaLive",
+         "reserveStudy", "proformaRenovation"].map(call));
 
       const n = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
       const g = (o: unknown, k: string): unknown => (o && typeof o === "object" ? (o as Record<string, unknown>)[k] : undefined);
@@ -840,7 +844,19 @@ export class PortalUI {
           mine: n(g(work, "mine")),
           overdue: Array.isArray(g(work, "overdue")) ? (g(work, "overdue") as string[]).slice(0, 3) : null,
         } : null,
-        deal: deal ? { irrPct: n(g(deal, "irr")) } : null,
+        // Both findings hang off the deal card because both are BOOLEANS with no chart to sit in.
+        // Read strictly: `=== false` and `=== true`, never truthiness. A missing field is "the engine
+        // did not answer", which must not read as "the suggestion fails" — inventing a risk line from
+        // an absent field is worse than showing none, because a false alarm here costs trust in every
+        // other line on the card.
+        deal: deal || reserve || renov ? {
+          irrPct: n(g(deal, "irr")),
+          reserveSuggestionFails: g(reserve, "suggestion_clears_horizon") === false,
+          nothingRenovated: g(renov, "nothing_renovated") === true
+            ? (typeof g(renov, "nothing_renovated_why") === "string"
+              ? g(renov, "nothing_renovated_why") as string : "no unit completed a start")
+            : null,
+        } : null,
       });
 
       const rail = pulseRailEl(cards);


### PR DESCRIPTION
## PULSE-FINDINGS — two silent-wrong-answer findings on the deal card

Wires `reserveStudy.suggestion_clears_horizon` and `proformaRenovation.nothing_renovated` into the home pulse. Lanes A + B, with Massing Core's explicit go-ahead on `portal.ts`.

### Why the pulse and not a panel

Both findings are **booleans**. Neither has a chart to sit in — *"the pace you chose renovates nothing across the entire hold"* is a sentence, not a metric — and Pulse's contract is that a card says what would move the number.

### Why they're worth a risk line

Both are **silent-wrong-answer** findings, which is the whole argument for surfacing them:

- A reserve suggestion that does **not** clear the horizon renders identically to one that does. `apps/web/src/proforma/proforma.ts` prints **"Suggested level contribution: $X/yr"** in bold either way and never reads the verification flag.
- A renovation pace that completes no unit returns a perfectly well-formed schedule.

In both cases the failure is a *plausible number*, not a missing one. Nothing on screen looks wrong.

Decoded **strictly** — `=== false` and `=== true`, never truthiness. A missing field means the engine did not answer; inventing a risk line from an absent field is worse than showing none, because one false alarm costs trust in every other line on the card.

### The ceiling dropped by one, not two

`UNCALLED_CEILING` 132 → **131**. It was expected to drop by two, for `reserveStudy` as well. That was wrong: `reserveStudy` already had a caller in `src/proforma/proforma.ts`, so it was never in the uncalled set. Caught by probing the measured value rather than deriving it from what the wiring touched — the number is the only reason the wrong premise surfaced.

The `clientCallers.test.ts` trio assertion went red on the same run, which is exactly what it exists to do, and `surface.test.ts`'s claim is **corrected rather than deleted**.

### A guard the tests could not previously provide

The decoding lives in `portal.ts` and nothing was checking it. Verified by mutation: replacing `=== false` with `!value` — which fires a false alarm on every project whose engine didn't answer — **passed all 77 portal tests**. There is now a source guard, in the same pattern `viewer/tools/projectPanel.test.ts` uses, and it fails under that mutation.

Also added a paired positive control on the card itself (the same card without the finding must read `good`), and an explicit assertion of the known limit: with no IRR there is no deal card, so the findings have nowhere to appear. That follows the panel's existing rule, but it is now a recorded decision rather than something discovered later.

### Verification

Full web suite green (123 files, 1,365 tests), `tsc` clean, `eslint` clean.

### Separate finding, not fixed here

`proforma.ts` displays the suggested contribution as an actionable recommendation without ever reading `suggestion_clears_horizon` — the strongest place to show it is right there, at the point of action. `apps/web/src/proforma/` belongs to no lane in the table, so I've left it alone and reported it rather than editing an unowned shared path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
