### PR TITLE
UNCALLED-SWEEP Lane C/G/I — ceiling 131 → 129, and the procurement cluster is not a screen

### DIFF
--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -105,7 +105,26 @@ function reached(m: string): boolean {
   return false;
 }
 
+/**
+ * Methods that should NOT have a screen, with the condition under which that stops being true.
+ *
+ * This is deliberately not a suppression list for work nobody has got to yet — those belong in the
+ * ceiling, where they stay visible and countable. An entry here is a positive argument that wiring
+ * the method would be a mistake, and it carries the condition that would retire the entry, so it
+ * cannot quietly become permanent.
+ */
+const KNOWN_UNCALLED: Record<string, string> = {
+  // Deletes a captured schedule baseline. R40-EOT ② has just made the NAMED baseline the auditable
+  // input to an extension-of-time figure that ends up in arbitration — slip is measured against it,
+  // and the whole point of sourcing it from the record was that a typed date is unauditable. A
+  // one-click destroy beside that is a footgun, and "it has no caller" is not a reason to give it
+  // one. EXPIRY: wire it once baseline deletion is behind a confirm-and-audit step.
+  clearBaseline: "until baseline deletion is behind a confirm-and-audit step",
+};
+
 const uncalled = surface.filter((m) => !NOT_ENDPOINTS.has(m) && !reached(m));
+/** The countable set: deliberate exclusions are held separately so they cannot pad the ceiling. */
+const uncalledCountable = uncalled.filter((m) => !(m in KNOWN_UNCALLED));
 
 //: CEILING — only ever revised DOWN. The measured value on 2026-08-07, so the set cannot grow
 //: quietly. Wiring a method to a screen lowers it; adding an unreachable endpoint raises it and has
@@ -115,7 +134,20 @@ const uncalled = surface.filter((m) => !NOT_ENDPOINTS.has(m) && !reached(m));
 //: drop by TWO, for `reserveStudy` as well — that was wrong, and the number is why it was caught:
 //: `reserveStudy` already had a caller in `src/proforma/proforma.ts`, so it was never in this set.
 //: Measured by probing rather than derived from what the wiring touched.
