### PR TITLE
lint: adopt the other two rules @eslint/js 10 adds, so #236 is a no-op

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -52,6 +52,21 @@ export default tseslint.config(
       // the initializer removed, which is the independent confirmation that they were unreachable.
       // "error", not "warn": the whole point is that it cannot silently accumulate again.
       "no-useless-assignment": "error",
+      // The other two rules `@eslint/js` 10 adds to `recommended`, adopted here so the dependency
+      // bump (#236) carries no behaviour change with it. The full delta 9.39.5 -> 10.0.1 is exactly
+      // three added rules and none removed: the one above, plus these. Both measure **0 findings**
+      // across `src/**/*.ts`, `scripts/**/*.mjs` and `capacitor.config.ts`.
+      //
+      // A zero is the result least worth trusting, so both were mutation-checked: a planted
+      // never-assigned `let` and a planted `catch (e) { throw new Error(...) }` are each reported.
+      // The rules are armed and the codebase genuinely has none — as opposed to a flag that quietly
+      // did nothing, which reads identically in the output.
+      //
+      // Worth recording why the bump was low-risk: the ESLint **engine** is already 10.8.0, so
+      // v10's breaking changes are live today. `@eslint/js` only supplies `configs.recommended`, so
+      // #236 moves which rules that preset turns on and nothing else.
+      "no-unassigned-vars": "error",
+      "preserve-caught-error": "error",
       "no-constant-condition": ["error", { checkLoops: false }],
     },
   },


### PR DESCRIPTION
## Result first

**#236 (`@eslint/js` 9.39.5 → 10.0.1) is a zero-code-change bump.** This PR adopts the two remaining rules it would turn on, so when the bump lands it carries no behaviour with it.

## The measured delta

I diffed `js.configs.recommended` between the two versions rather than reasoning about the changelog — 61 rules → 64, **three added, none removed**:

| rule | findings | status |
|---|---|---|
| `no-useless-assignment` | 14 | already fixed in #248 |
| `no-unassigned-vars` | **0** | adopted here |
| `preserve-caught-error` | **0** | adopted here |

Scope: `src/**/*.ts`, `scripts/**/*.mjs`, `capacitor.config.ts` — the same glob `npm run lint` uses, so the count is over what CI actually checks.

## Why the two zeros are worth anything

A zero is the result least worth trusting: *"the rule found nothing"* and *"the rule never ran"* render identically. Both were mutation-checked through the **real `npm run lint`**, not the ad-hoc `--rule` flag I used to measure:

```ts
export function a(): number { let n: number; return (n as number) ?? 0; }              // no-unassigned-vars
export function b(): void { try { JSON.parse("x"); } catch (e) { throw new Error("no cause"); } }  // preserve-caught-error
```

→ `npm run lint` exits 1 and names both rules. Remove the probe → exits 0. The rules are armed and the codebase genuinely has none.

## Why the bump was never the risk it looked like

Worth stating because the original framing of #236 was "a major version":

- **The ESLint *engine* is already 10.8.0.** `apps/web/package.json` declares `"eslint": "^10.8.0"` and the root carries an `overrides` pin to 10.8.0. So v10's breaking changes are already live in every CI run today.
- **`@eslint/js` only supplies `configs.recommended`.** It ships no rule implementations of its own. #236 therefore changes *which rules the preset enables* and nothing else — and that set is the three rules above.
- Its peer dep `eslint: ^10.0.0` is satisfied (and marked optional); its node floor `^20.19.0 || ^22.13.0 || >=24` is met by the pinned 24.

The genuinely risky half of "ESLint 10" shipped a while ago without incident. What remained was a preset delta, which is now measured and empty.

## Checks

- `npm run lint` clean, `tsc --noEmit` clean.
- Web suite **1383 passed**.
- Both new rules mutation-verified as armed (above).
- **No pin touched** — not `@eslint/js`, not `eslint`, not node 24. The bump itself stays #236's to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened code-quality checks for unused variable assignments and preserved error details.
  * Confirmed the new linting rules produce no existing findings and are compatible with the updated linting engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->