### PR TITLE
Do not present an unverified reserve suggestion as a target

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -2914,7 +2914,7 @@ export class ApiClient extends withAuth(withProforma(withDesignOptions(withProcu
       events: { year: number; item: string; cost: number; cost_escalated: number; source: string; ref: string }[];
       schedule: { year: number; outflows: number; contribution: number; balance: number }[];
       total_outflows: number; first_underfunded_year: number | null; adequately_funded: boolean;
-      suggested_level_contribution: number; note: string }>(
+      suggested_level_contribution: number; suggestion_clears_horizon?: boolean; note: string }>(
       `/projects/${pid}/reserves/study${qs ? `?${qs}` : ""}`);
   }
   camReconciliation(pid: string, opts: { year?: number; grossUpToPct?: number; buildingSf?: number } = {}) {

--- a/apps/web/src/proforma/proforma.render.test.ts
+++ b/apps/web/src/proforma/proforma.render.test.ts
@@ -168,3 +168,63 @@ describe("renderTestFit (characterization)", () => {
     expect(host.textContent).toContain("mix Σ 110%");        // round-tripped through localStorage
   });
 });
+
+/**
+ * RESERVE-SUGGESTION-UNVERIFIED — the banner must not present an unverified figure as a target.
+ *
+ * `reserve.py` solves the level contribution and then RE-RUNS it against the schedule to confirm it
+ * clears; `suggestion_clears_horizon` is that second answer. This banner printed the number in bold
+ * as a recommendation and never read the flag, so a figure that failed verification looked exactly
+ * like one that passed — at the moment a user would act on it.
+ *
+ * Read as `=== false`. The field is optional, and an older server that omits it means "not checked",
+ * which must not render as "does not work".
+ */
+const STUDY = {
+  horizon: { from: 2026, to: 2051 }, components: 12, components_missing_data: 0,
+  events: [], schedule: [], total_outflows: 900_000,
+  first_underfunded_year: 2033, adequately_funded: false,
+  suggested_level_contribution: 42_000, note: "",
+};
+
+describe("reserve study — an unverified suggestion says so", () => {
+  const mountAsset = async (study: Record<string, unknown>) => {
+    const { root, ui } = mount({ reserveStudy: vi.fn(async () => study) }, "P1");
+    const host = document.createElement("div"); root.appendChild(host);
+    await (ui as unknown as { renderAssetMgmt(h: HTMLElement): Promise<void> }).renderAssetMgmt(host);
+    await flush(); await flush();
+    return host;
+  };
+
+  it("warns when the solved figure did not clear the horizon", async () => {
+    const host = await mountAsset({ ...STUDY, suggestion_clears_horizon: false });
+    expect(host.textContent).toContain("did not clear the horizon when re-run");
+    expect(host.textContent, "the figure is still shown — it is unreliable, not absent")
+      .toContain("42,000");
+  });
+
+  it("stays silent when the figure verified — the paired control", async () => {
+    // Without this the assertion above could pass with the warning rendered unconditionally.
+    const host = await mountAsset({ ...STUDY, suggestion_clears_horizon: true });
+    expect(host.textContent).toContain("42,000");
+    expect(host.textContent).not.toContain("did not clear the horizon");
+  });
+
+  it("stays silent when the server did not answer — absent is not failed", async () => {
+    // An older server omits the field. Inventing a warning from a missing value is its own wrong
+    // answer, and one false alarm here costs trust in the figure every other time it is right.
+    const host = await mountAsset(STUDY);
+    expect(host.textContent).toContain("42,000");
+    expect(host.textContent).not.toContain("did not clear the horizon");
+  });
+
+  it("says only what the flag licenses — no invented cause", async () => {
+    // The first draft read "No flat contribution does; the shortfall needs a higher opening
+    // balance...". That is FALSE: `need` is the exact closed-form minimum, so a failed verification
+    // means the solved figure disagreed with the schedule, not that the horizon is unclearable.
+    // Explaining a cause it cannot know is the same defect this banner exists to fix.
+    const host = await mountAsset({ ...STUDY, suggestion_clears_horizon: false });
+    expect(host.textContent).not.toContain("No flat contribution");
+    expect(host.textContent).toContain("unreliable");
+  });
+});

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -542,12 +542,32 @@ export class ProformaUI {
           annualContribution: Number(contrib.inp.value) || 0, inflationPct: Number(infl.inp.value) || 0,
         });
         rout.innerHTML = "";