-const UNCALLED_CEILING = 131;
+//: 131 -> 129 on 2026-08-07 (UNCALLED-SWEEP, Lane C/G/I). The drop is TWO and was MEASURED by
+//: re-running the reachability scan before and after, not derived from what was wired — the
+//: `reserveStudy` note above is exactly why. `portfolioCompare` gained a caller (the returns spread
+//: on the portfolio panel) and `clearBaseline` moved into KNOWN_UNCALLED, which the countable set
+//: now excludes. Nothing became newly uncalled.
+//:
+//: HOW THIS NUMBER WAS OBTAINED, because it matters for trusting it: `vitest` is not installed in
+//: `apps/web` and the shared clone's `src/api` differs from `origin/main` by ~795 deletions, so this
+//: file could not be executed to produce it. The delta was measured with a static reproduction of
+//: the same predicate against a clean `origin/main` worktree, which counts ~127 where this file
+//: counts 131 — a different population, so its ABSOLUTE is not a valid ceiling input. The DELTA is
+//: sound because both affected methods are present in both populations. If this run reports anything
+//: other than 129, trust this file and not the reasoning above.
+const UNCALLED_CEILING = 129;
 
 describe("client methods the application actually calls", () => {
   it("agrees with a hand-checked sample in BOTH directions", () => {
@@ -142,10 +174,10 @@ describe("client methods the application actually calls", () => {
   });
 
   it("does not grow the set of client methods no screen can reach", () => {
-    expect(uncalled.length,
-      `${uncalled.length} client methods have no caller outside src/api and tests. ` +
+    expect(uncalledCountable.length,
+      `${uncalledCountable.length} client methods have no caller outside src/api and tests. ` +
       `Wire one to a screen (lowers the ceiling) or say in the commit why another unreachable ` +
-      `endpoint is worth shipping. First 25: ${uncalled.slice(0, 25).join(", ")}`)
+      `endpoint is worth shipping. First 25: ${uncalledCountable.slice(0, 25).join(", ")}`)
       .toBeLessThanOrEqual(UNCALLED_CEILING);
   });
 

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -1381,6 +1381,40 @@ export class PortalUI {
         pc.appendChild(pt);
         this.root.appendChild(pc);
       }).catch(() => { /* prioritization is best-effort */ });
+
+      // RETURNS SPREAD — the executive roll-up above gives a BLENDED equity IRR, which is one number
+      // for the whole book and cannot show that one deal is carrying it. `/proforma/portfolio/compare`
+      // gives per-project IRR / equity multiple / yield-on-cost from each project's latest solved
+      // scenario, plus the best-and-worst spread. An `absent` return renders as em-dash, never 0%:
+      // a project with no solved scenario has not returned zero, and on a spread a fabricated zero
+      // would take the "worst" slot away from a deal that genuinely holds it.
+      void this.host.api.portfolioCompare().then((pc2) => {
+        if (!pc2.rows.length) return;
+        const card = document.createElement("div"); card.className = "dash-card"; card.style.marginTop = "10px";
+        const num = (v: number | null, f: (n: number) => string) => v == null ? "—" : f(v);
+        const ct = document.createElement("table"); ct.className = "portal-table"; ct.style.fontSize = "11px";
+        ct.innerHTML = `<thead><tr><th scope="col" style="text-align:left">Project</th><th scope="col" style="text-align:left">Scenario</th>`
+          + `<th scope="col" style="text-align:right">Equity IRR</th><th scope="col" style="text-align:right">Multiple</th>`
+          + `<th scope="col" style="text-align:right">Yield on cost</th><th scope="col" style="text-align:right">Total uses</th></tr></thead>`;
+        const cb = document.createElement("tbody");
+        for (const r of pc2.rows) {
+          const tr = document.createElement("tr"); tr.className = "kpi-click";
+          tr.innerHTML = `<td>${esc(r.project_name)}</td><td class="meta">${esc(r.scenario_name)}</td>`
+            + `<td style="text-align:right">${num(r.equity_irr, (n) => `${(n * 100).toFixed(1)}%`)}</td>`
+            + `<td style="text-align:right">${num(r.equity_multiple, (n) => `${n.toFixed(2)}x`)}</td>`
+            + `<td style="text-align:right">${num(r.yield_on_cost, (n) => `${(n * 100).toFixed(2)}%`)}</td>`
+            + `<td style="text-align:right">${num(r.total_uses, usd)}</td>`;
+          tr.onclick = () => { if (r.project_id !== here) window.location.search = `?project=${r.project_id}`; };
+          cb.appendChild(tr);
+        }
+        ct.appendChild(cb);
+        const sp = pc2.spread?.equity_irr;
+        card.innerHTML = `<b>Returns spread</b> <span class="meta">${pc2.project_count} project(s), each from its latest solved scenario`
+          + (sp && sp.best ? ` · best ${esc(sp.best)} · worst ${esc(sp.worst ?? "—")}` : "")
+          + `</span>`;
+        card.appendChild(ct);
+        this.root.appendChild(card);
+      }).catch(() => { /* returns spread is best-effort; the roll-up above stands on its own */ });
     }).catch(() => { status.className = "empty-state"; status.innerHTML = `Portfolio unavailable<span class="es-hint">Needs at least one project with schedule/budget data.</span>`; });
   }
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1503,6 +1503,36 @@ expansion (IFC already covers the named authoring tools; the image is a landscap
   dashboard: multi-project KPI strip, cross-project Gantt, EVM PV/EV/AC + SPI/CPI, risk heat map,
   milestone tracking, resource allocation by department, cost-by-project).
 
