### PR TITLE
Assert the lane table covers the tree, not just that it is disjoint

### DIFF
--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve, sep } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -350,5 +350,91 @@ describe("the roadmap lane table", () => {
       }
     }
     expect(dupes, "an item in two lanes puts two sessions on one job").toEqual([]);
+  });
+});
+
+/**
+ * LANE-COVERAGE — the question the disjointness check above cannot ask.
+ *
+ * That check asserts no two lanes claim the same path, and it is right to. But **disjointness and
+ * coverage are two different claims, and only the first was tested.** A lane table that is perfectly
+ * disjoint and owns 62% of the tree passes every assertion above, and the remaining 38% is invisible:
+ * not contested, simply unclaimed.
+ *
+ * That is not theoretical. The table's own note records Lane J being created on 2026-08-06 after
+ * "three sessions in one day flagged a path belonging to no lane... Each flagged it correctly and
+ * then had to edit it anyway", and concludes: **"An unowned shared path is not neutral ground; it is
+ * a collision nobody is watching for."** The measurement that prompted this check found 152 of 390
+ * tracked files under `apps/web/src` unowned — 56 once vendored code is set aside — including
+ * `proforma/`, where a defect was fixed the same day under a one-change lane assignment because
+ * there was no row to point at.
+ *
+ * A RATCHET, not a wall. Requiring zero today would ship a red test, and a red test everyone learns
+ * to ignore protects nothing. The number only ever goes down, and it goes down by adding a row to the
+ * table — which is the actual work.
+ */
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = `${dir}/${e.name}`;
+    if (e.isDirectory()) walk(p, out); else out.push(p);
+  }
+  return out;
+}
+
+/** Not lanes: vendored copies re-synced by overwrite, and ambient type declarations. */
+const NOT_A_LANE = (rel: string) =>
+  rel.startsWith("apps/web/src/vendor/") || rel.endsWith(".d.ts");
+
+//: Measured 2026-08-07 BY THIS READER. Only ever revised DOWN, and the way down is a new row in the
+//: lane table rather than a bigger number here.
+//:
+//: 53, not the 56 my own probe reported. The gap is exactly the three `.d.ts` files this gate exempts
+//: by name and that probe did not — both counts are right for their own exclusions, and a threshold
+//: taken from a different reader is a threshold for a different question. `surface.test.ts` records
+//: being bitten by precisely this (698 from a probe vs 696 from the gate), so the number is read back
+//: out of the assertion that enforces it.
+const UNOWNED_CEILING = 53;
+
+describe("the lane table covers the tree it governs", () => {
+  const WEB = resolve(REPO, "apps/web/src");
+  const ROOT = resolve(REPO).split(sep).join("/");
+  const all = walk(WEB).map((p) => p.split(sep).join("/").slice(ROOT.length + 1));
+  // The table mixes notations: `apps/web/src/shell/` alongside bare `main.ts`, `portal/panels/`,
+  // `field/`. The bare ones are relative to `apps/web/src/`. Resolving them is not cosmetic — my
+  // first version filtered on `startsWith("apps/web/")` and reported 90 unowned instead of 56,
+  // because it silently dropped every relative claim. A population error, in the gate written to
+  // catch population errors.
+  //
+  // Worth flagging separately: the DISJOINTNESS check above compares these strings raw, so two lanes
+  // claiming the same directory in different notations — `field/` and `apps/web/src/field/` — would
+  // read as disjoint. That is a live gap in that check, not this one.
+  const claimed = LANES.flatMap((l) => l.paths)
+    .filter((p) => !p.startsWith("!") && !p.startsWith("services/") && !p.startsWith("docs/") && p !== "README.md")
+    .map((p) => (p.startsWith("apps/") ? p : `apps/web/src/${p}`))
+    .filter((p) => p.startsWith("apps/web/src/"));
+  const unowned = all.filter((f) => !NOT_A_LANE(f) && !claimed.some((p) => f === p || f.startsWith(p)));
+
+  it("can see the tree and the claims — else every count below is vacuous", () => {
+    // Both halves. An empty file list reports zero unowned and looks like total coverage; an empty
+    // claim list reports everything unowned and looks like a catastrophe. Neither is a measurement.
+    expect(all.length, "no web source files found — the walk is broken, not the table").toBeGreaterThan(200);
+    expect(claimed.length, "no lane claims any apps/web path — the table parse is broken").toBeGreaterThan(5);
+  });
+
+  it("does not grow the set of files no lane owns", () => {
+    const byDir = [...new Set(unowned.map((f) => f.split("/").slice(0, 4).join("/")))].sort();
+    expect(unowned.length,
+      `${unowned.length} file(s) under apps/web/src belong to no lane. Add a row to the lane table ` +
+      `in docs/roadmap.md rather than raising this number. Locations: ${byDir.join(", ")}`)
+      .toBeLessThanOrEqual(UNOWNED_CEILING);
+  });
+
+  it("names a path the table genuinely does not claim — so the checker is not always empty", () => {
+    // The paired control. A matcher that is too loose returns zero unowned for any table at all,
+    // which is indistinguishable from full coverage. `vendor/` is excluded by name above, so use a
+    // real unclaimed source path: this must be found, and it must stop being found once a row lands.
+    expect(unowned.some((f) => f.startsWith("apps/web/src/proforma/")),
+      "proforma/ is unclaimed today — if this fails, either a row was added (update this test) " +
+      "or the matcher stopped working").toBe(true);
   });
 });

