### PR TITLE
Resolve lane path claims against the repo — finds main.py owned by two lanes

### DIFF
--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { resolve, sep } from "node:path";
 
@@ -179,6 +180,65 @@ function parkedCodes(): Set<string> {
 }
 
 const LANES = laneRows();
+
+/**
+ * Resolve a lane's path claim to a repo-relative path.
+ *
+ * **Why this replaced a `replace(/^apps\/web\/src\//, "")`.** The table mixes notations —
+ * `apps/web/src/shell/` beside bare `main.ts`, `portal/panels/`, `field/`, `inference.ts`, `main.py` —
+ * and the old normaliser stripped exactly one prefix, `apps/web/src/`. That worked for the web lanes
+ * and was **blind on the services side**, which is where it mattered:
+ *
+ *   Lane G claims bare `main.py`  ->  services/api/src/aec_api/main.py
+ *   Lane C claims                     services/api/src/aec_api/   (carving out only routers/)
+ *
+ * C contains G's `main.py`, so the FastAPI entry point belonged to two lanes at once, and the
+ * disjointness check could not see it because those two strings never compared. That is the same
+ * defect the 2026-07-30 nested overlap was, in the half of the table nobody had normalised.
+ *
+ * Resolution is grounded in the repo rather than in a convention: walk each of the lane's QUALIFIED
+ * paths and their ancestor directories, and take the first that yields a tracked path. `inference.ts`
+ * resolves to `apps/web/src/viewer/inference.ts` and `main.py` to `services/api/src/aec_api/main.py`
+ * for the same reason, without either being special-cased.
+ *
+ * **A limit worth stating rather than discovering.** This takes the path alone, not the lane, so one
+ * bare name always resolves the same way whoever claims it. That is exactly what makes a duplicate
+ * claim detectable — and it means two lanes legitimately using the same bare name for *different*
+ * files (an `index.ts` in two directories) would be reported as a clash they do not have. No such
+ * pair exists today. If one appears, the fix is to qualify it in the table, which is the better
+ * outcome anyway: a bare name that is ambiguous to this resolver is ambiguous to a human reader too.
+ */
+const TRACKED: ReadonlySet<string> = new Set(
+  execFileSync("git", ["ls-files"], { cwd: resolve(REPO), encoding: "utf8", maxBuffer: 1 << 26 })
+    .split(/\r?\n/).map((l) => l.trim()).filter(Boolean),
+);
+const TRACKED_DIRS: ReadonlySet<string> = new Set(
+  [...TRACKED].flatMap((f) => {
+    const parts = f.split("/"); const out: string[] = [];
+    for (let i = 1; i < parts.length; i++) out.push(parts.slice(0, i).join("/") + "/");
+    return out;
+  }),
+);
+
+const ROOTS = ["apps/", "services/", "docs/", "scripts/", "integrations/", ".github/"];
+
+function qualify(p: string): string {
+  const raw = p.replace(/^\.\//, "").replace(/^!/, "");
+  if (ROOTS.some((r) => raw.startsWith(r)) || raw === "README.md") return raw;
+  for (const lane of LANES) {
+    if (!lane.paths.includes(p) && !lane.excludes.includes(p)) continue;
+    for (const q of lane.paths.map((x) => x.replace(/^!/, ""))) {
+      if (!ROOTS.some((r) => q.startsWith(r))) continue;
+      const segs = q.replace(/\/$/, "").split("/");
+      for (let i = segs.length; i > 0; i--) {
+        const cand = segs.slice(0, i).join("/") + "/" + raw;
+        if (TRACKED.has(cand) || TRACKED_DIRS.has(cand)) return cand;
+      }
+    }
+  }
+  return raw;
+}
+
 const CODES = itemCodes(OPEN);
 
 describe("the roadmap lane table", () => {
@@ -211,7 +271,7 @@ describe("the roadmap lane table", () => {
     // The real defect: `apps/web/src/portal/` (lane A) CONTAINED `portal/panels/` (lane B). Equality
     // is not the test — containment is, and only in the direction that matters: if one lane's path is
     // a prefix of another's, edits inside the deeper path belong to two lanes at once.
-    const norm = (p: string) => p.replace(/^apps\/web\/src\//, "").replace(/^\.\//, "");
+    const norm = qualify;
     const clashes: string[] = [];
     for (const a of LANES) {
       // A carve-out only excuses the overlap it actually names, and only for the lane that declared it.
@@ -235,7 +295,7 @@ describe("the roadmap lane table", () => {
     // The failure mode a carve-out introduces: `!routers/` removes it from lane C, and if no row then
     // claims it, the directory has no owner and any session may edit it — which is the exact state that
     // let one route be added twice. So an exclusion must hand the path to someone, not just drop it.
-    const norm = (p: string) => p.replace(/^apps\/web\/src\//, "").replace(/^\.\//, "");
+    const norm = qualify;
     const orphanCarves: string[] = [];
     for (const l of LANES) {
       for (const x of l.excludes.map(norm)) {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -280,7 +280,7 @@ two rows share a path, so two agents in different rows cannot collide.
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/portal/portal.ts`, `main.ts` | R24-CMDK-VERBS · R24-RUNS-INBOX · UX-READINESS-EVERYWHERE · UX-DUP-DESTINATIONS · UX-VIEWED · REL-4 · R36-DRAWINGS-RETURN · R40-RIBBON ② |
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-ELEMENT-CARD ② *(moved from E 2026-08-06 — the cell said E, the item's own text says the remaining work is "purely call sites: RFI, estimate line, pay app, COBie row", which live in `apps/web/src/ui/` and `apps/web/src/portal/panels/`. **A lane's paths and a lane's items are two claims and only the first is tested**, so the cell drifted from the item under it)* · R24-CHARTS-GRAMMAR · R24-REPORTS-BY-MOMENT · R24-DENSITY ② · R24-MONO-DATA · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R36-ROOM-BRIEFS · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
-| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/` | R22-ENTITLEMENT · R22-AGENT-PACKS · R22-PROVENANCE · R22-PIPELINE · R22-ROUTINES · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R40-EOT ② · R39-UPLOAD-CAP-APP ①◧ · R41-FDD-INGEST · R41-CLASH-TRIAGE · R41-COMMERCIAL-DRIFT · R41-UPLOAD-WARK |
+| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-AGENT-PACKS · R22-PROVENANCE · R22-PIPELINE · R22-ROUTINES · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R40-EOT ② · R39-UPLOAD-CAP-APP ①◧ · R41-FDD-INGEST · R41-CLASH-TRIAGE · R41-COMMERCIAL-DRIFT · R41-UPLOAD-WARK |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | SEC-PLUGIN-SANDBOX *(moved from C 2026-08-05 — the item said "Lane **D**, not C" all along; while one ID covered two items the table could not be right about both)* · R38-PLAN-IDENTITY ③ · R38-PLAN-TRANSFORM ③ *(new 2026-08-06 — blocks R38-SYNC-VIEW's cursor sync)* · R38-ARRAY-LIVE ③ · R21-4D-CLASH · R28-BUNDLE ② — **the three that landed in PRs #176/#178/#179 on 2026-08-02** (R28-ICDD, R23-STOREY-LOD, R28-UNIFY) are shipped and pending archive. **Corrected 2026-08-06: this read "all SHIPPED and MERGED", which was false for 8 of the 11 codes beside it** — SEC-PLUGIN-SANDBOX is ◧ with its `setrlimit` half explicitly REFUSED, R38-SYNC-VIEW and R21-4D-CLASH are ◧, and five carry no marker at all. A row-level word like "all" has no defined scope, so it drifts the moment the row grows; the item markers are the authority and this sentence is not. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* · R41-IDS-VALIDATE |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` |A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · R28-VIEWER ④ · R22-PUBLIC-VIEWER · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* · R41-MODEL-ALIGN |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
@@ -317,10 +317,17 @@ ceiling that only ever goes down, and the way down is adding a row here. Rows st
 `proforma/` · `drawings/` · `kernel/` · `pins/` · `studio/` · `tools/` · `tree/` · the loose `portal/`
 files · `tooling/` + `dev/` (probably J) · `account/` · `connections/` · `deploy/`.
 
-**One live gap in the disjointness check itself, found while measuring.** The table mixes notations —
-`apps/web/src/shell/` alongside bare `main.ts`, `portal/panels/`, `field/` — and that check compares
-the strings raw. Two lanes claiming the same directory in different notations (`field/` and
-`apps/web/src/field/`) would read as disjoint. Not fixed here; recorded so it is not re-discovered.
+**CORRECTED 2026-08-07, and the correction found a real overlap the original claim would not have.**
+This said the disjointness check "compares the strings raw", so `field/` and `apps/web/src/field/` in
+two lanes would read as disjoint. **That was false** — the check already stripped `apps/web/src/`, and
+planting exactly that duplicate proved it caught it, naming both lanes.
+
+The real gap was the *asymmetry*: it normalised **one** prefix, `apps/web/src/`, so it was blind on the
+services side — and that is where a live overlap was sitting. Lane G claims bare `main.py`, which is
+`services/api/src/aec_api/main.py`; Lane C claims `services/api/src/aec_api/` and carved out only
+`routers/`. **The FastAPI entry point belonged to two lanes at once**, and those two strings never
+compared. `main.py` is now carved out of C, and the check resolves every claim to a repo-relative path
+against `git ls-files` instead of stripping one hard-coded prefix.
 
 **Two lane boundaries were wrong until 2026-07-30 and are worth naming.** Lane A used to own
 `apps/web/src/portal/` *wholesale* while B owned `portal/panels/` — a nested overlap, so the two lanes


### PR DESCRIPTION
## A live two-lane overlap on `main.py` — and a correction to my own claim

Core asked me to take the disjointness normalisation I'd flagged on #257. Checking it first turned the item inside out.

### The claim I made was false

I wrote in #257 that the check *"compares the strings raw"*, so `field/` in one lane and `apps/web/src/field/` in another would read as disjoint. **Planting exactly that duplicate proved it is caught** — the check already stripped `apps/web/src/`, and it named both lanes.

### The real gap was the asymmetry, and something was sitting in it

It normalised **one** prefix — `apps/web/src/` — so it was blind on the services side:

```
Lane G claims bare `main.py`  ->  services/api/src/aec_api/main.py
Lane C claims                     services/api/src/aec_api/   (carving out only routers/)
```

C contains G's `main.py`. **The FastAPI entry point belonged to two lanes at once**, and those two strings never compared. That's the same defect as the 2026-07-30 nested overlap, in the half of the table nobody had normalised — and `main.py` is not an obscure file.

### The fix

`main.py` is carved out of Lane C using the same `!path` syntax `routers/` already uses, and the check now resolves **every** claim to a repo-relative path against `git ls-files` rather than stripping one hard-coded prefix. `inference.ts` resolves to `apps/web/src/viewer/inference.ts` and `main.py` to `services/api/src/aec_api/main.py` by the same rule, neither special-cased.

### Mutation-checked three ways

| mutation | result |
|---|---|
| one directory, two spellings (what Core asked for) | names both lanes |
| a bare services-side name claimed by two lanes | caught — **the new coverage** |
| remove the new carve-out | the live overlap comes straight back |

### A limit recorded rather than left to be discovered

The resolver takes the path, not the lane, so one bare name always resolves the same way whoever claims it. That is precisely what makes a duplicate detectable — and it means two lanes legitimately using one bare name for *different* files (an `index.ts` in two directories) would report a clash they don't have. No such pair exists today. If one appears, the fix is to qualify it in the table, which is the better outcome anyway: a bare name that's ambiguous to this resolver is ambiguous to a human reader too.

### Note

**Stacked on #257** (`chore/lane-table-unowned-paths`), which edits the same file and hasn't merged. Review after that one.

Full web suite green (1,392 tests), `tsc` + `eslint` clean, `test_claude_md_gates` and `test_alembic_single_head` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
