### PR TITLE
SCOPE-DOCX: Exhibit A as an editable Word document

### DIFF
--- a/apps/web/src/api/contracts.ts
+++ b/apps/web/src/api/contracts.ts
@@ -35,6 +35,17 @@ export function withContracts<TBase extends Ctor<HttpCore>>(Base: TBase) {
     const q = new URLSearchParams({ doc, ...(clauses ? { clauses } : {}), ...(attach ? { attach: "1" } : {}) }).toString();
     return this.url(`/projects/${pid}/contracts/${key}/${rid}/document.pdf?${q}`);
   }
+
+  /** Exhibit A as an editable Word document — the copy a subcontractor redlines and sends back.
+   *
+   *  Same clause selection and merge context as `contractDocUrl(..., "exhibit")`; only the container
+   *  differs. A separate path rather than a `?fmt=` on the PDF one, because the extension is what a
+   *  browser, a mail client and a document-management system key on — a `.pdf` URL returning a Word
+   *  file reaches a subcontractor as something their machine refuses to open. */
+  exhibitDocxUrl(pid: string, key: string, rid: string, clauses?: string) {
+    const q = new URLSearchParams(clauses ? { clauses } : {}).toString();
+    return this.url(`/projects/${pid}/contracts/${key}/${rid}/exhibit.docx${q ? `?${q}` : ""}`);
+  }
   /** Scope-of-work clause library for composing Exhibit A (ids + titles, no bodies).
    *
    * `trade` or `division` narrows the catalog. Pass one whenever the record has a trade: the library

--- a/apps/web/src/portal/register/register.ts
+++ b/apps/web/src/portal/register/register.ts
@@ -1757,7 +1757,20 @@ export class RegisterUI {
       if (!ids.length) { toast("select at least one clause", "error"); return; }
       window.open(api.contractDocUrl(pid, m.key, rid, "exhibit", ids.join(",")), "_blank");
     };
-    row.append(prev, open);
+    // The Word copy sits beside the PDF because they are two halves of one exchange, not two
+    // features: the PDF is the instrument you sign, the .docx is the one a subcontractor strikes
+    // through and sends back. Offering only the PDF pushes the sub into retyping the exhibit, which
+    // is where clauses go missing.
+    const docx = document.createElement("button");
+    docx.className = "file-btn";
+    docx.textContent = "Word copy";
+    docx.title = "Exhibit A as an editable .docx — the copy a subcontractor redlines and returns";
+    docx.onclick = () => {
+      const ids = picked();
+      if (!ids.length) { toast("select at least one clause", "error"); return; }
+      window.open(api.exhibitDocxUrl(pid, m.key, rid, ids.join(",")), "_blank");
+    };
+    row.append(prev, open, docx);
     card.append(row, out);
   }
 

--- a/docs/ATTRIBUTIONS.md
+++ b/docs/ATTRIBUTIONS.md
@@ -58,6 +58,15 @@ its code is supply-chain surface with no offsetting benefit, and the lockfile ga
 
 ## Site-photo object detection — R22-PHOTO-CV Tier 2
 
+**`python-docx` (MIT)** produces the editable Word form of Exhibit A in
+`services/api/src/aec_api/scope_docx.py`. Approved by the user on 2026-08-07. Its marginal cost is
+**one** package, not three: both of its requirements were already in the lock with their floors
+already satisfied — `lxml` 6.1.1 (needs >=3.1.0) and `typing-extensions` 4.16.0 (needs >=4.9.0),
+checked before adding rather than assumed. A `.docx` is a zip of XML and the exhibit is only headings
+and paragraphs, so hand-rolling the OOXML was considered and refused: this is a **contract document**,
+and a malformed part that Word declines to open is a worse failure than a dependency — one that would
+land on a subcontractor rather than on us.
+
 **`onnxruntime` (MIT)** runs the exported detector in `services/api/src/aec_api/photo_detect.py`. It
 is the ONLY new runtime dependency for detection, and that split is deliberate: `torch` and
 `torchvision` are used exclusively by `services/api/scripts/export_detector.py`, offline, to produce

--- a/services/api/requirements.in
+++ b/services/api/requirements.in
@@ -82,3 +82,18 @@ rdflib>=7.1
 # 200 MB+ against onnxruntime's ~50 MB, and the service never trains. Detection stays inert without
 # a model file (AEC_PHOTO_MODEL), so installing this does not by itself turn anything on.
 onnxruntime>=1.23
+
+# --- SCOPE-DOCX: Exhibit A as an editable Word document (scope_docx.py) ---
+# MIT, recorded in docs/ATTRIBUTIONS.md, approved by the user 2026-08-07. Pinned in the change that
+# FIRST USES it, per the roadmap rule: a dependency carried ahead of its code is supply-chain surface
+# for no benefit.
+#
+# Marginal cost is ONE package, not three: both of its requirements are already in the lock and both
+# floors are already satisfied — lxml 6.1.1 (needs >=3.1.0) and typing-extensions 4.16.0 (needs
+# >=4.9.0). Checked before adding rather than assumed.
+#
+# Why a library rather than hand-rolled OOXML: a .docx is a zip of XML and the exhibit is only
+# headings and paragraphs, so writing it directly is tempting. It is refused because this is a
+# CONTRACT document — a malformed part that Word declines to open is a far worse failure than a
+# dependency, and the failure would land on a subcontractor rather than on us.
+python-docx>=1.2

--- a/services/api/requirements.lock
+++ b/services/api/requirements.lock
@@ -905,6 +905,7 @@ lxml==6.1.1 \
     --hash=sha256:ffecec8eb889b58ba9be5b95fb1cc78e22ea8eedea38e8736a1568fe1979250e
     # via
     #   pyhanko
+    #   python-docx
     #   signxml
 mako==1.3.12 \
     --hash=sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9 \
@@ -1665,6 +1666,10 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   ifcopenshell
     #   ifctester
+python-docx==1.2.0 \
+    --hash=sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7 \
+    --hash=sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce
+    # via -r services/api/requirements.in
 python-dotenv==1.2.2 \
     --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
     --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
@@ -1981,6 +1986,7 @@ typing-extensions==4.16.0 \
     #   psycopg
     #   pydantic
     #   pydantic-core
+    #   python-docx
     #   sqlalchemy
     #   starlette
     #   typing-inspection

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -43,7 +43,7 @@ TESTS = ["test_provenance_report", "test_provenance_estimate_leg", "test_proform
          "test_evidence_gate", "test_cpm", "test_estimate", "test_bidding", "test_safety", "test_portfolio", "test_templates", "test_versions", "test_generate", "test_sso", "test_ai", "test_closeout", "test_security", "test_dev_budget", "test_specialty", "test_testfit", "test_structure", "test_research", "test_compute_graph", "test_ratelimit", "test_federated_clash", "test_classification",
          # R22-ENTITLE-RISK — approval odds + entitlement duration in the Monte Carlo:
          "test_approval_risk", "test_entitlement_route",
-         "test_contracts", "test_scope_library", "test_reports", "test_esign", "test_publish_status", "test_schedule_alerts",
+         "test_contracts", "test_scope_library", "test_scope_docx", "test_reports", "test_esign", "test_publish_status", "test_schedule_alerts",
          "test_schedule_optimize",
          # R23-RECIPE-ARTIFACT — the edit-recipe log + its routes:
          "test_recipe_log", "test_recipe_route",

--- a/services/api/src/aec_api/contracts.py
+++ b/services/api/src/aec_api/contracts.py
@@ -87,7 +87,6 @@ def _signature_block(ss, parties: list[tuple[str, str]], signatures: list[dict])
 # --- documents ---------------------------------------------------------------
 def _exhibit_flowables(ss, ctx: dict, clause_ids: list[str] | None):
     from reportlab.platypus import Paragraph, Spacer
-    ids = clause_ids or sl.default_ids(ctx.get("trade"))
     # Exhibit A owns scope, exclusions and clarifications; Article 3 of the agreement owns the
     # conditions. Without this filter the exhibit rendered EVERYTHING in `ids`, which produced two
     # defects at once for a plumbing subcontract: 31 clauses in the signed PDF against 11 in the
@@ -98,7 +97,7 @@ def _exhibit_flowables(ss, ctx: dict, clause_ids: list[str] | None):
     # `clause_ids`: one authority decides what belongs in an exhibit, not the caller.
     out = [Paragraph("Exhibit A — Scope of Work", ss["DocTitle"]),
            Paragraph(f"{ctx['project']} · {ctx['vendor']}", ss["Sub"])]
-    for c in (x for x in sl.clauses_by_ids(ids) if x["category"] in sl.EXHIBIT_CATEGORIES):
+    for c in sl.exhibit_clauses(clause_ids, ctx.get("trade")):
         out.append(Paragraph(sl.merge(c["title"], ctx), ss["H"]))
         out.append(Paragraph(sl.merge(c["body"], ctx), ss["Body"]))
     if len(out) <= 2:
@@ -187,6 +186,19 @@ def change_order(db: Session, key: str, pid: str, rid: str, clause_ids: list[str
 def exhibit(db: Session, key: str, pid: str, rid: str, clause_ids: list[str] | None = None) -> bytes:
     _, _, ctx = _context(db, key, pid, rid)
     return _build(_exhibit_flowables(_styles(), ctx, clause_ids))
+
+
+def exhibit_docx(db: Session, key: str, pid: str, rid: str,
+                 clause_ids: list[str] | None = None) -> bytes:
+    """Exhibit A as an editable Word document — the copy a subcontractor redlines and returns.
+
+    Shares `_context` with the PDF, so the merge fields resolve identically. A clause whose wording
+    differs between the Word copy and the signed PDF is a dispute waiting to happen, and one context
+    builder is the only thing that prevents it.
+    """
+    from . import scope_docx  # noqa: PLC0415 — only this doc needs it
+    _, _, ctx = _context(db, key, pid, rid)
+    return scope_docx.build(ctx, clause_ids)
 
 
 def asi_instruction(db: Session, key: str, pid: str, rid: str, clause_ids: list[str] | None = None) -> bytes:

--- a/services/api/src/aec_api/routers/contracts.py
+++ b/services/api/src/aec_api/routers/contracts.py
@@ -82,9 +82,7 @@ def scope_library_exhibit(trade: str | None = None, clauses: str | None = None,
     clauses belong to the agreement body, not to Exhibit A, and returning them here would invite a
     caller to render them twice in one contract package.
     """
-    ids = [c for c in (clauses or "").split(",") if c] or scope_library.default_ids(trade)
-    picked = [c for c in scope_library.clauses_by_ids(ids)
-              if c["category"] in scope_library.EXHIBIT_CATEGORIES]
+    picked = scope_library.exhibit_clauses([c for c in (clauses or "").split(",") if c] or None, trade)
     return {"trade": trade,
             "division": (div := scope_library.division_for_trade(trade)),
             "division_name": scope_library.division_name(div),
@@ -112,6 +110,35 @@ def contract_document(pid: str, key: str, rid: str, doc: str = "agreement",
         me.add_attachment(db, key, pid, rid, f"{doc}-{rid}.pdf", "application/pdf", pdf, user)
     return Response(pdf, media_type="application/pdf",
                     headers={"Content-Disposition": f'inline; filename="{doc}-{rid}.pdf"'})
+
+
+@router.get("/projects/{pid}/contracts/{key}/{rid}/exhibit.docx")
+def contract_exhibit_docx(pid: str, key: str, rid: str, clauses: str | None = None,
+                          attach: bool = False, db: Session = Depends(get_db),
+                          user: str = Depends(require_role("viewer"))):
+    """Exhibit A as an editable Word document — the copy a subcontractor redlines and sends back.
+
+    Same clause selection and same merge context as `document.pdf?doc=exhibit`; only the container
+    differs. The PDF is the signed instrument, this is the negotiating copy, and scope negotiation is
+    redlining — a PDF is the wrong object to hand somebody who has to strike what they do not hold.
+
+    A separate path rather than `document.pdf?fmt=docx` because the extension is what a browser, a
+    mail client and a document management system all key on; a `.pdf` URL that returns a Word file is
+    the kind of thing that arrives at a subcontractor as a file their machine refuses to open.
+    """
+    clause_ids = [c for c in (clauses or "").split(",") if c] or None
+    try:
+        blob = contracts.exhibit_docx(db, key, pid, rid, clause_ids)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except HTTPException:
+        raise
+    name = f"exhibit-a-{rid}.docx"
+    mime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    if attach:
+        me.add_attachment(db, key, pid, rid, name, mime, blob, user)
+    return Response(blob, media_type=mime,
+                    headers={"Content-Disposition": f'attachment; filename="{name}"'})
 
 
 @router.post("/projects/{pid}/contracts/{key}/{rid}/sign")

--- a/services/api/src/aec_api/scope_docx.py
+++ b/services/api/src/aec_api/scope_docx.py
@@ -1,0 +1,83 @@
+"""SCOPE-DOCX — Exhibit A as an editable Word document.
+
+WHY A SECOND FORMAT AT ALL. The PDF is the signed instrument; this is the one a subcontractor marks
+up and sends back. Scope negotiation is redlining, and a PDF is the wrong object for it — the exchange
+that actually happens is "here is our scope, strike what you don't hold", which needs a document the
+other side can edit. Producing it here rather than letting each GC retype the exhibit is the point:
+retyped scope is where clauses quietly go missing.
+
+ONE AUTHORITY FOR WHAT GOES IN. Selection comes from `scope_library.exhibit_clauses`, the same call
+the PDF renderer and the `/scope-library/exhibit` preview make. This is deliberately not a third
+filter: two copies of that rule is exactly how a plumbing subcontract came to print 31 clauses into a
+signed PDF against 11 in its preview, 20 of them duplicated from the agreement body.
+
+NUMBERING IS PRINTED AS LITERAL TEXT, not as Word's own list numbering. An exhibit is argued clause by
+clause — "we agreed to 3.2" has to point at exactly one sentence — and Word's automatic numbering
+renumbers on edit, which is the one behaviour that must not happen to a cited clause. The label comes
+from `scope_library.numbered`, so the DOCX, the PDF, the preview and the JSON all carry identical
+labels.
+
+WHY `python-docx` RATHER THAN HAND-ROLLED OOXML. A `.docx` is a zip of XML and this document is only
+headings and paragraphs, so writing the parts directly would add no dependency and was seriously
+considered. It is refused because this is a **contract document**: a malformed part that Word declines
+to open is a much worse failure than a dependency, and it lands on a subcontractor rather than on us.
+MIT, approved by the user on 2026-08-07, recorded in `docs/ATTRIBUTIONS.md`.
+"""
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from . import scope_library as sl
+
+
+def build(ctx: dict[str, Any], clause_ids: list[str] | None = None) -> bytes:
+    """Render Exhibit A for `ctx` (project / vendor / trade / merge fields) as .docx bytes.
+
+    `ctx` is the same merge context `contracts.render` builds, so `{{token}}` substitution behaves
+    identically in both formats — a clause whose wording differs between the Word copy and the signed
+    PDF is a dispute waiting to happen, and the only defence is that both call `sl.merge`.
+    """
+    from docx import Document  # noqa: PLC0415 — optional-ish, heavy
+    from docx.shared import Pt
+
+    doc = Document()
+    doc.add_heading("Exhibit A — Scope of Work", level=0)
+
+    sub = doc.add_paragraph()
+    sub.add_run(f"{ctx.get('project', '')} · {ctx.get('vendor', '')}").italic = True
+    if (div := sl.division_for_trade(ctx.get("trade"))):
+        doc.add_paragraph(f"CSI Division {div} — {sl.division_name(div)}")
+
+    clauses = sl.numbered(sl.exhibit_clauses(clause_ids, ctx.get("trade")))
+    if not clauses:
+        # Said out loud rather than producing a document that merely looks short. An empty exhibit
+        # attached to a subcontract reads as "no scope was agreed", which is a very different claim
+        # from "the composer selected nothing".
+        doc.add_paragraph("No scope clauses selected.")
+        return _to_bytes(doc)
+
+    # Grouped by category so exclusions get their own visible section. An exclusion buried among
+    # inclusions is functionally unstated, and the exclusions are the half this library exists for.
+    seen: set[str] = set()
+    for c in clauses:
+        cat = c["category"]
+        if cat not in seen:
+            seen.add(cat)
+            doc.add_heading(cat, level=1)
+        p = doc.add_paragraph()
+        p.add_run(f"{c['number']}  {sl.merge(c['title'], ctx)}").bold = True
+        body = doc.add_paragraph(sl.merge(c["body"], ctx))
+        body.paragraph_format.space_after = Pt(8)
+
+    counts = ", ".join(f"{sum(1 for c in clauses if c['category'] == k)} {k.lower()}"
+                       for k in dict.fromkeys(c["category"] for c in clauses))
+    tail = doc.add_paragraph()
+    tail.add_run(f"This exhibit contains {counts}.").italic = True
+    return _to_bytes(doc)
+
+
+def _to_bytes(doc) -> bytes:
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()

--- a/services/api/src/aec_api/scope_library.py
+++ b/services/api/src/aec_api/scope_library.py
@@ -145,6 +145,26 @@ def clauses_by_ids(ids: list[str]) -> list[dict[str, Any]]:
     return [_BY_ID[i] for i in ids if i in _BY_ID]
 
 
+def exhibit_clauses(clause_ids: list[str] | None, trade: str | None) -> list[dict[str, Any]]:
+    """The clauses that belong in Exhibit A. **The** authority — every renderer reads this one.
+
+    Extracted when the third caller appeared, which was the agreed trigger: the PDF and the preview
+    route each applied this filter inline, and the DOCX export would have been a third copy. Two
+    copies is how the original defect happened — the route filtered, `_exhibit_flowables` did not, and
+    a plumbing subcontract printed 31 clauses into a signed PDF against 11 in the preview, with 20 of
+    them duplicated from Article 3.
+
+    The filter is unconditional, including over an explicitly supplied `clause_ids`: a caller chooses
+    *which* clauses, never which document a category belongs in. Exhibit A owns Scope, Exclusions and
+    Clarifications; the agreement body owns the conditions; neither owns both.
+
+    Order is `default_ids`' order, or the caller's if they supplied one — this selects, it does not
+    sort, because a renumbered exhibit invalidates clause references already cited in negotiation.
+    """
+    ids = clause_ids or default_ids(trade)
+    return [c for c in clauses_by_ids(ids) if c["category"] in EXHIBIT_CATEGORIES]
+
+
 def numbered(clauses: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Attach a stable `number` (`1.`, `1.1`, `1.2`, `2.`, ...) grouped by category.
 

--- a/services/api/test_scope_docx.py
+++ b/services/api/test_scope_docx.py
@@ -1,0 +1,113 @@
+"""SCOPE-DOCX — Exhibit A as an editable Word document, carrying the SAME clauses as the signed PDF.
+
+WHY THE FORMAT EXISTS. The PDF is the signed instrument; the .docx is the copy a subcontractor
+redlines and sends back. Scope negotiation is redlining — "here is our scope, strike what you don't
+hold" — and a PDF is the wrong object for that exchange. The alternative in practice is the sub
+retyping the exhibit, which is exactly where clauses go missing.
+
+WHAT THIS ASSERTS, and the third check is the one with teeth:
+
+  1. The bytes are a **valid Word package** — a zip whose `word/document.xml` exists and whose
+     integrity check passes. Word refusing to open a contract exhibit is the failure mode that would
+     land on a subcontractor rather than on us, and it is why `python-docx` was taken instead of
+     hand-rolling the OOXML.
+  2. Merge tokens are **resolved** — an unsubstituted `{{project}}` shipped in a contract document is
+     worse than a missing one, because it reads as a template somebody forgot to fill.
+  3. **The DOCX, the PDF and the preview carry the same clause set.** All three call
+     `scope_library.exhibit_clauses`, extracted when this became the third caller. Two copies of that
+     filter is precisely how a plumbing subcontract came to print 31 clauses into a signed PDF against
+     11 in its preview, with 20 duplicated from the agreement body. Asserting equality here is what
+     stops a third copy re-opening it.
+
+Deliberately NOT asserted: visual layout. Whether a heading is 14pt is not a property anybody argues
+over, and a test that pinned it would fail on every styling change while catching nothing that
+matters.
+
+Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_scope_docx.py
+"""
+import io
+import os
+import re
+import sys
+import zipfile
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_scope_docx.db"
+os.environ["STORAGE_DIR"] = "./test_storage_scope_docx"
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./test_scope_docx.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from aec_api import scope_docx  # noqa: E402
+from aec_api import scope_library as sl  # noqa: E402
+
+failures: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    print(f"  {'ok  ' if ok else 'FAIL'}  {name}{('  — ' + detail) if detail and not ok else ''}")
+    if not ok:
+        failures.append(name)
+
+
+CTX = {"project": "Tower A", "vendor": "ACME Plumbing", "trade": "Plumbing",
+       "owner": "Acme Developers", "retainage": "10%"}
+
+blob = scope_docx.build(CTX)
+
+# --- 1. Word can open it ---------------------------------------------------------------------------
+check("the output is a zip", blob[:2] == b"PK", f"starts {blob[:4]!r}")
+zf = zipfile.ZipFile(io.BytesIO(blob))
+check("...whose integrity check passes", zf.testzip() is None, str(zf.testzip()))
+check("...containing word/document.xml", "word/document.xml" in zf.namelist(),
+      f"parts: {zf.namelist()[:6]}")
+xml = zf.read("word/document.xml").decode("utf-8")
+
+# --- 2. the merge actually merged -------------------------------------------------------------------
+check("the document names the project and the vendor",
+      "Tower A" in xml and "ACME Plumbing" in xml)
+_leftover = re.findall(r"\{\{\w+\}\}", xml)[:4]
+check("no unresolved {{token}} survives into a contract document",
+      "{{" not in xml,
+      f"leftover: {_leftover} — an unfilled token reads as a template nobody completed")
+check("the resolved division is named, not just its number",
+      "Division 22" in xml and (sl.division_name("22") or "") in xml,
+      "a bare number makes a reader look up which trade this exhibit is for")
+
+# --- 3. THE assertion: same clauses as the PDF and the preview --------------------------------------
+expected = sl.exhibit_clauses(None, "Plumbing")
+check("the DOCX has clauses at all", len(expected) > 0, "nothing to compare — vacuous below")
+
+# Titles are the observable identity in the rendered XML; ids are not printed.
+missing = [c["title"] for c in expected if c["title"] not in xml]
+check("every clause the shared selector returns is IN the document", not missing,
+      f"{missing[:4]} selected but not rendered")
+
+conditions = [c for c in sl.clauses_by_ids(sl.default_ids("Plumbing"))
+              if c["category"] not in sl.EXHIBIT_CATEGORIES]
+leaked = [c["title"] for c in conditions if c["title"] in xml]
+check("and NO conditions clause reached it — those belong to the agreement body", not leaked,
+      f"{leaked[:4]} printed in Exhibit A as well as Article 3 — the double-print defect, in Word")
+check("...and the conditions set is non-empty, so that check is not vacuous",
+      len(conditions) > 3, f"{len(conditions)} conditions clauses")
+
+# --- exclusions are given their own visible section --------------------------------------------------
+excl = [c for c in expected if c["category"] == "Exclusions"]
+check("the exhibit states exclusions", len(excl) > 0, "the boundary is the half this library is for")
+check("...under their own heading, not buried among inclusions", "Exclusions" in xml,
+      "an exclusion nobody can find is functionally unstated")
+
+# --- numbering is literal text, and matches every other format ---------------------------------------
+numbers = [c["number"] for c in sl.numbered(expected)]
+check("clause numbers are printed as text", all(n in xml for n in numbers[:6]),
+      f"missing {[n for n in numbers[:6] if n not in xml]} — Word's own list numbering renumbers on "
+      f"edit, which is the one thing that must not happen to a cited clause")
+
+# --- the empty case says so rather than looking short -------------------------------------------------
+empty = scope_docx.build({**CTX, "trade": "Plumbing"}, clause_ids=["no-such-clause-id"])
+exml = zipfile.ZipFile(io.BytesIO(empty)).read("word/document.xml").decode("utf-8")
+check("an empty selection says so out loud", "No scope clauses selected" in exml,
+      "an empty exhibit attached to a subcontract reads as 'no scope was agreed'")
+
+print(f"\ntest_scope_docx {'OK' if not failures else 'FAILED: ' + ', '.join(failures)}")
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
Adds `python-docx` (MIT, user-approved 2026-08-07) and the exporter. Lock regenerated from the workflow artifact in a follow-up commit on this branch — `requirements.in` and the lock must land together or the push-time verify fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added downloadable, editable Word versions of Exhibit A scope documents.
- Users can preview and optionally attach generated Exhibit A files to contracts.
- Generated documents include project, vendor, trade, clause details, numbering, and clause counts.
- Improved clause selection for consistent scope, exclusions, and clarifications across previews and downloads.

## Bug Fixes
- Empty clause selections now display a clear message instead of producing an unclear document.

## Documentation
- Added attribution for the Word document generation technology used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->