### PR TITLE
v0.3.988: readiness strip on every home, JSONDisk for bake-share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.988 (2026-08-19) — the readiness brief is on every home, and bake-share stores JSON
+
+Two leftovers from the upgrade audit, neither of which is a library swap.
+
+**The Master Builder 8-step brief was the product's own "what do I do next" surface, and it lived
+on one destination in Design.** A GC superintendent, a developer, or anyone who opened the workspace
+home never saw it. v0.3.988 mounts a compact strip on every portal home (construction / design /
+developer all pass through `renderHome`) and scopes the pills to that workspace, then to persona —
+intersected so a superintendent browsing Design still sees Design's questions rather than an empty
+strip. "Close this gap" hops to the first non-ready scoped step; "Full brief" still opens
+`__masterbuilder__`. Fail-open: a brief that cannot load leaves the host empty, same rule as Pulse.
+The strip sits above Pulse so the next action is above the risk numbers.
+
+Does not replace the eight-card panel. Does not invent a second protocol. The API is still
+`/projects/{id}/master-builder/brief`.
+
+**When bake-share is on, values are JSONDisk, not pickle.** `diskcache` 5.6.3 still has no published
+fix for CVE-2025-69872; the shared cache is still **off unless `AEC_BAKE_SHARE_DIR` is set**. The
+geometry payload was already nested lists of arrays, so pickle was never load-bearing here.
+`JSONDisk` is in the package we already pin. A row that cannot be JSON-encoded is refused rather than
+pickled. `mapped-diskcache` was not added. Default deployments still never construct a Cache.
+
 ## v0.3.986 (2026-08-18) — a comment that explains a pin gets believed because it is specific
 
 Three review findings, all of them claims that had drifted from what they described.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.3.986",
