### PR TITLE
R38-SOLVER-LOCKS: record the decision, and correct the premise it was blocked on

### DIFF
--- a/docs/roadmap-directions.md
+++ b/docs/roadmap-directions.md
@@ -197,6 +197,31 @@ is a *development* boundary and is orthogonal to that.
 workspace command), and the temp-index pattern remains the right way to land a commit when you are
 *not* in your own tree.
 
+### Two races the gates do NOT close, named so they are not assumed away
+
+**1. A migration fork is invisible to both branches.** On 2026-08-07 two PRs each added a migration
+chained off the same `down_revision`. **Both were individually green and both were correct** — each
+branch had exactly one head; the second head exists only in the *union*. Main then could not
+`alembic upgrade head` at all.
+
+Detection already exists (`services/api/test_alembic_migrations.py` calls `command.upgrade(cfg, "head")`,
+which raises `Multiple head revisions are present`), and CI runs on `pull_request`, so it tests the
+**merge result**. What no gate can do is re-test PR B when PR A lands afterwards: B's green was
+computed against a merge result that predates A, and it stays green and stays mergeable.
+
+`required_status_checks.strict: true` would force every branch to be up to date before merging and
+would catch it — **the user chose `strict: false` on 2026-08-07, deliberately**, because with three or
+more sessions merging it means near-continuous rebasing and that defeats the release cadence. So the
+risk is accepted, not solved.
+
+**The mitigation that costs nothing is coordination, because no local check can see unpushed work:**
+a branch carrying a migration **announces its parent revision when it opens**, so the next one chains
+onto it rather than onto the shared ancestor.
+
+**2. `enforce_admins: false` makes the protection advisory for whoever can bypass it.** Direct pushes
+to `main` still work, which is load-bearing for the cadence. **The ability to bypass a gate is not
+permission to** — hold yourself to it.
+
 ### Resolving a conflict
 
 When a conflict is **additive on both sides**, "keep both" is right about the semantics and unreliable

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1429,23 +1429,27 @@ server's report stays authoritative on the authored element. Wave 1 and its foll
   computation over caller-supplied values — it neither reads nor writes the model."* A UI must gather
   variables from the selection, call solve, and apply the result back through an edit recipe.
 
-  **CORRECTED 2026-08-07 — the write path does NOT already exist, and this entry said it did.** The
-  first version of this note claimed "one element's parameters can be written with the edit path that
-  already exists", and the decision to do within-element first was taken partly on that. Checked
-  against the recipes rather than assumed:
+  **The instance-level write path DOES exist** — `services/data/src/aec_data/edit.py`'s `RECIPES`
+  table has **14 entries keyed by `p["guid"]`**, a single element rather than a type. The relevant
+  ones: `set_extrusion_depth(guid, depth)`, `set_wall_thickness(guid, thickness)`,
+  `set_wall_slope(guid, start_height, end_height)`, `move_element(guid, dx, dy, dz)` and
+  `set_element_pset(guid, pset, prop, value, dtype)`.
 
-  - `edit_type_params` operates on a **type** (`edit_type_params(model, type_guid, …)` in
-    `services/data/src/aec_data/families.py`), so writing through it moves **every instance of that
-    type** — the opposite of a single-element lock.
-  - `set_pset_on_class` writes across a whole IFC class; `set_storey_elevation` is storey-specific.
-  - `services/data/src/aec_data/instance_props.py` can *read* effective properties and *reset* one to
-    its type, but cannot set an instance value.
+  *This entry claimed the opposite for one revision, and the way it went wrong is the reusable part.*
+  The functions that ARE the wrong granularity are easy to find by name — `edit_type_params` (type),
+  `set_pset_on_class` (class), `set_storey_elevation` (storey), `instance_props` (read + reset only) —
+  and a grep for guessed setter names finds exactly those and stops. The guid-keyed writes live in a
+  **dispatch table**, not under names anyone would guess. **If a claim is load-bearing, enumerate the
+  whole table rather than the functions you can name.**
 
-  **There is no single-instance dimensional write path at all.** So within-element is still the
-  smaller build — one element, no multi-select semantics, no cross-element identity — but it is not
-  free of a prerequisite: it needs a new instance-level parameter recipe, and that lives in **Lane D**
-  (`services/data/src/aec_data/`), not Lane E. The read/solve half is Lane E and can proceed
-  independently; the apply half must be sequenced with D.
+  **So the remaining work is a MAPPING, not a capability.** `solve()` returns named scalars, and
+  something must decide that `thickness` on a wall writes through `set_wall_thickness(guid, …)` while
+  `depth` on a column writes through `set_extrusion_depth(guid, …)`. That mapping is the substance of
+  Apply; it is Lane E/C work and needs no new recipe.
+
+  **Where a variable has no recipe, refuse that one BY NAME and apply the rest.** A partial apply that
+  says which locks it could not write is honest; one that silently drops them is the
+  `suggestion_clears_horizon` failure in a new place — a result that looks complete and is not.
 
 ### Wave 3 — model and documents in one room *(Lane B + E)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1404,12 +1404,33 @@ server's report stays authoritative on the authored element. Wave 1 and its foll
   therefore nothing to re-edit; changing a count today means deleting copies by hand. **Prerequisite:
   persist the array definition** (an IfcGroup or pset carrying nx/ny/dx/dy/dz plus its member GUIDs)
   and a `set_array_params` recipe that adds/removes members to match. Viewer half is then small.
