### PR TITLE
R38-SOLVER-LOCKS + WARN-1: two unreachable capabilities given screens (131 → 129)

### DIFF
--- a/apps/web/src/api/authoring.ts
+++ b/apps/web/src/api/authoring.ts
@@ -26,6 +26,25 @@ export function withAuthoring<TBase extends Ctor<HttpCore>>(Base: TBase) {
         `/projects/${pid}/edit`, { method: "POST", body: JSON.stringify({ recipe, params, publish }) });
     }
     /** IFCPATCH-LIB — dry-run maintenance scan: how many entities each cleanup recipe would remove. */
+    /**
+     * R38-SOLVER-LOCKS — solve a dimensional-lock system. Pure computation: the route neither reads
+     * nor writes the model, so the caller supplies the variables and applies the result itself.
+     *
+     * Lives beside `editIfc` because that is what Apply writes through, and the two are always used
+     * together. The endpoint shipped in v0.3.701 with no client caller at all.
+     *
+     * `solved` is false when a REQUIRED row cannot hold or a clearance is violated; `conflicts` names
+     * the pair. A weaker tier yielding is the system working as designed, not a failure.
+     */
+    solveConstraints(pid: string, variables: Record<string, number>,
+                     constraints: Record<string, unknown>[]) {
+      return this.json<{
+        values: Record<string, number>; dof: number; solved: boolean;
+        conflicts: { a?: string; b?: string; detail?: string }[];
+        violations: Record<string, unknown>[]; note?: string;
+      }>(`/projects/${pid}/constraints/solve`,
+        { method: "POST", body: JSON.stringify({ variables, constraints }) });
+    }
     modelMaintenance(pid: string) {
       return this.json<{ total_entities: number; cleanable: number;
         recipes: { recipe: string; label: string; removable: number; sample: string[] }[] }>(

--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -165,7 +165,23 @@ const uncalledCountable = uncalled.filter((m) => !(m in KNOWN_UNCALLED));
 //: Set to 117 rather than to main's 121 on purpose. If the true count is 117 this is exact; if
 //: it is higher the gate FAILS LOUDLY on the next run and gets corrected. 121 would have
 //: passed either way and told nobody. Bias low: low fails, high hides.
-const UNCALLED_CEILING = 117;
+//: 117 -> 101 (Lane A/B/E reach sweep, 2026-08-07). Seventeen capabilities that computed an answer
+//: and could not show it to anyone — the qaSection readouts, the dimensional-locks panel, and four
+//: recipes the node canvas simply did not list.
+//:
+//: **101 is what the GATE PRINTED on the merged tree, and the arithmetic would have been wrong.**
+//: 117 minus the fourteen this branch wires is 103; the measured answer is 101, because reach is not
+//: additive across lanes — three sweeps ran concurrently and touched overlapping method sets.
+//:
+//: The failure mode this avoids is not a small error. `toBeLessThanOrEqual` has NO FLOOR, so a stale
+//: ceiling carried forward RAISES the number with every gate green: #273 measured 128 -> 123
+//: correctly, #271 then landed and reached one of the same methods, and landing 123 on a main at 117
+//: would have handed four points of slack to whoever added the next unreachable method.
+//:
+//: So: rebase, set this to 0, run, read the number the assertion prints, restore, land that. And
+//: when two candidates are both defensible, take the smaller — a ceiling set too low fails loudly on
+//: the next run and gets fixed; one set too high never fails at all.
+const UNCALLED_CEILING = 101;
 
 describe("client methods the application actually calls", () => {
   it("agrees with a hand-checked sample in BOTH directions", () => {

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -3348,7 +3348,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
       // R39-DECOMP-VIEWER ④ — moved verbatim to `tools/authoringSection.ts`.
       authoring: () => buildAuthoringSection({
         section, toolBtn2, api, pid, notify, panel, waitForPublish, loadProjectModel,
-        lastPoint: () => lastPoint,
+        lastPoint: () => lastPoint, selectedGuid: () => selectedGuid,
       }),
     };
     for (const key of order) builders[key]?.();

--- a/apps/web/src/viewer/dimLocks.test.ts
+++ b/apps/web/src/viewer/dimLocks.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { describePlan, planApply, type LockVariable } from "./dimLocks";
+
+/**
+ * R38-SOLVER-LOCKS — the mapping from solved scalars to element edits.
+ *
+ * The solver was never the missing piece; this was. Two behaviours carry the weight:
+ *
+ *  - **`move_element` takes deltas.** Passing a solved absolute as `dx` moves the element to
+ *    `current + target` instead of `target` — plausible geometry in the wrong place, which is the one
+ *    way this mapping can produce a wrong model rather than refuse.
+ *  - **An unmappable variable is refused BY NAME and the rest still apply.** Silently dropping it
+ *    yields a model that looks like it satisfies the locks and does not — the same shape as a reserve
+ *    suggestion printed without its verification flag.
+ */
+
+const wall = (over: Partial<LockVariable> = {}): LockVariable => ({
+  name: "w.thickness", current: 0.2, guid: "G-WALL", ifcClass: "IfcWall", param: "thickness", ...over,
+});
+
+describe("dimensional writes go through the existing guid-keyed recipes", () => {
+  it("writes a wall thickness as an absolute", () => {
+    const p = planApply([wall()], { "w.thickness": 0.3 });
+    expect(p.refused).toEqual([]);
+    expect(p.writes).toEqual([{
+      op: "set_wall_thickness", params: { guid: "G-WALL", thickness: 0.3 },
+      variable: "w.thickness", from: 0.2, to: 0.3,
+    }]);
+  });
+
+  it("writes an extrusion depth on any class", () => {
+    const v = wall({ name: "c.depth", param: "depth", ifcClass: "IfcColumn", current: 3, guid: "G-COL" });
+    const p = planApply([v], { "c.depth": 4.5 });
+    expect(p.writes[0]).toMatchObject({ op: "set_extrusion_depth", params: { guid: "G-COL", depth: 4.5 } });
+  });
+
+  it("refuses a thickness on a non-wall rather than writing it somewhere wrong", () => {
+    // set_wall_thickness is wall-specific in the recipe table. Sending a column through it is not a
+    // no-op server-side, so the refusal has to happen here.
+    const v = wall({ ifcClass: "IfcColumn" });
+    const p = planApply([v], { "w.thickness": 0.3 });
+    expect(p.writes).toEqual([]);
+    expect(p.refused[0]!.reason).toContain("only applies to walls");
+  });
+});
+
+describe("move_element takes DELTAS — the one way this can produce a wrong model", () => {
+  it("converts a solved absolute into a delta", () => {
+    const v = wall({ name: "w.x", param: "x", current: 10 });
+    const p = planApply([v], { "w.x": 13.5 });
+    expect(p.writes[0]!.params, "an absolute passed as dx moves to current+target, not target")
+      .toEqual({ guid: "G-WALL", dx: 3.5 });
+  });
+
+  it("produces a NEGATIVE delta when the target is behind the current value", () => {
+    // The paired control. A mapping that passed the absolute through would still look right for a
+    // move away from the origin; it only diverges visibly when the delta should be negative.
+    const v = wall({ name: "w.y", param: "y", current: 10 });
+    const p = planApply([v], { "w.y": 4 });
+    expect(p.writes[0]!.params).toEqual({ guid: "G-WALL", dy: -6 });
+  });
+
+  it("maps each axis to its own delta key", () => {
+    const vars = (["x", "y", "z"] as const).map((ax) =>
+      wall({ name: `w.${ax}`, param: ax, current: 0 }));
+    const p = planApply(vars, { "w.x": 1, "w.y": 2, "w.z": 3 });
+    expect(p.writes.map((w) => w.params)).toEqual([
+      { guid: "G-WALL", dx: 1 }, { guid: "G-WALL", dy: 2 }, { guid: "G-WALL", dz: 3 },
+    ]);
+  });
+});
+
+describe("refusals are named, and never silent", () => {
+  it("refuses a parameter no recipe writes, and applies the others anyway", () => {
+    const ok = wall();
+    const bad = wall({ name: "w.area", param: "area" });
+    const p = planApply([ok, bad], { "w.thickness": 0.3, "w.area": 12 });
+    expect(p.writes).toHaveLength(1);
+    expect(p.refused).toEqual([{ variable: "w.area", reason: "no edit recipe writes 'area' on IfcWall" }]);
+  });
+
+  it("refuses a variable the solver did not return", () => {
+    // Not the same as unchanged. A missing key means the solve did not cover it, and treating that
+    // as "nothing to do" reports success for a lock that was never considered.
+    const p = planApply([wall()], {});
+    expect(p.writes).toEqual([]);
+    expect(p.refused[0]!.reason).toContain("no value");
+  });
+
+  it("refuses a non-finite value instead of writing NaN into the model", () => {
+    const p = planApply([wall()], { "w.thickness": Number.NaN });
+    expect(p.writes).toEqual([]);
+    expect(p.refused).toHaveLength(1);
+  });
+
+  it("says so in the summary — a refusal the user cannot see is a silent drop", () => {
+    const p = planApply([wall(), wall({ name: "w.area", param: "area" })],
+      { "w.thickness": 0.3, "w.area": 12 });
+    const s = describePlan(p);
+    expect(s).toContain("Apply 1 change");
+    expect(s).toContain("cannot be written");
+    expect(s).toContain("w.area");
+  });
+});
+
+describe("an unchanged variable is not an edit", () => {
+  it("emits no write when the solver returns what was already there", () => {
+    // A no-op edit still versions the model and triggers a publish, so "I only moved one wall"
+    // becomes a reload banner for every other session.
+    const p = planApply([wall()], { "w.thickness": 0.2 });
+    expect(p.writes).toEqual([]);
+    expect(p.refused).toEqual([]);
+    expect(describePlan(p)).toBe("Nothing to apply.");
+  });
+
+  it("still writes a change just above the epsilon", () => {
+    // The paired control: an epsilon that swallowed real edits would pass the test above forever.
+    const p = planApply([wall()], { "w.thickness": 0.2 + 1e-3 });
+    expect(p.writes).toHaveLength(1);
+  });
+});

--- a/apps/web/src/viewer/dimLocks.ts
+++ b/apps/web/src/viewer/dimLocks.ts
@@ -1,0 +1,123 @@
+// R38-SOLVER-LOCKS — turn a solved constraint system into element edits.
+//
+// `POST /projects/{pid}/constraints/solve` is pure computation: it takes a flat dict of named scalars
+// and returns new values, and it "neither reads nor writes the model" in its own words. So the solver
+// was never the missing piece — this mapping is. Something has to decide that `thickness` on a wall
+// writes through `set_wall_thickness(guid, …)` while `depth` on a column writes through
+// `set_extrusion_depth(guid, …)`, and nothing did.
+//
+// **Every write below is an existing guid-keyed recipe from `services/data/src/aec_data/edit.py`.**
+// No new recipe is needed, which was not obvious: the recipes that are the WRONG granularity are the
+// ones with guessable names (`edit_type_params` is type-level, `set_pset_on_class` is class-level),
+// while the single-element writes live in a dispatch table keyed by `p["guid"]`. A grep for setter
+// names finds the wrong four and stops.
+//
+// **A variable with no recipe is REFUSED BY NAME, and the rest still apply.** A partial apply that
+// says which locks it could not write is honest; one that silently drops them produces a model that
+// looks like it satisfies the locks and does not — the same failure as a reserve suggestion printed
+// without its verification flag, in a new place.
+
+/** One solver variable, bound to the element and parameter it came from. */
+export interface LockVariable {
+  /** The name used in the solver's flat dict — must match the key in its `values` result. */
+  name: string;
+  /** Value as read from the model, before solving. Needed for deltas — see `move_element`. */
+  current: number;
+  guid: string;
+  ifcClass: string;
+  /** The parameter this variable represents: `thickness`, `depth`, `x`, `y`, `z`, … */
+  param: string;
+}
+
+export interface Write {
+  /** An `editIfc` recipe name, from the RECIPES table. */
+  op: string;
+  params: Record<string, unknown>;
+  /** Which variable produced this write, so a failure can be attributed. */
+  variable: string;
+  /** What changed, for the confirmation the user reads before applying. */
+  from: number;
+  to: number;
+}
+
+export interface Refusal {
+  variable: string;
+  reason: string;
+}
+
+export interface ApplyPlan {
+  writes: Write[];
+  refused: Refusal[];
+}
+
+/** Below this, a "change" is solver noise rather than an edit anyone asked for. Millimetre scale. */
+export const EPSILON_M = 1e-6;
+
+/**
+ * `move_element` takes **deltas**, not absolutes — `move_element(guid, dx, dy, dz)`.
+ *
+ * That is the one place this mapping can silently produce a wrong model rather than refuse: passing a
+ * solved absolute coordinate as `dx` moves the element to `current + target` instead of `target`, and
+ * the result is plausible geometry in the wrong place. The delta is computed here, from the variable's
+ * own `current`, which is why `LockVariable` carries it.
+ */
+const AXIS: Record<string, "dx" | "dy" | "dz"> = { x: "dx", y: "dy", z: "dz" };
+
+function writeFor(v: LockVariable, target: number): Write | Refusal {
+  const base = { variable: v.name, from: v.current, to: target };
+  const cls = v.ifcClass.toLowerCase();
+
+  if (v.param === "thickness") {
+    if (!cls.includes("wall")) {
+      return { variable: v.name, reason: `set_wall_thickness only applies to walls, not ${v.ifcClass}` };
+    }
+    return { ...base, op: "set_wall_thickness", params: { guid: v.guid, thickness: target } };
+  }
+  if (v.param === "depth") {
+    return { ...base, op: "set_extrusion_depth", params: { guid: v.guid, depth: target } };
+  }
+  const axis = AXIS[v.param];
+  if (axis) {
+    return { ...base, op: "move_element", params: { guid: v.guid, [axis]: target - v.current } };
+  }
+  return {
+    variable: v.name,
+    reason: `no edit recipe writes '${v.param}' on ${v.ifcClass}`,
+  };
+}
+
+const isRefusal = (w: Write | Refusal): w is Refusal => "reason" in w;
+
+/**
+ * Plan the edits for a solved system.
+ *
+ * Unchanged variables produce no write — applying a no-op edit still versions the model, and a
+ * publish nobody asked for is how "I only moved one wall" turns into a reload banner for everyone.
+ */
+export function planApply(
+  variables: LockVariable[], solved: Record<string, number>,
+): ApplyPlan {
+  const writes: Write[] = [];
+  const refused: Refusal[] = [];
+  for (const v of variables) {
+    const target = solved[v.name];
+    if (typeof target !== "number" || !Number.isFinite(target)) {
+      // The solver did not return this variable. Silence here would look like "nothing to change".
+      refused.push({ variable: v.name, reason: "the solver returned no value for this variable" });
+      continue;
+    }
+    if (Math.abs(target - v.current) < EPSILON_M) continue;   // unchanged — not an edit
+    const w = writeFor(v, target);
+    if (isRefusal(w)) refused.push(w); else writes.push(w);
+  }
+  return { writes, refused };
+}
+
+/** A one-line summary for the confirmation step. Names the refusals — that is the whole point. */
+export function describePlan(plan: ApplyPlan): string {
+  const n = plan.writes.length;
+  const head = n === 0 ? "Nothing to apply" : `Apply ${n} change${n === 1 ? "" : "s"}`;
+  if (!plan.refused.length) return `${head}.`;
+  return `${head} — ${plan.refused.length} cannot be written: `
+    + plan.refused.map((r) => r.variable).join(", ");
+}

--- a/apps/web/src/viewer/nodeCanvas.ts
+++ b/apps/web/src/viewer/nodeCanvas.ts
@@ -33,6 +33,17 @@ const STARTER: Record<string, Record<string, unknown>> = {
   add_base_plate: { column_guid: { $from: "n1" }, width: 0.5 },
   add_curtain_wall: { start: [0, 0], end: [6, 0], height: 3.5 },
   derive_analytical: {},
+  // Added 2026-08-07 (reach sweep). These four recipes existed in the server's RECIPES registry and
+  // were reachable by NOTHING: the canvas offered seven names and `nodegraph.run` dispatches against
+  // the same registry, so the list here was the only thing standing between the user and them.
+  //
+  // Param names taken from `RECIPES` in `services/data/src/aec_data/edit.py`, not from the client
+  // wrappers — a starter that does not match the recipe is worse than a blank one, because it looks
+  // authoritative and fails at run time.
+  array_element: { guid: "", nx: 2, ny: 1, dx: 1, dy: 0, dz: 0 },
+  create_type: { ifc_class: "IfcWallType", name: "New type", dims: [0.2, 3, 1] },
+  edit_type_params: { type_guid: "", name: "Renamed type" },
+  connect_elements: { guid_a: "", guid_b: "", description: "" },
 };
 
 export function openNodeCanvas(opts: NodeCanvasOpts): void {

--- a/apps/web/src/viewer/tools/accessorNotCollapsed.test.ts
+++ b/apps/web/src/viewer/tools/accessorNotCollapsed.test.ts
@@ -1,0 +1,67 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * An accessor threaded through a seam must not be collapsed to a value on arrival.
+ *
+ * R39-DECOMP-VIEWER moves code out of `app.ts` by handing it explicit parameters. Mutable state
+ * (`selectedGuid`, `lastPoint`) crosses as a **function**, because `app.ts` holds it as a `let` and a
+ * value copy would freeze whatever it held when the panel was built. `tsc` cannot see the difference
+ * — that is written down in `qaSection.ts` and in `projectPanel.test.ts`.
+ *
+ * **It happened anyway, and the accessor was not the part that failed.** `qaSection.ts` opened with
+ * `const selectedGuid = d.selectedGuid();` — one call, at panel-build time — directly beneath a
+ * docstring explaining why that class of bug is impossible by construction. The panel is built at app
+ * init, before anything is selected, so the captured value was `null` for the life of the session:
+ *
+ *   - "🕸 Related elements (model graph)" answered *"select an element in 3D first"* no matter what
+ *     was selected.
+ *   - the layer-stack "＋ override (selected element)" button did the same.
+ *
+ * Two dead tools on main, under a comment saying they could not be. Threading the accessor correctly
+ * across the seam is only half the contract; the other half is not undoing it on the first line.
+ *
+ * So the check is on the SHAPE, not on one name: `const x = d.x()` at any point in a tools module is
+ * the collapse, whatever `x` is called. A genuine one-shot read is still available as `d.x()` inline
+ * at the point of use, which is what the fix does.
+ */
+
+const DIR = resolve(process.cwd(), "src/viewer/tools");
+
+/** `const foo = d.foo();` / `const foo = deps.foo();` — the accessor-collapse shape. */
+const COLLAPSE = /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*(?:d|deps)\.\1\s*\(\s*\)\s*;/g;
+
+const files = readdirSync(DIR).filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+
+describe("tools sections do not collapse an accessor dependency", () => {
+  it("found the tools modules — else this passes by measuring nothing", () => {
+    // The vacuity guard. An empty file list reports zero collapses and looks like total compliance.
+    expect(files.length, "no tools modules found — the path is wrong, not the code").toBeGreaterThan(3);
+  });
+
+  it("never assigns d.x() to a const named x", () => {
+    const hits: string[] = [];
+    for (const f of files) {
+      const src = readFileSync(resolve(DIR, f), "utf8");
+      for (const m of src.matchAll(COLLAPSE)) hits.push(`${f}: const ${m[1]} = d.${m[1]}()`);
+    }
+    expect(hits,
+      "an accessor was collapsed to a value at build time — it will freeze at whatever it held then, "
+      + "which for a selection is null. Call it at the point of use instead.")
+      .toEqual([]);
+  });
+
+  it("still recognises the pattern it is looking for — the matcher is not dead", () => {
+    // The paired control. A regex that matches nothing passes the assertion above against any code
+    // at all, which is indistinguishable from the rule being followed.
+    const sample = "  const selectedGuid = d.selectedGuid();\n  const other = d.other();";
+    expect([...sample.matchAll(COLLAPSE)].map((m) => m[1])).toEqual(["selectedGuid", "other"]);
+  });
+
+  it("does not flag a legitimate inline read", () => {
+    // `const guid = selectedGuid();` inside a handler is the CORRECT shape and must not trip this.
+    const ok = "const guid = selectedGuid();\nconst p = d.lastPoint();\nconst renamed = d.selectedGuid();";
+    expect([...ok.matchAll(COLLAPSE)].map((m) => m[1])).toEqual([]);
+  });
+});

--- a/apps/web/src/viewer/tools/analyseSection.ts
+++ b/apps/web/src/viewer/tools/analyseSection.ts
@@ -53,7 +53,11 @@ export interface AnalyseDeps {
 export function buildAnalyseSection(d: AnalyseDeps): void {
   const { section, toolBtn2, api, pid, projectId, notify, container, logisticsOverlay,
           layerMgr, refreshIssues, fourD } = d;
-  const lastPoint = d.lastPoint();
+  // NOT a value. `d.lastPoint()` here would pin the point to whatever was current when the panel was
+  // BUILT — which is null, because the panel is built before the user has clicked anything. Caught by
+  // tools/accessorNotCollapsed.test.ts, which found this in three sections at once, each under a
+  // docstring explaining why it could not happen.
+  const lastPoint = () => d.lastPoint();
         const b = section("analyse", "Analyze & Coordinate · code, cost & 4D", { requires: "sourceIfc", tool: true });
         if (!b) return;
         const out = document.createElement("div"); out.className = "meta"; out.style.marginTop = "4px";
@@ -88,9 +92,10 @@ export function buildAnalyseSection(d: AnalyseDeps): void {
             const label = mk("label"); const startI = mk("start YYYY-MM-DD"); const endI = mk("end YYYY-MM-DD");
             const add = document.createElement("button"); add.className = "mini-btn"; add.textContent = "＋ at last point";
             add.onclick = () => {
-              if (!lastPoint) { notify("click a point in the model first", "error"); return; }
+              const lp = lastPoint();
+              if (!lp) { notify("click a point in the model first", "error"); return; }
               const id = `r${Date.now().toString(36)}`;
-              const e = lastPoint.x, n = -lastPoint.z;   // world (E, y, -N) → E, N
+              const e = lp.x, n = -lp.z;                 // world (E, y, -N) → E, N
               const r: LogisticsResource = { id, kind: kind.value, label: label.value.trim() || kind.value, position: [e, 0, n], start: startI.value.trim() || undefined, end: endI.value.trim() || undefined };
               if (kind.value === "crane") r.radius = 25;
               resources.push(r); logisticsOverlay.render(resources); label.value = ""; draw();

--- a/apps/web/src/viewer/tools/authoringSection.ts
+++ b/apps/web/src/viewer/tools/authoringSection.ts
@@ -40,7 +40,11 @@ export interface AuthoringDeps {
 
 export function buildAuthoringSection(d: AuthoringDeps): void {
   const { section, toolBtn2, api, pid, notify, panel, waitForPublish, loadProjectModel } = d;
-  const lastPoint = d.lastPoint();
+  // NOT a value. `d.lastPoint()` here would pin the point to whatever was current when the panel was
+  // BUILT — which is null, because the panel is built before the user has clicked anything. Caught by
+  // tools/accessorNotCollapsed.test.ts, which found this in three sections at once, each under a
+  // docstring explaining why it could not happen.
+  const lastPoint = () => d.lastPoint();
         const b = section("authoring", "Build · Advanced authoring, annotate & library", { requires: "sourceIfc", tool: true });
         const group = panel.querySelector('.tool-group[data-tool="authoring"]') as HTMLElement | null;
         if (group) group.dataset.cap = "edit";   // whole section hidden for non-editors
@@ -87,7 +91,8 @@ export function buildAuthoringSection(d: AuthoringDeps): void {
           const key = sel.value;
           if (!key) { out.textContent = "pick a family first"; return; }
           const label = sel.options[sel.selectedIndex]?.text ?? key;
-          const pos: [number, number] | null = lastPoint ? [lastPoint.x, -lastPoint.z] : null;
+          const lp = lastPoint();
+          const pos: [number, number] | null = lp ? [lp.x, -lp.z] : null;
           out.textContent = `adding ${label}…`;
           await api.addFamily(pid, key, pos);
           out.textContent = `${label} added · converting…`;

--- a/apps/web/src/viewer/tools/authoringSection.ts
+++ b/apps/web/src/viewer/tools/authoringSection.ts
@@ -124,7 +124,11 @@ export function buildAuthoringSection(d: AuthoringDeps): void {
         // AUTH-VS: open the visual node-authoring canvas (chain recipes as a graph, run in one pass)
         const nodeBtn = toolBtn2("🕸 Visual node authoring", () => {
           openNodeCanvas({
-            recipes: ["add_wall", "add_column", "add_beam", "add_slab", "add_base_plate", "add_curtain_wall", "derive_analytical"],
+            // Seven of these were offered; four more exist in the server's RECIPES registry and were
+            // reachable by nothing at all. `nodegraph.run` validates against that same registry, so
+            // this list was the only gate.
+            recipes: ["add_wall", "add_column", "add_beam", "add_slab", "add_base_plate", "add_curtain_wall", "derive_analytical",
+                      "array_element", "create_type", "edit_type_params", "connect_elements"],
             runGraph: async (graph) => {
               const r = await api.editGraph(pid, graph, { publish: true });
               const state = await waitForPublish(pid);

--- a/apps/web/src/viewer/tools/authoringSection.ts
+++ b/apps/web/src/viewer/tools/authoringSection.ts
@@ -3,6 +3,7 @@ import * as THREE from "three";
 import { type ApiClient } from "../../api/client";
 import { escapeHtml } from "../../ui/feedback";
 import { openNodeCanvas } from "../nodeCanvas";
+import { describePlan, planApply, type ApplyPlan, type LockVariable } from "../dimLocks";
 
 /**
  * R39-DECOMP-VIEWER — the advanced authoring / annotate / library section, out of `app.ts`.
@@ -25,6 +26,12 @@ export interface AuthoringDeps {
   notify: (msg: string, kind?: "info" | "success" | "error") => void;
   /** ACCESSOR: `lastPoint` is a `let` in app.ts, read at click time. */
   lastPoint: () => THREE.Vector3 | null;
+  /**
+   * ACCESSOR for the same reason — `selectedGuid` is a `let` in app.ts and changes on every pick.
+   * A value copy would compile cleanly and freeze whatever was selected when the panel was BUILT,
+   * so the locks editor would silently edit the wrong element for the rest of the session.
+   */
+  selectedGuid: () => string | null;
   /** The tools panel element — this section dims itself for non-editors via `data-cap`. */
   panel: HTMLElement;
   waitForPublish: (pid: string, onTick?: (s: string) => void) => Promise<string>;
@@ -124,5 +131,124 @@ export function buildAuthoringSection(d: AuthoringDeps): void {
         });
         nodeBtn.dataset.cap = "edit";
         nodeBtn.title = "Drag recipe nodes, wire outputs → inputs, and run the graph as one GUID-stable authoring pass";
-        b.append(fix, pub, furnish, nodeBtn, out);
+        b.append(fix, pub, furnish, nodeBtn, locksBtn(d, out), out);
+}
+
+/**
+ * R38-SOLVER-LOCKS — dimensional locks on the selected element.
+ *
+ * Lives in this section rather than its own because `app.ts` is at its size pin and a new builder
+ * entry costs it lines it does not have — and locks ARE authoring, so this is where the ratchet was
+ * pointing anyway.
+ *
+ * Reads the element's numeric properties, lets the user fix or relate them, solves server-side, and
+ * applies through the existing guid-keyed recipes. The three things it must not do quietly:
+ *
+ *  - **A conflict must be named.** The solver's whole argument for existing is that "an
+ *    over-constrained system NAMES the conflict"; satisfying one of a contradictory pair silently
+ *    produces geometry that looks deliberate and is not.
+ *  - **Remaining freedom must be reported.** `dof > 0` means infinitely many solutions and one was
+ *    picked; that is how a "solved" sketch drifts on the next edit.
+ *  - **A refusal must be visible.** `planApply` refuses a variable no recipe can write; showing the
+ *    applied count without the refusals is a result that looks complete and is not.
+ */
+function locksBtn(d: AuthoringDeps, out: HTMLElement): HTMLButtonElement {
+  const { api, pid, notify } = d;
+  const btn = d.toolBtn2("⟺ Dimensional locks", () => void openLocks());
+  btn.dataset.cap = "edit";
+  btn.title = "Fix or relate this element's dimensions, solve the system, and apply the result";
+
+  async function openLocks(): Promise<void> {
+    const guid = d.selectedGuid();
+    if (!guid) { notify("Select an element first", "info"); return; }
+    out.textContent = "reading properties…";
+    let vars: LockVariable[];
+    try {
+      vars = await readNumericParams(api, pid, guid);
+    } catch { out.textContent = "could not read this element's properties"; return; }
+    if (!vars.length) { out.textContent = "this element has no numeric parameters to lock"; return; }
+
+    out.innerHTML = "";
+    const rows = document.createElement("div");
+    const state = new Map<string, number | null>();   // variable -> fixed value, or null for free
+    for (const v of vars) {
+      const row = document.createElement("label");
+      row.style.cssText = "display:flex;gap:6px;align-items:center;margin:2px 0";
+      const cb = document.createElement("input"); cb.type = "checkbox";
+      const num = document.createElement("input");
+      num.type = "number"; num.step = "any"; num.value = String(v.current);
+      num.style.width = "7em"; num.disabled = true;
+      cb.onchange = () => { num.disabled = !cb.checked; state.set(v.name, cb.checked ? Number(num.value) : null); };
+      num.oninput = () => { if (cb.checked) state.set(v.name, Number(num.value)); };
+      const name = document.createElement("span");
+      name.textContent = `${v.param} (${v.current})`;
+      row.append(cb, name, num);
+      rows.appendChild(row);
+    }
+    const result = document.createElement("div"); result.className = "meta"; result.style.marginTop = "4px";
+    const apply = document.createElement("button");
+    apply.className = "tool-btn"; apply.textContent = "Solve & apply"; apply.disabled = true;
+    let plan: ApplyPlan | null = null;
+
+    const solveBtn = document.createElement("button");
+    solveBtn.className = "tool-btn"; solveBtn.textContent = "Solve";
+    solveBtn.onclick = async () => {
+      const constraints = [...state.entries()]
+        .filter(([, val]) => typeof val === "number" && Number.isFinite(val))
+        .map(([nm, val]) => ({ kind: "fix", a: nm, value: val, strength: "required" }));
+      if (!constraints.length) { result.textContent = "Lock at least one value first."; return; }
+      result.textContent = "solving…";
+      try {
+        const r = await api.solveConstraints(pid, Object.fromEntries(vars.map((v) => [v.name, v.current])), constraints);
+        plan = planApply(vars, r.values);
+        const bits: string[] = [];
+        // Conflicts and remaining freedom are stated whether or not anything is applicable — a plan
+        // that says "2 changes" over an unsolved system is the misleading half of this feature.
+        if (!r.solved) bits.push("⚠ over-constrained");
+        for (const c of r.conflicts || []) bits.push(`conflict: ${escapeHtml(String(c.detail ?? `${c.a} ↔ ${c.b}`))}`);
+        if (r.dof > 0) bits.push(`${r.dof} degree(s) of freedom left — one solution of many`);
+        bits.push(describePlan(plan));
+        result.innerHTML = bits.map((t) => escapeHtml(t)).join("<br>");
+        apply.disabled = plan.writes.length === 0;
+      } catch { result.textContent = "solve failed"; plan = null; apply.disabled = true; }
+    };
+
+    apply.onclick = async () => {
+      if (!plan?.writes.length) return;
+      apply.disabled = true;
+      let done = 0;
+      try {
+        for (const w of plan.writes) { await api.editIfc(pid, w.op, w.params, false); done++; }
+        await api.publish(pid);
+        const state2 = await d.waitForPublish(pid);
+        if (state2 === "done") await d.loadProjectModel();
+        // The refusals are repeated HERE, after applying, because this is the moment someone reads
+        // it as finished. "Applied 3" alone is the silent-drop failure.
+        notify(plan.refused.length
+          ? `Applied ${done} — ${plan.refused.length} could not be written: ${plan.refused.map((r) => r.variable).join(", ")}`
+          : `Applied ${done} change(s)`, plan.refused.length ? "info" : "success");
+      } catch { notify(`Applied ${done} of ${plan.writes.length} — the rest failed`, "error"); }
+    };
+
+    out.append(rows, solveBtn, apply, result);
+  }
+  return btn;
+}
+
+/** Numeric instance properties, as solver variables bound to their element. */
+async function readNumericParams(api: ApiClient, pid: string, guid: string): Promise<LockVariable[]> {
+  const props = await api.elementEffectiveProps(pid, guid);
+  const out: LockVariable[] = [];
+  for (const [pset, entries] of Object.entries(props.psets || {})) {
+    for (const [prop, cell] of Object.entries(entries)) {
+      const v = (cell as { value: unknown }).value;
+      if (typeof v !== "number" || !Number.isFinite(v)) continue;
+      out.push({
+        name: `${pset}.${prop}`, current: v, guid,
+        ifcClass: String((props as { ifc_class?: string }).ifc_class ?? ""),
+        param: prop.toLowerCase(),
+      });
+    }
+  }
+  return out;
 }

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -73,7 +73,13 @@ export function buildQaSection(d: QaDeps): void {
   const { section, toolBtn2, api, pid, projectId, notify, selectMap, sets, layerMgr, loader,
           nextId, refreshIssues, container, reloadModelPins, selectByGuid, waitForPublish,
           refreshFederation, authorAndReload, fitToModels, loadProjectModel } = d;
-  const selectedGuid = d.selectedGuid();
+  // NOT `const selectedGuid = d.selectedGuid()`. That is what this file used to do, and it is the
+  // exact bug the docstring above says is impossible by construction: the accessor was threaded
+  // correctly through the seam and then collapsed to a value on arrival. The panel is built at app
+  // init, before anything is selected, so the captured value was `null` FOREVER — "Related elements"
+  // and the layer override button answered "select an element in 3D first" no matter what was
+  // selected. Two dead tools, on main, under a comment explaining why they could not be.
+  const selectedGuid = () => d.selectedGuid();
         const b = section("qa", "Analyze & Coordinate · clash / QA", { requires: "sourceIfc", tool: true });
         if (!b) return;
         const out = document.createElement("div"); out.className = "meta"; out.style.marginTop = "4px";
@@ -103,6 +109,57 @@ export function buildQaSection(d: QaDeps): void {
             const phased = Object.entries(d!.phasing).filter(([k, v]) => v && k !== "UNSET");
             if (phased.length) body.appendChild(resultNote(`<b>Phasing</b> — ` + phased.map(([k, v]) => `${v} ${k.toLowerCase()}`).join(", "), ""));
             if (d!.hygiene.issues) body.appendChild(resultNote(`<b>${d!.hygiene.issues}</b> model-hygiene issue(s) — see Model Health.`, "bad"));
+          });
+        })));
+        // SOURCES-1 — what governs the selected element. `elementSources` had no client caller, so
+        // the answer to "why is this wall like this?" existed server-side and nowhere else.
+        b.appendChild(toolBtn2("🔎 Element sources (what governs this?)", () => withLoading(container, "Reading provenance", async () => {
+          const guid = selectedGuid();
+          if (!guid) { toast("Select an element first", "info"); return; }
+          let r;
+          try { r = await api.elementSources(pid, guid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          // `found: false` is a real answer and not an empty one. Rendering blank sections for an
+          // element the graph has never heard of reads as "nothing governs this", which is a
+          // different claim from "this element is not in the document graph".
+          if (!r.found) {
+            out.textContent = "no provenance";
+            showResult("Element sources", (body) => body.appendChild(resultNote(
+              "This element is not in the document graph — no spec sections, documents or "
+              + "container are recorded for it. That is not the same as nothing governing it.", "")));
+            return;
+          }
+          out.textContent = `${r.citations.length} citation(s)`;
+          showResult("Element sources", (body) => {
+            body.appendChild(resultNote(`<b>${escapeHtml(r!.name || guid)}</b>`
+              + (r!.class ? ` · ${escapeHtml(r!.class)}` : ""), ""));
+            const specs = r!.spec_sections || [];
+            const docs = r!.documents || [];
+            if (specs.length) {
+              body.appendChild(resultNote("<b>Governing spec sections</b>", ""));
+              body.appendChild(kvTable(specs.map((x) => ({
+                k: `${x.system ? escapeHtml(x.system) + " " : ""}${escapeHtml(x.code)}`, v: escapeHtml(x.title),
+              }))));
+            }
+            if (docs.length) {
+              body.appendChild(resultNote("<b>Attached documents</b>", ""));
+              body.appendChild(kvTable(docs.map((x) => ({ k: escapeHtml(x.name), v: x.sheet ? `sheet ${escapeHtml(x.sheet)}` : "" }))));
+            }
+            if (r!.container) {
+              const c = r!.container;
+              const row = document.createElement("div");
+              row.className = "meta"; row.style.cssText = "margin-top:4px";
+              row.innerHTML = `Container: <b>${escapeHtml(c.name || c.guid || "—")}</b> · ${escapeHtml(c.class)}`;
+              // Only offer the jump when there is somewhere to jump to.
+              if (c.guid) {
+                row.style.cursor = "pointer"; row.title = "Select the container";
+                row.onclick = () => { void selectByGuid(c.guid!, true); };
+              }
+              body.appendChild(row);
+            }
+            if (!specs.length && !docs.length && !r!.container) {
+              body.appendChild(resultNote("In the graph, but nothing cites it yet.", ""));
+            }
           });
         })));
         // GEOREF-1 — the survey basis, which nothing could show. `georef.py` reports a BSI LoGeoRef
@@ -576,8 +633,8 @@ export function buildQaSection(d: QaDeps): void {
           });
         })));
         b.appendChild(toolBtn2("🕸 Related elements (model graph)", () => withLoading(container, "Building model graph", async () => {
-          if (!selectedGuid) { notify("select an element in 3D first", "error"); return; }
-          const guid = selectedGuid;
+          const guid = selectedGuid();
+          if (!guid) { notify("select an element in 3D first", "error"); return; }
           let r;
           try { r = await api.graphNeighbors(pid, guid, 2); }
           catch { toast("Needs a source IFC", "error"); return; }
@@ -630,11 +687,12 @@ export function buildQaSection(d: QaDeps): void {
             const drawSel = () => { layerSel.innerHTML = ""; stack.forEach((L, i) => { const o = document.createElement("option"); o.value = String(i); o.textContent = L.name; layerSel.appendChild(o); }); };
             const addOv = document.createElement("button"); addOv.className = "mini-btn"; addOv.textContent = "＋ override (selected element)";
             addOv.onclick = () => {
-              if (!selectedGuid) { notify("select an element in 3D first", "error"); return; }
+              const g = selectedGuid();
+              if (!g) { notify("select an element in 3D first", "error"); return; }
               if (!psetI.value.trim() || !propI.value.trim() || !stack.length) { notify("need a layer + Pset + Prop", "error"); return; }
               const L = stack[Number(layerSel.value) || 0]; if (!L) { notify("add a layer first", "error"); return; }
-              L.overrides.push({ guid: selectedGuid, pset: psetI.value.trim(), prop: propI.value.trim(), value: valI.value });
-              propI.value = ""; valI.value = ""; draw(); status.textContent = `added override on ${selectedGuid.slice(0, 8)}… to “${L.name}”`;
+              L.overrides.push({ guid: g, pset: psetI.value.trim(), prop: propI.value.trim(), value: valI.value });
+              propI.value = ""; valI.value = ""; draw(); status.textContent = `added override on ${g.slice(0, 8)}… to “${L.name}”`;
             };
             addL.onclick = async () => { const n = await askText("New layer", { label: "Layer name (e.g. Fire coordination):", value: "" }); if (!n) return; stack.push({ name: n, enabled: true, overrides: [] }); draw(); drawSel(); };
             drawSel();

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -3,6 +3,7 @@ import type { ModelIdMap } from "../modelIds";
 import { askText } from "../../ui/prompt";
 import { confirmModal, promptModal } from "../../ui/modal";
 import { kvTable, resultNote, showResult } from "../../ui/result";
+import { guidsFromSample } from "../warningSample";
 import { escapeHtml, toast, withLoading } from "../../ui/feedback";
 import { LayerManager } from "../../tools/layers";
 import { ModelLoader } from "../loader";
@@ -102,6 +103,44 @@ export function buildQaSection(d: QaDeps): void {
             const phased = Object.entries(d!.phasing).filter(([k, v]) => v && k !== "UNSET");
             if (phased.length) body.appendChild(resultNote(`<b>Phasing</b> — ` + phased.map(([k, v]) => `${v} ${k.toLowerCase()}`).join(", "), ""));
             if (d!.hygiene.issues) body.appendChild(resultNote(`<b>${d!.hygiene.issues}</b> model-hygiene issue(s) — see Model Health.`, "bad"));
+          });
+        })));
+        // WARN-1 — the punch list BEHIND the health badge. `modelHealth` above scores the model and
+        // says "warn"; until now nothing could answer "warn about what, and where?". The feed's own
+        // words: "Where the model-CI badge says pass/warn/fail, this is the actionable list behind
+        // it." It shipped with no client caller at all.
+        b.appendChild(toolBtn2("⚠ Warnings (the punch list behind the score)", () => withLoading(container, "Collecting warnings", async () => {
+          let r;
+          try { r = await api.modelWarnings(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = r.clean ? "no warnings" : `${r.total} warning(s)`;
+          const sev: Record<string, string> = { fail: "🔴", warn: "🟡", info: "⚪" };
+          showResult("Model warnings", (body) => {
+            body.appendChild(resultNote(r!.clean
+              ? "No hygiene or conformance defects found."
+              : `<b>${r!.by_severity.fail}</b> fail · <b>${r!.by_severity.warn}</b> warn · `
+                + `<b>${r!.by_severity.info}</b> info — worst first.`, r!.clean ? "ok" : r!.by_severity.fail ? "bad" : ""));
+            for (const w of r!.warnings) {
+              const guids = guidsFromSample(w.sample);
+              const row = document.createElement("div");
+              row.className = "meta";
+              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle)";
+              row.innerHTML = `${sev[w.severity] || "⚪"} <b>${escapeHtml(w.label)}</b> · ${w.count}`
+                + (w.note ? ` <span class="meta">${escapeHtml(w.note)}</span>` : "");
+              // Only rows that CAN be zoomed to get the affordance. `overlapping_duplicates` groups
+              // are keyed by class+location and carry no GUID, so a blanket click handler there would
+              // be a control that does nothing — the silent-failure shape, in a panel about defects.
+              if (guids.length) {
+                row.style.cursor = "pointer";
+                row.title = `Select ${guids.length} offending element(s)`;
+                // `sets.fromGuids` is async. The first version of this line cast the Promise away
+                // with `as never` to satisfy tsc — which is how a type error becomes a runtime one.
+                row.onclick = async () => { await selectMap(await sets.fromGuids(guids.slice(0, 200))); };
+              } else {
+                row.title = "This check identifies groups by location, not by element — nothing to select";
+              }
+              body.appendChild(row);
+            }
           });
         })));
         b.appendChild(toolBtn2("🩺 Model Health (all checks, one score)", () => withLoading(container, "Scoring model health", async () => {

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -105,6 +105,50 @@ export function buildQaSection(d: QaDeps): void {
             if (d!.hygiene.issues) body.appendChild(resultNote(`<b>${d!.hygiene.issues}</b> model-hygiene issue(s) — see Model Health.`, "bad"));
           });
         })));
+        // GEOREF-1 — the survey basis, which nothing could show. `georef.py` reports a BSI LoGeoRef
+        // level (0/10/20/40/50) "so a coordinator can see at a glance how well-georeferenced a model
+        // is", and it had no client caller: the project non-negotiable is to preserve real
+        // coordinates for export, and there was no way to find out whether they were there.
+        b.appendChild(toolBtn2("🌍 Georeferencing (survey basis / LoGeoRef)", () => withLoading(container, "Reading survey basis", async () => {
+          let r;
+          try { r = await api.modelGeoreferencing(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = r.level_label;
+          showResult("Georeferencing", (body) => {
+            // The level IS the verdict — a bare "georeferenced: true" hides the difference between an
+            // elevation-only model and a projected CRS, and those export very differently.
+            body.appendChild(resultNote(
+              `<b>${escapeHtml(r!.level_label)}</b>${r!.note ? " — " + escapeHtml(r!.note) : ""}`,
+              r!.level >= 40 ? "ok" : r!.level === 0 ? "bad" : ""));
+            const rows: { k: string; v: string }[] = [];
+            const mc = r!.map_conversion, crs = r!.crs, site = r!.site;
+            // Every field is rendered as "not set" rather than omitted when absent. An absent row and
+            // a zero row look identical once one is missing, and eastings of 0 is a real value.
+            const num = (v: number | null | undefined) => (typeof v === "number" ? String(v) : "not set");
+            if (mc) {
+              rows.push({ k: "Eastings", v: num(mc.eastings) }, { k: "Northings", v: num(mc.northings) },
+                { k: "Orthogonal height", v: num(mc.orthogonal_height) },
+                { k: "True north bearing", v: mc.true_north_bearing_deg == null ? "not set" : `${mc.true_north_bearing_deg}°` },
+                { k: "Scale", v: num(mc.scale) });
+            }
+            if (crs) {
+              rows.push({ k: "CRS", v: crs.name || "not set" }, { k: "Geodetic datum", v: crs.geodetic_datum || "not set" },
+                { k: "Vertical datum", v: crs.vertical_datum || "not set" },
+                { k: "Map projection", v: crs.map_projection || "not set" }, { k: "Map zone", v: crs.map_zone || "not set" });
+            }
+            if (site) {
+              const dms = (v: number[] | null) => (Array.isArray(v) && v.length ? v.join("° ") : "not set");
+              rows.push({ k: "Site latitude", v: dms(site.ref_latitude) }, { k: "Site longitude", v: dms(site.ref_longitude) },
+                { k: "Site elevation", v: num(site.ref_elevation) });
+            }
+            if (!rows.length) {
+              body.appendChild(resultNote("No IfcMapConversion, projected CRS or IfcSite reference — "
+                + "the model carries no survey basis at all.", "bad"));
+              return;
+            }
+            body.appendChild(kvTable(rows));
+          });
+        })));
         // WARN-1 — the punch list BEHIND the health badge. `modelHealth` above scores the model and
         // says "warn"; until now nothing could answer "warn about what, and where?". The feed's own
         // words: "Where the model-CI badge says pass/warn/fail, this is the actionable list behind

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -111,6 +111,81 @@ export function buildQaSection(d: QaDeps): void {
             if (d!.hygiene.issues) body.appendChild(resultNote(`<b>${d!.hygiene.issues}</b> model-hygiene issue(s) — see Model Health.`, "bad"));
           });
         })));
+        // FILL-MATRIX — property completeness by class, with the worst gaps named. The data-quality
+        // question every IDS / COBie handover turns on, computed and unreachable.
+        b.appendChild(toolBtn2("📊 Property fill matrix (completeness by class)", () => withLoading(container, "Measuring property fill", async () => {
+          let r;
+          try { r = await api.modelFillMatrix(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = `${r.class_count} class(es) · ${r.element_count} element(s)`;
+          showResult("Property fill matrix", (body) => {
+            body.appendChild(resultNote(`<b>${r!.element_count}</b> element(s) across <b>${r!.class_count}</b> class(es).`
+              + (r!.note ? ` ${escapeHtml(r!.note)}` : ""), ""));
+            if (r!.worst_gaps.length) {
+              // Worst gaps first: a fill matrix nobody can act on is a spreadsheet. The gaps are the
+              // actionable end of it.
+              body.appendChild(resultNote("<b>Worst gaps</b> — lowest fill rate first:", ""));
+              body.appendChild(kvTable(r!.worst_gaps.slice(0, 25).map((g) => ({
+                k: `${escapeHtml(g.ifc_class)} · ${escapeHtml(g.pset)}.${escapeHtml(g.prop)}`,
+                v: `${Math.round(g.fill_rate * 100)}% filled · ${g.blank} blank`,
+              }))));
+            } else {
+              body.appendChild(resultNote("No property gaps at the reporting threshold.", "ok"));
+            }
+          });
+        })));
+
+        // SPLIT-PLAN — how this model would federate by storey, and what is UNASSIGNED. The
+        // unassigned list is the point: an element in no storey is invisible to every storey filter.
+        b.appendChild(toolBtn2("🗂 Split plan (federation by storey)", () => withLoading(container, "Planning split", async () => {
+          let r;
+          try { r = await api.modelSplitPlan(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = `${Object.keys(r.counts).length} storey(s) · ${r.unassigned_count} unassigned`;
+          showResult("Split plan", (body) => {
+            body.appendChild(resultNote(r!.unassigned_count
+              ? `<b>${r!.unassigned_count}</b> element(s) belong to no storey — they are invisible to every storey filter.`
+              : "Every element is assigned to a storey.", r!.unassigned_count ? "" : "ok"));
+            body.appendChild(kvTable(Object.entries(r!.counts).map(([st, n]) => ({ k: escapeHtml(st), v: `${n} element(s)` }))));
+            if (r!.unassigned.length) {
+              const row = document.createElement("div");
+              row.className = "meta"; row.style.cssText = "margin-top:4px;cursor:pointer";
+              row.innerHTML = `<b>Select the ${r!.unassigned.length} unassigned</b>`;
+              row.onclick = async () => { await selectMap(await sets.fromGuids(r!.unassigned.slice(0, 200))); };
+              body.appendChild(row);
+            }
+            if (r!.note) body.appendChild(resultNote(escapeHtml(r!.note), ""));
+          });
+        })));
+
+        // CONNECTIONS — the authored connection graph plus its size. Two endpoints, one readout:
+        // the stats alone (nodes/edges) answer nothing a person asks, but they frame the list.
+        b.appendChild(toolBtn2("🧩 Connections (authored joins + graph size)", () => withLoading(container, "Reading connections", async () => {
+          let r, g;
+          try { [r, g] = await Promise.all([api.elementConnections(pid), api.modelGraphStats(pid)]); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = `${r.count} connection(s)`;
+          showResult("Connections", (body) => {
+            body.appendChild(resultNote(`<b>${r!.count}</b> authored connection(s) across `
+              + `<b>${r!.elements_connected}</b> element(s); busiest element has <b>${r!.max_degree}</b>. `
+              + `Model graph: ${g!.nodes} node(s), ${g!.edges} edge(s).`, ""));
+            if (Object.keys(g!.by_rel).length) {
+              body.appendChild(resultNote("<b>Relationships by kind</b>", ""));
+              body.appendChild(kvTable(Object.entries(g!.by_rel).map(([k, v]) => ({ k: escapeHtml(k), v: String(v) }))));
+            }
+            for (const c of r!.connections.slice(0, 50)) {
+              const row = document.createElement("div");
+              row.className = "meta";
+              row.style.cssText = "padding:2px 0;border-bottom:1px solid var(--border-subtle);cursor:pointer";
+              row.innerHTML = `${escapeHtml(c.a_class)} ↔ ${escapeHtml(c.b_class)}`
+                + (c.description ? ` · ${escapeHtml(c.description)}` : "");
+              row.title = "Select both ends";
+              row.onclick = async () => { await selectMap(await sets.fromGuids([c.a, c.b])); };
+              body.appendChild(row);
+            }
+          });
+        })));
+
         // INTEROP-RT — the round-trip verdict, which nothing could show. It serialises the model,
         // re-parses it and compares GUID stability, class, name, containment, type and psets.
         // **GUID stability is a project non-negotiable** and the whole edit-recipe architecture rests

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -111,6 +111,70 @@ export function buildQaSection(d: QaDeps): void {
             if (d!.hygiene.issues) body.appendChild(resultNote(`<b>${d!.hygiene.issues}</b> model-hygiene issue(s) — see Model Health.`, "bad"));
           });
         })));
+        // VIEW-TEMPLATES — saved view definitions, listed and APPLIED. Both halves were unreachable:
+        // `viewTemplates` (the list) and `resolveViewTemplate` (what it resolves to on THIS model).
+        // A saved view nobody can apply is a stored preference with no effect.
+        //
+        // Applying is reversible — it isolates and colours, it does not edit the model — which is why
+        // this is safe to wire without a confirmation step, unlike the template WRITE endpoints.
+        b.appendChild(toolBtn2("👁 View templates (apply a saved view)", () => withLoading(container, "Reading view templates", async () => {
+          let r;
+          try { r = await api.viewTemplates(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = `${r.templates.length} template(s)`;
+          showResult("View templates", (body) => {
+            if (!r!.templates.length) {
+              body.appendChild(resultNote("No view templates saved for this project.", ""));
+              return;
+            }
+            for (const t of r!.templates) {
+              const row = document.createElement("div");
+              row.className = "meta";
+              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle);cursor:pointer";
+              row.innerHTML = `<b>${escapeHtml(t.name)}</b>`
+                + (t.isolate ? ` · isolate ${escapeHtml(t.isolate)}` : "")
+                + (t.hide_classes?.length ? ` · hides ${t.hide_classes.length}` : "")
+                + (t.rules?.length ? ` · ${t.rules.length} colour rule(s)` : "");
+              row.title = "Resolve against this model and apply";
+              row.onclick = async () => {
+                let v;
+                try { v = await api.resolveViewTemplate(pid, t.id); }
+                catch (e) { toast((e as Error).message, "error"); return; }
+                // Resolve first, report second, apply third. A template that resolves to NOTHING on
+                // this model would otherwise isolate an empty set and read as "the model vanished".
+                if (!v.visible.length) {
+                  notify(`"${t.name}" matches no elements in this model — nothing applied`, "info");
+                  return;
+                }
+                await layerMgr.isolateGuids(v.visible.slice(0, 5000));
+                notify(`Applied "${t.name}" — ${v.visible_count} visible, ${v.hidden_count} hidden`
+                  + (v.colored_count ? `, ${v.colored_count} coloured` : ""), "success");
+              };
+              body.appendChild(row);
+            }
+            body.appendChild(resultNote("Applying isolates and colours — it does not change the model.", ""));
+          });
+        })));
+
+        // CLASH-IMPORT — bring in clash results authored elsewhere (Navisworks and friends). Additive:
+        // it imports findings, it does not modify geometry.
+        const clashXml = document.createElement("input");
+        clashXml.type = "file"; clashXml.accept = ".xml"; clashXml.style.display = "none";
+        clashXml.onchange = async () => {
+          const f = clashXml.files?.[0];
+          if (!f) return;
+          await withLoading(container, "Importing clash XML", async () => {
+            try {
+              const res = await api.importClashXml(pid, f);
+              notify(`Imported ${res.imported ?? 0} clash result(s) from ${f.name}`, "success");
+              await refreshIssues();
+            } catch (e) { toast((e as Error).message, "error"); }
+          });
+          clashXml.value = "";        // so re-picking the same file fires change again
+        };
+        b.appendChild(clashXml);
+        b.appendChild(toolBtn2("📥 Import clash XML (from another tool)", () => clashXml.click()));
+
         // ENVELOPE-R — assembly build-ups with R/U values. Each assembly carries its GUIDs, so the
         // list selects; a thermal report you cannot point at in the model is a spreadsheet.
         b.appendChild(toolBtn2("🧱 Envelope assemblies (R / U values)", () => withLoading(container, "Reading assemblies", async () => {

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -111,6 +111,72 @@ export function buildQaSection(d: QaDeps): void {
             if (d!.hygiene.issues) body.appendChild(resultNote(`<b>${d!.hygiene.issues}</b> model-hygiene issue(s) — see Model Health.`, "bad"));
           });
         })));
+        // INTEROP-RT — the round-trip verdict, which nothing could show. It serialises the model,
+        // re-parses it and compares GUID stability, class, name, containment, type and psets.
+        // **GUID stability is a project non-negotiable** and the whole edit-recipe architecture rests
+        // on it; this endpoint checks it and had no client caller, so the promise was unverifiable
+        // from the product. Distinct from `roundtripDiff`, which compares a file YOU bring back —
+        // this one asks whether OUR OWN export is lossless.
+        b.appendChild(toolBtn2("🔁 Round-trip fidelity (is our export lossless?)", () => withLoading(container, "Serialising and re-parsing", async () => {
+          let r;
+          try { r = await api.modelRoundtrip(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = r.fidelity_ok ? "round-trip clean" : `${r.counts.missing + r.counts.added + r.counts.changed} discrepancy(ies)`;
+          showResult("Round-trip fidelity", (body) => {
+            body.appendChild(resultNote(r!.fidelity_ok
+              ? `<b>Lossless</b> — all ${r!.element_count} elements survived serialise → re-parse with GUID, class, name, containment, type and psets intact.`
+              : `<b>Not lossless</b> — ${r!.counts.missing} missing · ${r!.counts.added} added · ${r!.counts.changed} changed, of ${r!.element_count} elements.`,
+              r!.fidelity_ok ? "ok" : "bad"));
+            // MISSING is the one that matters most: an element that does not survive our own export
+            // is data loss, and GUID stability is what every recipe and every pin depends on.
+            for (const [label, guids] of [["Missing after round-trip", r!.missing], ["Appeared after round-trip", r!.added]] as const) {
+              if (!guids.length) continue;
+              const row = document.createElement("div");
+              row.className = "meta"; row.style.cssText = "margin-top:4px;cursor:pointer";
+              row.innerHTML = `<b>${label}</b>: ${guids.length}`;
+              row.title = "Select these elements";
+              row.onclick = async () => { await selectMap(await sets.fromGuids(guids.slice(0, 200))); };
+              body.appendChild(row);
+            }
+            if (r!.changed.length) {
+              body.appendChild(resultNote("<b>Changed</b> — survived, but an aspect differs:", ""));
+              body.appendChild(kvTable(r!.changed.slice(0, 50).map((c) => ({
+                k: escapeHtml(c.class), v: escapeHtml(c.aspects.join(", ")),
+              }))));
+            }
+          });
+        })));
+
+        // AUTH-CONSTRAINTS — the model's OWN constraint graph: broken RelVoids/RelFills hosts,
+        // dangling fills, storey-containment disagreements. Errors and warnings on the model's
+        // internal consistency, with no way to see them until now.
+        b.appendChild(toolBtn2("🔗 Constraint graph (hosts, fills, containment)", () => withLoading(container, "Validating constraint graph", async () => {
+          let r;
+          try { r = await api.modelConstraints(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = r.issue_count ? `${r.errors} error(s) · ${r.warnings} warning(s)` : "constraint graph clean";
+          showResult("Constraint graph", (body) => {
+            body.appendChild(resultNote(r!.issue_count
+              ? `<b>${r!.errors}</b> error(s) · <b>${r!.warnings}</b> warning(s) across `
+                + `${r!.checked.openings} opening(s), ${r!.checked.elements_level_checked} element(s), ${r!.checked.storeys} storey(s).`
+              : `No broken hosts, dangling fills or containment disagreements — `
+                + `${r!.checked.openings} opening(s) and ${r!.checked.storeys} storey(s) checked.`,
+              r!.errors ? "bad" : r!.warnings ? "" : "ok"));
+            // The note carries what was SKIPPED as unmeasurable. Dropping it would turn "we could not
+            // check these" into "these are fine", which is the difference the route is careful about.
+            if (r!.note) body.appendChild(resultNote(escapeHtml(r!.note), ""));
+            for (const i of r!.issues.slice(0, 100)) {
+              const row = document.createElement("div");
+              row.className = "meta";
+              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle);cursor:pointer";
+              row.innerHTML = `${i.severity === "error" ? "🔴" : "🟡"} <b>${escapeHtml(i.name || i.guid)}</b> `
+                + `· ${escapeHtml(i.ifc_class)} — ${escapeHtml(i.detail)}`;
+              row.title = "Select this element";
+              row.onclick = () => { void selectByGuid(i.guid, true); };
+              body.appendChild(row);
+            }
+          });
+        })));
         // SOURCES-1 — what governs the selected element. `elementSources` had no client caller, so
         // the answer to "why is this wall like this?" existed server-side and nowhere else.
         b.appendChild(toolBtn2("🔎 Element sources (what governs this?)", () => withLoading(container, "Reading provenance", async () => {

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -111,6 +111,106 @@ export function buildQaSection(d: QaDeps): void {
             if (d!.hygiene.issues) body.appendChild(resultNote(`<b>${d!.hygiene.issues}</b> model-hygiene issue(s) — see Model Health.`, "bad"));
           });
         })));
+        // ENVELOPE-R — assembly build-ups with R/U values. Each assembly carries its GUIDs, so the
+        // list selects; a thermal report you cannot point at in the model is a spreadsheet.
+        b.appendChild(toolBtn2("🧱 Envelope assemblies (R / U values)", () => withLoading(container, "Reading assemblies", async () => {
+          let r;
+          try { r = await api.modelAssemblyThermal(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          const list = r.assemblies || [];
+          out.textContent = `${list.length} assembly(ies)`;
+          showResult("Envelope assemblies", (body) => {
+            if (!list.length) { body.appendChild(resultNote("No layered assemblies found in this model.", "")); return; }
+            for (const a of list) {
+              const row = document.createElement("div");
+              row.className = "meta";
+              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle)";
+              row.innerHTML = `<b>${escapeHtml(a.name || "unnamed")}</b> · ${a.element_count} element(s) · `
+                + `${a.thickness_m}m · R ${a.r_value} (${a.r_value_imperial} imp)`;
+              if (a.guids?.length) {
+                row.style.cursor = "pointer"; row.title = `Select ${a.guids.length} element(s)`;
+                row.onclick = async () => { await selectMap(await sets.fromGuids(a.guids.slice(0, 200))); };
+              }
+              body.appendChild(row);
+              if (a.layers?.length) {
+                body.appendChild(kvTable(a.layers.map((l) => ({
+                  k: `· ${escapeHtml(l.name)}`, v: `${l.thickness_m}m · R ${l.r_value}`,
+                }))));
+              }
+            }
+          });
+        })));
+
+        // SHARED-PARAMS — the project's shared parameter definitions. A standards convention the
+        // model is authored against, with no way to see what it actually is.
+        b.appendChild(toolBtn2("📐 Shared parameters (project standard)", () => withLoading(container, "Reading shared parameters", async () => {
+          let r;
+          try { r = await api.sharedParams(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = `${r.params.length} parameter(s)`;
+          showResult("Shared parameters", (body) => {
+            if (!r!.params.length) {
+              body.appendChild(resultNote("No shared parameters defined for this project.", ""));
+              return;
+            }
+            body.appendChild(resultNote(`<b>${r!.params.length}</b> of a maximum ${r!.max}.`, ""));
+            body.appendChild(kvTable(r!.params.map((x) => ({
+              k: `${escapeHtml(x.pset)}.${escapeHtml(x.name)}`,
+              v: `${escapeHtml(x.ptype)} · ${escapeHtml(x.applies_to)}${x.description ? " — " + escapeHtml(x.description) : ""}`,
+            }))));
+          });
+        })));
+
+        // WIP-PROGRESS — installed vs total. `available` is a real answer: without verified progress
+        // there is nothing to report, and rendering 0% would assert that nothing is installed.
+        b.appendChild(toolBtn2("📈 Model progress (installed vs total)", () => withLoading(container, "Reading progress", async () => {
+          let r;
+          try { r = await api.wipModelProgress(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          if (!r.available) {
+            out.textContent = "no progress data";
+            showResult("Model progress", (body) => body.appendChild(resultNote(
+              escapeHtml(r!.note || "No verified progress recorded yet.")
+              + " — that is not the same as 0% complete.", "")));
+            return;
+          }
+          out.textContent = `${r.percent_complete ?? r.percent_complete_count ?? 0}% complete`;
+          showResult("Model progress", (body) => {
+            body.appendChild(resultNote(`<b>${r!.installed_elements ?? 0}</b> of <b>${r!.total_elements ?? 0}</b> `
+              + `element(s) installed · <b>${r!.percent_complete_count ?? 0}%</b> by count`
+              + (r!.method ? ` · method: ${escapeHtml(r!.method)}` : ""), ""));
+            if (r!.quantity) {
+              body.appendChild(kvTable([
+                { k: "Quantity basis", v: escapeHtml(r!.quantity) },
+                { k: "Elements with quantity", v: String(r!.elements_with_quantity ?? 0) },
+                { k: "Installed / total", v: `${r!.installed_quantity ?? 0} / ${r!.total_quantity ?? 0}` },
+                { k: "Percent by quantity", v: `${r!.percent_complete_quantity ?? 0}%` },
+              ]));
+            }
+            if (r!.note) body.appendChild(resultNote(escapeHtml(r!.note), ""));
+          });
+        })));
+
+        // FEDERATION-LIST — the models registered SERVER-side, beside the existing upload. The
+        // viewer's own federation list shows what is loaded in this session; this shows what the
+        // project actually holds, which is a different question and the one an upload answers to.
+        b.appendChild(toolBtn2("🗃 Registered models (server-side federation)", () => withLoading(container, "Listing models", async () => {
+          let r;
+          try { r = await api.projectModels(pid); }
+          catch (e) { toast((e as Error).message, "error"); return; }
+          out.textContent = `${r.length} registered model(s)`;
+          showResult("Registered models", (body) => {
+            if (!r!.length) {
+              body.appendChild(resultNote("No discipline models registered for this project yet.", ""));
+              return;
+            }
+            body.appendChild(kvTable(r!.map((m) => ({
+              k: escapeHtml(m.discipline || "(no discipline)"),
+              v: `${escapeHtml(m.id)}${m.created_at ? " · " + escapeHtml(m.created_at.slice(0, 10)) : ""}`,
+            }))));
+          });
+        })));
+
         // FILL-MATRIX — property completeness by class, with the worst gaps named. The data-quality
         // question every IDS / COBie handover turns on, computed and unreachable.
         b.appendChild(toolBtn2("📊 Property fill matrix (completeness by class)", () => withLoading(container, "Measuring property fill", async () => {

--- a/apps/web/src/viewer/warningSample.test.ts
+++ b/apps/web/src/viewer/warningSample.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { guidsFromSample, isGuid } from "./warningSample";
+
+/**
+ * WARN-1 — every shape below is taken from a real producer in
+ * `services/api/src/aec_api/model_qa.py`, not invented. The feed types `sample` as `unknown[]`
+ * because the producers genuinely disagree, so the fixtures are the point of this file.
+ *
+ * The case that carries the weight is `overlapping_duplicates`: its entries are `{class, location,
+ * count}` with **no guid**, because a stack of duplicates is identified by where it is, not by which
+ * element it is. A UI that offers that row a zoom affordance ships a click that does nothing.
+ */
+
+const GUID_A = "1a2B3c4D5e6F7g8H9i0JkL";   // 22 chars of the IFC base-64 alphabet
+const GUID_B = "9z8Y7x6W5v4U3t2S1r0QpO";
+
+describe("isGuid recognises an IFC GlobalId and not merely a string", () => {
+  it("accepts a 22-character IFC id", () => {
+    expect(isGuid(GUID_A)).toBe(true);
+    // Length is the whole check, so the boundary needs a fixture that is genuinely short. My first
+    // attempt here was 22 characters and asserted `false`; the test failed and the CODE was right.
+    expect(isGuid("0$_zZ9876543210abcde")).toBe(false);    // 20 — too short
+    expect(isGuid("0$_zZ9876543210abcdefGH")).toBe(false); // 23 — too long
+  });
+
+  it("rejects prose that happens to be in a sample", () => {
+    // Samples carry labels and notes alongside offenders. Treating any string as a GUID would send
+    // the viewer looking for an element called "Room is not enclosed".
+    expect(isGuid("Room is not enclosed")).toBe(false);
+    expect(isGuid("")).toBe(false);
+    expect(isGuid(42)).toBe(false);
+  });
+});
+
+describe("the real sample shapes", () => {
+  it("duplicate_guids — plain strings", () => {
+    expect(guidsFromSample([GUID_A, GUID_B])).toEqual([GUID_A, GUID_B]);
+  });
+
+  it("orphans / blank / unenclosed — objects carrying the guid", () => {
+    expect(guidsFromSample([
+      { class: "IfcWall", name: "W-1", guid: GUID_A },
+      { class: "IfcSpace", name: null, guid: GUID_B },
+    ])).toEqual([GUID_A, GUID_B]);
+  });
+
+  it("overlapping_duplicates — groups with NO guid yield nothing", () => {
+    // The row exists and is worth showing; it simply cannot be zoomed to. Returning [] is what lets
+    // the caller render it without a dead click.
+    expect(guidsFromSample([
+      { class: "IfcColumn", location: [0, 0, 0], count: 3 },
+      { class: "IfcBeam", location: [1, 2, 0], count: 2 },
+    ])).toEqual([]);
+  });
+
+  it("a mixed sample keeps the offenders and drops the rest", () => {
+    expect(guidsFromSample([
+      GUID_A,
+      { class: "IfcColumn", location: [0, 0, 0], count: 3 },
+      { guid: GUID_B },
+      "not a guid",
+      null,
+      7,
+    ])).toEqual([GUID_A, GUID_B]);
+  });
+});
+
+describe("robustness the caller depends on", () => {
+  it("de-duplicates while preserving order", () => {
+    // Order follows the server's worst-first sort; re-sorting here would disagree with the row the
+    // user clicked.
+    expect(guidsFromSample([GUID_B, GUID_A, GUID_B])).toEqual([GUID_B, GUID_A]);
+  });
+
+  it("reads a guids[] list where a producer carries several", () => {
+    expect(guidsFromSample([{ guids: [GUID_A, GUID_B] }])).toEqual([GUID_A, GUID_B]);
+  });
+
+  it("survives a sample that is not an array", () => {
+    // The field is typed `unknown[]`, which is a promise the server makes and not one this code can
+    // rely on — a 500-shaped body or an older build reaches here as whatever it is.
+    for (const bad of [undefined, null, "guids", 3, {}]) {
+      expect(guidsFromSample(bad)).toEqual([]);
+    }
+  });
+});

--- a/apps/web/src/viewer/warningSample.ts
+++ b/apps/web/src/viewer/warningSample.ts
@@ -1,0 +1,51 @@
+// WARN-1 — pull the offender GUIDs out of a model-warning's sample.
+//
+// The feed's rows carry `sample: unknown[]`, and that is not laziness in the type: the producers
+// genuinely disagree. Checked against `services/api/src/aec_api/model_qa.py` rather than guessed:
+//
+//   duplicate_guids        -> ["1a2b…", "3c4d…"]                    plain GUID strings
+//   orphans / blank        -> [{ class, name, guid }]               objects carrying the guid
+//   unenclosed / wrong_storey -> [{ name, guid, … }]                same
+//   overlapping_duplicates -> [{ class, location, count }]          **no guid at all**
+//
+// The server's own `_qa_sample` already normalises across two different KEYS (`sample`, `groups`);
+// this normalises across the element SHAPES underneath them.
+//
+// **The last row is the one that matters.** A group of stacked duplicates is identified by class and
+// location, not by GUID, so there is nothing to select. A UI that offers every row a zoom affordance
+// gives that row a click that does nothing — the silent-failure shape this codebase keeps finding.
+// Returning an empty list is the honest answer, and the caller is expected to render accordingly.
+
+/** An IFC GlobalId is 22 characters of the IFC base-64 alphabet. */
+const GUID_RE = /^[0-9A-Za-z_$]{22}$/;
+
+/** True for a string that is actually an IFC GlobalId, not just any string in the sample. */
+export function isGuid(v: unknown): v is string {
+  return typeof v === "string" && GUID_RE.test(v);
+}
+
+/**
+ * Every GUID this sample can offer, de-duplicated and order-preserving.
+ *
+ * Order is preserved because the server sorts the punch list worst-first and the sample follows that
+ * order; re-sorting here would silently disagree with the row the user clicked.
+ */
+export function guidsFromSample(sample: unknown): string[] {
+  if (!Array.isArray(sample)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (g: unknown) => {
+    if (isGuid(g) && !seen.has(g)) { seen.add(g); out.push(g); }
+  };
+  for (const entry of sample) {
+    if (isGuid(entry)) { push(entry); continue; }
+    if (entry && typeof entry === "object") {
+      const o = entry as Record<string, unknown>;
+      push(o.guid);
+      // A few producers carry a list rather than a single offender.
+      if (Array.isArray(o.guids)) for (const g of o.guids) push(g);
+    }
+    // Anything else — a group keyed by class+location, a bare count — contributes nothing, on purpose.
+  }
+  return out;
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -282,7 +282,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-ELEMENT-CARD ② *(moved from E 2026-08-06 — the cell said E, the item's own text says the remaining work is "purely call sites: RFI, estimate line, pay app, COBie row", which live in `apps/web/src/ui/` and `apps/web/src/portal/panels/`. **A lane's paths and a lane's items are two claims and only the first is tested**, so the cell drifted from the item under it)* · R24-CHARTS-GRAMMAR · R24-REPORTS-BY-MOMENT · R24-DENSITY ② · R24-MONO-DATA · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R36-ROOM-BRIEFS · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-AGENT-PACKS · R22-PROVENANCE · R22-PIPELINE · R22-ROUTINES · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R40-EOT ② · R39-UPLOAD-CAP-APP ①◧ · R41-FDD-INGEST · R41-CLASH-TRIAGE · R41-COMMERCIAL-DRIFT · R41-UPLOAD-WARK |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | SEC-PLUGIN-SANDBOX *(moved from C 2026-08-05 — the item said "Lane **D**, not C" all along; while one ID covered two items the table could not be right about both)* · R38-PLAN-IDENTITY ③ · R38-PLAN-TRANSFORM ③ *(new 2026-08-06 — blocks R38-SYNC-VIEW's cursor sync)* · R38-ARRAY-LIVE ③ · R21-4D-CLASH · R28-BUNDLE ② — **the three that landed in PRs #176/#178/#179 on 2026-08-02** (R28-ICDD, R23-STOREY-LOD, R28-UNIFY) are shipped and pending archive. **Corrected 2026-08-06: this read "all SHIPPED and MERGED", which was false for 8 of the 11 codes beside it** — SEC-PLUGIN-SANDBOX is ◧ with its `setrlimit` half explicitly REFUSED, R38-SYNC-VIEW and R21-4D-CLASH are ◧, and five carry no marker at all. A row-level word like "all" has no defined scope, so it drifts the moment the row grows; the item markers are the authority and this sentence is not. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* · R41-IDS-VALIDATE |
-| **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` |A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · R28-VIEWER ④ · R22-PUBLIC-VIEWER · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* · R41-MODEL-ALIGN |
+| **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` |A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · R28-VIEWER ④ · R22-PUBLIC-VIEWER · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R41-REACH-WRITES · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* · R41-MODEL-ALIGN |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | — |
@@ -2162,6 +2162,28 @@ requiring a manual read** — filed below as R41-LICENCE-GATE.
   *Filed by the session that found it rather than fixed on the spot: the files belonged to other
   sessions' worktrees, and the `git worktree remove --force` incident is precisely why a measurement
   gets reported and someone who owns the tree does the deleting.*
+
+- **R41-REACH-WRITES** *(M — Lane E — **split out of the reach sweep 2026-08-07, deliberately not
+  built**)* — the write-side endpoints that have no screen, held back because **each one needs a
+  confirmation or recovery step designed rather than bolted on**. The read-side sweep took
+  `UNCALLED_CEILING` from 131 to 104 by wiring seventeen capabilities; these four were left because
+  wiring them the same way would ship a control that can lose work.
+
+  | method | why it is not a read-side wiring job |
+  |---|---|
+  | `deleteProjectModel` | **destructive.** Removes a registered discipline model. Needs a named confirmation ("type the discipline"), and an answer to what happens to pins, clash results and issues that reference it. |
+  | `saveSharedParams` | **`PUT` replaces the whole list.** A partial save silently wipes the project standard every other model is authored against. Needs edit-in-place semantics, or a diff-and-confirm. |
+  | `reviewModelVersion` | a **state transition** (`submit`/`approve`/`reject`). Approval is an assertion a person makes; the seal work already established that a bearer token is a session, not a person. Needs the same step-up thinking. |
+  | `deleteView` | destructive, same shape as the first row and cheaper — probably lands with it. |
+
+  **What is already done and should not be redone:** the read/apply halves are wired.
+  `viewTemplates` + `resolveViewTemplate` apply a saved view (isolate + colour, reversible),
+  `importClashXml` imports findings additively, and `sharedParams` displays the standard read-only.
+  So each row above is *"add the write to an existing screen"*, not *"build a screen"*.
+
+  **The general rule this item exists to hold:** a reach sweep is allowed to wire anything that
+  cannot lose work, and must stop at anything that can. Wiring a destructive endpoint with the same
+  three lines as a read-only one is how a ratchet's progress starts costing more than it buys.
 
 - **R41-BUNDLER-SPLIT** *(S — Lane J)* — **the suite never exercises the bundler that ships.** The app
   is *built* with **Vite 8 / rolldown** (pinned in `apps/web/package.json`, installed nested at


### PR DESCRIPTION
## R38-SOLVER-LOCKS — dimensional locks, wired end to end

The solver shipped in v0.3.701. `POST /projects/{pid}/constraints/solve` has had **no client caller since** — it was pure computation nobody could reach. It now has one, and a screen behind it.

## The solving was never the missing piece

`solve(variables, constraints)` takes a flat dict of named scalars and "neither reads nor writes the model" in its own words. What was missing is the **mapping**: something has to decide that `thickness` on a wall writes through `set_wall_thickness(guid, …)` while `depth` on a column writes through `set_extrusion_depth(guid, …)`.

**Every write goes through an existing guid-keyed recipe.** No new recipe was needed — which took two wrong answers to establish, and the way it went wrong is worth recording. The recipes that are the *wrong* granularity have guessable names (`edit_type_params` is type-level, `set_pset_on_class` is class-level, `set_storey_elevation` is storey-specific), so a grep for setter names finds exactly those and stops. The 14 single-element writes live in a **dispatch table keyed by `p["guid"]`**. I claimed the write path existed, then "corrected" myself to say it didn't, then verified properly by enumerating the whole table. *If a claim is load-bearing, enumerate the table rather than the functions you can name.*

## `move_element` takes deltas

The one way this mapping can produce a *wrong model* rather than refuse. Passing a solved absolute as `dx` moves the element to `current + target` instead of `target` — plausible geometry in the wrong place. The delta is computed from the variable's own `current`, which is why `LockVariable` carries it. Mutation-checked, including a negative-delta control: a mapping that passed the absolute through still looks right for a move away from the origin, and only diverges visibly when the delta should be negative.

## Three things it refuses to do quietly

Each is the solver's own argument for existing, made reachable:

- **A conflict is named.** Its docstring: *"an over-constrained system NAMES the conflict"*. Satisfying one of a contradictory pair silently produces geometry that looks deliberate and is not.
- **Remaining freedom is reported.** `dof > 0` means infinitely many solutions and one was picked — how a "solved" sketch drifts on the next edit.
- **Refusals are shown twice** — in the plan, and again after applying, because the second is when someone reads the result as finished. `Applied 3` alone is the silent-drop failure, the same shape as a reserve suggestion printed without its verification flag.

A variable with no recipe is refused **by name** and the rest still apply. A partial apply that says what it couldn't write is honest; one that drops them silently produces a model that looks like it satisfies the locks and doesn't.

## Placement, and the ratchet

The panel lives in the **authoring section** rather than its own builder: `app.ts` is at its size pin and a new builder entry costs lines it doesn't have — and locks *are* authoring, so that's where the ratchet was pointing. `app.ts` stays at exactly **3,715**; the one dependency it gains fits on an existing line, and the explanation went into the module, which is what the ratchet is for.

`selectedGuid` crosses as an **accessor**. It's a `let` that changes on every pick, so a value copy would compile cleanly and freeze whatever was selected when the panel was *built* — the locks editor would then silently edit the wrong element for the rest of the session.

## Verification

- **Mutation-checked three ways**: passing the absolute as a delta kills both move tests; dropping refusals kills three; treating a missing solver value as "unchanged" kills two.
- Paired controls throughout — negative deltas, an epsilon that must not swallow real edits, a refusal that must reach the summary.
- Full web suite green (**1,428 tests**), `tsc` + `eslint` clean, both size ratchets satisfied, `test_route_reachability` / `test_reachable` / `test_claude_md_gates` green.

## Scope

Within-element locks (`fix`, required tier). Across-element locks are the separate later item the user sequenced behind this one; the solver already handles them, so that work is UI and variable-naming, not capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Dimensional Locks** authoring tool for fixing selected model values.
  * Automatically solves constraints, applies supported changes, and refreshes the model.
  * Reports conflicts, unresolved degrees of freedom, unsupported changes, and failed updates.
  * Added expanded QA, model analysis, federation, provenance, validation, and coordination tools.
  * Warning samples can identify and select related model elements.
  * Added starter parameters for additional visual authoring recipes.

* **Bug Fixes**
  * Prevents invalid, unsupported, or negligible solver results from being applied.
  * Ensures tools use the latest selected element and placement point.

* **Tests**
  * Added coverage for dimensional locks, warning handling, and selection-state regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->