+  "version": "0.3.988",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.986",
+  "version": "0.3.988",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/portal/panels/readinessStrip.test.ts
+++ b/apps/web/src/portal/panels/readinessStrip.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  STEPS_BY_WORKSPACE, firstOpenStep, mountReadinessStrip, readinessStepKeys,
+  type ReadinessBrief, type ReadinessStep,
+} from "./readinessStrip";
+
+const step = (over: Partial<ReadinessStep> & Pick<ReadinessStep, "key" | "status">): ReadinessStep => ({
+  n: 1, title: over.key, dest: `__${over.key}__`, gaps: [], ...over,
+});
+
+const brief = (steps: ReadinessStep[], over: Partial<ReadinessBrief> = {}): ReadinessBrief => ({
+  readiness_pct: 40, ready_steps: 2, gap_steps: 3, step_count: 8,
+  grounded_in_place: true, steps, ...over,
+});
+
+describe("readinessStepKeys scopes the protocol, and never empties the strip", () => {
+  it("a designer sees place/program/design/regulatory, not delivery", () => {
+    expect(readinessStepKeys("design", "all")).toEqual(
+      ["place", "program", "design", "regulatory"]);
+    expect(readinessStepKeys("design", "architect")).toEqual(
+      ["place", "program", "design", "regulatory"]);
+  });
+
+  it("a superintendent on the GC home sees field steps, not feasibility", () => {
+    expect(readinessStepKeys("construction", "superintendent")).toEqual(
+      ["delivery", "risk", "handover"]);
+  });
+
+  it("a superintendent browsing Design still sees Design's steps rather than nothing", () => {
+    // Intersecting with delivery/risk/handover would empty the strip. An empty "what's next"
+    // on a live project is worse than showing the workspace's own questions.
+    expect(readinessStepKeys("design", "superintendent")).toEqual(
+      ["place", "program", "design", "regulatory"]);
+  });
+
+  it("an unknown workspace falls back to the builder's set", () => {
+    expect(readinessStepKeys("nonsense", "all")).toEqual(
+      [...STEPS_BY_WORKSPACE.construction!]);
+  });
+});
+
+describe("firstOpenStep is the gap the button names", () => {
+  it("skips ready steps and returns the first partial or gap", () => {
+    const steps = [
+      step({ key: "place", status: "ready" }),
+      step({ key: "design", status: "partial", title: "Design integration" }),
+      step({ key: "regulatory", status: "gap" }),
+    ];
+    expect(firstOpenStep(steps)?.key).toBe("design");
+  });
+
+  it("is null when every scoped step is ready — the strip still renders, the hop does not", () => {
+    expect(firstOpenStep([step({ key: "place", status: "ready" })])).toBeNull();
+  });
+});
+
+describe("mountReadinessStrip", () => {
+  it("fails open — a thrown brief leaves the host empty, not a broken dashboard", async () => {
+    const host = document.createElement("div");
+    await mountReadinessStrip(host, {
+      load: async () => { throw new Error("offline"); },
+      workspace: "design", persona: "all", onOpen: () => {},
+    });
+    expect(host.childNodes.length).toBe(0);
+  });
+
+  it("renders scoped pills and hops to the first gap", async () => {
+    const host = document.createElement("div");
+    const onOpen = vi.fn();
+    await mountReadinessStrip(host, {
+      load: async () => brief([
+        step({ n: 1, key: "place", title: "Place & context", status: "gap", dest: "__modelanalysis__",
+          gaps: ["Jurisdiction"] }),
+        step({ n: 5, key: "design", title: "Design integration", status: "ready", dest: "__modelqa__" }),
+        step({ n: 6, key: "delivery", title: "Delivery strategy", status: "gap", dest: "__schedule__" }),
+      ]),
+      workspace: "design", persona: "all", onOpen,
+    });
+    expect(host.querySelector("[data-readiness=strip]")).toBeTruthy();
+    expect(host.textContent).toContain("Place & context");
+    expect(host.textContent).toContain("Design integration");
+    expect(host.textContent).not.toContain("Delivery strategy"); // construction-only
+    const close = [...host.querySelectorAll("button")].find((b) => b.textContent?.includes("Close this gap"));
+    expect(close?.textContent).toMatch(/Place & context/);
+    close!.click();
+    expect(onOpen).toHaveBeenCalledWith("__modelanalysis__");
+  });
+
+  it("says when the project is not grounded, rather than implying the score is enough", async () => {
+    const host = document.createElement("div");
+    await mountReadinessStrip(host, {
+      load: async () => brief([step({ key: "place", status: "gap" })], { grounded_in_place: false }),
+      workspace: "design", persona: "all", onOpen: () => {},
+    });
+    expect(host.textContent).toMatch(/Not grounded in place/);
+  });
+
+  it("portal.ts actually mounts it on home — defined-but-never-called is this repo's expensive miss", () => {
+    const src = readFileSync(resolve(process.cwd(), "src/portal/portal.ts"), "utf8");
+    expect(src).toMatch(/from "\.\/panels\/readinessStrip"/);
+    expect(src).toContain("mountReadinessStrip");
+    expect(src).toContain("masterBuilderBrief");
+  });
+});

