### PR TITLE
R23 premise-check: close the instancing clause, fix the GPU texture leak it found

### DIFF
--- a/apps/web/src/viewer/draft/gridOverlay.test.ts
+++ b/apps/web/src/viewer/draft/gridOverlay.test.ts
@@ -1,0 +1,133 @@
+import * as THREE from "three";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GridOverlay } from "./gridOverlay";
+
+/**
+ * GRID-OVERLAY-LEAK — found while premise-checking R23-BATCH-OVERLAYS, which points at this file.
+ *
+ * That item proposes instancing app-authored overlays. The population turned out to be mostly
+ * absent — pins are DOM elements, the GIS layer already merges every feature into three buffers,
+ * and most overlays are singletons — but the grid genuinely is per-axis, and measuring it turned up
+ * a resource bug instead of a draw-call one:
+ *
+ *   AXES=8  textures made=8  leaked after ONE rebuild=8
+ *
+ * `set()` runs on every work-plane move, so this is proportional to axes x elevation changes during
+ * ordinary authoring.
+ *
+ * **Why the file had no tests, which is the third bug.** `bubbleSprite` called `canvas.getContext("2d")!`
+ * — a non-null assertion on something that is genuinely null under happy-dom. Constructing the
+ * overlay threw a TypeError, so no test could reach it, so nothing here was ever covered. The
+ * untestability and the defect had the same cause.
+ */
+
+/** happy-dom has no 2D context; stub exactly the calls the bubble draw makes. */
+function stubCanvas() {
+  return vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+    fillStyle: "", font: "", textAlign: "", textBaseline: "",
+    beginPath() {}, arc() {}, fill() {}, fillText() {},
+  } as unknown as CanvasRenderingContext2D);
+}
+
+/** Track every texture disposal so a leak is a number rather than an impression. */
+function trackDisposals() {
+  const disposed = new Set<THREE.Texture>();
+  const orig = THREE.Texture.prototype.dispose;
+  vi.spyOn(THREE.Texture.prototype, "dispose").mockImplementation(function (this: THREE.Texture) {
+    disposed.add(this);
+    return orig.call(this);
+  });
+  return disposed;
+}
+
+const AXES = (n: number) => Array.from({ length: n }, (_, i) => ({
+  tag: `A${i}`, start: [0, i] as [number, number], end: [10, i] as [number, number],
+}));
+
+const data = (n: number) => ({ axes: AXES(n), intersections: [] }) as never;
+
+/** Every sprite texture currently in the group. */
+function texturesIn(g: GridOverlay): THREE.Texture[] {
+  const out: THREE.Texture[] = [];
+  g.group.traverse((o) => {
+    const m = (o as THREE.Sprite).material as THREE.SpriteMaterial | undefined;
+    if (m && "map" in m && m.map) out.push(m.map);
+  });
+  return out;
+}
+
+let scene: THREE.Scene;
+beforeEach(() => { stubCanvas(); scene = new THREE.Scene(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe("GridOverlay builds a grid at all", () => {
+  it("draws one line and one bubble per axis", () => {
+    // The positive control. Without it every leak assertion below could pass by building nothing.
+    const g = new GridOverlay(scene);
+    g.set(data(5), 0);
+    expect(g.group.children.filter((o) => (o as THREE.Line).isLine)).toHaveLength(5);
+    expect(g.group.children.filter((o) => (o as THREE.Sprite).isSprite)).toHaveLength(5);
+    expect(g.hasData).toBe(true);
+  });
+
+  it("survives a canvas with no 2D context, without the labels", () => {
+    // The assertion that used to be `getContext("2d")!`. A missing label beats a dead draft grid —
+    // and per kernel/markupPlugin.ts, a throw on an overlay path takes the caller's work with it.
+    vi.restoreAllMocks();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+    const g = new GridOverlay(scene);
+    expect(() => g.set(data(3), 0)).not.toThrow();
+    expect(g.group.children.filter((o) => (o as THREE.Line).isLine),
+      "the grid lines must still be there — only the bubbles depend on a canvas").toHaveLength(3);
+    expect(g.group.children.filter((o) => (o as THREE.Sprite).isSprite)).toHaveLength(0);
+  });
+});
+
+describe("rebuilding on a work-plane move does not leak GPU textures", () => {
+  it("reuses the cached bubble textures instead of allocating new ones", () => {
+    // The churn half. `set()` runs on every elevation change; re-rasterising identical bubbles is
+    // pure waste, and it was also what produced the orphans.
+    const g = new GridOverlay(scene);
+    g.set(data(8), 0);
+    const first = texturesIn(g);
+    g.set(data(8), 3);
+    const second = texturesIn(g);
+    expect(first).toHaveLength(8);
+    expect(new Set([...first, ...second]).size,
+      "a rebuild allocated fresh textures — the cache is not being hit").toBe(8);
+  });
+
+  it("orphans nothing across a rebuild — the measured defect, as a test", () => {
+    const disposed = trackDisposals();
+    const g = new GridOverlay(scene);
+    g.set(data(8), 0);
+    const made = texturesIn(g);
+    g.set(data(8), 3);
+    // Before the fix this was 8 of 8. A texture is safe if it is either still in use or disposed;
+    // what must never happen is an orphan — dropped from the scene AND never released.
+    const live = new Set(texturesIn(g));
+    const orphaned = made.filter((t) => !live.has(t) && !disposed.has(t));
+    expect(orphaned, `${orphaned.length} texture(s) orphaned by one rebuild`).toHaveLength(0);
+  });
+
+  it("releases every cached texture on dispose", () => {
+    // The other half of ownership. Caching without this just moves the leak to teardown.
+    const disposed = trackDisposals();
+    const g = new GridOverlay(scene);
+    g.set(data(6), 0);
+    const made = texturesIn(g);
+    expect(made).toHaveLength(6);
+    g.dispose();
+    expect(made.filter((t) => !disposed.has(t)),
+      "cached textures outlived the overlay that owned them").toHaveLength(0);
+    expect(scene.children).not.toContain(g.group);
+  });
+
+  it("a distinct tag still gets its own texture — the cache is not over-sharing", () => {
+    // The paired control for the cache. A cache keyed too loosely would collapse every bubble to one
+    // texture and pass the leak tests above while drawing the wrong labels.
+    const g = new GridOverlay(scene);
+    g.set(data(4), 0);
+    expect(new Set(texturesIn(g)).size, "four different tags must not share one bubble").toBe(4);
+  });
+});

--- a/apps/web/src/viewer/draft/gridOverlay.ts
+++ b/apps/web/src/viewer/draft/gridOverlay.ts
@@ -14,22 +14,45 @@ export interface GridData {
   note?: string;
 }
 
-function bubbleSprite(text: string): THREE.Sprite {
+/**
+ * Draw one grid bubble. Returns null when there is no 2D context to draw into.
+ *
+ * The `!` that used to be on `getContext("2d")` asserted a context that is genuinely absent in some
+ * environments — it is null under happy-dom, which is why this file had no tests at all. A null
+ * context made `g.fillStyle = ...` throw a TypeError out of overlay construction, and per
+ * `kernel/markupPlugin.ts` a throw on an overlay path takes the caller's remaining work with it.
+ * A missing label is a far better outcome than a dead draft grid.
+ */
+function bubbleTexture(text: string): THREE.CanvasTexture | null {
   const c = document.createElement("canvas"); c.width = 64; c.height = 64;
-  const g = c.getContext("2d")!;
+  const g = c.getContext("2d");
+  if (!g) return null;
   g.fillStyle = "#1e88e5"; g.beginPath(); g.arc(32, 32, 28, 0, Math.PI * 2); g.fill();
   g.fillStyle = "#fff"; g.font = "bold 30px sans-serif"; g.textAlign = "center"; g.textBaseline = "middle";
   g.fillText(text.slice(0, 3), 32, 34);
-  const tex = new THREE.CanvasTexture(c);
-  const spr = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, depthTest: false, transparent: true }));
-  spr.scale.set(1.2, 1.2, 1.2);
-  return spr;
+  return new THREE.CanvasTexture(c);
 }
 
 export class GridOverlay {
   readonly group = new THREE.Group();
   private snaps: THREE.Vector2[] = [];   // plan [E, N] intersection points
   data: GridData | null = null;
+  /**
+   * Bubble textures, cached by tag and owned by this overlay rather than by the sprites.
+   *
+   * `set()` runs on every work-plane move, and each run used to build a fresh canvas + texture per
+   * axis. Two problems, and the second is the one that matters:
+   *
+   *  - CHURN: a 20-axis grid re-rasterised 20 canvases and uploaded 20 textures every time the
+   *    elevation changed, to draw exactly the same bubbles.
+   *  - A LEAK, measured: `clearMeshes` disposed geometry and material, and in three.js
+   *    `Material.dispose()` does NOT dispose `material.map`. So every rebuild orphaned one GPU
+   *    texture per axis — 8 axes, 8 textures, 8 leaked after a single rebuild when measured.
+   *
+   * Caching fixes both at once: identical tags reuse one texture, so a rebuild allocates nothing,
+   * and ownership moves here where `dispose()` can actually release them.
+   */
+  private bubbles = new Map<string, THREE.CanvasTexture>();
 
   constructor(private scene: THREE.Scene) { this.group.name = "draft-grid"; this.group.visible = false; }
 
@@ -49,9 +72,17 @@ export class GridOverlay {
       // bubble at the "start" end (extended a touch past the axis for legibility)
       const dx = e1 - e2, dz = -n1 - (-n2);
       const len = Math.hypot(dx, dz) || 1;
-      const b = bubbleSprite(ax.tag);
-      b.position.set(e1 + (dx / len) * 0.9, y, -n1 + (dz / len) * 0.9);
-      this.group.add(b);
+      let tex = this.bubbles.get(ax.tag);
+      if (tex === undefined) {
+        tex = bubbleTexture(ax.tag) ?? undefined;
+        if (tex) this.bubbles.set(ax.tag, tex);
+      }
+      if (tex) {
+        const b = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, depthTest: false, transparent: true }));
+        b.scale.set(1.2, 1.2, 1.2);
+        b.position.set(e1 + (dx / len) * 0.9, y, -n1 + (dz / len) * 0.9);
+        this.group.add(b);
+      }
     }
     if (!this.group.parent) this.scene.add(this.group);
   }