+## Reach sweep — Lane C/G/I *(2026-08-07)*
+
+**Measured, then acted on.** `UNCALLED_CEILING` **131 → 129**, the drop measured by re-running the
+scan rather than derived from what was wired.
+
+- `portfolioCompare` wired into the portfolio panel as a **returns spread**. The executive roll-up
+  gives a *blended* equity IRR — one number for the whole book, which cannot show that a single deal
+  is carrying it. This gives per-project IRR / multiple / yield-on-cost from each project's latest
+  solved scenario plus best-and-worst. An absent return renders em-dash, never 0%: a project with no
+  solved scenario has not returned zero, and a fabricated zero would take the "worst" slot from a deal
+  that genuinely holds it. **This is the R22-PIPELINE finding landing** — capability present, reach
+  absent — folded into the sweep rather than re-listed as new work.
+- `clearBaseline` → `KNOWN_UNCALLED`, **with an expiry condition**. It deletes a captured schedule
+  baseline, and R40-EOT ② has just made the *named* baseline the auditable input to an extension-of-
+  time figure that ends up in arbitration. A one-click destroy beside that is a footgun, and "it has
+  no caller" is not a reason to give it one. Retires when baseline deletion is behind a
+  confirm-and-audit step.
+
+**The procurement cluster is NOT a missing screen, and this is the correction worth carrying.** The
+sweep's premise is that every uncalled method has a live server route, so the remedy is uniformly
+"build the screen" — verified true for 110 of them. **A live route is not an available input.**
+`buyoutPackages`, `buyoutSchedule`, `procurementLevel` and `procurementLevelQuotes` are POST endpoints
+whose QTO lines must carry `{item, qty, unit, trade}`; the engine **skips any line without an `item`**
+and falls back to a single `"General"` package without a grouping key. Both model-derived sources
+(`qtoByFloor`, `estimateFromModel`) return `{ifc_class, count, unit, quantity, rate, amount}` — **no
+`item`, no trade/csi/material_class/discipline**. Nothing in the client surface returns a
+procurement-shaped line. A screen built on today's sources would render one package called "General"
+and read as "this project has no scope". **These four need a trade classification on QTO lines
+first**; that is the blocking item, not a panel.
+
 ## 🔬 R41 — EXTERNAL SCAN *(27 sources, 2026-08-06; licences read from the LICENSE file, not the README)*
 
 **Why this ring reads differently from the others.** Three of the six code repositories examined carry


### PR DESCRIPTION
Measured before building, as assigned. **16 of the measured uncalled set are in Lane C/G/I.**

## Wired

**`portfolioCompare` → a "Returns spread" on the portfolio panel.** The executive roll-up already there gives a **blended** equity IRR — one number for the whole book, which cannot show that a single deal is carrying it. This gives per-project IRR / equity multiple / yield-on-cost from each project's latest solved scenario, plus best-and-worst.

An absent return renders em-dash, **never 0%**: a project with no solved scenario has not returned zero, and on a spread a fabricated zero would take the *worst* slot away from a deal that genuinely holds it.

This is the **R22-PIPELINE premise-check landing** — capability present, reach absent — folded into the sweep rather than re-listed as new work.

## Excluded, with an expiry

**`clearBaseline` → `KNOWN_UNCALLED`.** It deletes a captured schedule baseline, and R40-EOT ② has just made the *named* baseline the auditable input to an EOT figure that ends up in arbitration. A one-click destroy beside that is a footgun, and **"it has no caller" is not a reason to give it one.**

Retires when baseline deletion is behind a confirm-and-audit step. The countable set now excludes deliberate entries so they cannot pad the ceiling.

## The ceiling drop is measured, not derived

**131 → 129.** The scan was re-run before and after and reports exactly two — `portfolioCompare` gained a caller, `clearBaseline` left the countable set — with **nothing newly uncalled**. That is the `reserveStudy` lesson: deriving the drop from what was wired gave the wrong answer once already.

**How the number was obtained, because it matters for trusting it.** `vitest` is not installed in `apps/web`, and the shared clone's `src/api` differs from `origin/main` by ~795 deletions — so this file could not be executed to produce it. The **delta** was measured with a static reproduction of the same predicate against a clean `origin/main` worktree, which counts ~127 where the gate counts 131. **A different population, so its absolute is not a valid ceiling input; the delta is sound because both affected methods are in both populations.** That reasoning sits beside the constant, with an instruction to trust the gate over it if they disagree.

## The correction worth carrying

The sweep's premise is that every uncalled method has a live server route, so the remedy is uniformly "build the screen" — verified true for 110 of them.

**A live route is not an available input.**

`buyoutPackages`, `buyoutSchedule`, `procurementLevel` and `procurementLevelQuotes` are POST endpoints whose QTO lines must carry `{item, qty, unit, trade}`. The engine **skips any line without an `item`** and falls back to a single `"General"` package when the grouping key is absent. Both model-derived sources (`qtoByFloor`, `estimateFromModel`) return `{ifc_class, count, unit, quantity, rate, amount}` — **no `item`, no trade/csi/material_class/discipline** — and nothing in the client surface returns a procurement-shaped line.

A screen built on today's sources would render **one package called "General"** and read as *"this project has no scope"*. These four need a **trade classification on QTO lines** first; that is the blocking item, not a panel.

## Verification

- Typecheck and vitest are CI's — `node_modules` is absent in a worktree and I am not claiming otherwise.
- **A declaration-order bug was caught by reading rather than running**: `uncalledCountable` referenced `KNOWN_UNCALLED` before its `const` declaration — a temporal-dead-zone throw at module load. Declaration moved above first use.