### PR TITLE
R23: camera fov/near/far by viewport class and mode

### DIFF
--- a/apps/web/src/viewer/applyCameraProfile.test.ts
+++ b/apps/web/src/viewer/applyCameraProfile.test.ts
@@ -1,0 +1,81 @@
+import * as THREE from "three";
+import { describe, expect, it, vi } from "vitest";
+import { applyCameraProfile } from "./world";
+
+/**
+ * The wiring half. `cameraProfile.test.ts` proves the arithmetic; nothing proved the numbers reach
+ * the camera, and the failure mode there is silent.
+ *
+ * **`updateProjectionMatrix()` is the whole risk.** three caches the projection matrix, so assigning
+ * `cam.fov` and forgetting the call leaves the camera rendering exactly as before — every assertion
+ * about `cam.fov` still passes, the view never changes, and it looks like the profile is wrong rather
+ * than uncalled. Asserted directly below.
+ *
+ * `world.ts` builds a real WebGL world, but `applyCameraProfile` was deliberately written to take the
+ * minimum structurally (`{ camera?: { three?: unknown } }`), so it can be exercised with a plain
+ * three camera and no context — which is also what lets `walkMode.ts` call it without giving up its
+ * three-free core.
+ */
+
+const world = (cam: unknown) => ({ camera: { three: cam } });
+
+describe("applyCameraProfile puts the profile on the live camera", () => {
+  it("writes fov, near and far", () => {
+    const cam = new THREE.PerspectiveCamera(60, 1.6, 1, 1000);
+    applyCameraProfile(world(cam), 375, 812);          // portrait phone
+    expect(cam.fov).toBe(85);
+    expect(cam.near).toBe(1);
+    expect(cam.far).toBe(1000);
+  });
+
+  it("calls updateProjectionMatrix — without it the change is inert", () => {
+    const cam = new THREE.PerspectiveCamera(60, 1.6, 1, 1000);
+    const spy = vi.spyOn(cam, "updateProjectionMatrix");
+    applyCameraProfile(world(cam), 375, 812);
+    expect(spy, "fov changed but the projection was never rebuilt — the view will not move")
+      .toHaveBeenCalled();
+  });
+
+  it("applies the walk depth range when asked", () => {
+    const cam = new THREE.PerspectiveCamera(60, 1.6, 1, 1000);
+    applyCameraProfile(world(cam), 1280, 800, true);
+    expect(cam.near).toBe(0.1);
+    expect(cam.far).toBe(200);
+  });
+
+  it("restores the orbit range when walk mode ends", () => {
+    // The half that matters after the user has moved on: a walk range left on an orbit camera clips
+    // any model wider than 200 m, in a mode they already exited.
+    const cam = new THREE.PerspectiveCamera(60, 1.6, 1, 1000);
+    applyCameraProfile(world(cam), 1280, 800, true);
+    applyCameraProfile(world(cam), 1280, 800, false);
+    expect(cam.near).toBe(1);
+    expect(cam.far).toBe(1000);
+  });
+
+  it("does nothing when the profile already matches — no needless matrix rebuild", () => {
+    const cam = new THREE.PerspectiveCamera(60, 1.6, 1, 1000);
+    applyCameraProfile(world(cam), 1280, 800);          // desktop profile == the defaults
+    const spy = vi.spyOn(cam, "updateProjectionMatrix");
+    applyCameraProfile(world(cam), 1280, 800);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("leaves an orthographic camera alone — plan mode has no fov to set", () => {
+    // The paired control for the isPerspectiveCamera guard. Writing `fov` onto an ortho camera is
+    // not an error in JS; it is simply ignored, so a missing guard would be invisible here without
+    // asserting the ortho case explicitly.
+    const cam = new THREE.OrthographicCamera(-1, 1, 1, -1, 1, 1000);
+    const spy = vi.spyOn(cam, "updateProjectionMatrix");
+    applyCameraProfile(world(cam), 375, 812);
+    expect(cam.near).toBe(1);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("survives a world with no camera at all", () => {
+    // Reached during teardown and before the world is built. A throw here would come out of a
+    // ResizeObserver, where nothing catches it.
+    expect(() => applyCameraProfile({}, 375, 812)).not.toThrow();
+    expect(() => applyCameraProfile({ camera: {} }, 375, 812)).not.toThrow();
+  });
+});

--- a/apps/web/src/viewer/cameraProfile.test.ts
+++ b/apps/web/src/viewer/cameraProfile.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { cameraProfile, horizontalFov, viewportClass } from "./cameraProfile";
+
+/**
+ * R23-CAMERA-CLASS. The assertions that matter are the two the fix exists for — a phone gets a
+ * usable horizontal view, and desktop is provably unchanged — plus the one that stops the near-plane
+ * change from being made globally.
+ *
+ * The library default is `PerspectiveCamera(60, aspect, 1, 1e3)`, so every "before" number below is
+ * what ships today, not a strawman.
+ */
+
+const PHONE: [number, number] = [375, 812];
+const TABLET: [number, number] = [768, 1024];
+const DESKTOP: [number, number] = [1280, 800];
+const WIDE: [number, number] = [1920, 900];
+
+describe("viewport class", () => {
+  it("bands on the app's own breakpoints", () => {
+    expect(viewportClass(375)).toBe("phone");
+    expect(viewportClass(767)).toBe("phone");
+    expect(viewportClass(768)).toBe("tablet");
+    expect(viewportClass(1023)).toBe("tablet");
+    expect(viewportClass(1024)).toBe("desktop");
+  });
+
+  it("falls back to desktop when the width is unmeasurable", () => {
+    // A container measured at 0 during layout is a real state — `world.ts` skips resizing at 0x0 for
+    // exactly that reason. Guessing "phone" there would narrow a desktop user's camera mid-load.
+    expect(viewportClass(0)).toBe("desktop");
+    expect(viewportClass(Number.NaN)).toBe("desktop");
+  });
+});
+
+describe("the fix: a portrait phone gets a usable horizontal view", () => {
+  it("widens the phone's horizontal fov well past today's 30 degrees", () => {
+    const p = cameraProfile(...PHONE);
+    const before = horizontalFov(60, ...PHONE);          // what ships today
+    const after = horizontalFov(p.fov, ...PHONE);
+    expect(Math.round(before)).toBe(30);                  // pins the defect, not a guess
+    expect(after).toBeGreaterThan(44);
+    expect(after / before).toBeGreaterThan(1.4);
+  });
+
+  it("clamps rather than fisheyeing — the unclamped answer is 127 degrees vertical", () => {
+    const p = cameraProfile(...PHONE);
+    expect(p.fov).toBeLessThanOrEqual(85);
+    expect(p.fov).toBe(85);
+  });
+});
+
+describe("it can only widen, never narrow — no silent regression", () => {
+  it("leaves desktop exactly at the library default", () => {
+    // The floor is 60 for this reason. A profile that computed a "better" 51 for desktop would ship
+    // a regression as an improvement: nobody reports it as a bug, they just see less.
+    expect(cameraProfile(...DESKTOP).fov).toBe(60);
+    expect(cameraProfile(...WIDE).fov).toBe(60);
+  });
+
+  it("never returns a vertical fov below today's value, at any aspect", () => {
+    // The property, over the whole range rather than three sampled points — a per-viewport check
+    // cannot see a regression at an aspect nobody listed.
+    for (let w = 240; w <= 3840; w += 40) {
+      for (const h of [400, 800, 1200]) {
+        expect(cameraProfile(w, h).fov,
+          `${w}x${h} narrowed the view below the shipped default`).toBeGreaterThanOrEqual(60);
+      }
+    }
+  });
+
+  it("is monotonic — a narrower viewport never gets a narrower camera", () => {
+    let prev = 0;
+    for (let w = 3840; w >= 240; w -= 40) {
+      const f = cameraProfile(w, 800).fov;
+      expect(f, `fov went backwards at width ${w}`).toBeGreaterThanOrEqual(prev);
+      prev = f;
+    }
+  });
+});
+
+describe("walk mode moves the near plane, and only walk mode does", () => {
+  it("lets you approach a surface instead of clipping through it", () => {
+    // walkMode.ts puts the eye at 1.65m. At near=1 everything within a metre of the eye is clipped,
+    // so walking up to a wall makes it vanish — in the mode whose whole purpose is close inspection.
+    expect(cameraProfile(...DESKTOP, { walk: true }).near).toBe(0.1);
+  });
+
+  it("leaves the orbit camera's near plane alone — the paired control", () => {
+    // The important half. Making this global would trade a walk-mode defect for a rendering one:
+    // guideUnderlay.ts lifts its plane 5mm, and at near=0.1 the resolvable depth gap passes 5mm
+    // before 100m, so the underlay would z-fight on any model of real size.
+    expect(cameraProfile(...DESKTOP).near).toBe(1);
+    expect(cameraProfile(...PHONE).near).toBe(1);
+    expect(cameraProfile(...TABLET).near).toBe(1);
+  });
+
+  it("pulls `far` in with `near` so the precision loss stays bounded", () => {
+    const walk = cameraProfile(...DESKTOP, { walk: true });
+    const orbit = cameraProfile(...DESKTOP);
+    expect(walk.far).toBeLessThan(orbit.far);
+    // Guard the actual property rather than the two numbers: the depth-precision argument is about
+    // the RATIO, so a future edit that lowers `near` again must lower `far` too or fail here.
+    expect(walk.far / walk.near).toBeLessThanOrEqual(orbit.far / orbit.near * 2);
+  });
+
+  it("still applies the viewport widening while walking", () => {
+    // The two concerns are independent and both must survive being combined.
+    expect(cameraProfile(...PHONE, { walk: true }).fov).toBe(cameraProfile(...PHONE).fov);
+  });
+});

--- a/apps/web/src/viewer/cameraProfile.ts
+++ b/apps/web/src/viewer/cameraProfile.ts
@@ -1,0 +1,87 @@
+// R23-CAMERA-CLASS — camera parameters chosen from the viewport and the mode, instead of once.
+//
+// `@thatopen/components` constructs the world camera as `PerspectiveCamera(60, aspect, 1, 1e3)` and
+// nothing in this app has ever revisited those numbers. Two measured consequences:
+//
+// **1. A fixed VERTICAL fov gives a phone a third of the view a desktop gets.** Horizontal fov is
+// derived from vertical fov and aspect, so a portrait viewport collapses it:
+//
+//     phone portrait  aspect 0.46  ->  30deg horizontal
+//     tablet          aspect 0.75  ->  47deg
+//     desktop         aspect 1.60  ->  85deg
+//
+// The fix is to hold the HORIZONTAL angle roughly constant and derive vertical from it — the "Hor+"
+// convention games have used for two decades. Clamped, because the un-clamped answer for a portrait
+// phone is a 127deg vertical fov, which is a fisheye.
+//
+// **The clamp floor is 60 — today's value — on purpose: this can only ever WIDEN the view, never
+// narrow it.** A profile that computed a "better" 51deg for desktop would be a regression shipped as
+// an improvement, and nobody would report it as a bug; they would just see less.
+//
+// **2. `near = 1 metre` is wrong for a first-person walkthrough.** `walkMode.ts` puts the eye at
+// 1.65 m and calls itself "the coordination-review move that orbit cameras hide" — but everything
+// within a metre of the eye is clipped, so walking up to a wall, a column or a duct makes it vanish
+// before you reach it. You cannot inspect anything closely, which is the entire point of the mode.
+//
+// **Why that is not simply fixed globally, with the number that decides it.** Depth precision at
+// distance scales with `near`. For a 24-bit buffer the resolvable gap is about `z^2 / (near * 2^24)`:
+//
+//     near=1     0.1mm @50m   0.6mm @100m   2.4mm @200m
+//     near=0.1   1.5mm @50m   6.0mm @100m  23.8mm @200m
+//
+// `guideUnderlay.ts` lifts its plane by `LEVEL_LIFT_M = 0.005` (5 mm) to avoid z-fighting with the
+// storey slab. At `near=0.1` the resolvable gap passes 5 mm before 100 m, so a global change would
+// make that underlay z-fight on any model of real size — trading a walk-mode defect for a rendering
+// one. So the near plane moves **only in walk mode**, where `far` comes in too: indoors you are not
+// looking 1 km, and pulling `far` back keeps the far-field precision loss bounded.
+
+export type ViewportClass = "phone" | "tablet" | "desktop";
+
+export interface CameraProfile {
+  /** Vertical field of view, degrees. */
+  fov: number;
+  near: number;
+  far: number;
+  viewport: ViewportClass;
+}
+
+/** Breakpoints match the app's own responsive CSS rather than inventing a second set. */
+export function viewportClass(width: number): ViewportClass {
+  if (!Number.isFinite(width) || width <= 0) return "desktop";   // unmeasurable: keep today's behaviour
+  if (width < 768) return "phone";
+  if (width < 1024) return "tablet";
+  return "desktop";
+}
+
+/** The horizontal angle a 60deg vertical fov gives at a reference 16:10 desktop — the target to hold. */
+const TARGET_H_FOV = 85;
+/** Never narrower than the library default (no regression), never wide enough to fisheye. */
+const FOV_MIN = 60;
+const FOV_MAX = 85;
+
+const deg = (r: number) => (r * 180) / Math.PI;
+const rad = (d: number) => (d * Math.PI) / 180;
+
+export function cameraProfile(
+  width: number, height: number, opts: { walk?: boolean } = {},
+): CameraProfile {
+  const viewport = viewportClass(width);
+  const aspect = width > 0 && height > 0 ? width / height : 16 / 10;
+
+  // vertical from horizontal: tan(v/2) = tan(h/2) / aspect
+  const v = 2 * deg(Math.atan(Math.tan(rad(TARGET_H_FOV) / 2) / aspect));
+  const fov = Math.min(FOV_MAX, Math.max(FOV_MIN, Math.round(v)));
+
+  // Walk mode trades far-field depth precision for being able to see what you walk up to. `far` is
+  // pulled in with `near` so the ratio — and so the precision loss — stays bounded; 200 m of draw
+  // distance is far more than an interior review needs.
+  return opts.walk
+    ? { fov, near: 0.1, far: 200, viewport }
+    : { fov, near: 1, far: 1000, viewport };
+}
+
+/** The horizontal angle a profile actually achieves — what the user experiences. Reported by tests. */
+export function horizontalFov(fov: number, width: number, height: number): number {
+  const aspect = width > 0 && height > 0 ? width / height : 16 / 10;
+  return 2 * deg(Math.atan(Math.tan(rad(fov) / 2) * aspect));
+}

--- a/apps/web/src/viewer/walkMode.test.ts
+++ b/apps/web/src/viewer/walkMode.test.ts
@@ -1,6 +1,7 @@
+import * as THREE from "three";
 import { describe, expect, it } from "vitest";
 
-import { WalkController } from "./walkMode";
+import { installWalkMode, WalkController } from "./walkMode";
 
 describe("WalkController (WALK-MODE core)", () => {
   it("walks forward along -Z at yaw 0 at walk speed", () => {
@@ -70,5 +71,60 @@ describe("WalkController (WALK-MODE core)", () => {
     c.keyDown("KeyS");
     c.step(1.0);
     expect(c.pos.z).toBeCloseTo(0, 5);
+  });
+});
+
+/**
+ * R23-CAMERA-CLASS — the depth range must follow walk mode in AND out.
+ *
+ * Found by mutation: deleting the restore on exit passed all 433 viewer tests. Only `WalkController`
+ * had coverage — the headless core — and `installWalkMode` itself was never driven, so everything
+ * the toggle does to the camera was unguarded.
+ *
+ * The exit half is the one worth holding. A walk range (`near 0.1 / far 200`) left on an orbit camera
+ * clips any model wider than 200 m and z-fights `guideUnderlay`'s 5 mm lift past ~100 m — a rendering
+ * bug in a mode the user has already left, which is close to impossible to attribute back to here.
+ */
+describe("installWalkMode drives the camera depth range", () => {
+  function harness() {
+    const cam = new THREE.PerspectiveCamera(60, 1.6, 1, 1000);
+    const controls = {
+      getPosition: (v: THREE.Vector3) => v.set(0, 1.65, 0),
+      getTarget: (v: THREE.Vector3) => v.set(0, 1.65, -1),
+      setLookAt: () => {},
+    };
+    const canvas = document.createElement("canvas");
+    Object.defineProperty(canvas, "clientWidth", { value: 1280 });
+    Object.defineProperty(canvas, "clientHeight", { value: 800 });
+    let click: (() => void) | null = null;
+    const toolBtn = (_i: string, _t: string, onClick: (b: HTMLButtonElement) => void) => {
+      const b = document.createElement("button");
+      click = () => onClick(b);
+      return b;
+    };
+    const api = installWalkMode({
+      viewer: { world: { camera: { three: cam, controls } } },
+      canvas, toolBtn, setStatus: () => {},
+    } as unknown as Parameters<typeof installWalkMode>[0]);
+    return { cam, api, toggle: () => click?.() };
+  }
+
+  it("drops the near plane on enter so you can approach a surface", () => {
+    const h = harness();
+    expect(h.cam.near, "precondition: the shipped default").toBe(1);
+    h.toggle();
+    expect(h.api.walking()).toBe(true);
+    expect(h.cam.near).toBe(0.1);
+    expect(h.cam.far).toBe(200);
+    h.api.exit();
+  });
+
+  it("restores the orbit range on exit — the mutation that survived until now", () => {
+    const h = harness();
+    h.toggle();
+    h.api.exit();
+    expect(h.api.walking()).toBe(false);
+    expect(h.cam.near, "a walk near-plane left on the orbit camera z-fights past ~100m").toBe(1);
+    expect(h.cam.far, "...and clips any model wider than 200m").toBe(1000);
   });
 });

--- a/apps/web/src/viewer/walkMode.ts
+++ b/apps/web/src/viewer/walkMode.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { applyCameraProfile } from "./world";
 
 /** WALK-MODE (R17 Sprint B) — first-person walkthrough over the loaded model: WASD + pointer-lock at
  *  eye height, the coordination-review move that orbit cameras hide. The math lives in a headless
@@ -62,7 +63,7 @@ export class WalkController {
 }
 
 export interface WalkModeDeps {
-  viewer: { world: { camera: { controls: { getPosition(v: THREE.Vector3): void; getTarget(v: THREE.Vector3): void; setLookAt(px: number, py: number, pz: number, tx: number, ty: number, tz: number, transition?: boolean): void } } } };
+  viewer: { world: { camera: { three?: unknown; controls: { getPosition(v: THREE.Vector3): void; getTarget(v: THREE.Vector3): void; setLookAt(px: number, py: number, pz: number, tx: number, ty: number, tz: number, transition?: boolean): void } } } };
   canvas: HTMLElement;
   toolBtn: (icon: string, title: string, onClick: (b: HTMLButtonElement) => void, cap?: "edit" | "review") => HTMLButtonElement;
   setStatus: (m: string) => void;
@@ -71,6 +72,19 @@ export interface WalkModeDeps {
 /** Install the 🚶 walk-mode toggle. Enter = pointer-lock + WASD from the current camera position;
  *  Esc (or the button) exits and the orbit camera resumes exactly where the walk ended. */
 export function installWalkMode(d: WalkModeDeps): { walking: () => boolean; exit: () => void } {
+  /**
+   * Swap the camera between the orbit and walk depth ranges.
+   *
+   * Restoring on exit is not tidiness. The walk range is `near 0.1 / far 200`, and leaving it on an
+   * orbit camera would z-fight `guideUnderlay`'s 5 mm plane lift past ~100 m and clip any model
+   * wider than 200 m — a rendering bug in a mode the user has already left, which is close to
+   * impossible to attribute back to walk mode.
+   */
+  const setWalkCamera = (walk: boolean) => {
+    const el = d.canvas as HTMLCanvasElement;
+    applyCameraProfile(d.viewer.world, el.clientWidth || el.width, el.clientHeight || el.height, walk);
+  };
+
   const ctl = new WalkController();
   let walking = false;
   let raf = 0;
@@ -106,6 +120,10 @@ export function installWalkMode(d: WalkModeDeps): { walking: () => boolean; exit
     const horiz = Math.hypot(t.x - p.x, t.z - p.z);
     ctl.pitch = Math.max(-PITCH_LIMIT, Math.min(PITCH_LIMIT, Math.atan2(t.y - p.y, horiz || 1e-6)));
     walking = true;
+    // R23-CAMERA-CLASS — drop the near plane so you can actually approach a surface. At the library
+    // default of 1 m, everything within a metre of the eye is clipped, so walking up to a wall makes
+    // it vanish: the mode exists for close inspection and could not do it.
+    setWalkCamera(true);
     last = performance.now();
     document.addEventListener("keydown", keyDown, true);
     document.addEventListener("keyup", keyUp, true);
@@ -120,6 +138,7 @@ export function installWalkMode(d: WalkModeDeps): { walking: () => boolean; exit
   function exit() {
     if (!walking) return;
     walking = false;
+    setWalkCamera(false);          // restore the orbit near/far — see setWalkCamera on why it matters
     cancelAnimationFrame(raf);
     ctl.clearKeys();
     document.removeEventListener("keydown", keyDown, true);

--- a/apps/web/src/viewer/world.ts
+++ b/apps/web/src/viewer/world.ts
@@ -1,5 +1,6 @@
 import * as OBC from "@thatopen/components";
 import * as THREE from "three";
+import { cameraProfile } from "./cameraProfile";
 import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
 import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
 import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
@@ -110,10 +111,38 @@ export function createViewer(container: HTMLElement): Viewer {
     if (w === lastW && h === lastH) return;     // observers fire on no-op layout passes too
     lastW = w; lastH = h;
     world.renderer?.resize();
+    applyCameraProfile(world, w, h);
   });
   ro.observe(container);
+  // Apply once at construction as well as on resize. The observer fires on the first layout pass in
+  // a browser, but not if the container is already at its final size — and a camera that only gets
+  // its profile when something moves is a camera that is wrong on the paths where nothing does.
+  applyCameraProfile(world, container.clientWidth, container.clientHeight);
 
   return { components, world, container, grid, stopPixelGovernor, stopResizeObserver: () => ro.disconnect() };
+}
+
+/**
+ * R23-CAMERA-CLASS — put the viewport-derived fov/near/far onto the live camera.
+ *
+ * Separate from `cameraProfile()` so the arithmetic stays testable without a WebGL context: that
+ * module is pure and unit-tested, this is the three lines that touch the renderer.
+ *
+ * `updateProjectionMatrix()` is not optional — three caches the projection and a changed `fov` is
+ * inert until it is called, which fails silently and looks exactly like the profile being wrong.
+ */
+export function applyCameraProfile(
+  world: { camera?: { three?: unknown } }, width: number, height: number, walk = false,
+): void {
+  // Structural, not `World`: `walkMode.ts` types its viewer with the minimum it needs precisely to
+  // keep three/DOM out of its core, and demanding the full library type here would force that file
+  // to give that up for three lines of camera state.
+  const cam = world.camera?.three as THREE.PerspectiveCamera | undefined;
+  if (!cam?.isPerspectiveCamera) return;          // ortho/plan mode has no fov to set
+  const p = cameraProfile(width, height, { walk });
+  if (cam.fov === p.fov && cam.near === p.near && cam.far === p.far) return;
+  cam.fov = p.fov; cam.near = p.near; cam.far = p.far;
+  cam.updateProjectionMatrix();
 }
 
 const SUN = "aec-sun", HEMI = "aec-hemi", FILL = "aec-fill", GROUND = "aec-shadow-ground";

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -846,9 +846,28 @@ exists: the repo has a 220 KB bundle budget and **zero** runtime perf assertions
   is null under happy-dom, which is **why the file had no tests at all** — the untestability and the
   defect had one cause.
 
-  **Still open, and genuinely unbuilt:** make FOV/FAR responsive by viewport class. The default BIM
-  pass is already off `MeshStandardMaterial` — every remaining use is GIS context, not the BIM pass —
-  so that clause needs no work.
+  **The FOV/FAR clause is now BUILT** (`apps/web/src/viewer/cameraProfile.ts`), and measuring it found
+  a second defect the clause did not describe. The library constructs the camera as
+  `PerspectiveCamera(60, aspect, 1, 1e3)` and nothing had revisited it:
+
+  - **A fixed VERTICAL fov gives a phone a third of the view a desktop gets** — horizontal fov is
+    derived from vertical and aspect, so portrait collapses it: **30°** on a phone against **85°** on
+    desktop. Now derived from a target horizontal angle and clamped, so a phone gets ~46°. The clamp
+    floor is 60° — today's value — deliberately: this can only ever *widen*, never narrow. A profile
+    that computed a "better" 51° for desktop would be a regression shipped as an improvement, and
+    nobody reports seeing less as a bug.
+  - **`near = 1 m` is wrong for the first-person walkthrough.** `apps/web/src/viewer/walkMode.ts` puts
+    the eye at 1.65 m and exists for close inspection — but everything within a metre of the eye was
+    clipped, so walking up to a wall or a column made it vanish before you reached it.
+
+  **Why the near plane moves only in walk mode, with the number that decides it.** Depth precision at
+  distance scales with `near`; for a 24-bit buffer the resolvable gap is about `z²/(near·2²⁴)`:
+  `near=1` gives 2.4 mm at 200 m, `near=0.1` gives **6.0 mm at 100 m**. `apps/web/src/viewer/guideUnderlay.ts`
+  lifts its plane 5 mm to avoid z-fighting, so a *global* change would make that underlay z-fight on
+  any model of real size — trading a walk-mode defect for a rendering one.
+
+  The `MeshStandardMaterial` clause needs no work — every remaining use is GIS context, not the BIM
+  pass.
 - **R23-SYMBOL-COUNT** *(M)* — deterministic template-match symbol counting in the **existing** pdf.js
   takeoff worker: mark one instance, normalised cross-correlation, non-maximum suppression.
   **Zero new dependencies**, offline, auditable — which matters for quantities that feed a bid.


### PR DESCRIPTION
## R23's last clause: camera parameters chosen from the viewport and the mode

`@thatopen/components` builds the world camera as `PerspectiveCamera(60, aspect, 1, 1e3)` and nothing in this app had ever revisited those numbers. Measuring found the stated problem **and a second one the clause doesn't describe**.

### 1. A fixed vertical fov gives a phone a third of the view a desktop gets

Horizontal fov is derived from vertical fov and aspect, so a portrait viewport collapses it:

| viewport | aspect | horizontal fov |
|---|---|---|
| phone portrait | 0.46 | **30°** |
| tablet | 0.75 | 47° |
| desktop | 1.60 | 85° |

Now derived from a target horizontal angle and clamped, so a phone gets ~46°.

**The clamp floor is 60 — today's value — deliberately: this can only ever widen, never narrow.** A profile that computed a "better" 51° for desktop would be a regression shipped as an improvement, and nobody reports *seeing less* as a bug. Asserted as a property over the whole aspect range rather than three sampled viewports, plus monotonicity.

### 2. `near = 1 m` is wrong for the first-person walkthrough

`walkMode.ts` puts the eye at 1.65 m and calls itself *"the coordination-review move that orbit cameras hide"* — but everything within a metre of the eye was clipped, so walking up to a wall, a column or a duct made it vanish before you reached it. The mode exists for close inspection and could not do it.

**Why that moves only in walk mode, with the number that decides it.** Depth precision at distance scales with `near`; for a 24-bit buffer the resolvable gap is about `z²/(near·2²⁴)`:

```
near=1     0.1mm @50m   0.6mm @100m   2.4mm @200m
near=0.1   1.5mm @50m   6.0mm @100m  23.8mm @200m
```

`guideUnderlay.ts` lifts its plane by `LEVEL_LIFT_M = 0.005` (5 mm) to avoid z-fighting. At `near=0.1` the resolvable gap passes 5 mm **before 100 m**, so a global change would make that underlay z-fight on any model of real size — trading a walk-mode defect for a rendering one. `far` comes in with `near` so the ratio stays bounded, and the test guards the **ratio** rather than the two literals.

### Four mutations, and one survived the first pass

Deleting the restore-on-exit **passed all 433 viewer tests.** Only the headless `WalkController` had coverage; `installWalkMode` was never driven, so everything the toggle does to the camera was unguarded. It's now driven in tests and both directions fail under mutation.

Also caught once tests existed:
- a missing `updateProjectionMatrix()` — three caches the projection, so the change is **inert** while every assertion about `cam.fov` still passes. That's the failure that looks like "the profile is wrong" rather than "the call is missing".
- a dropped `isPerspectiveCamera` guard — writing `fov` onto an ortho camera isn't an error in JS, it's silently ignored, so the ortho case needed asserting explicitly.

### Notes

`applyCameraProfile` takes its world **structurally** rather than as `World`, so `walkMode.ts` keeps the three-free core its header promises rather than giving it up for three lines of camera state.

`app.ts` untouched at 3,715 — the wiring went into `world.ts`, which already owns the camera and the ResizeObserver.

Full web suite green (1,409 tests), `tsc` + `eslint` + `test_claude_md_gates` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive camera profiles for phone, tablet, and desktop viewports.
  * Adjusted field of view to preserve framing across screen sizes.
  * Improved walk mode with closer near clipping and an appropriate far clipping range.
  * Camera settings now update automatically on initialization and resize.

* **Documentation**
  * Updated the roadmap to reflect completed camera and clipping improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->