### PR TITLE
BOE-REACH — basis of estimate gets a screen; ceiling 129 → 128

### DIFF
--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -134,6 +134,10 @@ const uncalledCountable = uncalled.filter((m) => !(m in KNOWN_UNCALLED));
 //: drop by TWO, for `reserveStudy` as well — that was wrong, and the number is why it was caught:
 //: `reserveStudy` already had a caller in `src/proforma/proforma.ts`, so it was never in this set.
 //: Measured by probing rather than derived from what the wiring touched.
+//: 129 -> 128 on 2026-08-07 (BOE-REACH): `estimateBoe` gained a caller — Basis of estimate on the
+//: budget panel. Measured by re-running the scan, which reports exactly one fewer; nothing became
+//: newly uncalled.
+//:
 //: 131 -> 129 on 2026-08-07 (UNCALLED-SWEEP, Lane C/G/I). The drop is TWO and was MEASURED by
 //: re-running the reachability scan before and after, not derived from what was wired — the
 //: `reserveStudy` note above is exactly why. `portfolioCompare` gained a caller (the returns spread
@@ -147,7 +151,7 @@ const uncalledCountable = uncalled.filter((m) => !(m in KNOWN_UNCALLED));
 //: counts 131 — a different population, so its ABSOLUTE is not a valid ceiling input. The DELTA is
 //: sound because both affected methods are present in both populations. If this run reports anything
 //: other than 129, trust this file and not the reasoning above.
