### PR TITLE
fix(test): hoist lazy imports out of per-test budgets in three suites

### DIFF
--- a/apps/web/src/api/library.test.ts
+++ b/apps/web/src/api/library.test.ts
@@ -37,22 +37,43 @@ describe("the library client", () => {
   });
 });
 
-/** Source of `main.ts`, for the wiring assertions below. */
+/**
+ * Sources of `main.ts` and the viewer, read ONCE at module scope.
+ *
+ * WHY NOT LAZILY INSIDE THE TESTS, WHICH IS WHERE THEY USED TO BE
+ *     `?raw` makes Vite transform the whole file, and `main.ts` and `viewer/app.ts` are two of the
+ *     largest in the repo. Imported from inside a test, that cost lands entirely in **whichever test
+ *     happens to call it first** — an ordering artifact, not a property of the assertion. Measured
+ *     idle: the first caller took 160 ms while every other test in this file took 0–3 ms.
+ *
+ *     Under a loaded suite that one test is the one that dies. It timed out at vitest's 5 s default
+ *     on 2026-08-07 while the other ten passed, which reads as "that assertion is slow" and is really
+ *     "that assertion drew the short straw". Several sessions run suites in this clone, so contention
+ *     is the normal condition, not an edge case.
+ *
+ *     At module scope the transform happens during collection, outside the per-test budget, and no
+ *     single test inherits it. This is the same remedy `tooling/deleteRatchet.test.ts` settled on for
+ *     a different cause — there the per-test cost was a `git log` walk, here it is a Vite transform.
+ *     The shared rule is that **fixture cost does not belong inside a per-test timeout**, and the
+ *     shared anti-pattern is raising the timeout, which keeps the cliff and moves it somewhere less
+ *     predictable.
+ *
+ * The vacuity guards stay: a `?raw` that silently resolved to undefined would make every assertion
+ * below pass against an empty string.
+ */
+const MAIN_SRC = ((await import("../main.ts?raw")) as { default: string }).default;
+const VIEWER_SRC = ((await import("../viewer/app.ts?raw")) as { default: string }).default;
+
 async function mainSource(): Promise<string> {
-  const mod = await import("../main.ts?raw");
-  const src = (mod as { default: string }).default;
-  expect(typeof src, "?raw did not resolve — the assertions below would be vacuous").toBe("string");
-  expect(src.length).toBeGreaterThan(1000);
-  return src;
+  expect(typeof MAIN_SRC, "?raw did not resolve — the assertions below would be vacuous").toBe("string");
+  expect(MAIN_SRC.length).toBeGreaterThan(1000);
+  return MAIN_SRC;
 }
 
