### PR TITLE
fix(test): move the delete-ratchet history walk to module scope

### DIFF
--- a/apps/web/src/tooling/deleteRatchet.test.ts
+++ b/apps/web/src/tooling/deleteRatchet.test.ts
@@ -94,6 +94,39 @@ const REMOVED: Record<string, string> = {
 const TRACKED = new Set(git("ls-files").split("\n").map((s) => s.trim()).filter(Boolean));
 const SHALLOW = git("rev-parse", "--is-shallow-repository").trim() === "true";
 
+/**
+ * Every path ever ADDED under `docs/`, in any commit on any branch — or null on a shallow clone,
+ * where history is not available to walk. Used by the enrollment assertion below.
+ *
+ * THIS RUNS AT MODULE SCOPE ON PURPOSE, AND IT IS THE SECOND FIX TO THE SAME TIMEOUT
+ *     The first version ran `git log --all` once per entry — eight walks, 4.7 s — and timed out at
+ *     vitest's 5 s default. That was fixed by doing the work once: a single walk over `docs/`
+ *     measures 1.2 s, and the comment recorded it as "3.8x faster and clear of the limit".
+ *
+ *     **It timed out again on 2026-08-07**, at 1.2 s of work against a 5 s budget. Nothing about
+ *     the walk had changed; the machine was busier. A full-suite run under contention took 50 s
+ *     where an idle one takes 21 s, and this test went from 3.4 s standalone to over 5 s inside it.
+ *
+ *     So "1.2 s is clear of 5 s" was never a property of the test — it was a property of an idle
+ *     machine, measured once and written down as if it were fixed. With several sessions running
+ *     suites in one clone, that assumption is the thing that is actually false.
+ *
+ *     Raising the timeout was rejected last time for a reason that no longer applies: the objection
+ *     was that it "keeps the same eight walks and moves the cliff somewhere less predictable". There
+ *     is one walk now, and it is already minimal — the residual variance is scheduling, not work.
+ *     But the better answer is that **the per-test budget is the wrong instrument for this cost.**
+ *     `git ls-files` and `rev-parse` above have always run out here, untimed, because they are
+ *     fixture setup. The history walk is the same kind of thing and belongs beside them. Moving it
+ *     removes the cliff rather than relocating it, and needs no number that a future load will
+ *     falsify.
+ */
+const EVER_ADDED_UNDER_DOCS = SHALLOW ? null : new Set(
+  // `--all` so a file deleted on a branch that later merged is still found; `--diff-filter=A` lists
+  // additions; `--name-only --format=` prints just the paths.
+  git("log", "--all", "--diff-filter=A", "--name-only", "--format=", "--", "docs/")
+    .split("\n").map((s) => s.trim().replace(/\\/g, "/")).filter(Boolean),
+);
+
 describe("deliberately removed files stay removed", () => {
   it("has a non-empty population — an empty list passes forever", () => {
     // The vacuity guard. Without it, emptying REMOVED turns every assertion below green.
@@ -134,19 +167,9 @@ describe("deliberately removed files stay removed", () => {
       expect(SHALLOW).toBe(true);
       return;
     }
-    // ONE history walk, not one per entry. The first version ran `git log --all` eight times and
-    // **timed out at vitest's 5 s default** — 4.7 s measured, which passes alone and fails under a
-    // loaded suite. That is the same load-sensitive threshold `shell/roadmapStale.test.ts` hit today,
-    // and the fix is the one it settled on: **do the work once, do not raise the timeout.** A single
-    // walk over `docs/` measures 1.2 s, 3.8x faster and clear of the limit. Raising the timeout keeps
-    // the same eight walks and moves the cliff somewhere less predictable.
-    //
-    // `--all` so a file deleted on a branch that later merged is still found; `--diff-filter=A` lists
-    // additions; `--name-only --format=` prints just the paths.
-    const everAdded = new Set(
-      git("log", "--all", "--diff-filter=A", "--name-only", "--format=", "--", "docs/")
-        .split("\n").map((s) => s.trim().replace(/\\/g, "/")).filter(Boolean),
-    );
+    // The walk itself runs at module scope — see EVER_ADDED_UNDER_DOCS for why. The SHALLOW guard
+    // above is what makes this non-null here.
+    const everAdded = EVER_ADDED_UNDER_DOCS!;
     expect(everAdded.size, "the history walk returned nothing — this check would pass vacuously")
       .toBeGreaterThan(20);
     const never = Object.keys(REMOVED).filter((p) => !everAdded.has(p));


### PR DESCRIPTION
## What

`deleteRatchet.test.ts`'s enrollment assertion timed out on a full-suite run today. This moves its `git log --all` walk to module scope, beside the two git calls that already run there.

**This is the second timeout fix to the same assertion, and what failed is the first one's reasoning — which is the part worth reading.**

## The first fix, and why it wasn't one

The original ran `git log --all` once per entry — eight walks, 4.7 s — and hit vitest's 5 s default. That was fixed by doing the work once. A single walk over `docs/` measures 1.2 s, and the comment recorded it as *"3.8x faster and clear of the limit"*.

It timed out again today **at that same 1.2 s of work**. Nothing about the walk had changed. The machine was busier: several sessions run suites in this one clone, and a contended full run takes 50–64 s where an idle one takes 21 s. That was enough to push a 3.4 s standalone test past 5 s.

So `1.2 s is clear of 5 s` was never a property of the test. It was **a property of an idle machine, measured once and written into a comment as though it were fixed** — the same shape as an unattached number drifting, except here the number was accurate and the environment moved.

## Why module scope rather than a bigger timeout

Raising the timeout was rejected last time because it *"keeps the same eight walks and moves the cliff somewhere less predictable"*. That objection no longer applies — there is one walk now, it is already minimal, and the residual variance is scheduling rather than work.

But the better answer is that **the per-test budget is the wrong instrument for this cost.** `git ls-files` and `git rev-parse` have always run at module scope, untimed, because they are fixture setup. The history walk is the same kind of thing. Moving it removes the cliff instead of relocating it, and needs no threshold that a future load can falsify.

The `SHALLOW` guard is preserved — on a shallow clone the walk is skipped entirely (`null`) and the test still reports loudly that enrollment was not verified.

## Verification

- **Per-test time: 1.91 s → 9 ms.** The cost moved to import, where it isn't racing a 5 s clock.
- **Mutation-checked.** Planting `docs/never-existed-mutation-probe.md` into `REMOVED` still fails with the intended message (*"these were never added in any commit"*), so the restructure did not make the assertion vacuous. Restored → 4 pass.
- **Full suite green: 1361 tests at 63.7 s wall** — *more* contended than the 50 s run that produced the failure, which is the condition that matters here.
- `tsc --noEmit` and `npm run lint` clean.

## Not caused by, and not fixing, anything in #248

Flagged while verifying #248 after a rebase. #248 doesn't touch `src/tooling/` — this is pre-existing on main and is kept separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of historically added documentation paths.
  * Added support for running the validation reliably in shallow Git clones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->