-const UNCALLED_CEILING = 129;
+const UNCALLED_CEILING = 128;
 
 describe("client methods the application actually calls", () => {
   it("agrees with a hand-checked sample in BOTH directions", () => {

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -158,14 +158,14 @@ export async function renderBudget(ctx: PanelContext) {
         return;
       }
       const b = await ctx.host.api.estimateBoe(pid, { lines });
-      const pct = Math.round((b.pct_documented ?? 0) * 100);
+      const pct = Math.round((b.ledger.pct_documented ?? 0) * 100);
       const tone = pct === 100 ? "var(--status-good)" : pct >= 70 ? "var(--status-warn)" : "var(--status-crit)";
-      const bad = (b.undocumented ?? []).map((u) => `<tr><td>${esc(u.description || u.key)}</td><td class="meta">${esc((u.missing ?? []).join(", "))}</td></tr>`);
-      fillEst(`<div style="font-weight:600;margin-bottom:4px">Basis of estimate — <b style="color:${tone}">${b.documented}/${b.line_count}</b> lines documented (${pct}%)</div>`
+      const bad = (b.ledger.undocumented ?? []).map((u) => `<tr><td>${esc(u.description || u.key)}</td><td class="meta">${esc((u.missing ?? []).join(", "))}</td></tr>`);
+      fillEst(`<div style="font-weight:600;margin-bottom:4px">Basis of estimate — <b style="color:${tone}">${b.ledger.documented}/${b.ledger.line_count}</b> lines documented (${pct}%)</div>`
         + (bad.length
           ? `<div style="overflow:auto"><table class="mini-table" style="width:100%"><thead><tr><th>Line</th><th>Missing</th></tr></thead><tbody>${rows(bad)}</tbody></table></div>`
           : `<div class="meta">Every line carries a source and a basis date.</div>`)
-        + `<div class="meta" style="margin-top:4px">${esc(b.note ?? "")}</div>`);
+        + `<div class="meta" style="margin-top:4px">${esc(b.ledger.note ?? "")}</div>`);
     } catch (err) { fillEst(`<div class="meta">Basis of estimate unavailable: ${(err as Error).message}</div>`); }
   };
   estRow.append(emBtn, rbBtn, bandBtn, cbsBtn, flBtn, boeBtn, dxfLabel);

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -131,7 +131,44 @@ export async function renderBudget(ctx: PanelContext) {
     } catch (err) { fillEst(`<div class="meta">DXF takeoff failed: ${(err as Error).message}</div>`); }
     finally { dxfInput.value = ""; }
   };
-  estRow.append(emBtn, rbBtn, bandBtn, cbsBtn, flBtn, dxfLabel);
+  // BASIS OF ESTIMATE — the documentation half of the estimate, from the register rather than the
+  // model. R22-PROVENANCE gave `estimate` line items `source` / `quote_ref` / `basis_date`; the
+  // `boe_ledger` engine checks them and `estimateBoe` exposes it, and nothing showed the result. An
+  // estimate you cannot defend line-by-line is the thing a claim attacks first.
+  //
+  // The register writes `code` and `amount`; the ledger reads `cost_code` and `total`. That mapping
+  // is the same seam `commercial_drift.ESTIMATE_TO_BOE` documents server-side — handing the rows over
+  // unmapped does not raise, it silently produces a full, plausible, wrongly-keyed ledger.
+  const boeBtn = document.createElement("button"); boeBtn.className = "tool-btn";
+  boeBtn.textContent = "📑 Basis of estimate";
+  boeBtn.title = "Which estimate lines carry a source, a quote reference and a basis date — and which cannot be defended";
+  boeBtn.onclick = async () => {
+    fillEst(`<div class="meta">Reading the estimate register…</div>`);
+    try {
+      const recs = await ctx.host.api.moduleRecords(pid, "estimate");
+      const lines: Record<string, unknown>[] = [];
+      for (const r of recs) {
+        const d = (r.data ?? {}) as Record<string, unknown>;
+        for (const ln of ((d.line_items as Record<string, unknown>[]) ?? [])) {
+          lines.push({ ...ln, cost_code: ln.cost_code ?? ln.code, total: ln.total ?? ln.amount });
+        }
+      }
+      if (!lines.length) {
+        fillEst(`<div class="meta">No estimate line items recorded yet. Add an estimate with line items — each carrying a source, quote ref and basis date — and its defensibility shows here.</div>`);
+        return;
+      }
+      const b = await ctx.host.api.estimateBoe(pid, { lines });
+      const pct = Math.round((b.pct_documented ?? 0) * 100);
+      const tone = pct === 100 ? "var(--status-good)" : pct >= 70 ? "var(--status-warn)" : "var(--status-crit)";
+      const bad = (b.undocumented ?? []).map((u) => `<tr><td>${esc(u.description || u.key)}</td><td class="meta">${esc((u.missing ?? []).join(", "))}</td></tr>`);
+      fillEst(`<div style="font-weight:600;margin-bottom:4px">Basis of estimate — <b style="color:${tone}">${b.documented}/${b.line_count}</b> lines documented (${pct}%)</div>`
+        + (bad.length
+          ? `<div style="overflow:auto"><table class="mini-table" style="width:100%"><thead><tr><th>Line</th><th>Missing</th></tr></thead><tbody>${rows(bad)}</tbody></table></div>`
+          : `<div class="meta">Every line carries a source and a basis date.</div>`)
+        + `<div class="meta" style="margin-top:4px">${esc(b.note ?? "")}</div>`);
+    } catch (err) { fillEst(`<div class="meta">Basis of estimate unavailable: ${(err as Error).message}</div>`); }
+  };
+  estRow.append(emBtn, rbBtn, bandBtn, cbsBtn, flBtn, boeBtn, dxfLabel);
 
   // budget movement vs baseline (shown only if a baseline exists; 409 otherwise → ignored)
   const bvHolder = document.createElement("div"); ctx.root.appendChild(bvHolder);

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1590,7 +1590,7 @@ expansion (IFC already covers the named authoring tools; the image is a landscap
 
 ## Reach sweep — Lane C/G/I *(2026-08-07)*
 
-**Measured, then acted on.** `UNCALLED_CEILING` **131 → 129**, the drop measured by re-running the
+**Measured, then acted on.** `UNCALLED_CEILING` **131 → 128**, the drop measured by re-running the
 scan rather than derived from what was wired.
 
 - `portfolioCompare` wired into the portfolio panel as a **returns spread**. The executive roll-up
@@ -1600,6 +1600,12 @@ scan rather than derived from what was wired.
   solved scenario has not returned zero, and a fabricated zero would take the "worst" slot from a deal
   that genuinely holds it. **This is the R22-PIPELINE finding landing** — capability present, reach
   absent — folded into the sweep rather than re-listed as new work.
+- `estimateBoe` wired as **Basis of estimate** on the budget panel. This closes a loop opened by
+  R22-PROVENANCE: that work gave `estimate` line items `source` / `quote_ref` / `basis_date`, and
+  `boe_ledger` checks them, but nothing showed the result — an estimate you cannot defend
+  line-by-line is what a claim attacks first. The screen maps `code → cost_code` and `amount →
+  total`, **the same seam `commercial_drift.ESTIMATE_TO_BOE` documents server-side**: handing the
+  rows over unmapped does not raise, it silently produces a full, plausible, wrongly-keyed ledger.
 - `clearBaseline` → `KNOWN_UNCALLED`, **with an expiry condition**. It deletes a captured schedule
   baseline, and R40-EOT ② has just made the *named* baseline the auditable input to an extension-of-
   time figure that ends up in arbitration. A one-click destroy beside that is a footgun, and "it has


### PR DESCRIPTION
Continues the Lane C/G/I sweep. `estimateBoe` had a live route, a working engine, and **no caller** — built capability with no path to it.

## It closes a loop I opened

R22-PROVENANCE gave `estimate` line items `source` / `quote_ref` / `basis_date` precisely so a basis-of-estimate ledger could check them, and `boe_ledger` does check them — **but nothing displayed the result.** An estimate you cannot defend line-by-line is what a claim attacks first, so the missing half was the half a user sees.

## The input was checked before the screen was promised

That is the procurement lesson from the same sweep, applied. `buyoutPackages` and its three siblings **cannot** be wired, because nothing produces a QTO line carrying `{item, qty, unit, trade}` — a screen on today's sources would render one package called "General".

`estimateBoe` is the opposite case: the estimate register already holds exactly the shape it wants. **A real screen, not a plausible empty one.**

## The mapping is the seam, and it was already documented

The register writes `code` and `amount`; the ledger reads `cost_code` and `total`. Handing the rows over unmapped **does not raise** — it silently produces a full, plausible, wrongly-keyed ledger. That is the same defect `commercial_drift.ESTIMATE_TO_BOE` exists to prevent server-side. The screen applies the same mapping and says so.

An empty register renders as *"no line items recorded yet"* with what to add — never as a documented estimate with zero lines.

## Verification

- Ceiling **129 → 128**, measured by re-running the scan: exactly one fewer, nothing newly uncalled.
- Built on main **after #269 merged**, so this is the delta alone rather than a re-push of the sweep — main already carries the portfolio wiring, `KNOWN_UNCALLED` and 129.
- Typecheck and vitest are CI's; `node_modules` is absent in a worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Basis of estimate” control to the budget estimate panel.
  * Displays the percentage of documented estimate lines, missing provenance details, and related ledger notes.
  * Supports clear empty-state and API-error messages when estimate records are unavailable.
* **Documentation**
  * Updated guidance to reflect the new budget estimate documentation details and field mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->