--- a/apps/web/src/portal/panels/readinessStrip.ts
+++ b/apps/web/src/portal/panels/readinessStrip.ts
@@ -1,0 +1,159 @@
+/**
+ * UX-READINESS-EVERYWHERE — the Master Builder 8-step synthesis, as a home strip.
+ *
+ * The full brief already exists (`panels/masterBuilder.ts`) and is reachable from Design only.
+ * That is the defect: the product's own "what do I do next" surface is hidden on the one workspace
+ * whose occupant already lives in the model. This module is the *strip*: score, the steps that
+ * belong to this workspace/persona, and one hop to close the first gap. The full eight-card brief
+ * stays on `__masterbuilder__`.
+ *
+ * Fail-open: a brief that cannot load leaves the host empty. A summary must not take down the
+ * dashboard it summarises (same rule as Pulse).
+ */
+export type ReadinessStatus = "ready" | "partial" | "gap";
+
+export interface ReadinessStep {
+  n: number;
+  key: string;
+  title: string;
+  dest: string;
+  status: ReadinessStatus;
+  gaps: string[];
+}
+
+export interface ReadinessBrief {
+  readiness_pct: number;
+  ready_steps: number;
+  gap_steps: number;
+  step_count: number;
+  grounded_in_place: boolean;
+  steps: ReadinessStep[];
+}
+
+/** Protocol keys this workspace actually asks. Unknown workspaces get the builder's set. */
+export const STEPS_BY_WORKSPACE: Record<string, readonly string[]> = {
+  construction: ["delivery", "risk", "design", "handover"],
+  design: ["place", "program", "design", "regulatory"],
+  developer: ["place", "program", "feasibility", "regulatory"],
+};
+
+/**
+ * Persona overlay — intersected with the workspace set so a superintendent on Design still sees
+ * design steps rather than an empty strip. `all` (and unknown) keep the workspace set whole.
+ */
+export const STEPS_BY_PERSONA: Record<string, readonly string[]> = {
+  superintendent: ["delivery", "risk", "handover"],
+  project_manager: ["delivery", "risk", "feasibility", "design"],
+  gc: ["delivery", "risk", "design", "feasibility"],
+  architect: ["place", "program", "design", "regulatory"],
+  engineer: ["design", "regulatory", "place"],
+  developer: ["place", "program", "feasibility", "regulatory"],
+  subcontractor: ["delivery", "risk"],
+};
+
+export function readinessStepKeys(workspace: string, persona: string): string[] {
+  const ws = STEPS_BY_WORKSPACE[workspace] ?? STEPS_BY_WORKSPACE.construction!;
+  const p = persona && persona !== "all" ? STEPS_BY_PERSONA[persona] : undefined;
+  if (!p) return [...ws];
+  const keep = new Set(p);
+  const scoped = ws.filter((k) => keep.has(k));
+  return scoped.length ? scoped : [...ws];
+}
+
+export function firstOpenStep(steps: ReadinessStep[]): ReadinessStep | null {
+  return steps.find((s) => s.status !== "ready") ?? null;
+}
+
+const PILL_COL: Record<ReadinessStatus, string> = {
+  ready: "var(--status-good)",
+  partial: "var(--status-warn)",
+  gap: "var(--status-crit)",
+};
+
+export async function mountReadinessStrip(
+  host: HTMLElement,
+  opts: {
+    load: () => Promise<ReadinessBrief>;
+    workspace: string;
+    persona: string;
+    onOpen: (dest: string) => void;
+  },
+): Promise<void> {
+  host.replaceChildren();
+  let brief: ReadinessBrief;
+  try { brief = await opts.load(); }
+  catch { return; }
+
+  const want = new Set(readinessStepKeys(opts.workspace, opts.persona));
+  const steps = brief.steps.filter((s) => want.has(s.key));
+  if (!steps.length) return;
+
+  const wrap = document.createElement("div");
+  wrap.className = "dash-card";
+  wrap.setAttribute("data-readiness", "strip");
+  wrap.style.cssText = "margin-bottom:8px";
+
+  const head = document.createElement("div");
+  head.style.cssText = "display:flex;justify-content:space-between;align-items:baseline;gap:8px;flex-wrap:wrap";
+  const title = document.createElement("div");
+  title.className = "section-title";
+  title.style.margin = "0";
+  title.textContent = "Next on this project";
+  const pct = document.createElement("div");
+  pct.style.cssText = "font-size:18px;font-weight:800";
+  const col = brief.readiness_pct >= 66 ? "var(--status-good)"
+    : brief.readiness_pct >= 33 ? "var(--status-warn)" : "var(--status-crit)";
+  pct.style.color = col;
+  pct.textContent = `${brief.readiness_pct}%`;
+  pct.title = `${brief.ready_steps}/${brief.step_count} protocol steps ready`;
+  head.append(title, pct);
+  wrap.appendChild(head);
+
+  const meta = document.createElement("div");
+  meta.className = "meta";
+  meta.style.margin = "2px 0 6px";
+  meta.textContent = brief.grounded_in_place
+    ? "Labels reflect what is present, not what is correct."
+    : "Not grounded in place — set a jurisdiction so code editions and loads resolve.";
+  wrap.appendChild(meta);
+
+  const row = document.createElement("div");
+  row.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;align-items:center";
+  for (const s of steps) {
+    const pill = document.createElement("button");
+    pill.type = "button";
+    pill.className = "tool-btn";
+    pill.style.cssText = "font-size:11px;padding:2px 8px";
+    const mark = document.createElement("span");
+    mark.style.cssText = `color:${PILL_COL[s.status]};font-weight:700;margin-right:4px`;
+    mark.textContent = s.status === "ready" ? "●" : s.status === "partial" ? "◐" : "○";
+    pill.append(mark, document.createTextNode(s.title));
+    pill.title = s.gaps.length ? `needs: ${s.gaps.join("; ")}` : s.status;
+    pill.onclick = () => opts.onOpen(s.dest);
+    row.appendChild(pill);
+  }
+  wrap.appendChild(row);
+
+  const actions = document.createElement("div");
+  actions.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;margin-top:6px";
+  const open = firstOpenStep(steps);
+  if (open) {
+    const go = document.createElement("button");
+    go.type = "button";
+    go.className = "btn";
+    go.style.cssText = "font-size:11px;padding:2px 8px";
+    go.textContent = `→ Close this gap — ${open.title}`;
+    go.onclick = () => opts.onOpen(open.dest);
+    actions.appendChild(go);
+  }
+  const full = document.createElement("button");
+  full.type = "button";
+  full.className = "tool-btn";
+  full.style.cssText = "font-size:11px;padding:2px 8px";
+  full.textContent = "Full brief";
+  full.onclick = () => opts.onOpen("__masterbuilder__");
+  actions.appendChild(full);
+  wrap.appendChild(actions);
+
+  host.appendChild(wrap);
+}

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -4,6 +4,7 @@ import { progressBar, usd } from "../ui/charts";
 import { countNarrative, statusChip } from "../ui/chips";
 import { noProjectHtml } from "../ui/empty";
 import { buildPulse, pulseRailEl } from "./panels/pulse";