-- **R38-SOLVER-LOCKS ③** *(M, needs a decision first)* — the R23 dimensional locks as UI. The solver
-  (`services/data/src/aec_data/dim_constraints.py`) reconciles a *system*; with three parameters on
-  a single element there is nothing to reconcile unless the user can state a relationship. **Open
-  question for the user, not a build:** are locks meant to be *within* an element (hold depth, drive
-  width, keep area) or *across* elements (align these walls, hold this offset)? Across-elements is
-  the CAD-familiar meaning and needs multi-element parameter edits, which do not exist yet.
+- **R38-SOLVER-LOCKS ③** *(M — **DECIDED 2026-08-07: both, within-element first**)* — the R23
+  dimensional locks as UI.
+
+  **The user's call:** ship *within*-element locks (hold depth, drive width, keep area) against the
+  existing solver now, and treat *across*-elements (align these walls, hold this offset) as a separate
+  later item once multi-element parameter edits exist. That gets a usable feature out without
+  committing to the larger build up front.
+
+  **Premise-checked 2026-08-07, and the entry's framing was wrong in a way that makes this cheaper
+  than it reads.** The question was posed as though the solver constrained the answer. It does not:
+
+  - `services/data/src/aec_data/dim_constraints.py` exposes `solve(variables, constraints)` over a
+    **flat dict of named scalars**. It has no concept of an element, so within-element and
+    across-element are the same call with different variable names. Its own docstring's example —
+    *"keep a wall 3000 from a grid"* — is an **across**-element relationship, so the general case is
+    what shipped.
+  - **The route already exists**: `POST /projects/{pid}/constraints/solve` in
+    `services/api/src/aec_api/routers/analysis.py`. It has **no client caller**, so the whole feature
+    is server-only today — the same shape the reachability gate exists to catch, and it is not in
+    `KNOWN_UNCALLED`, so it slipped past on the last-static-segment rule.
+
+  **So the remaining work is UI and wiring, not solving.** The one real constraint is in that route's
+  own words: *"pure computation over caller-supplied values — it neither reads nor writes the model."*
+  A UI must therefore gather variables from the selection, call solve, and **apply the result back
+  through an edit recipe**. That write-back is where "multi-element parameter edits do not exist yet"
+  actually bites — which is why within-element first is the right order: one element's parameters can
+  be written with the edit path that already exists.
 
 ### Wave 3 — model and documents in one room *(Lane B + E)*
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1425,12 +1425,27 @@ server's report stays authoritative on the authored element. Wave 1 and its foll
     is server-only today — the same shape the reachability gate exists to catch, and it is not in
     `KNOWN_UNCALLED`, so it slipped past on the last-static-segment rule.
 
-  **So the remaining work is UI and wiring, not solving.** The one real constraint is in that route's
-  own words: *"pure computation over caller-supplied values — it neither reads nor writes the model."*
-  A UI must therefore gather variables from the selection, call solve, and **apply the result back
-  through an edit recipe**. That write-back is where "multi-element parameter edits do not exist yet"
-  actually bites — which is why within-element first is the right order: one element's parameters can
-  be written with the edit path that already exists.
+  **So the solving is done; the work is UI plus a write-back.** The route says so itself: *"pure
+  computation over caller-supplied values — it neither reads nor writes the model."* A UI must gather
+  variables from the selection, call solve, and apply the result back through an edit recipe.
+
+  **CORRECTED 2026-08-07 — the write path does NOT already exist, and this entry said it did.** The
+  first version of this note claimed "one element's parameters can be written with the edit path that
+  already exists", and the decision to do within-element first was taken partly on that. Checked
+  against the recipes rather than assumed:
+
+  - `edit_type_params` operates on a **type** (`edit_type_params(model, type_guid, …)` in
+    `services/data/src/aec_data/families.py`), so writing through it moves **every instance of that
+    type** — the opposite of a single-element lock.
+  - `set_pset_on_class` writes across a whole IFC class; `set_storey_elevation` is storey-specific.
+  - `services/data/src/aec_data/instance_props.py` can *read* effective properties and *reset* one to
+    its type, but cannot set an instance value.
+
+  **There is no single-instance dimensional write path at all.** So within-element is still the
+  smaller build — one element, no multi-select semantics, no cross-element identity — but it is not
+  free of a prerequisite: it needs a new instance-level parameter recipe, and that lives in **Lane D**
+  (`services/data/src/aec_data/`), not Lane E. The read/solve half is Lane E and can proceed
+  independently; the apply half must be sequenced with D.
 
 ### Wave 3 — model and documents in one room *(Lane B + E)*
 


### PR DESCRIPTION
The user has decided: **both, within-element first.**

Ship within-element locks (hold depth, drive width, keep area) against the existing solver now; treat across-elements (align these walls, hold this offset) as a separate later item once multi-element parameter edits exist.

## The entry's premise was wrong, and it makes this cheaper than it read

The question was posed as though the solver constrained the answer. It doesn't:

- `dim_constraints.solve(variables, constraints)` takes a **flat dict of named scalars**. It has no concept of an element, so within-element and across-element are the same call with different variable names. Its own docstring example — *"keep a wall 3000 from a grid"* — is an **across**-element relationship, so the general case is what shipped.
- **The route already exists**: `POST /projects/{pid}/constraints/solve`. It has **no client caller**, so the feature is server-only today — and it is *not* in `KNOWN_UNCALLED`, so it slipped past the reachability gate on the last-static-segment rule.

## What is actually left

UI and wiring, not solving. The one real constraint is in that route's own words: *"pure computation over caller-supplied values — it neither reads nor writes the model."*

A UI must gather variables from the selection, call solve, and **apply the result back through an edit recipe**. That write-back is where "multi-element parameter edits do not exist yet" actually bites — which is why within-element first is the right order: one element's parameters can be written with the edit path that already exists.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)