-/** Source of the viewer, which held the same filenames one file away from the check below. */
 async function viewerSource(): Promise<string> {
-  const mod = await import("../viewer/app.ts?raw");
-  const src = (mod as { default: string }).default;
-  expect(typeof src, "?raw did not resolve — the assertions below would be vacuous").toBe("string");
-  expect(src.length).toBeGreaterThan(1000);
-  return src;
+  expect(typeof VIEWER_SRC, "?raw did not resolve — the assertions below would be vacuous").toBe("string");
+  expect(VIEWER_SRC.length).toBeGreaterThan(1000);
+  return VIEWER_SRC;
 }
 
 describe("the Open menu uses the library, not a hard-coded list", () => {

--- a/apps/web/src/drawings/pdfVendor.test.ts
+++ b/apps/web/src/drawings/pdfVendor.test.ts
@@ -14,26 +14,43 @@ import { VENDOR_ENTRIES } from "../../vendorAlias";
  * shipped with no route to them, and every gate measured the engine while none measured the path.
  * A vendored package nothing imports is the same defect with a bigger diff.
  */
+
+/**
+ * The vendored engine, imported ONCE at module scope. Importing it is itself the assertion — if the
+ * alias does not resolve, this module fails to load and every test below reports it.
+ *
+ * THIS WAS A 20s PER-TEST TIMEOUT, AND THE TIMEOUT WAS NOT ENOUGH
+ *     The previous note here was right about the cause — the first import pays the whole transform
+ *     for a ~20k-line library, ~800 ms alone — and chose to raise that one test's budget from 5 s to
+ *     20 s, reasoning that a cold transform is not what the assertion tests. That reasoning is sound
+ *     and the fix still failed: on 2026-08-07 it **timed out at 20 s**, and the next test failed at
+ *     5 s in the same run, because when the first caller's import never resolves, everything else
+ *     awaiting the same module dies with it. One slow first-caller takes the file down.
+ *
+ *     Raising a budget keeps the cliff and moves it somewhere less predictable — which is exactly
+ *     what happened, and the second failure is the evidence. Hoisting removes it: the transform runs
+ *     once during collection, outside any per-test budget, and no test inherits it.
+ *
+ *     Same remedy as `api/library.test.ts` (a `?raw` transform) and `tooling/deleteRatchet.test.ts`
+ *     (a `git log` walk), from three different causes. The shared rule: **fixture cost does not
+ *     belong inside a per-test timeout**, and a margin measured on an idle machine is a property of
+ *     the machine, not of the test.
+ */
+const VENDOR = await import("@massingcloud/pdf-viewer");
+
 describe("the vendored PDF engine", () => {
   it("is registered in the one alias map", () => {
     expect(VENDOR_ENTRIES["@massingcloud/pdf-viewer"]).toBe("./src/vendor/massingpdf/index.ts");
   });
 
-  // 20s, not the 5s default. This is the FIRST import of the vendored engine in the run, so it pays
-  // the whole transform cost for a ~20k-line library at once. Alone it takes ~800ms; under the full
-  // suite it reliably crossed 5s and failed — a real gate breaking on a real cost, not a flake.
-  // Raising the budget is right here: the assertion is "the alias resolves", and how long a cold
-  // transform takes is not what it is testing. If this ever needs raising again, the vendored copy
-  // has grown enough to be worth a second look.
-  it("actually imports through the alias, not just through a relative path", async () => {
-    const mod = await import("@massingcloud/pdf-viewer");
-    expect(mod).toBeTruthy();
-  }, 20_000);
+  // The import is at module scope (see VENDOR above), so neither of these carries the transform.
+  it("actually imports through the alias, not just through a relative path", () => {
+    expect(VENDOR).toBeTruthy();
+  });
 
-  it("exposes the surface the takeoff flow will need", async () => {
-    const mod = await import("@massingcloud/pdf-viewer");
+  it("exposes the surface the takeoff flow will need", () => {
     for (const name of ["Viewer", "PdfDocument", "AnnotationStore", "definePlugin"]) {
-      expect(typeof (mod as Record<string, unknown>)[name], name).not.toBe("undefined");
+      expect(typeof (VENDOR as Record<string, unknown>)[name], name).not.toBe("undefined");
     }
   });
 

--- a/apps/web/src/shell/spine.test.ts
+++ b/apps/web/src/shell/spine.test.ts
@@ -3,6 +3,21 @@ import { FALLBACK_ROOMS, ROOM_HOME, ROOM_IDS, destRoom, orderRooms, preselectedR
 import type { RoomDef } from "../api/types";
 
 /**
+ * Modules this file inspects, imported ONCE at module scope rather than inside the tests.
+ *
+ * Each was a lazy `await import()` in the test that used it, so the first caller paid the
+ * transform inside its own 5 s budget. This file timed out under a loaded suite on 2026-08-07 —
+ * least dramatically of the three that did, its slowest test measuring 14 ms idle, which is
+ * precisely why it is worth hoisting: a cost small enough to look safe is still a cost sitting
+ * inside a timeout, and that margin is a property of the machine, not of the assertion.
+ *
+ * Same remedy as `api/library.test.ts` and `drawings/pdfVendor.test.ts`, from the same cause.
+ */
+const SPINE_MOD = await import("./spine") as Record<string, unknown>;
+const PARITY_SRC = await import("./parity.test?raw") as { default: string };
+const DESTS_MOD = await import("./destinations");
+
+/**
  * R26-SHELL. The audit found seven workspaces carrying four different left-rail taxonomies, so
  * nothing learned in one transferred to the next. The spine is one constant structure for every role.
  * What is tested here is the property that distinguishes a spine from another mode switch: a
@@ -53,7 +68,7 @@ describe("the shell has no opt-out — there is one front door (v0.3.779)", () =
     // change, two places a bug can hide, and — as this repo actually managed — a render audit whose
     // verdict depends on which one it happened to measure. Asserting the exports are GONE is what
     // stops the flag being quietly reintroduced by a revert.
-    const mod = await import("./spine") as Record<string, unknown>;
+    const mod = SPINE_MOD;
     expect(mod.spineEnabled, "spineEnabled must not come back").toBeUndefined();
     expect(mod.SPINE_FLAG, "the storage key must not come back").toBeUndefined();
   });
@@ -62,7 +77,7 @@ describe("the shell has no opt-out — there is one front door (v0.3.779)", () =
     // Deleting the comparison must not delete the property it protected. `parity.test` asserts the
     // room rail reaches every destination the lifecycle-stage catalog lists — that is what "nothing
     // became unreachable" now rests on, and it survives the shell that motivated it.
-    const parity = await import("./parity.test?raw") as { default: string };
+    const parity = PARITY_SRC;
     expect(parity.default).toMatch(/unroomed|DEST_ROOM|destRoom/);
   });
 });
@@ -144,7 +159,7 @@ describe("every room opens onto something", () => {
     // exactly the defect the room work set out to kill: the tab lit, the marker said Underwriting,
     // and the content pane still showed Budget. Every gate passed, because the rationale forbidding
     // it lived in a COMMENT. It lives here now.
-    const { ALL_DESTS } = await import("./destinations");
+    const { ALL_DESTS } = DESTS_MOD;
     const goto = new Set(ALL_DESTS.filter((d) => d.goto).map((d) => d.key));
     expect(goto.size, "if no destination hops workspaces this test is vacuous").toBeGreaterThan(0);
     for (const [room, home] of Object.entries(ROOM_HOME)) {


### PR DESCRIPTION
## What

Five tests across three files timed out in one loaded run today, and **all five passed in isolation**. Not flakes — the same structural defect [#253](https://github.com/ibuilder/massing/pull/253) fixed in `deleteRatchet.test.ts`, reached by a different cause.

## The mechanism

Each file did `await import(...)` **inside a test**. Vite transforms the module on first use, so the whole cost lands on whichever test happens to call it first — an **ordering artifact**, not a property of that assertion. Measured idle:

| file | first caller | every other test |
|---|---|---|
| `api/library.test.ts` | **160 ms** (`main.ts?raw` + `viewer/app.ts?raw`) | 0–3 ms |
| `drawings/pdfVendor.test.ts` | **813 ms** (~20k-line vendored engine) | 0–19 ms |
| `shell/spine.test.ts` | **14 ms** | 0–3 ms |

Under contention the first caller is the one that dies. That reads as *"that assertion is slow"* and is really *"that assertion drew the short straw"*.

## `pdfVendor.test.ts` is the instructive one

It had **already diagnosed this correctly** and raised that single test from 5 s to 20 s, with a stated rationale: the assertion is "the alias resolves", and how long a cold transform takes is not what it tests. That reasoning is sound — and the fix still failed. On 2026-08-07 it **timed out at 20 s**, and the *next* test failed at 5 s in the same run, because when the first caller's import never resolves, everything awaiting the same module dies with it. One slow first-caller takes the file down.

**Raising a budget keeps the cliff and moves it somewhere less predictable.** The second failure is the evidence. Hoisting removes it.

## After

```
library.test.ts    160ms -> 1ms
pdfVendor.test.ts  813ms -> 0ms   (and the 20s special case is deleted)
spine.test.ts       16ms -> 5ms
```

`spine.test.ts` is included on the thinnest evidence — 14 ms idle, and it only timed out once. That is precisely why it is worth doing: a cost small enough to look safe is still a cost sitting inside a timeout, and the margin is a property of the machine rather than of the assertion. Several sessions run suites in this clone, so contention is the normal condition.

## Assertions preserved, not weakened

- `pdfVendor`'s import **is** its assertion. At module scope it now fails by the module failing to load — **mutation-checked** with a deliberately broken alias, which exits 1.
- `library.test.ts` keeps its `?raw` vacuity guards, so a `?raw` that silently resolved to undefined still fails rather than making every assertion pass against an empty string.

## Checks

- Suite **1416 passed / 128 files**; `tsc --noEmit` and `npm run lint` clean.
- Per-test durations above measured with `--reporter=verbose` before and after.

One honest caveat on the measurements: within a file the first import pays and later ones hit cache, so an isolated run *understates* what a full run costs. The direction is not in doubt — the cost moves out of the per-test budget either way — but the idle numbers are a floor, not the figure that broke CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)