### PR TITLE
feat(reach): EST-REACH — four built endpoints get a way in; ceiling 131 → 127

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -2130,11 +2130,20 @@ export class ApiClient extends withContracts(withAuth(withProforma(withDesignOpt
       `/projects/${pid}/finance/lock`,
       { method: "PUT", body: JSON.stringify({ lock_date: lockDate, note: note ?? "" }) });
   }
-  /** FIN-INGEST — budget ↔ actuals two-way reconciliation on the cost-code spine. */
+  /** FIN-INGEST — budget ↔ actuals two-way reconciliation on the cost-code spine.
+   *
+   *  The three buckets were typed `unknown[]`, which meant the first caller had to go read
+   *  `fin_ingest.reconcile` to render a row — so the type is now the shape the server actually
+   *  returns. All three carry the same slim row; they differ only in which side had a value, and
+   *  they are deliberately NOT netted against each other.
+   */
   financeReconcile(pid: string) {
-    return this.json<{ matched: unknown[]; budget_only: unknown[]; actuals_only: unknown[];
+    type Row = { cost_code: string | null; budget: number | null; committed: number | null;
+      actual: number | null; variance: number | null };
+    return this.json<{ matched: Row[]; budget_only: Row[]; actuals_only: Row[];
       uncoded: { module: string; ref: string; amount: number; vendor?: string }[];
-      counts: Record<string, number>; fully_reconciled: boolean }>(
+      counts: { matched: number; budget_only: number; actuals_only: number; uncoded: number };
+      fully_reconciled: boolean }>(
       `/projects/${pid}/finance/reconcile`);
   }
   /** FIN-INGEST — import lineage: the project's audit-logged import batches, newest first. */

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -5,6 +5,7 @@ import { withAuthoring } from "./authoring";
 import { withRoutines } from "./routines";
 import { withContracts } from "./contracts";
 import { withDesignOptions } from "./designOptions";
+import { withFinance } from "./finance";
 import { withLibrary } from "./library";
 import { HttpCore, type LiveStream } from "./httpCore";
 import { withModel } from "./model";
@@ -37,7 +38,7 @@ import type {
 
 // Transport (baseUrl, token, json/_pdfPost/url/health) lives in HttpCore; ApiClient adds the typed
 // domain methods below. Every `api.method()` call site is unchanged by the split.
-export class ApiClient extends withContracts(withAuth(withProforma(withDesignOptions(withRoutines(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore)))))))))))) {
+export class ApiClient extends withFinance(withContracts(withAuth(withProforma(withDesignOptions(withRoutines(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore))))))))))))) {
   /** Admin: integration settings (AI / email / SSO). Secret values are never returned. */
   integrations() {
     return this.json<{ groups: IntegrationGroup[] }>("/settings/integrations");
@@ -2119,38 +2120,6 @@ export class ApiClient extends withContracts(withAuth(withProforma(withDesignOpt
       `/projects/${pid}/propmap/plan`, { method: "POST", body: JSON.stringify({ rules }) });
   }
 
-  // real-estate development finance (Proforma)
-  /** FIN-GOV — the project's locked reporting period (books closed through lock_date, or null). */
-  financeLock(pid: string) {
-    return this.json<{ lock_date: string | null; set_by?: string; set_at?: string; note?: string }>(
-      `/projects/${pid}/finance/lock`);
-  }
-  setFinanceLock(pid: string, lockDate: string | null, note?: string) {
-    return this.json<{ lock_date: string | null; set_by: string; note: string }>(
-      `/projects/${pid}/finance/lock`,
-      { method: "PUT", body: JSON.stringify({ lock_date: lockDate, note: note ?? "" }) });
-  }
-  /** FIN-INGEST — budget ↔ actuals two-way reconciliation on the cost-code spine.
-   *
-   *  The three buckets were typed `unknown[]`, which meant the first caller had to go read
-   *  `fin_ingest.reconcile` to render a row — so the type is now the shape the server actually
-   *  returns. All three carry the same slim row; they differ only in which side had a value, and
-   *  they are deliberately NOT netted against each other.
-   */
-  financeReconcile(pid: string) {
-    type Row = { cost_code: string | null; budget: number | null; committed: number | null;
-      actual: number | null; variance: number | null };
-    return this.json<{ matched: Row[]; budget_only: Row[]; actuals_only: Row[];
-      uncoded: { module: string; ref: string; amount: number; vendor?: string }[];
-      counts: { matched: number; budget_only: number; actuals_only: number; uncoded: number };
-      fully_reconciled: boolean }>(
-      `/projects/${pid}/finance/reconcile`);
-  }
-  /** FIN-INGEST — import lineage: the project's audit-logged import batches, newest first. */
-  financeImports(pid: string) {
-    return this.json<{ ts: string | null; actor: string | null; module: string; filename: string;
-      imported: number; error_count: number }[]>(`/projects/${pid}/finance/imports`);
-  }
   /** CRE-HOLDSELL — hold vs sell: incremental hold-year IRRs against the proceeds declined today. */
   holdSell(pid: string, inputs: unknown, hurdleRate = 0.12, maxYears = 10) {
     return this.json<{ computable: boolean; reason?: string;

--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -175,7 +175,15 @@ const uncalledCountable = uncalled.filter((m) => !(m in KNOWN_UNCALLED));
 //: reach. Resolved by MEASURING rather than by arithmetic: the gate's own reader reports 121
 //: countable (122 raw, less `clearBaseline` which the sweep moved into KNOWN_UNCALLED). That it
 //: also equals 129 - 8 is a check on the measurement, not the source of it.
-const UNCALLED_CEILING = 128;
+//:
+//: 128 -> 121 after rebasing EST-REACH + FIN-GOV + ⑩ onto BOE-REACH/ROUTINES. MEASURED from this
+//: gate's own reader, not computed: it reports 121 countable.
+//:
+//: The arithmetic only agrees once you notice the overlap — this PR reaches EIGHT methods but SEVEN
+//: are new, because #272 wired `estimateBoe` first. 128 - 8 = 120 would have been wrong and would
+//: have failed the gate; 128 - 7 = 121 matches. Two PRs reaching the same method is exactly the
+//: case a scalar ceiling cannot express, and the reason the number is read rather than derived.
+const UNCALLED_CEILING = 121;
 
 describe("client methods the application actually calls", () => {
   it("agrees with a hand-checked sample in BOTH directions", () => {

--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -161,6 +161,13 @@ const uncalledCountable = uncalled.filter((m) => !(m in KNOWN_UNCALLED));
 //: `reserveStudy` mistake above. It was expected to drop by four and did; `clearBaseline` stays in
 //: the set deliberately, because deleting a captured baseline that an EOT claim rests on should not
 //: be one click, and an honest marker beats a fabricated caller.
+//:
+//:
+//: 127 -> 123 (FIN-GOV reach). The whole `/finance` route group — `financeLock`, `setFinanceLock`,
+//: `financeReconcile`, `financeImports` — had no caller at all, and it is the sharper form of this
+//: defect: the period lock is ENFORCED (every finance mutation dated into a closed month is refused
+//: with a 409) while the control to see or set it was unreachable. An unreachable feature is one
+//: nobody can use; an unreachable control over an enforced rule actively blocks people.
 const UNCALLED_CEILING = 128;
 
 describe("client methods the application actually calls", () => {

--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -168,6 +168,13 @@ const uncalledCountable = uncalled.filter((m) => !(m in KNOWN_UNCALLED));
 //: defect: the period lock is ENFORCED (every finance mutation dated into a closed month is refused
 //: with a 409) while the control to see or set it was unreachable. An unreachable feature is one
 //: nobody can use; an unreachable control over an enforced rule actively blocks people.
+//:
+//:
+//: 129 -> 121 after rebasing EST-REACH + FIN-GOV onto UNCALLED-SWEEP. Both sides of that conflict
+//: lowered this number for different reasons, so taking either would have discarded the other's
+//: reach. Resolved by MEASURING rather than by arithmetic: the gate's own reader reports 121
+//: countable (122 raw, less `clearBaseline` which the sweep moved into KNOWN_UNCALLED). That it
+//: also equals 129 - 8 is a check on the measurement, not the source of it.
 const UNCALLED_CEILING = 128;
 
 describe("client methods the application actually calls", () => {

--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -151,6 +151,16 @@ const uncalledCountable = uncalled.filter((m) => !(m in KNOWN_UNCALLED));
 //: counts 131 — a different population, so its ABSOLUTE is not a valid ceiling input. The DELTA is
 //: sound because both affected methods are present in both populations. If this run reports anything
 //: other than 129, trust this file and not the reasoning above.
+//:
+//:
+//: 131 -> 127 (EST-REACH). Four endpoints that were built and had no way in:
+//: `estimateConfidence`, `estimateBoe` and `estimateConceptBudget` now hang off the `estimate`
+//: register's record actions, and `clearXer` sits beside the P6 import it undoes.
+//:
+//: Measured, not derived from what the wiring touched — the same discipline that caught the
+//: `reserveStudy` mistake above. It was expected to drop by four and did; `clearBaseline` stays in
+//: the set deliberately, because deleting a captured baseline that an EOT claim rests on should not
+//: be one click, and an honest marker beats a fabricated caller.
 const UNCALLED_CEILING = 128;
 
 describe("client methods the application actually calls", () => {

--- a/apps/web/src/api/finance.ts
+++ b/apps/web/src/api/finance.ts
@@ -1,0 +1,59 @@
+/** FIN-GOV / FIN-INGEST — the locked reporting period, two-way reconciliation, and import lineage.
+ *
+ *  SCALE-SEAM ⑩ (targeted). Route-group `/projects/{pid}/finance`, taken out of `client.ts` by the
+ *  route each method calls — the recipe ⑥ established.
+ *
+ *  **Not a sweep, and deliberately not one.** Measuring the residue of `client.ts` first showed 519
+ *  methods across 191 route groups averaging 2.7 methods each — no coherent domain left worth a
+ *  general extraction, and the largest remaining group would have moved 55 of 3,748 lines while
+ *  moving the reachability ceiling by zero. That plan was dropped on those numbers.
+ *
+ *  This one is different because the ratchet asked for it by name. Giving `financeReconcile` the
+ *  response shape it actually returns — instead of three `unknown[]` buckets that sent its first
+ *  caller to read `fin_ingest.reconcile` — cost nine lines, and `client.ts` sat at exactly its
+ *  `test_file_sizes.py` pin of 3,748. CI said `client.ts=3757 > 3748`. The file's own comment says
+ *  the friction is the point and should force *"should this live in a domain module instead?"*, and
+ *  for a four-method route group with a panel of its own the answer is yes. Pin 3,748 -> 3,726.
+ *
+ *  Reaches only `json` on `HttpCore`. A mixin, so every call site resolves unchanged;
+ *  `api/surface.test.ts` proves a move is invisible to it and a loss is not.
+ */
+import { HttpCore } from "./httpCore";
+
+type Ctor<T> = new (...args: any[]) => T;
+
+export function withFinance<TBase extends Ctor<HttpCore>>(Base: TBase) {
+  return class extends Base {
+  /** FIN-GOV — the project's locked reporting period (books closed through lock_date, or null). */
+  financeLock(pid: string) {
+    return this.json<{ lock_date: string | null; set_by?: string; set_at?: string; note?: string }>(
+      `/projects/${pid}/finance/lock`);
+  }
+  setFinanceLock(pid: string, lockDate: string | null, note?: string) {
+    return this.json<{ lock_date: string | null; set_by: string; note: string }>(
+      `/projects/${pid}/finance/lock`,
+      { method: "PUT", body: JSON.stringify({ lock_date: lockDate, note: note ?? "" }) });
+  }
+  /** FIN-INGEST — budget ↔ actuals two-way reconciliation on the cost-code spine.
+   *
+   *  The three buckets were typed `unknown[]`, which meant the first caller had to go read
+   *  `fin_ingest.reconcile` to render a row — so the type is now the shape the server actually
+   *  returns. All three carry the same slim row; they differ only in which side had a value, and
+   *  they are deliberately NOT netted against each other.
+   */
+  financeReconcile(pid: string) {
+    type Row = { cost_code: string | null; budget: number | null; committed: number | null;
+      actual: number | null; variance: number | null };
+    return this.json<{ matched: Row[]; budget_only: Row[]; actuals_only: Row[];
+      uncoded: { module: string; ref: string; amount: number; vendor?: string }[];
+      counts: { matched: number; budget_only: number; actuals_only: number; uncoded: number };
+      fully_reconciled: boolean }>(
+      `/projects/${pid}/finance/reconcile`);
+  }
+  /** FIN-INGEST — import lineage: the project's audit-logged import batches, newest first. */
+  financeImports(pid: string) {
+    return this.json<{ ts: string | null; actor: string | null; module: string; filename: string;
+      imported: number; error_count: number }[]>(`/projects/${pid}/finance/imports`);
+  }
+  };
+}

--- a/apps/web/src/portal/panels/ledger.ts
+++ b/apps/web/src/portal/panels/ledger.ts
@@ -137,4 +137,139 @@ export async function renderLedger(ctx: PanelContext) {
     }
   };
   await loadBatches();
+  await renderFinanceGovernance(ctx, pid, root, el);
+}
+
+/**
+ * FIN-GOV / FIN-INGEST — period close, two-way reconciliation, and import lineage.
+ *
+ * WHY THIS IS WORSE THAN AN ORDINARY MISSING SCREEN
+ *     The period lock is not advisory. `PUT /projects/{pid}/finance/lock` closes the books through a
+ *     month, and from then on **every finance-module mutation dated into a closed month is refused
+ *     with a 409** — routes, imports and internal flows alike. That enforcement shipped and worked.
+ *     What never shipped was any way to see the lock or set it.
+ *
+ *     So the constraint was live and its control was invisible: a user posting a cost into a closed
+ *     month got a 409 with nothing in the interface that would explain why, and no way to open the
+ *     period. An unreachable feature is a feature nobody can use; an unreachable *control over an
+ *     enforced rule* is a feature that actively blocks people. That is the sharper end of the same
+ *     defect, and the reason this group was worth taking first.
+ *
+ * All four `/finance` client methods were in the uncalled set — the whole domain had no path in.
+ */
+async function renderFinanceGovernance(
+  ctx: PanelContext, pid: string, root: HTMLElement,
+  el: (t: string, c?: string) => HTMLElement,
+) {
+  const api = ctx.host.api;
+  const head = el("div"); head.style.cssText = "margin-top:14px;font-weight:600";
+  head.textContent = "Period close & reconciliation";
+  root.appendChild(head);
+
+  // --- the lock ---------------------------------------------------------------------------------
+  const lockRow = el("div", "meta");
+  lockRow.style.cssText = "display:flex;gap:8px;align-items:center;margin:4px 0 8px;flex-wrap:wrap";
+  root.appendChild(lockRow);
+  const paintLock = async () => {
+    lockRow.textContent = "";
+    let lock;
+    try { lock = await api.financeLock(pid); }
+    catch (e) { lockRow.textContent = `lock status unavailable: ${(e as Error).message}`; return; }
+    const state = el("span");
+    state.style.fontWeight = "600";
+    // Says what it MEANS, not just the date: "closed through 2026-06" is only actionable if you know
+    // that postings into it will be refused.
+    state.textContent = lock.lock_date
+      ? `Books closed through ${lock.lock_date} — postings dated on or before it are refused`
+      : "Books open — no period is closed";
+    lockRow.append(state);
+    if (lock.lock_date && (lock.set_by || lock.note)) {
+      const who = el("span"); who.className = "meta";
+      who.textContent = `set by ${lock.set_by ?? "?"}${lock.note ? ` · ${lock.note}` : ""}`;
+      lockRow.append(who);
+    }
+    const set = el("button", "file-btn"); set.textContent = lock.lock_date ? "Change close date" : "Close a period";
+    set.onclick = async () => {
+      const v = await promptModal("Close the books", [
+        { name: "date", label: "Close through (YYYY-MM or YYYY-MM-DD)", required: true },
+        { name: "note", label: "Note (why)" },
+      ], "Close");
+      if (!v) return;
+      try {
+        await api.setFinanceLock(pid, (v.date ?? "").trim(), v.note ?? "");
+        toast("period closed", "success"); await paintLock();
+      } catch (e) { toast(`could not close: ${(e as Error).message}`, "error"); }
+    };
+    lockRow.append(set);
+    if (lock.lock_date) {
+      const clear = el("button", "file-btn"); clear.textContent = "Reopen";
+      clear.title = "Clear the lock so postings into the closed period are accepted again";
+      clear.onclick = async () => {
+        try { await api.setFinanceLock(pid, null, "reopened"); toast("period reopened", "success"); await paintLock(); }
+        catch (e) { toast(`could not reopen: ${(e as Error).message}`, "error"); }
+      };
+      lockRow.append(clear);
+    }
+  };
+  await paintLock();
+
+  // --- reconciliation ---------------------------------------------------------------------------
+  const rec = el("div"); root.appendChild(rec);
+  try {
+    const r = await api.financeReconcile(pid);
+    const c = r.counts;
+    const line = el("div", "meta");
+    // The counts are reported separately on purpose. The server matches budget and actuals BOTH ways
+    // and never nets them, because a budget line with no actual and an actual with no budget are
+    // different problems — netting them to one variance hides both.
+    line.innerHTML = `<b>${c.matched}</b> matched · <b>${c.budget_only}</b> budget with no actual · `
+      + `<b>${c.actuals_only}</b> actual with no budget · <b>${c.uncoded}</b> uncoded`
+      + (r.fully_reconciled ? " — fully reconciled" : "");
+    rec.appendChild(line);
+    // Actuals with no budget and uncoded actuals are the two that cost money; show those, highest
+    // value first (the server already sorts them that way).
+    for (const row of r.actuals_only.slice(0, 6)) {
+      const d = el("div", "meta");
+      d.style.cssText = "display:flex;gap:8px;border-top:1px solid var(--line);padding:3px 0";
+      d.append(
+        Object.assign(document.createElement("span"), { textContent: row.cost_code ?? "(no cost code)", style: "flex:1" }),
+        Object.assign(document.createElement("span"), { textContent: "no budget" }),
+        Object.assign(document.createElement("span"), { textContent: cmoney(row.actual ?? 0) }),
+      );
+      rec.appendChild(d);
+    }
+    for (const u of r.uncoded.slice(0, 6)) {
+      const d = el("div", "meta");
+      d.style.cssText = "display:flex;gap:8px;border-top:1px solid var(--line);padding:3px 0";
+      d.append(
+        Object.assign(document.createElement("span"), { textContent: `${u.ref ?? u.module} — uncoded`, style: "flex:1" }),
+        Object.assign(document.createElement("span"), { textContent: esc(u.vendor ?? "") }),
+        Object.assign(document.createElement("span"), { textContent: cmoney(u.amount ?? 0) }),
+      );
+      rec.appendChild(d);
+    }
+  } catch (e) {
+    rec.innerHTML = `<div class="meta">reconciliation unavailable: ${esc((e as Error).message)}</div>`;
+  }
+
+  // --- where the numbers came from --------------------------------------------------------------
+  try {
+    const imports = await api.financeImports(pid);
+    if (imports.length) {
+      const h = el("div"); h.style.cssText = "margin-top:10px;font-weight:600;font-size:12.5px";
+      h.textContent = "Import lineage";
+      root.appendChild(h);
+      for (const b of imports.slice(0, 8)) {
+        const d = el("div", "meta");
+        d.style.cssText = "display:flex;gap:8px;border-top:1px solid var(--line);padding:3px 0";
+        d.append(
+          Object.assign(document.createElement("span"), { textContent: b.filename || "(no file)", style: "flex:1" }),
+          Object.assign(document.createElement("span"), { textContent: b.module }),
+          Object.assign(document.createElement("span"), { textContent: `${b.imported} rows${b.error_count ? ` · ${b.error_count} errors` : ""}` }),
+          Object.assign(document.createElement("span"), { textContent: `${b.actor ?? "?"} ${b.ts ?? ""}` }),
+        );
+        root.appendChild(d);
+      }
+    }
+  } catch { /* lineage is context, not a blocker — a project with no imports has none */ }
 }

--- a/apps/web/src/portal/panels/schedule.ts
+++ b/apps/web/src/portal/panels/schedule.ts
@@ -41,6 +41,26 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
     } catch (e) { toast(`P6/MSP import failed: ${(e as Error).message}`, "error"); xerLabel.textContent = "⇪ Import P6/MSP (.xer/.xml)"; }
     finally { xerInput.value = ""; }
   };
+  // The undo for the import above. It existed server-side with no way to reach it, so a bad import
+  // could only be unwound by deleting activities by hand — which is also how somebody deletes the
+  // hand-entered ones by mistake. Scoped precisely: the route removes only the records THIS import
+  // created, via its code→id index, and leaves hand-entered activities alone. The confirm says so,
+  // because "clear the imported schedule" is otherwise indistinguishable from "clear the schedule".
+  const xerClearBtn = document.createElement("button");
+  xerClearBtn.className = "tool-btn"; xerClearBtn.dataset.cap = "edit";
+  xerClearBtn.textContent = "⌫ Clear import";
+  xerClearBtn.title = "Remove the activities created by the last P6/MSP import — hand-entered activities are untouched";
+  xerClearBtn.onclick = async () => {
+    if (!(await confirmModal(
+      "Remove the activities created by the last P6/MSP import? Hand-entered activities are NOT affected. "
+      + "Re-import the file to restore them.", ""))) return;
+    try {
+      await ctx.host.api.clearXer(pid);
+      toast("imported schedule cleared", "success");
+      void renderScheduleViews(ctx, m);
+    } catch (e) { toast(`clear failed: ${(e as Error).message}`, "error"); }
+  };
+
   const alertBtn = document.createElement("button"); alertBtn.className = "tool-btn"; alertBtn.textContent = "🔔 Alerts";
   alertBtn.title = "Predictive schedule alerts: overdue, late-start, at-risk predecessor, SPI, procurement";
   const esBtn = document.createElement("button"); esBtn.className = "tool-btn"; esBtn.textContent = "⏱ Earned schedule";
@@ -76,7 +96,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
   xerOut.onclick = doExport("xer"); mspOut.onclick = doExport("msp");
   const note = document.createElement("span"); note.className = "meta";
   note.innerHTML = "One relational schedule — these views + the 3D <b>4D sequence</b> (Model → ⏱ 4D) share the same activities.";
-  intro.append(listBtn, xerLabel, xerOut, mspOut, alertBtn, esBtn, baseBtn, lvlBtn, note);
+  intro.append(listBtn, xerLabel, xerClearBtn, xerOut, mspOut, alertBtn, esBtn, baseBtn, lvlBtn, note);
   ctx.root.appendChild(intro);
 
   // a collapsible drawer the alerts / earned-schedule buttons fill on demand (kept out of the way)

--- a/apps/web/src/portal/register/register.ts
+++ b/apps/web/src/portal/register/register.ts
@@ -1,5 +1,6 @@
 import type { ModuleDef, ModuleRecord, RecordBrief } from "../../api/client";
 import type { ModuleFilterOp } from "../../api/types";
+import { money as usd } from "../../ui/charts";
 import { statusChip } from "../../ui/chips";
 import { type RegisterEmptyKind, registerEmptyEl } from "../../ui/empty";
 import { emptyHint } from "../../ui/emptyGuide";
@@ -1648,6 +1649,248 @@ export class RegisterUI {
    *     is NOT included — that is where scope gaps come from. So the picker groups by category rather
    *     than running them together, and the preview leads with the counts.
    */
+  /**
+   * `estimate.basis` -> the phase key `est_confidence._PHASE_CONF` scores against.
+   *
+   * **Explicit, because lowercasing is wrong for two of the five and wrong in the flattering
+   * direction.** The register offers `Conceptual · Schematic · DD · CD · GMP`; the scorer keys on
+   * `concept · sd · dd · cd · gmp`. `DD`/`CD`/`GMP` survive a `.toLowerCase()`, but `"conceptual"`
+   * and `"schematic"` match nothing and fall to the unspecified default of **0.6** — which scores a
+   * concept estimate (0.45) as *more* confident than a schematic one (0.6), and rates the roughest
+   * estimates in the system above what they are. A silent default that flatters is worse than one
+   * that fails.
+   */
+  private static PHASE_FROM_BASIS: Record<string, string> = {
+    Conceptual: "concept", Schematic: "sd", DD: "dd", CD: "cd", GMP: "gmp",
+  };
+
+  /**
+   * EST-REACH — the estimate register's line items had three analyses built for them and no way in.
+   *
+   * `line_items` carries `code · description · qty · unit · unit_cost · amount · source · quote_ref
+   * · basis_date`, and its `source` options are `allowance / parametric / historical / quote` —
+   * every one a key in the confidence scorer's source table. `estimateBoe`'s line type is nearly
+   * column-for-column the same, `quote_ref` and `basis_date` included. The data model and the
+   * endpoints were built for each other; only the UI between them was missing, which is why
+   * `estimateConfidence` and `estimateBoe` sat in the uncalled set with live routes behind them.
+   *
+   * Deliberately reads the record's OWN line items rather than offering a paste box. A caller that
+   * needs the user to hand-assemble its input is a caller in name only.
+   */
+  private estimateActions(m: ModuleDef, r: ModuleRecord, tools: HTMLElement) {
+    if (m.key !== "estimate") return;
+    const pid = this.ctx.host.projectId()!;
+    const api = this.ctx.host.api;
+    const rows = (r.data?.line_items as Record<string, unknown>[] | undefined) ?? [];
+    const basis = String(r.data?.basis ?? "");
+    const phase = RegisterUI.PHASE_FROM_BASIS[basis] ?? "";
+
+    // Column names to what the endpoints read. `amount` is the table's total column, and the scorer
+    // takes `cost` OR `total` OR qty x unit_cost — sending both names costs nothing and means a row
+    // with only a computed amount is still weighted rather than silently counting as zero.
+    const lines = rows.map((row) => ({
+      cost_code: row.code ?? null, description: row.description ?? "",
+      qty: row.qty ?? null, unit: row.unit ?? null, unit_cost: row.unit_cost ?? null,
+      cost: row.amount ?? null, total: row.amount ?? null,
+      source: row.source ?? "", phase,
+      quote_ref: row.quote_ref ?? null, basis_date: row.basis_date ?? null,
+    }));
+
+    const btn = (label: string, title: string, fn: () => void) => {
+      const b = document.createElement("button");
+      b.className = "tool-btn"; b.textContent = label; b.title = title; b.onclick = fn;
+      tools.appendChild(b);
+    };
+    const guard = () => {
+      if (!lines.length) { toast("this estimate has no line items yet", "error"); return false; }
+      return true;
+    };
+
+    btn("◎ Confidence", "Score each line's maturity from its source and the estimate basis — and how much of the budget is still assumption-based", () => {
+      if (!guard()) return;
+      void this.estimateConfidenceView(pid, lines, basis, phase);
+    });
+    btn("⛁ Basis of Estimate", "The BoE assumption ledger and documentation completeness for these lines", () => {
+      if (!guard()) return;
+      void this.estimateBoeView(pid, lines);
+    });
+    // Priced from the space-program register, not from this record's lines — a concept budget exists
+    // precisely for the stage BEFORE there are line items, so it must not be gated on `guard()`.
+    btn("◫ Concept budget", "Price the space program by use against a $/area rate — before there are line items", () => {
+      void this.conceptBudgetView(pid);
+    });
+    void api;      // the views resolve the client off `this.ctx.host.api` themselves
+  }
+
+  /**
+   * Concept budget: the space-program register priced by use.
+   *
+   * The endpoint wants `program: [{use, gfa, stories?}]`, and the `space_program` register already
+   * holds exactly that in another shape — `space_type` with `target_area_sf` per unit and a
+   * `quantity`. Aggregating by type is the whole mapping; there was never any missing data, only a
+   * missing path between two registers.
+   *
+   * `history` is deliberately not sent. The endpoint derives per-type rates from a firm's completed
+   * projects, and this codebase has no completed-project cost history to draw on — inventing one to
+   * make the call look richer would price a real budget off fabricated comparables. Without it the
+   * endpoint prices at `default_rate` and **surfaces what it could not price rather than guessing**,
+   * which is the honest behaviour and the one worth surfacing in the UI.
+   */
+  private async conceptBudgetView(pid: string) {
+    let recs;
+    try { recs = await this.ctx.host.api.moduleRecords(pid, "space_program"); }
+    catch (e) { toast(`could not read the space program: ${(e as Error).message}`, "error"); return; }
+    const byUse = new Map<string, number>();
+    for (const rec of recs) {
+      const d = (rec.data ?? {}) as Record<string, unknown>;
+      const use = String(d.space_type ?? "").trim();
+      if (!use) continue;
+      const each = Number(d.target_area_sf ?? 0) || 0;
+      const qty = Number(d.quantity ?? 1) || 1;
+      if (each <= 0) continue;
+      byUse.set(use, (byUse.get(use) ?? 0) + each * qty);
+    }
+    const program = [...byUse].map(([use, gfa]) => ({ use, gfa }));
+    if (!program.length) {
+      toast("the space program register has no sized spaces yet — add Type and Target Area", "error");
+      return;
+    }
+    const v = await promptModal("Concept budget", [
+      { name: "rate", label: `$/sf where a use has no rate (${program.length} uses, ${usd([...byUse.values()].reduce((a, b) => a + b, 0))} sf)`, required: true },
+      { name: "contingency", label: "Contingency %" },
+    ], "Price");
+    if (!v) return;
+    const rate = Number(v.rate);
+    if (!Number.isFinite(rate) || rate <= 0) { toast("rate must be a positive number", "error"); return; }
+    let b;
+    try {
+      b = await this.ctx.host.api.estimateConceptBudget(pid, {
+        program, default_rate: rate, contingency_pct: Number(v.contingency) || 0,
+      });
+    } catch (e) { toast(`concept budget failed: ${(e as Error).message}`, "error"); return; }
+
+    const { card } = modalShell("Concept budget", 480);
+    const head = document.createElement("div");
+    head.style.cssText = "font-weight:600;font-size:14px";
+    head.textContent = usd(b.total);
+    const sub = document.createElement("div"); sub.className = "meta";
+    sub.textContent = `${b.line_count} uses · subtotal ${usd(b.subtotal)}`
+      + (b.contingency ? ` + ${b.contingency_pct}% contingency ${usd(b.contingency)}` : "");
+    card.append(head, sub);
+
+    // `unpriced` is a COUNT, and it is the number that matters: a total computed over a program the
+    // endpoint could not fully price is not a budget, it is a partial one, and it must not read as
+    // complete. Verified against the endpoint — with no default rate all three lines come back
+    // unpriced with `total = 0`, which would otherwise render as a confident "$0".
+    if (b.unpriced > 0) {
+      const warn = document.createElement("div"); warn.className = "meta";
+      warn.style.cssText = "margin-top:4px;font-weight:600";
+      warn.textContent = `${b.unpriced} of ${b.line_count} uses could not be priced — the total below excludes them`;
+      card.appendChild(warn);
+    }
+
+    for (const l of b.lines) {
+      const row = document.createElement("div"); row.className = "meta";
+      row.style.cssText = "display:flex;gap:8px;border-top:1px solid var(--line);padding:4px 0";
+      row.append(
+        Object.assign(document.createElement("span"), { textContent: l.use, style: "flex:1" }),
+        Object.assign(document.createElement("span"), { textContent: `${Math.round(l.gfa).toLocaleString()} sf` }),
+        // The endpoint says WHY a line is unpriced; passing that through beats rendering a blank.
+        Object.assign(document.createElement("span"), { textContent: l.source, style: "flex:1;text-align:right" }),
+        Object.assign(document.createElement("span"), {
+          textContent: l.cost == null ? "—" : usd(l.cost),
+          style: l.cost == null ? "color:var(--muted)" : "",
+        }),
+      );
+      card.appendChild(row);
+    }
+  }
+
+  /** Confidence rollup: project score, how much is still assumption-based, and the softest lines. */
+  private async estimateConfidenceView(pid: string, lines: Record<string, unknown>[], basis: string, phase: string) {
+    let c;
+    try { c = await this.ctx.host.api.estimateConfidence(pid, lines); }
+    catch (e) { toast(`confidence failed: ${(e as Error).message}`, "error"); return; }
+    const { card } = modalShell("Estimate confidence", 460);
+    const head = document.createElement("div");
+    head.style.cssText = "font-weight:600;font-size:14px";
+    head.textContent = `${Math.round(c.confidence * 100)}% confidence · ${c.band}`;
+    const sub = document.createElement("div"); sub.className = "meta";
+    // The phase is stated, not assumed. An unmapped basis scores against the scorer's neutral
+    // default, and saying so is the difference between a number and a number you can act on.
+    sub.textContent = `${c.line_count} lines · ${usd(c.total_cost)} · `
+      + (phase ? `basis “${basis}” → phase ${phase}` : `basis “${basis || "unset"}” — phase unspecified, scored at the neutral default`);
+    card.append(head, sub);
+
+    const kpi = document.createElement("div"); kpi.className = "meta"; kpi.style.marginTop = "6px";
+    // UNITS ARE NOT CONSISTENT ACROSS THIS ONE RESPONSE, and both were verified against the running
+    // scorer rather than read off the field names. `pct_assumption_based` is a FRACTION (0.715 for a
+    // set that is 72% assumption-based) while `avg_contingency_pct` is already a PERCENTAGE (10.63).
+    // Rounding the first without scaling renders "1%" for a budget that is 72% unsupported — a
+    // plausible number, badly wrong, in the reassuring direction. `confidence` is a fraction too.
+    kpi.innerHTML = `<b>${Math.round(c.pct_assumption_based * 100)}%</b> of budget still assumption-based `
+      + `(${esc(usd(c.assumption_based_cost))}) · avg contingency ${Math.round(c.avg_contingency_pct)}%`;
+    card.appendChild(kpi);
+
+    const soft = c.worst_lines;
+    if (soft.length) {
+      const h = document.createElement("div");
+      h.style.cssText = "font-weight:600;margin-top:8px;font-size:12.5px";
+      h.textContent = "Least grounded, by value";
+      card.appendChild(h);
+      for (const l of soft.slice(0, 10)) {
+        const row = document.createElement("div"); row.className = "meta";
+        row.style.cssText = "display:flex;gap:8px;border-top:1px solid var(--line);padding:4px 0";
+        row.append(
+          Object.assign(document.createElement("span"), { textContent: l.description || "(no description)", style: "flex:1" }),
+          Object.assign(document.createElement("span"), { textContent: l.source }),
+          Object.assign(document.createElement("span"), { textContent: usd(l.cost) }),
+        );
+        card.appendChild(row);
+      }
+    }
+  }
+
+  /** The BoE assumption ledger + documentation completeness for the record's lines. */
+  private async estimateBoeView(pid: string, lines: Record<string, unknown>[]) {
+    let b;
+    try { b = await this.ctx.host.api.estimateBoe(pid, { lines }); }
+    catch (e) { toast(`basis of estimate failed: ${(e as Error).message}`, "error"); return; }
+    const { card } = modalShell("Basis of Estimate", 480);
+    // No cast. `estimateBoe`'s declared type already describes `ledger` exactly — an earlier draft
+    // here used `as unknown as {...}` with hand-written field names, two of which were wrong
+    // (`documented_pct` for `pct_documented`, and `weakest` for `worst_lines` next door). The cast is
+    // what allowed them: it switches off the one check that would have said so at compile time.
+    const led = b.ledger;
+    const head = document.createElement("div"); head.className = "meta";
+    head.style.fontWeight = "600";
+    // `pct_documented` is a FRACTION (0.5 for one of two), the same trap as `pct_assumption_based`.
+    head.textContent = `${Math.round(led.pct_documented * 100)}% of lines carry a documented basis `
+      + `(${led.documented} of ${led.line_count})`;
+    card.appendChild(head);
+
+    // What is MISSING is the point of a BoE — an undocumented line is the one that gets argued.
+    const gaps = led.undocumented;
+    if (gaps.length) {
+      const g = document.createElement("div"); g.className = "meta";
+      g.style.cssText = "margin-top:4px;color:var(--muted)";
+      const worst = gaps.slice(0, 3).map((u) => `${u.description || u.key} (${u.missing.join(", ")})`);
+      g.textContent = `${gaps.length} undocumented: ${worst.join(" · ")}${gaps.length > 3 ? " …" : ""}`;
+      card.appendChild(g);
+    }
+    for (const l of led.lines.slice(0, 25)) {
+      const row = document.createElement("div"); row.className = "meta";
+      row.style.cssText = "display:flex;gap:8px;border-top:1px solid var(--line);padding:4px 0";
+      row.append(
+        Object.assign(document.createElement("span"), { textContent: l.description || "(no description)", style: "flex:1" }),
+        Object.assign(document.createElement("span"), { textContent: l.source ?? "unspecified" }),
+        Object.assign(document.createElement("span"), { textContent: l.quote_ref ? `ref ${l.quote_ref}` : "no ref" }),
+        Object.assign(document.createElement("span"), { textContent: l.total != null ? usd(l.total) : "—" }),
+      );
+      card.appendChild(row);
+    }
+  }
+
   private async composeExhibit(m: ModuleDef, r: ModuleRecord, rid: string) {
     const pid = this.ctx.host.projectId()!;
     const api = this.ctx.host.api;
@@ -1930,6 +2173,7 @@ export class RegisterUI {
       tools.append(cb);
     }
     this.contractActions(m, r, rid, tools);
+    this.estimateActions(m, r, tools);
     if (m.key === "rfi") {
       const tb = document.createElement("button");
       tb.className = "tool-btn"; tb.textContent = "✨ Triage (AI)"; tb.title = "AI: categorize + ball-in-court + draft response";

--- a/services/api/test_file_sizes.py
+++ b/services/api/test_file_sizes.py
@@ -72,7 +72,7 @@ PER_FILE = {
     #: other modules and one got a field in only by appending to an existing line. That is the
     #: friction this ratchet is for, and it asked the intended question — the contract documents had
     #: a whole domain to leave with, so the number goes DOWN by 32 instead of up by one.
-    "apps/web/src/api/client.ts": 3_749,   # +1 = the withRoutines IMPORT, not an endpoint:   # ⑨ contracts -> contracts.ts; ⑧ 3,796; ⑦ 3,871; before ⑦ 3,967
+    "apps/web/src/api/client.ts": 9_999,   # PLACEHOLDER — measured below
     #: R39-DECOMP-VIEWER. Pinned at its CURRENT size before any extraction, deliberately.
     #:
     #: `app.ts` had no per-file entry, so it lived under the 5,200 global — which it also *set*, being

--- a/services/api/test_file_sizes.py
+++ b/services/api/test_file_sizes.py
@@ -72,7 +72,7 @@ PER_FILE = {
     #: other modules and one got a field in only by appending to an existing line. That is the
     #: friction this ratchet is for, and it asked the intended question — the contract documents had
     #: a whole domain to leave with, so the number goes DOWN by 32 instead of up by one.
-    "apps/web/src/api/client.ts": 3_728,   # ⑩ finance -> finance.ts   # ⑨ contracts -> contracts.ts; ⑧ 3,796; ⑦ 3,871; before ⑦ 3,967
+    "apps/web/src/api/client.ts": 3_727,   # ⑩ finance -> finance.ts   # ⑨ contracts -> contracts.ts; ⑧ 3,796; ⑦ 3,871; before ⑦ 3,967
     #: R39-DECOMP-VIEWER. Pinned at its CURRENT size before any extraction, deliberately.
     #:
     #: `app.ts` had no per-file entry, so it lived under the 5,200 global — which it also *set*, being

--- a/services/api/test_file_sizes.py
+++ b/services/api/test_file_sizes.py
@@ -72,7 +72,7 @@ PER_FILE = {
     #: other modules and one got a field in only by appending to an existing line. That is the
     #: friction this ratchet is for, and it asked the intended question — the contract documents had
     #: a whole domain to leave with, so the number goes DOWN by 32 instead of up by one.
-    "apps/web/src/api/client.ts": 9_999,   # PLACEHOLDER — measured below
+    "apps/web/src/api/client.ts": 3_727,   # ⑩ finance -> finance.ts; ⑨ contracts; ⑧ 3,796; ⑦ 3,871
     #: R39-DECOMP-VIEWER. Pinned at its CURRENT size before any extraction, deliberately.
     #:
     #: `app.ts` had no per-file entry, so it lived under the 5,200 global — which it also *set*, being


### PR DESCRIPTION
## Result

**`UNCALLED_CEILING` 131 → 127**, measured before and after rather than derived from what the wiring touched — the same discipline that caught the `reserveStudy` mistake recorded in that file. All four targets confirmed reached; `clearBaseline` confirmed still uncalled, on purpose.

## What was actually missing

The `estimate` register's `line_items` table carries `code · description · qty · unit · unit_cost · amount · source · quote_ref · basis_date`, and its `source` options are `allowance / parametric / historical / quote` — **every one a key in the confidence scorer's source table**. `estimateBoe`'s line type is nearly column-for-column identical, `quote_ref` and `basis_date` included.

The data model and the endpoints were built for each other. Only the path between them was missing — which is the whole thesis behind driving this number.

| action | endpoint | where |
|---|---|---|
| ◎ Confidence | `estimateConfidence` | `estimate` record |
| ⛁ Basis of Estimate | `estimateBoe` | `estimate` record |
| ◫ Concept budget | `estimateConceptBudget` | `estimate` record, priced from the `space_program` register |
| ⌫ Clear import | `clearXer` | beside the P6/MSP import it undoes |

Each reads data the app already holds. A caller that needs the user to hand-assemble its input is a caller in name only, so there is no paste box anywhere here.

## Three things that would have shipped wrong

Each was caught by asking the running code, not by reading a field name.

**1. Units are inconsistent inside one response.** `pct_assumption_based` is a **fraction** (0.715) while `avg_contingency_pct` in the same payload is already a **percentage** (10.63). Rounding the first without scaling renders **"1%"** for a budget that is **72%** unsupported — plausible, badly wrong, and wrong in the reassuring direction.

**2. I invented two field names, and a cast hid it.** I wrote `weakest` and `documented_pct`; they are `worst_lines` and `pct_documented`. The declared client types were **correct all along** — but I had written `as unknown as {...}`, which switches off exactly the check that would have told me at compile time. Cast removed; the declared types are used directly.

**3. Two of five phase values silently mis-score.** `estimate.basis` offers `Conceptual · Schematic · DD · CD · GMP`; the scorer keys on `concept · sd · dd · cd · gmp`. `DD`/`CD`/`GMP` survive a `.toLowerCase()`; `"conceptual"` and `"schematic"` match nothing and fall to the neutral default of **0.6** — scoring a concept estimate (0.45) as *more* confident than a schematic one. An explicit map, with the reasoning recorded next to it.

## One thing deliberately not sent

`estimateConceptBudget` accepts `history` to derive per-type rates from a firm's completed projects. **This codebase has no completed-project cost history**, and inventing comparables to make the call look richer would price a real budget off fabricated data. Without it the endpoint prices at `default_rate` and surfaces what it could not price — so the UI leads with that count. Verified: with no default rate, all lines come back unpriced and `total` is `0`, which must not render as a confident **$0**.

## `clearBaseline` stays uncalled

Not an oversight and not mine — Subagent 1 owns it, with the expiry *"until baseline deletion is behind a confirm-and-audit step"*. It deletes a captured baseline that an EOT claim rests on; a one-click destroy beside that would be worse than leaving it unreachable. An honest marker beats a fabricated caller.

## Checks

- **Ceiling mutation-checked**: removing the `clearXer` caller fails the gate with `expected 128 to be less than or equal to 127`.
- Response shapes verified against the running endpoints for all four.
- Suite **1416 passed / 128 files**; `tsc --noEmit` and `npm run lint` clean.

**Not clicked through in a browser** — `preview_start` serves the primary clone, not a worktree. Everything checkable without one was checked: response shapes, the phase mapping, the unpriced path, and the reachability delta itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added finance governance tools for managing period locks, reviewing budget-to-actual discrepancies, and viewing import history.
  * Added estimate analysis tools with line-item details, confidence insights, assumptions, documentation gaps, and concept-budget calculations.
  * Added a schedule option to clear activities from the most recent P6/MSP import while preserving manually entered activities.
* **Improvements**
  * Finance and estimate actions are now available directly from relevant record and ledger tools.
  * Added clearer feedback for finance and schedule operations, including confirmations and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->