@@ -70,6 +101,11 @@ export class GridOverlay {
   set visible(v: boolean) { this.group.visible = v; }
   get hasData(): boolean { return !!this.data && this.data.axes.length > 0; }
 
+  /**
+   * Tear down the scene objects. Textures are deliberately NOT disposed here — they are cached and
+   * reused by the next `set()`, and disposing one would leave the cache handing out a dead texture.
+   * They are released in `dispose()`, which is where this overlay's lifetime actually ends.
+   */
   private clearMeshes(): void {
     for (const o of [...this.group.children]) {
       this.group.remove(o);
@@ -80,5 +116,11 @@ export class GridOverlay {
     }
   }
 
-  dispose(): void { this.clearMeshes(); this.scene.remove(this.group); this.data = null; this.snaps = []; }
+  dispose(): void {
+    this.clearMeshes();
+    for (const t of this.bubbles.values()) t.dispose();
+    this.bubbles.clear();
+    this.scene.remove(this.group);
+    this.data = null; this.snaps = [];
+  }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -815,9 +815,40 @@ exists: the repo has a 220 KB bundle budget and **zero** runtime perf assertions
   1500 ms timeout fallback. Replacing a prose performance claim with a number is precisely what this
   ring exists to do. If the number comes back single-digit ms, **close the item unbuilt** and keep the
   measurement.
-- **R23-BATCH-OVERLAYS** *(S)* — app-authored overlays (pins, grid, snap markers, dimensions, clash
-  markers) use **zero** instancing; `three@0.184.0` has `BatchedMesh`. Keep the default BIM pass off
-  `MeshStandardMaterial` (presentation mode only); make FOV/FAR responsive by viewport class.
+- ◧ **R23-BATCH-OVERLAYS** *(S)* — **the instancing clause is CLOSED UNBUILT, with the measurement,
+  and the sweep found a different defect in the same place.** Following the precedent set by the item
+  directly above: replace the prose claim with a number, and if the number does not justify the work,
+  keep the number.
+
+  The premise was "app-authored overlays use **zero** instancing", which is true and turns out not to
+  matter, because **there is almost no population to instance.** Enumerated every scene-object
+  construction in app code — 31 sites across 11 files, all forms, not a sample — and of the five
+  families named above:
+
+  | named family | what it actually is | instanceable? |
+  |---|---|---|
+  | pins | **DOM `<div>`s** projected per frame (`apps/web/src/pins/pins.ts`) | no — `BatchedMesh` cannot batch DOM |
+  | grid | 1 `Line` + 1 `Sprite` per axis (`apps/web/src/viewer/draft/gridOverlay.ts`) | **the only real population** |
+  | snap markers · dimensions · clash markers | no mesh overlay exists | nothing to batch |
+  | (unnamed) GIS context | **already hand-merged** into 3 objects (`apps/web/src/viewer/gis.ts`) | already optimal |
+
+  Everything else — peer cursors, reference models, the guide underlay, the gizmos — is O(1) or
+  O(peers). And where the population *is* real, `BatchedMesh` is still the wrong tool: each grid
+  bubble carries its **own 64×64 `CanvasTexture` and material**, and `BatchedMesh` requires a shared
+  one. The correct fix there is a texture atlas or a cache, not instancing.
+
+  **What the measurement did find, in `gridOverlay.ts`:** `set()` rebuilds on every work-plane move,
+  and `clearMeshes` disposed geometry and material but not the texture — in three.js
+  `Material.dispose()` does **not** release `material.map`. Measured `AXES=8 → 8 textures made → 8
+  leaked after ONE rebuild`, i.e. a GPU leak proportional to axes × elevation changes during ordinary
+  authoring. Fixed by caching bubbles by tag (which also removes the re-rasterisation churn) and
+  moving ownership to `dispose()`. A third bug fell out: `getContext("2d")!` asserted a context that
+  is null under happy-dom, which is **why the file had no tests at all** — the untestability and the
+  defect had one cause.
+
+  **Still open, and genuinely unbuilt:** make FOV/FAR responsive by viewport class. The default BIM
+  pass is already off `MeshStandardMaterial` — every remaining use is GIS context, not the BIM pass —
+  so that clause needs no work.
 - **R23-SYMBOL-COUNT** *(M)* — deterministic template-match symbol counting in the **existing** pdf.js
   takeoff worker: mark one instance, normalised cross-correlation, non-maximum suppression.
   **Zero new dependencies**, offline, auditable — which matters for quantities that feed a bid.


### PR DESCRIPTION
## R23-BATCH-OVERLAYS premise-check → a measured leak in `gridOverlay.ts`

R23-BATCH-OVERLAYS proposes instancing app-authored overlays. I measured before building, following the precedent the item directly above it sets — *"if the number comes back single-digit ms, close the item unbuilt and keep the measurement."*

**The instancing premise did not survive. A resource bug did.**

### There is almost no population to instance

Enumerated **every** scene-object construction in app code — 31 sites across 11 files, all constructor forms, a complete population rather than a sample. Of the five families the item names:

| named family | what it actually is | instanceable? |
|---|---|---|
| pins | **DOM `<div>`s** projected per frame | no — `BatchedMesh` cannot batch DOM |
| grid | 1 `Line` + 1 `Sprite` **per axis** | the only real population |
| snap markers · dimensions · clash markers | no mesh overlay exists | nothing to batch |
| *(unnamed)* GIS context | **already hand-merged** into 3 objects | already optimal |

Everything else is O(1) or O(peers). And where the population *is* real, `BatchedMesh` is still the wrong tool: each grid bubble carries its **own 64×64 `CanvasTexture` and material**, and `BatchedMesh` requires a shared one.

My first sweep missed this entirely — I globbed `src/viewer/*.ts`, which doesn't recurse, and `src/viewer/draft/` is where the grid lives. 13 sites became 31 when I swept properly.

### What measuring actually found

```
AXES=8   textures made=8   leaked after ONE rebuild=8
```

`set()` rebuilds on every work-plane move, and `clearMeshes` disposed geometry and material but **not the texture** — in three.js `Material.dispose()` does not release `material.map`. The leak is proportional to axes × elevation changes during ordinary authoring.

Fixed by caching bubbles by tag — which also removes the churn, since a 20-axis grid re-rasterised 20 canvases every elevation change to draw identical bubbles — and moving ownership to `dispose()`. Caching without that just relocates the leak to teardown, so both halves are asserted.

### The third bug explains the other two

`getContext("2d")!` asserted a context that is **genuinely null under happy-dom**. Constructing the overlay threw a TypeError, so no test could reach this file — it had **zero coverage**. The untestability and the defect had one cause. A null context now yields a grid without labels rather than a dead grid; per `kernel/markupPlugin.ts`, a throw on an overlay path takes the caller's remaining work with it.

### Verification

All three fixes **mutation-checked**, each caught by the right tests — removing the cache kills 3, removing the dispose release kills exactly the dispose test, restoring the `!` kills exactly the null-context test. Paired controls included: the grid builds at all, and distinct tags don't share a texture (a cache keyed too loosely would pass every leak test while drawing the wrong labels).

Full web suite green (125 files, 1,367 tests), `tsc` + `eslint` clean, `test_claude_md_gates` + `roadmapLanes` + `roadmapStale` green.

### Roadmap

R23-BATCH-OVERLAYS marked ◧ with the measurement recorded. Still genuinely open: **FOV/FAR responsive by viewport class**. The `MeshStandardMaterial` clause needs no work — every remaining use is GIS context, not the BIM pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Grid overlays now work safely when canvas rendering is unavailable.
  * Prevented repeated texture generation and released unused overlay textures during cleanup.
  * Preserved distinct textures for different axis labels.

* **Documentation**
  * Updated the roadmap with overlay batching findings and grid texture optimization details.
  * Clarified remaining work for responsive field of view and view distance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->