+        // RESERVE-SUGGESTION-UNVERIFIED. The server SOLVES the level contribution and then RE-RUNS it
+        // against the schedule to confirm it clears; `suggestion_clears_horizon` is that second
+        // answer. This banner printed the number in bold as a recommendation and never read the
+        // flag, so a suggestion that does not actually clear looked exactly like one that does — at
+        // the precise moment someone would act on it.
+        //
+        // Read as `=== false`, never falsily: the field is optional, and an older server that omits
+        // it means "not checked", which must not render as "does not work". Inventing a warning from
+        // an absent field is its own wrong answer.
+        //
+        // The wording says only what the flag actually licenses. `reserve.py` computes `need` as the
+        // EXACT closed-form minimum — `max` over k of `(cum - opening) / k`, then ceiled — so a failed
+        // verification does NOT mean "no flat contribution clears this horizon". It means the solved
+        // figure disagreed with the schedule when re-run, i.e. a residual. The first draft of this
+        // sentence explained a cause it could not know, which is the same defect it exists to fix.
+        const unverified = rs.suggestion_clears_horizon === false;
         const banner = document.createElement("div"); banner.className = "meta";
-        banner.style.cssText = `padding:6px 8px;border-left:3px solid var(${rs.adequately_funded ? "--status-good" : "--status-warn"});margin-bottom:6px`;
+        banner.style.cssText = `padding:6px 8px;border-left:3px solid var(${rs.adequately_funded && !unverified ? "--status-good" : "--status-warn"});margin-bottom:6px`;
         banner.innerHTML = rs.adequately_funded
           ? `<b>Adequately funded</b> through ${rs.horizon.to} at this contribution.`
           : `<b>Underfunded</b> — reserve balance goes negative in <b>${rs.first_underfunded_year}</b>. `
-            + `Suggested level contribution: <b>${money(rs.suggested_level_contribution)}/yr</b>.`;
+            + `Suggested level contribution: <b>${money(rs.suggested_level_contribution)}/yr</b>`
+            + (unverified
+              ? ` — <b>which did not clear the horizon when re-run.</b> Treat this figure as `
+                + `unreliable rather than as a target.`
+              : `.`);
         rout.appendChild(banner);
         const meta = document.createElement("div"); meta.className = "meta"; meta.style.marginBottom = "6px";
         meta.textContent = `${rs.components} component(s) in the study · ${rs.components_missing_data} missing `


### PR DESCRIPTION
## The reserve suggestion was presented as a target without ever being checked

`reserve.py` solves the level contribution and then **re-runs it against the schedule** to confirm it clears. `suggestion_clears_horizon` is that second answer. This banner printed the figure in bold as a recommendation and **never read the flag** — so a figure that failed verification looked exactly like one that passed, at the precise moment a user would act on it.

That's *"a search that never checks its bound"* reaching the user, which is where it does real damage. The Pulse card in #251 says something is wrong; **this line was telling them the wrong thing to do.**

Read as `=== false`, never falsily. The field is optional and an older server that omits it means "not checked", which must not render as "does not work" — one false alarm here costs trust in the figure every other time it's right.

## The first draft of the sentence was itself wrong

It read:

> No flat contribution does; the shortfall needs a higher opening balance, a longer horizon, or deferred replacements.

That is **false**, and checking it against `reserve.py` is the only reason it didn't ship. `need` is the **exact closed-form minimum** — `max` over k of `(cum − opening) / k`, then ceiled — so a failed verification does *not* mean the horizon is unclearable. It means the solved figure disagreed with the schedule when re-run: a residual.

Explaining a cause it cannot know is the same defect this banner exists to fix. It now says only what the flag licenses — the figure did not clear when re-run, treat it as unreliable — and there's a test asserting the invented cause stays out.

## Verification

- **Mutation-checked**: never reading the flag kills the two positive tests; a falsy read kills exactly the "absent is not failed" test.
- Paired control included, so the warning cannot pass by being rendered unconditionally.
- `client.ts` gains `suggestion_clears_horizon?: boolean` on an **existing line**, so it stays at its 3,780 pin.
- Full web suite green (125 files, 1,387 tests), `tsc` + `eslint` clean.

**One honest caveat:** one suite run showed 2 failures. That run took 2.5× longer than normal (transform 217s vs 33s), which reads as machine contention from a concurrent session rather than a defect — but I could not identify the tests, because my command truncated the output before the names printed. Four subsequent full runs were clean, including three consecutive. Recording it rather than calling it nothing.

## Lane

`apps/web/src/proforma/` belongs to no lane in the table. Massing Core assigned it to me explicitly for this one change; **it returns to unowned now.** A follow-up change will propose lane rows for the unowned paths under `apps/web/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