--- a/docs/roadmap-directions.md
+++ b/docs/roadmap-directions.md
@@ -164,6 +164,24 @@ So the marginal cost of an isolated session is a source checkout — tens of MB,
    `PYTHONPATH`, not `node_modules`.
 3. **Distinct dev-server ports per session.** `:8093` and `:5173` are singletons; tests are already
    headless (happy-dom, no browser) so only a live preview needs one.
+4. **Branch from `origin/main`, never `main`.** In a worktree `git checkout main` **cannot succeed** —
+   main is checked out in the primary clone and git refuses to have one branch in two working trees.
+   That refusal is one line on stderr and nothing else changes, so a `2>/dev/null` turns it into a
+   silent no-op and the next command inherits a state nobody chose. `git checkout -b <new> main` then
+   works fine and resolves `main` as a **ref**, pointing wherever the local ref last pointed — which
+   in a worktree is wherever it was when the session began.
+
+   Measured 2026-08-07: a branch created that way was **140 commits stale** and every command reported
+   success. It was caught only because `app.ts` measured 5,064 lines against a ratchet pinned at 3,751,
+   and a ratchet that only revises down cannot sit below the file it measures. **The contradiction
+   between two numbers was the entire signal.**
+
+   Two generalisations worth more than the command: **never `2>/dev/null` a state-changing git
+   command** — suppressing stderr on a query is untidy, suppressing it on `checkout` converts a
+   refusal into a silent no-op; and **a ref name is not a ref** — `main` and `origin/main` are
+   different objects that read identically in a command line.
+
+        git fetch -q origin main && git checkout -q -b <branch> origin/main
 
     git worktree add .claude/worktrees/<lane> -b <branch> origin/main
     cd .claude/worktrees/<lane>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -294,6 +294,34 @@ nobody starts one thinking it is a sprint item: QUALITY-ROOM · R26-V-TIMING · 
 R24-IDENTITY · R32-TAXONOMY-LIFECYCLE (all five need the user's call) · PHOTO-PIN · CMMS-OPS (BIG-TICKET: open **one**, slice
 it) · REL-7 (gated on RT-KNIP) · R35-SANDBOX-ISOLATION (process/container isolation for snippet execution — a genuine design change, needs the user's call on deployment shape) · R35-PREFLIGHT-CI (run the prod-config validator against the **actual deploy overlay** in CI — still needs a decision on where the deploy env template lives. **Split 2026-08-02:** the half that needs NO decision — smoke the validator against a *synthetic* safe posture → exit 0 and an unsafe one → exit 1, catching a validator crash, a check regressed to a no-op, or a FAIL demoted — is unparked as a ~10-line CI step; the security session has claimed it).
 
+**A fourth was wrong until 2026-08-07, and it is wrong in the way the table could not see.**
+`roadmapLanes.test.ts` asserts the rows are **disjoint** — no two lanes claim the same path — and it
+is right to. But **disjointness and coverage are two different claims, and only the first was
+tested.** A table that is perfectly disjoint and owns 62% of the tree passes every assertion, and the
+rest is invisible: not contested, simply unclaimed.
+
+Measured: **152 of 390 tracked files under `apps/web/src` belonged to no lane — 53 once vendored code
+and ambient type declarations are set aside.** The unowned set includes `proforma/`, `drawings/`,
+`kernel/`, `pins/`, `studio/`, `tools/`, `tree/`, `connections/`, `account/`, `deploy/`, and the loose
+files in `portal/` that are neither `portal.ts` (A) nor `panels/`/`register/` (B) — `offlineQueue.ts`,
+`prefs.ts`, `panelContext.ts`, sitting between the two lanes least likely to be watching each other.
+That is the same shape as the 2026-07-30 nested overlap, one level up.
+
+This is not theoretical: Lane J's own note records three sessions in one day hitting a path belonging
+to no lane, and on 2026-08-07 a real defect in `apps/web/src/proforma/proforma.ts` — a reserve
+contribution presented as a recommendation without reading the flag that says whether it verified —
+had to be fixed under a one-change lane assignment because there was no row to point at.
+
+**It is now a ratchet rather than a proposal.** `roadmapLanes.test.ts` counts unowned files against a
+ceiling that only ever goes down, and the way down is adding a row here. Rows still to agree:
+`proforma/` · `drawings/` · `kernel/` · `pins/` · `studio/` · `tools/` · `tree/` · the loose `portal/`
+files · `tooling/` + `dev/` (probably J) · `account/` · `connections/` · `deploy/`.
+
+**One live gap in the disjointness check itself, found while measuring.** The table mixes notations —
+`apps/web/src/shell/` alongside bare `main.ts`, `portal/panels/`, `field/` — and that check compares
+the strings raw. Two lanes claiming the same directory in different notations (`field/` and
+`apps/web/src/field/`) would read as disjoint. Not fixed here; recorded so it is not re-discovered.
+
 **Two lane boundaries were wrong until 2026-07-30 and are worth naming.** Lane A used to own
 `apps/web/src/portal/` *wholesale* while B owned `portal/panels/` — a nested overlap, so the two lanes
 least likely to notice each other shared a directory. And `routers/` sat inside C's path with no owner

--- a/scripts/reconcile_test_manifest.py
+++ b/scripts/reconcile_test_manifest.py
@@ -1,0 +1,101 @@
+"""Reconcile `TESTS` / `DATA_TESTS` across a rebase or merge of `services/api/run_tests.py`.
+
+WHY THIS EXISTS. That manifest is one packed line that every lane edits, and it is the worst shared
+surface in the repo — see `services/api/test_manifest.py` and the roadmap's Lane J note. When two
+branches both add an entry, git presents a conflict on a line carrying 200+ names, and resolving it by
+reading is a coin flip. On 2026-08-07 a resolution looked like competing edits to one entry and was
+actually main *repacking* the region onto a single line against a split version: 207 entries a side,
+exactly one different.
+
+WHAT `test_manifest.py` DOES NOT COVER. It catches an entry registered twice and an entry naming a
+file that does not exist. It does not tell you whether a CONFLICT RESOLUTION silently dropped an
+entry that should have survived, because a dropped entry is simply absent and absence is not an error
+there — the suite just quietly stops running that file. This script answers that question, and
+reports duplicates separately because a packed-line resolution can repeat an entry as easily as lose
+one.
+
+HOW TO USE IT, from the repo root, before staging the resolved file:
+
+    git show $(git merge-base HEAD origin/main):services/api/run_tests.py > /tmp/base.py
+    git show HEAD:services/api/run_tests.py                              > /tmp/mine.py
+    git show origin/main:services/api/run_tests.py                       > /tmp/main.py
+    cp services/api/run_tests.py                                           /tmp/after.py
+    python scripts/reconcile_test_manifest.py /tmp/base.py /tmp/mine.py /tmp/main.py /tmp/after.py
+
+Exit 0 means the entry sets reconcile exactly. Omit the fourth argument to see the expected result
+before resolving.
+
+TWO THINGS THAT MATTER MORE THAN THE CODE.
+
+  1. **Derive the expected delta from the merge-base; never accept one that was handed to you.** The
+     first use of this was prompted by a message saying main had added one entry. It had added two —
+     the second came from a PR merged an hour earlier that the author had forgotten. Asserting the
+     handed-over value would have gone red on a *correct* resolution, and the tempting repair for that
+     is to delete the entry that "shouldn't" be there. A hand-supplied expected value is itself an
+     unverified claim.
+
+  2. **Run it twice on a rebase** — once at the conflict, and again after the remaining commits
+     replay. A later commit in the same rebase can touch the same file, and the first run cannot see
+     that.
+
+AST, not regex: the manifest is packed, and a naive pattern over-counts by matching names in
+comments and docstrings.
+"""
+import ast
+import sys
+
+
+def lists(path: str) -> dict[str, list[str]]:
+    """Every string entry of the module-level TESTS / DATA_TESTS assignments."""
+    tree = ast.parse(open(path, encoding="utf-8").read())
+    out: dict[str, list[str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id in ("TESTS", "DATA_TESTS"):
+                    if isinstance(node.value, (ast.List, ast.Tuple)):
+                        out[t.id] = [e.value for e in node.value.elts if isinstance(e, ast.Constant)]
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if not 4 <= len(argv) <= 5:
+        print(__doc__)
+        return 2
+    # argv[0] is this script. Slicing from 1 is not a detail: the first draft used `argv[:4]`, parsed
+    # ITSELF as the base revision, and reported MANIFEST DAMAGED against a resolution already proven
+    # correct. A checker that mis-reads its own inputs fails toward alarm, which at least is loud.
+    base, mine, main_ = (lists(a) for a in argv[1:4])
+    after = lists(argv[4]) if len(argv) == 5 else None
+
+    ok = True
+    for key in ("TESTS", "DATA_TESTS"):
+        b, m, n = set(base.get(key, [])), set(mine.get(key, [])), set(main_.get(key, []))
+        expected = (b | (m - b) | (n - b)) - ((b - m) | (b - n))
+        print(f"\n=== {key} ===")
+        print(f"  base           : {len(b)}")
+        print(f"  mine adds      : {sorted(m - b) or '(none)'}")
+        print(f"  main adds      : {sorted(n - b) or '(none)'}")
+        print(f"  mine removes   : {sorted(b - m) or '(none)'}")
+        print(f"  main removes   : {sorted(b - n) or '(none)'}")
+        print(f"  EXPECTED after : {len(expected)}")
+        if after is None:
+            continue
+        a = set(after.get(key, []))
+        dropped, unexpected = expected - a, a - expected
+        dupes = len(after.get(key, [])) - len(a)
+        print(f"  ACTUAL after   : {len(a)}")
+        print(f"  DROPPED        : {sorted(dropped) or '(none)'}")
+        print(f"  UNEXPECTED     : {sorted(unexpected) or '(none)'}")
+        print(f"  DUPLICATES     : {dupes}")
+        if dropped or unexpected or dupes:
+            ok = False
+
+    if after is not None:
+        print("\n" + ("RESULT: entry sets reconcile exactly" if ok else "RESULT: MANIFEST DAMAGED"))
+        return 0 if ok else 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## The lane table was tested for disjointness, never for coverage

`roadmapLanes.test.ts` asserts no two lanes claim the same path — and it's right to. But **disjointness and coverage are two different claims, and only the first was tested.** A table that is perfectly disjoint and owns 62% of the tree passes every assertion, and the rest is invisible: not contested, simply unclaimed.

**Measured: 152 of 390 tracked files under `apps/web/src` belonged to no lane** — 53 once vendored code and ambient `.d.ts` are set aside.

The unowned set includes `proforma/`, `drawings/`, `kernel/`, `pins/`, `studio/`, `tools/`, `tree/`, and the loose files in `portal/` that are neither `portal.ts` (Lane A) nor `panels/`/`register/` (Lane B) — `offlineQueue.ts`, `prefs.ts`, `panelContext.ts`, sitting between the two lanes least likely to be watching each other. That's the 2026-07-30 nested-overlap shape, one level up.

Not theoretical: a real defect in `proforma/proforma.ts` (#255) was fixed today under a **one-change lane assignment**, because there was no row to point at.

### A ratchet, not a wall

Requiring zero today would ship a red test, and a red test everyone learns to ignore protects nothing. The number only goes down, and the way down is adding a row to the table — which is the actual work. Rows still to agree are listed in the roadmap.

### My first version had the defect it was written to catch

It filtered claims on `startsWith("apps/web/")` and reported **90** unowned. The table mixes `apps/web/src/shell/` with bare `main.ts`, `portal/panels/`, `field/` — so it silently dropped every relative claim. A population error, in the population gate.

**The ceiling is 53, read back out of the assertion that enforces it** — not the 56 my own probe reported. The gap is exactly the three `.d.ts` files the gate exempts and the probe didn't. `surface.test.ts` records being bitten by this precisely (698 from a probe vs 696 from the gate): a threshold taken from a different reader is a threshold for a different question.

### Flagged, not fixed

The **disjointness** check compares path strings raw, so two lanes claiming one directory in different notations (`field/` and `apps/web/src/field/`) would read as disjoint. Recorded in the roadmap so it isn't re-discovered.

### Also in this change

**`scripts/reconcile_test_manifest.py`** — AST-diffs `TESTS`/`DATA_TESTS` across a rebase so a packed-line conflict cannot silently drop or duplicate an entry. `test_manifest.py` catches a duplicate and an entry naming a missing file; it **cannot** catch a resolution that dropped an entry which should have survived, because absence isn't an error there — the suite just quietly stops running that file. Written after #243's rebase, where the conflict turned out to be main *repacking* a 207-entry line rather than competing edits.

Its own first draft parsed **itself** as the base revision (`argv[:4]` includes `argv[0]`) and reported damage against an already-proven-correct resolution. Fixed and mutation-checked both ways: a dropped entry is named, a duplicate is counted, exit 1 in each case.

**The worktree branching rule**, added to the directions: branch from `origin/main`, never `main`. `git checkout main` cannot succeed in a worktree (main is checked out in the primary clone), the refusal is one line on stderr, and a swallowed error gave me a **140-commit-stale base with every command reporting success**. Caught only because `app.ts` measured 5,064 lines against a ratchet pinned at 3,751 — a ratchet that only revises down cannot sit below the file it measures, and that contradiction was the entire signal.

### Verification

Mutation-checked: dropping `field/` from Lane B moves 53 → 55 and fails the ratchet; breaking the tree walk fires the vacuity guard rather than reporting a comfortable zero. Full web suite green (125 files, 1,386 tests), `tsc` + `eslint` + `ruff` clean, `test_claude_md_gates` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