+import { mountReadinessStrip } from "./panels/readinessStrip";
 import type { PanelContext } from "./panelContext";
 import { type RegisterFilter, RegisterUI } from "./register/register";
 import { SECTIONS_BY_PERSONA, readDensity, readFavs, readRecents, readRoomOpen, setDensity, setRoomOpen, toggleFav } from "./prefs";
@@ -816,7 +817,7 @@ export class PortalUI {
    * does not own, so it is kept narrow and optional-chained throughout: a renamed field costs a
    * missing card, never a thrown home panel.
    */
-  private async renderPulse(pid: string, root: HTMLElement) {
+  private async renderPulse(pid: string, root: HTMLElement, after?: HTMLElement) {
     try {
       const api = this.host.api as unknown as Record<string, (p: string) => Promise<unknown>>;
       const call = async (name: string) => {
@@ -861,7 +862,13 @@ export class PortalUI {
       // The home panel may have been re-rendered while this was in flight — appending into a root
       // that is no longer on screen would leave a rail nobody can see and a duplicate on the next
       // pass. Check before touching the DOM.
-      if (rail && root.isConnected) root.prepend(rail);
+      // After the density row and the readiness strip when those exist; otherwise the top of home.
+      // Prepend used to win the "first thing on the dashboard" slot; the readiness strip is now
+      // that slot, and Pulse sits under it rather than covering it.
+      if (rail && root.isConnected) {
+        if (after?.isConnected) after.after(rail);
+        else root.prepend(rail);
+      }
     } catch {
       /* a pulse that cannot be built is simply absent */
     }
@@ -889,13 +896,27 @@ export class PortalUI {
     densRow.append(densBtn);
     root.append(densRow);
 
-    // PROJECT PULSE — five numbers, each with a sentence naming what is at risk. Appended before the
-    // rest of the home panel so the state of the job is the first thing read, not the last.
+    // UX-READINESS-EVERYWHERE — the 8-step brief used to live only on Design → Master Builder.
+    // Mount a scoped strip on every home (GC / design / developer all pass through here) so
+    // "what do I do next" is the first project question, not a destination you have to know exists.
+    // Fail-open: a brief that 500s leaves this host empty.
+    const readyHost = el("div");
+    root.append(readyHost);
+    const persona = document.body.dataset.persona || localStorage.getItem("persona") || "all";
+    void mountReadinessStrip(readyHost, {
+      load: () => this.host.api.masterBuilderBrief(pid),
+      workspace: this.wsFilter,
+      persona,
+      onOpen: (dest) => this.goToDest(dest),
+    });
+
+    // PROJECT PULSE — five numbers, each with a sentence naming what is at risk. Sits under the
+    // readiness strip so "what is next" is above "what is at risk".
     //
     // Deliberately fire-and-forget and fully fail-open: a summary must never be able to break the
     // page it summarises. If an engine is slow or missing, the rail simply does not appear — which
     // is also why `pulseRailEl` returns null for an empty pulse rather than an empty heading.
-    void this.renderPulse(pid, root);
+    void this.renderPulse(pid, root, readyHost);
 
     // cross-module search
     const search = el("input") as HTMLInputElement;

--- a/docs/internal/dependency-advisories.md
+++ b/docs/internal/dependency-advisories.md
@@ -33,6 +33,13 @@ deployment `diskcache.Cache` is never constructed and nothing is ever unpickled.
 it exists, comes from that environment variable alone; no request, header, or stored record
 influences it, and an environment variable is operator-supplied by definition.
 
+**When the operator does turn it on** (v0.3.988), values go through diskcache's `JSONDisk`, not the
+default pickle `Disk`. The payload was already nested lists of mesh arrays (`numpy.ndarray.tolist()`
+on the way in); a value that cannot be JSON-encoded is refused rather than pickled. That does not
+retire the advisory — pickle remains how diskcache works for any *other* Cache in the process, and
+this one is still off by default — but it does mean the bake-share path no longer deserializes with
+pickle. `mapped-diskcache` was not added; JSONDisk is already in the pinned package.
+
 Two corrections to what a first pass wanted to write here, both worth keeping as a warning about
 which facts get assumed:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -652,7 +652,7 @@ two rows share a path, so two agents in different rows cannot collide.
 
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
-| **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/portal/portal.ts`, `main.ts` | R24-RUNS-INBOX · UX-READINESS-EVERYWHERE · UX-DUP-DESTINATIONS · REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
+| **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/portal/portal.ts`, `main.ts` | R24-RUNS-INBOX · UX-DUP-DESTINATIONS · REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-ELEMENT-CARD ② *(moved from E 2026-08-06 — the cell said E, the item's own text says the remaining work is "purely call sites: RFI, estimate line, pay app, COBie row", which live in `apps/web/src/ui/` and `apps/web/src/portal/panels/`. **A lane's paths and a lane's items are two claims and only the first is tested**, so the cell drifted from the item under it)* · R24-CHARTS-GRAMMAR · R24-REPORTS-BY-MOMENT · R24-DENSITY ② · R24-MONO-DATA · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R36-ROOM-BRIEFS · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R39-UPLOAD-CAP-APP ①◧ · R41-UPLOAD-WARK · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | R38-ARRAY-LIVE ③ · R21-4D-CLASH · R28-BUNDLE ② — **the three that landed in PRs #176/#178/#179 on 2026-08-02** (R28-ICDD, R23-STOREY-LOD, R28-UNIFY) are shipped and pending archive. **Corrected 2026-08-06: this read "all SHIPPED and MERGED", which was false for 8 of the 11 codes beside it** — SEC-PLUGIN-SANDBOX is ◧ with its `setrlimit` half explicitly REFUSED, R38-SYNC-VIEW and R21-4D-CLASH are ◧, and five carry no marker at all. A row-level word like "all" has no defined scope, so it drifts the moment the row grows; the item markers are the authority and this sentence is not. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* |
@@ -1511,7 +1511,8 @@ refute one, so this goes first even though it is the least visible.
   like it walks to a GlobalId while actually asserting one. That is the fabrication shape this repo
   has spent a day naming, and it would have been shipped as the on-stage demo. Whoever picked up
   Sprint 2 would have started in the client and found nothing to render.
-- ◧ **R24-RUNS-INBOX** *(M; history half v0.3.947)* — clash, IDS, cost and energy become durable Runs
+- ✅ **R24-READINESS-HOME** *(S — **SHIPPED v0.3.988** as the UX-READINESS-EVERYWHERE strip)* — see
+  `apps/web/src/portal/panels/readinessStrip.ts`. Not a second protocol.
   (inputs, timestamp, author, artifact, **diff against the previous run**) with a per-project inbox.
   Most externally validated item in the ring — see the corroboration note above.
 
@@ -2259,14 +2260,11 @@ which 7 were project accounting, and `Model & standards` held 14 mixing project 
 findings. Split into Build/Money and Model & standards/Analyse & check — **max group 14 → 7**, nothing
 removed. Remaining, in priority order:
 
-- ⭐ **UX-READINESS-EVERYWHERE** *(M; superseded by **R24-READINESS-HOME**, kept for its evidence)* — **the app already contains its own "simple stupid" front door
-  and hides it.** The Master Builder panel is a live 8-step readiness synthesis: each step reads
-  ready / partial / gap against real project data, names exactly what is missing ("needs: Jurisdiction
-  so code editions + loads resolve"), and offers **→ Close this gap** straight to the tool that fixes
-  it — plus an honest disclaimer that labels reflect what is *present*, not what is *correct*. That is
-  precisely the "tell me what to do next" surface a builder/developer/architect/engineer wants on
-  opening a project, and it is reachable from exactly ONE destination inside ONE workspace (Design).
-  Promote the readiness strip to every workspace dashboard, scoped per persona.
+- ✅ **UX-READINESS-EVERYWHERE** / **R24-READINESS-HOME** *(M — **SHIPPED v0.3.988**)* — the Master
+  Builder 8-step brief is no longer Design-only. `apps/web/src/portal/panels/readinessStrip.ts` mounts
+  a scoped strip on every portal home (`apps/web/src/portal/portal.ts` `renderHome`); workspace ∩
+  persona, empty-intersect falls back to the workspace set; fail-open; Full brief still
+  `__masterbuilder__`. The eight-card panel is unchanged.
   `Model Health` (8 references), `Model Analysis` (5) and `BIM KPIs` (5) are three
   destinations whose names do not tell a user which answers their question; all three now sit together
   under `Analyse & check`, which makes the overlap visible and worth resolving rather than hiding it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.986",
+      "version": "0.3.988",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/test_bake_shared.py
+++ b/services/api/test_bake_shared.py
@@ -64,6 +64,18 @@ with tempfile.TemporaryDirectory() as d:
     check("what comes back is what went in", got == payload)
     check("a different key is still a miss", bs.get("model-B") is None)
 
+    store = bs._store()
+    check("the on-disk codec is JSONDisk, not pickle Disk",
+          store is not None and type(store.disk).__name__ == "JSONDisk",
+          type(getattr(store, "disk", None)).__name__ if store else "no store")
+
+    four = [("2O2Fr$t4X7Zf8NOew3FNrX", "IfcWall",
+             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], [[0, 1, 0]])]
+    check("a 4-tuple row (guid, class, verts, faces) round-trips",
+          bs.put("model-4", four) is True and bs.get("model-4") == four)
+    check("bytes in the mesh are refused rather than pickled",
+          bs.put("model-bin", [("IfcWall", b"nope", [[0, 1, 0]])]) is False)
+
     st = bs.stats()
     check("the cache can be measured", st.get("enabled") and st.get("entries", 0) >= 1,
           f"entries={st.get('entries')} bytes={st.get('bytes')}")

--- a/services/data/src/aec_data/bake_shared.py
+++ b/services/data/src/aec_data/bake_shared.py
@@ -14,10 +14,10 @@ exactly the kind of code that works in testing and corrupts under load.
 a temp directory the operator never chose is a surprise, and on a single-worker deployment it buys
 nothing — the in-process cache already covers that case.
 
-The stored value is the mesh arrays, not trimesh objects: a pickled third-party object is a format
-that changes when that library upgrades, and a cache entry that deserialises into something subtly
-different is worse than a miss. Vertices and faces are plain arrays, so what comes back is what went
-in or nothing at all.
+The stored value is JSON lists of mesh arrays, not trimesh objects and not pickle. Vertices and
+faces round-trip as nested lists (numpy `.tolist()` on the way in). What comes back is what went
+in or nothing at all. JSONDisk is the answer to CVE-2025-69872 for this store: the values were
+already arrays, so pickle was never load-bearing.
 """
 from __future__ import annotations
 
@@ -38,6 +38,66 @@ def enabled() -> bool:
     return bool(os.environ.get(_ENV_DIR))
 
 
+def _as_list(value):
+    """JSONDisk cannot store numpy arrays or tuples. Nested lists round-trip as themselves.
+
+    Bytes are refused (TypeError) rather than left for pickle: JSONDisk would fail the write
+    anyway, and a silent fallback to Disk is exactly the advisory path this exists to close.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        raise TypeError("bake share stores JSON, not bytes")
+    if hasattr(value, "tolist"):
+        return _as_list(value.tolist())
+    if isinstance(value, tuple):
+        return [_as_list(x) for x in value]
+    if isinstance(value, list):
+        return [_as_list(x) for x in value]
+    if isinstance(value, dict):
+        return {str(k): _as_list(v) for k, v in value.items()}
+    raise TypeError(f"bake share cannot JSON-encode {type(value).__name__}")
+
+
+def _jsonable(payload):
+    """Mesh rows → nested lists, or None if the shape is wrong.
+
+    Production writes `(guid, cls, vertices, faces)` (R38-PLAN-IDENTITY). A payload we cannot
+    encode is refused rather than pickled — falling back to pickle on 'just this one array'
+    would re-open the advisory this exists to answer.
+    """
+    rows = []
+    try:
+        for row in payload:
+            if len(row) == 4:
+                guid, cls, verts, faces = row
+                rows.append([guid, cls, _as_list(verts), _as_list(faces)])
+            elif len(row) == 3:
+                cls, verts, faces = row
+                rows.append([cls, _as_list(verts), _as_list(faces)])
+            else:
+                return None
+    except (TypeError, ValueError):
+        return None
+    return rows
+
+
+def _from_json(raw):
+    if not isinstance(raw, list):
+        return None
+    out = []
+    for row in raw:
+        if not isinstance(row, (list, tuple)) or len(row) not in (3, 4):
+            return None
+        if len(row) == 4:
+            guid, cls, verts, faces = row
+            out.append((guid, cls, verts, faces))
+        else:
+            cls, verts, faces = row
+            out.append((cls, verts, faces))
+    return out
+
+
 def _store():
     """The shared cache, or None. Opened once; a failure to open disables sharing rather than
     breaking rendering — geometry must still be produced on a box where the directory is unwritable."""
@@ -51,8 +111,11 @@ def _store():
     try:
         import diskcache
         limit = int(os.environ.get(_ENV_MB, "4096")) * 1024 * 1024
-        _cache = diskcache.Cache(d, size_limit=limit, eviction_policy="least-recently-used")
-        log.info("shared bake cache at %s (limit %d MB)", d, limit // (1024 * 1024))
+        # JSONDisk: the pickle path is CVE-2025-69872. Geometry is arrays; JSON lists are enough.
+        _cache = diskcache.Cache(
+            d, size_limit=limit, eviction_policy="least-recently-used",
+            disk=diskcache.JSONDisk)
+        log.info("shared bake cache at %s (limit %d MB, JSONDisk)", d, limit // (1024 * 1024))
     except Exception as exc:            # noqa: BLE001 — sharing is an optimisation, never a hard dep
         log.warning("shared bake cache unavailable (%s) — falling back to per-process only", exc)
         _cache = None
@@ -69,7 +132,7 @@ def get(key: str):
     if c is None:
         return None
     try:
-        return c.get(key)
+        return _from_json(c.get(key))
     except Exception:                   # noqa: BLE001 — a corrupt or locked entry is a miss
         log.debug("shared bake read failed for %s", key, exc_info=True)
         return None
@@ -82,7 +145,10 @@ def put(key: str, payload) -> bool:
     if c is None:
         return False
     try:
-        return bool(c.set(key, payload))
+        encoded = _jsonable(payload)
+        if encoded is None:
+            return False
+        return bool(c.set(key, encoded))
     except Exception:                   # noqa: BLE001
         log.debug("shared bake write failed for %s", key, exc_info=True)
         return False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Do **not** merge this in place of #292 / #294 / #295. Those stay at v0.3.987 for Opus 5 to land. This is branched from `main` (v0.3.986) as **v0.3.988** so the version numbers do not collide. Suggested land order: **#294 → #292 → #295**, then rebase this and keep 988 (rebump only if 987 already took the number — they claimed it first).

## What
1. **UX-READINESS-EVERYWHERE / R24-READINESS-HOME** — compact Master Builder strip on every portal workspace home (GC / design / developer all go through `renderHome`). Scoped by workspace ∩ persona; empty intersect falls back to the workspace set so a superintendent on Design is not given a blank strip. Fail-open. “Close this gap” → first non-ready scoped step. “Full brief” still `__masterbuilder__`. Pulse sits under the strip.
2. **diskcache pickle (CVE-2025-69872)** — when `AEC_BAKE_SHARE_DIR` is set, store through diskcache `JSONDisk` (already in the pinned package). Geometry was already nested lists. Non-JSON payloads are refused, not pickled. Share remains **off by default**. No `mapped-diskcache`.

## Out of scope (as asked)
- Merging #292 / #294 / #295
- Incremental fragment reload, job-queue clash/IDS, growing `app.ts`, new libraries, inventing proforma GUID provenance
- Turning bake-share on by default

## Verify (this revision)
- `cd services/api && python -m ruff check src/ ../data/src/` — clean
- `PYTHONPATH=src:../data/src python test_bake_shared.py` — OK (JSONDisk, 4-tuple, bytes refused, subprocess HIT)
- `test_claude_md_gates.py` — OK
- Web Node 24: `npm run typecheck && npm run lint && npm run build` — clean
- vitest: `readinessStrip.test.ts`, `pulse.test.ts`, `versionConsistency.test.ts`, `no-import-cycles.test.ts` — pass

**Not exercised live:** this cloud image has no `services/api` venv and no FastAPI, so the portal brief cannot be fetched. The strip is fail-open (empty host). **#295 live pass** (empty-canvas `setStatus`, Place `waitForPublish` ticks, RFI/estimate/pay-app/asset cards) was not driven for the same reason; those remain unit-tested on #295. Geometry Place still needs a published model.

## Checklist
- [x] Backend ruff from `services/api`
- [x] Affected `test_bake_shared.py` (already registered)
- [x] Web typecheck / lint / build (Node 24)
- [x] No import cycles (`no-import-cycles.test.ts`)
- [x] CHANGELOG + roadmap + version in package.json, tauri.conf.json, package-lock `packages["apps/web"]`
- [x] No secrets, no competitor names

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added readiness strips to every portal home.
  * Displays workspace- and persona-specific progress, grounding status, unresolved gaps, and links to the relevant next step or full brief.
  * Includes workspace fallback behavior and preserves existing project-pulse and panel functionality.

* **Bug Fixes**
  * Portal readiness loading now fails gracefully when data is unavailable.

* **Security & Reliability**
  * Shared bake caching now uses JSON-compatible storage and rejects unsupported data instead of serializing it unsafely.

* **Documentation**
  * Updated the changelog, roadmap, and cache advisory for the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->