### PR TITLE
v0.3.1002 — R24-CHARTS-GRAMMAR: series colour is not a traffic light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1002 (2026-08-19) — a series is not a traffic light
+
+R24-CHARTS-GRAMMAR ③ closes the item. `chartColor` is a seven-slot categorical ramp that does not
+include passing-green, warn-gold, failing-red, or `--accent`. Signed charts and the CPI–SPI
+quadrant still use those status hues. A mix donut that means on-track / at-risk must pass the
+hues in.
+
 ## v0.3.1001 (2026-08-19) — field mode: 56 px, the queue, and a mic that can be missing
 
 R24-FIELD-MODE ①. A stored mode (`aec-field-mode`, `?field=1`), not a breakpoint: 56 px targets

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.3.1001",
+  "version": "0.3.1002",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1001",
+  "version": "0.3.1002",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/ui/charts.test.ts
+++ b/apps/web/src/ui/charts.test.ts
@@ -7,7 +7,7 @@ import {
   CHART_KINDS, NO_DATA_MARK,
   compact, money, chartColor, lineChart, groupedBar, stackedBar, waterfall,
   tornado, histogram, donut, progressBar, sparkline, signedBars, scatterQuadrant,
-  Y_TICKS, usd, qty,
+  Y_TICKS, usd, qty, SERIES_PALETTE, STATUS_GOOD, STATUS_WARN, STATUS_CRIT,
 } from "./charts";
 
 describe("number formatting", () => {
@@ -24,6 +24,7 @@ describe("number formatting", () => {
   });
   it("palette cycles", () => {
     expect(chartColor(0)).toBe(chartColor(7));   // 7 colors → wraps
+    expect(chartColor(0)).toBe(SERIES_PALETTE[0]);
   });
 });
 
@@ -338,5 +339,67 @@ describe("R24-CHARTS-GRAMMAR ② — one currency format for the whole app", () 
       expect(qty(12_500)).not.toContain("$");
       expect(qty(null)).toBe("—");
     });
+  });
+});
+
+/**
+ * R24-CHARTS-GRAMMAR ③ — series identity is not status.
+ *
+ * Slot 0 used to be `--accent` and slot 1 the same green as "passing". An S-curve then read as
+ * "PV is the thing you can act on, EV is fine". Status hues stay for signed magnitude and the
+ * quadrant; `chartColor` is a categorical ramp that does not include them.
+ */
+describe("R24-CHARTS-GRAMMAR ③ — series colour is not a traffic light", () => {
+  const SRC = readFileSync(resolve(__dirname, "charts.ts"), "utf8");
+  const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  const STATUS = [STATUS_GOOD, STATUS_WARN, STATUS_CRIT] as const;
+
+  it("the categorical ramp has seven slots and none of them is a status hue or --accent", () => {
+    expect(SERIES_PALETTE).toHaveLength(7);
+    for (const c of SERIES_PALETTE) {
+      expect(STATUS, c).not.toContain(c);
+      expect(c).not.toMatch(/accent|status-/);
+    }
+  });
+
+  it("chartColor never returns a status hue", () => {
+    for (let i = 0; i < 21; i++) {
+      expect(STATUS, `slot ${i}`).not.toContain(chartColor(i));
+    }
+  });
+
+  it("a multi-series line is categorical, not good/warn/crit", () => {
+    const svg = lineChart([
+      { name: "PV", values: [0, 5, 12] },
+      { name: "EV", values: [0, 4, 10] },
+      { name: "AC", values: [0, 6, 13] },
+    ]);
+    expect(svg).toContain(SERIES_PALETTE[0]);
+    expect(svg).toContain(SERIES_PALETTE[1]);
+    expect(svg).not.toContain(STATUS_GOOD);
+    expect(svg).not.toContain(STATUS_CRIT);
+    expect(svg).not.toContain("var(--accent)");
+  });
+
+  it("signed magnitude still uses the status hues — that is what they are for", () => {
+    const sb = signedBars([-10, 5]);
+    expect(sb).toContain(STATUS_CRIT);
+    expect(sb).toContain(STATUS_GOOD);
+    const wf = waterfall([{ label: "in", value: 4 }, { label: "out", value: -2 }]);
+    expect(wf).toContain(STATUS_GOOD);
+    expect(wf).toContain(STATUS_CRIT);
+  });
+
+  it("a progress bar's complete / low states are status; mid-flight is series 0", () => {
+    expect(progressBar(100, 100, {})).toContain(STATUS_GOOD);
+    expect(progressBar(10, 100, {})).toContain(STATUS_WARN);
+    expect(progressBar(60, 100, {})).toContain(SERIES_PALETTE[0]);
+  });
+
+  it("each status hex is declared once — copies are how EV became 'passing'", () => {
+    for (const hex of STATUS) {
+      const hits = [...CODE.matchAll(new RegExp(hex.replace(/[.#]/g, "\\$&"), "g"))];
+      expect(hits, hex).toHaveLength(1);
+    }
   });
 });

--- a/apps/web/src/ui/charts.ts
+++ b/apps/web/src/ui/charts.ts
@@ -9,13 +9,36 @@
  * waterfall (JV / sources-uses), tornado (sensitivity), histogram (Monte Carlo), donut, progress.
  */
 
-const PALETTE = ["var(--accent)", "#33d17a", "#e6a700", "#9b7cff", "#4ac6e2", "#e2554a", "#e07b39"];
-const POS = "#33d17a";
-const NEG = "#e2554a";
+/**
+ * R24-CHARTS-GRAMMAR ③ — series identity is not status.
+ *
+ * The audit asked to restrict colour to four semantic hues. That is right for *status* (good / warn /
+ * crit) and wrong for *series identity*: a seven-series S-curve collapsed onto those four is
+ * unreadable, and painting PV with `--accent` (the "you can act on this" token) plus EV with the
+ * same green as "passing" is how a chart starts lying. CSS selector paint is `colorContract.ts`;
+ * SVG fills are this contract.
+ *
+ * `chartColor` is the categorical ramp. Waterfall signs, signed bars, the CPI–SPI quadrant, and a
+ * progress bar's complete/low states use the status hues. Callers who mean status (a mix donut of
+ * on-track / at-risk) pass those hues in; they do not get them by occupying slot 0.
+ */
+export const STATUS_GOOD = "#33d17a";
+export const STATUS_WARN = "#e6a700";
+export const STATUS_CRIT = "#e2554a";
+const POS = STATUS_GOOD;
+const NEG = STATUS_CRIT;
+
+/** Paul Tol-ish categorical set with traffic-light hexes and `--accent` kept out. */
+export const SERIES_PALETTE = [
+  "#4e79a7", "#b07aa1", "#76b7b2", "#9c755f", "#79706e", "#d37295", "#86bcb6",
+] as const;
+
 const GRID = "var(--line)";
 const AXIS = "var(--muted)";
 
-export function chartColor(i: number): string { return PALETTE[i % PALETTE.length] ?? PALETTE[0]!; } // safe: PALETTE is a non-empty literal
+export function chartColor(i: number): string {
+  return SERIES_PALETTE[i % SERIES_PALETTE.length] ?? SERIES_PALETTE[0]!;
+}
 
 export function esc(s: unknown): string {
   return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -212,8 +235,8 @@ export function scatterQuadrant(points: { label: string; x: number; y: number; k
   const cx = sx(c), cy = sy(c), x0 = sx(lo), x1 = sx(hi), y0 = sy(lo), y1 = sy(hi);
   const tint = (ax: number, ay: number, bx: number, by: number, fill: string): string =>
     `<rect x="${Math.min(ax, bx).toFixed(1)}" y="${Math.min(ay, by).toFixed(1)}" width="${Math.abs(bx - ax).toFixed(1)}" height="${Math.abs(by - ay).toFixed(1)}" fill="${fill}" opacity="0.1"/>`;
-  let g = tint(cx, cy, x1, y1, POS) + tint(x0, cy, cx, y1, "#e6a700")
-        + tint(cx, cy, x1, y0, "#e6a700") + tint(x0, cy, cx, y0, NEG);
+  let g = tint(cx, cy, x1, y1, POS) + tint(x0, cy, cx, y1, STATUS_WARN)
+        + tint(cx, cy, x1, y0, STATUS_WARN) + tint(x0, cy, cx, y0, NEG);
   g += `<line x1="${cx.toFixed(1)}" y1="${T}" x2="${cx.toFixed(1)}" y2="${(H - B).toFixed(1)}" stroke="${AXIS}" stroke-width="0.6" stroke-dasharray="2 2"/>`;
   g += `<line x1="${L}" y1="${cy.toFixed(1)}" x2="${(W - R).toFixed(1)}" y2="${cy.toFixed(1)}" stroke="${AXIS}" stroke-width="0.6" stroke-dasharray="2 2"/>`;
   for (const v of [lo, c, hi]) {
@@ -222,7 +245,7 @@ export function scatterQuadrant(points: { label: string; x: number; y: number; k
   }
   g += points.map((p) => {
     const proj = p.kind === "project";
-    const col = proj ? "var(--accent)" : (p.x >= c && p.y >= c ? POS : (p.x < c && p.y < c ? NEG : "#e6a700"));
+    const col = proj ? "var(--accent)" : (p.x >= c && p.y >= c ? POS : (p.x < c && p.y < c ? NEG : STATUS_WARN));
     return `<circle cx="${sx(p.x).toFixed(1)}" cy="${sy(p.y).toFixed(1)}" r="${proj ? 3.2 : 2}" fill="${col}" stroke="var(--panel2)" stroke-width="0.6"><title>${esc(p.label)} — SPI ${p.x.toFixed(2)} / CPI ${p.y.toFixed(2)}</title></circle>`;
   }).join("");
   g += txt(W / 2, H - 1, opts.xLabel ?? "SPI (schedule) →", { anchor: "middle", size: 7 });
@@ -325,7 +348,7 @@ export function tornado(rows: { label: string; low: number; high: number }[],
   rows.forEach((r, i) => {
     const yb = T + i * 18, h = 12;
     const xl = x(Math.min(r.low, r.high)), xh = x(Math.max(r.low, r.high));
-    g += `<rect x="${xl.toFixed(1)}" y="${yb.toFixed(1)}" width="${Math.max(xh - xl, 1).toFixed(1)}" height="${h}" fill="var(--accent)" opacity="0.85"><title>${esc(r.label)}: ${fmt(r.low)} … ${fmt(r.high)}</title></rect>`;
+    g += `<rect x="${xl.toFixed(1)}" y="${yb.toFixed(1)}" width="${Math.max(xh - xl, 1).toFixed(1)}" height="${h}" fill="${chartColor(0)}" opacity="0.85"><title>${esc(r.label)}: ${fmt(r.low)} … ${fmt(r.high)}</title></rect>`;
     g += txt(L - 4, yb + 9, r.label, { anchor: "end", size: 7.5 });
   });
   return wrap(H, g, opts.title ?? "tornado", opts.height ?? Math.max(70, 20 * rows.length + 26));
@@ -344,7 +367,7 @@ export function histogram(values: number[], opts: { title?: string; bins?: numbe
   const bw = (W - L - R) / bins;
   let g = counts.map((c, i) => {
     const bh = (c / cmax) * (H - T - B), x = L + i * bw, y = (H - B) - bh;
-    return `<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${Math.max(bw - 0.4, 0.6).toFixed(1)}" height="${bh.toFixed(1)}" fill="var(--accent)" opacity="0.8"><title>${fmt(lo + i * w)}–${fmt(lo + (i + 1) * w)}: ${c}</title></rect>`;
+    return `<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${Math.max(bw - 0.4, 0.6).toFixed(1)}" height="${bh.toFixed(1)}" fill="${chartColor(0)}" opacity="0.8"><title>${fmt(lo + i * w)}–${fmt(lo + (i + 1) * w)}: ${c}</title></rect>`;
   }).join("");
   const mx = (v: number) => L + ((v - lo) / (hi - lo || 1)) * (W - L - R);
   for (const m of opts.markers ?? []) {
@@ -382,7 +405,7 @@ export function donut(slices: { label: string; value: number; color?: string }[]
 // --- progress bar / gauge ---------------------------------------------------
 export function progressBar(value: number, max: number, opts: { label?: string; color?: string; suffix?: string } = {}): string {
   const pct = max ? Math.max(0, Math.min(1, value / max)) : 0;
-  const col = opts.color ?? (pct >= 1 ? POS : pct >= 0.5 ? "var(--accent)" : "#e6a700");
+  const col = opts.color ?? (pct >= 1 ? POS : pct >= 0.5 ? chartColor(0) : STATUS_WARN);
   return `<div style="margin:3px 0"><div style="display:flex;justify-content:space-between;font-size:11px;color:var(--muted)">`
     + `<span>${esc(opts.label ?? "")}</span><span>${Math.round(pct * 100)}%${opts.suffix ? " " + esc(opts.suffix) : ""}</span></div>`
     + `<div style="height:7px;background:var(--bg);border:1px solid var(--line);border-radius:4px;overflow:hidden">`
@@ -395,7 +418,7 @@ export function sparkline(values: number[], opts: { color?: string; width?: numb
   if (values.length < 2) return `<svg width="${w}" height="${h}"></svg>`;
   const max = Math.max(...values), min = Math.min(...values);
   const pts = values.map((v, i) => `${(i / (values.length - 1) * w).toFixed(1)},${(h - (v - min) / (max - min || 1) * h).toFixed(1)}`).join(" ");
-  return `<svg width="${w}" height="${h}" style="vertical-align:middle"><polyline points="${pts}" fill="none" stroke="${opts.color ?? "var(--accent)"}" stroke-width="1.2"/></svg>`;
+  return `<svg width="${w}" height="${h}" style="vertical-align:middle"><polyline points="${pts}" fill="none" stroke="${opts.color ?? chartColor(0)}" stroke-width="1.2"/></svg>`;
 }
 
 // --- signed bars (equity cash flow) -----------------------------------------

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -653,7 +653,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/portal/portal.ts`, `main.ts` | R24-RUNS-INBOX · REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-CHARTS-GRAMMAR · R24-REPORTS-BY-MOMENT · R24-MONO-DATA · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-MONO-DATA · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R39-UPLOAD-CAP-APP ①◧ · R41-UPLOAD-WARK · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | R38-ARRAY-LIVE ③ · R21-4D-CLASH · R28-BUNDLE ② — **the three that landed in PRs #176/#178/#179 on 2026-08-02** (R28-ICDD, R23-STOREY-LOD, R28-UNIFY) are shipped and pending archive. **Corrected 2026-08-06: this read "all SHIPPED and MERGED", which was false for 8 of the 11 codes beside it** — SEC-PLUGIN-SANDBOX is ◧ with its `setrlimit` half explicitly REFUSED, R38-SYNC-VIEW and R21-4D-CLASH are ◧, and five carry no marker at all. A row-level word like "all" has no defined scope, so it drifts the moment the row grows; the item markers are the authority and this sentence is not. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · R28-VIEWER ④ · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* · R41-MODEL-ALIGN · R43-VIEWER-CONFORMANCE |
@@ -1443,7 +1443,7 @@ is recorded. Filed under Decisions below.
 | 12 | mobile is a bottom sheet in a desktop IA | R24-FIELD-MODE | ◧ **v0.3.1001** — mode flag, 56 px field chrome, outdoor contrast, always-visible sync strip, dictation (`apps/web/src/field/fieldMode.ts`). Capture-first home is still open; default remains the desktop IA |
 | 13 | search is scoped to modules | R24-CMDK-VERBS | ✅ **v0.3.946** — verbs, elements, reports and an assistant fallback; `apps/web/src/ui/paletteProviders.ts`. Fixed a second defect on the way: async hits were `concat`ed onto an already-grouped list, so a record landed under a **second** RECORDS heading below Modules |
 | 14 | empty states | R24-EMPTY-GUIDE | ✅ **verified done 2026-08-14** — the "24 lines, 'no project' only" reading is stale by a wide margin. `apps/web/src/ui/empty.ts` is 156 lines and R36-EMPTY-STATE shipped the hard part: a register with no rows distinguishes **none / filtered / failed**, because those send a reader to three different places and rendering them identically was the defect. Plus acronym-safe nouns ("No rfis yet" was the bug), `textContent` throughout since the name and the error body are untrusted, and `data-empty` so a test can assert WHICH kind was decided. Curated hints in `apps/web/src/ui/emptyGuide.ts` (157 lines), wired at two `register.ts` call sites, covered by `apps/web/src/ui/empty.test.ts` and `apps/web/src/ui/emptyGuide.test.ts` |
-| 15 | charts have no grammar | *(none)* | ❌ dropped → `R24-CHARTS-GRAMMAR` |
+| 15 | charts have no grammar | *(none)* | ✅ **SHIPPED v0.3.1002** — no-data, ticks/legend/currency, then series vs status (`SERIES_PALETTE` / `STATUS_*` in `apps/web/src/ui/charts.ts`) |
 | 16 | Report Center is a list of nouns | *(none)* | ❌ dropped → `R24-REPORTS-BY-MOMENT` |
 | 17 | three vocabularies collide | R24-TERMS | 🟡 **storey/floor settled v0.3.945** — `storey` was already canonical in the API, QUERY-DSL and both table headers; three chrome strings disagreed, one of them with its own tooltip. Gated by `apps/web/src/shell/storeyVocabulary.test.ts`, which permits *gross floor area* and *floor plan*. The element/component and estimate/budget/cost pairs are NOT settled and are a user decision, not a cleanup |
 | 18 | site promises a lifecycle, app opens on a shell | *(none)* | 🟡 R26-VITALS (v0.3.773) is arguably a **better** answer than the audit's lifecycle strip — treat as closed |
@@ -1547,41 +1547,13 @@ refute one, so this goes first even though it is the least visible.
   `?field=1` / `aec-field-mode`, 56 px targets and ~7:1 on field chrome only (`apps/web/src/field/fieldMode.css`),
   always-visible sync strip, dictation when the browser has SpeechRecognition (`apps/web/src/field/dictate.ts`).
   Capture-first home is still open. Register density is unchanged (R24-DENSITY).
-- 🟡 **R24-CHARTS-GRAMMAR** — **no-data rule SHIPPED v0.3.783**, the rest open. Only `histogram`
-  handled empty input; the other twelve drew their axes, gridlines and legend with nothing in them —
-  no `NaN`, nothing broken, and therefore indistinguishable from a chart whose data failed to load.
-  All nine framed charts now share `noData()`, and `CHART_KINDS` + `charts.test.ts` fail the build if
-  a new chart skips it.
-  **Tick / legend / currency SHIPPED v0.3.948**, and none of the three was cosmetic once measured:
-  - **Ticks.** Three charts hand-rolled the same gridline loop and the copies had already diverged —
-    `lineChart` labelled `max − (k/4)(max − min)`, `groupedBar` and `waterfall` labelled
-    `max − (k/4)·max`, a different axis whenever the minimum is not zero. And **`stackedBar` drew no
-    gridlines at all**, so a cash-flow chart beside a budget chart was read against different
-    furniture. One `yGrid`, and a source scan that fails on a local gridline loop.
-  - **Legend.** Four hand-rolled copies of the same magic coordinates → one `legendRow`. The donut
-    keeps the one legitimate position difference (under the ring, which has no plot to sit above) and
-    still goes through the helper, so swatch, size and spacing cannot drift.
-  - **Currency.** The real number was **22 declarations in six behaviours**, not the 18 a first grep
-    found — the gate enumerated the population and my grep had not. **Ten wrote
-    `` `$${Math.round(n).toLocaleString()}` ``, which renders a loss as `$-1,000`** with the currency
-    mark on the wrong side of the minus; three had already fixed it locally, so the panels disagreed
-    with themselves. `inspectorTabs.ts` used `Intl` currency *and* mapped a non-finite value to
-    **`$0`** — an absent number rendering as a plausible zero, the failure the vitals strip exists to
-    prevent. `proforma/format.ts` **exported** a competing one. All 22 now import `usd` from
-    `apps/web/src/ui/charts.ts`; `chartsGrammar` bans re-declaring it.
-    **And one of the 22 was not money at all**: the stormwater card's `usd` emitted no `$` because it
-    formats cubic feet. Converting it would have put a currency mark on a detention volume — so `qty`
-    exists, and the rule bans *declaring* a formatter rather than banning the name.
-  - `unit: "money" | "percent" | "count"` now says what a chart's numbers **are** rather than making
-    every caller remember a formatter; an explicit `fmt` still wins.
-
-  **Still open:** the series-colour split below.
-  **And one correction to the audit, made deliberately:** it says colour should be "restricted to the
-  four semantic hues". That is right for *status* and wrong for *series identity* — a seven-series
-  S-curve needs seven distinguishable colours, and collapsing them to four makes the chart unreadable
-  in service of a rule about badges. The split to enforce is **semantic hues for status, a
-  categorical ramp for series**, which is a different contract from `ui/colorContract.ts` (that one
-  governs CSS selectors; SVG fills are outside it entirely).
+- ✅ **R24-CHARTS-GRAMMAR** *(**SHIPPED v0.3.1002**)* — no-data (v0.3.783), ticks/legend/currency
+  (v0.3.948), **series vs status (v0.3.1002)**. `chartColor` is `SERIES_PALETTE` (seven categorical
+  slots, none of them a traffic-light hue or `--accent`). Signed magnitude, the CPI–SPI quadrant, and
+  a progress bar's complete/low states keep `STATUS_GOOD` / `STATUS_WARN` / `STATUS_CRIT`. A status
+  mix donut must pass those hues in; occupying slot 0 is not how you get "passing". SVG fills stay
+  outside `ui/colorContract.ts` (that list is CSS selectors). The audit's "four semantic hues" rule
+  stays for status and does not apply to series identity.
 - 🟡 **R24-REPORTS-BY-MOMENT** — **grouping SHIPPED v0.3.785; scheduling still open.** The catalog was
   **56 reports under 18 group headings, six holding a single report**. Seven packages now sit above
   them — owner monthly · lender draw · IC · precon/GMP · design issue · closeout · ownership quarter —

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1001",
+      "version": "0.3.1002",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R24-CHARTS-GRAMMAR ③ — **stacked on #297** (`cursor/runway-claude-6e15` / v0.3.1001). Merge #297 first (after the 987 stack), then this.

## What

`chartColor` is a seven-slot **categorical** ramp (`SERIES_PALETTE`). It no longer includes passing-green, warn-gold, failing-red, or `--accent`.

Status hues stay for:

- waterfall / signed bars (sign)
- CPI–SPI quadrant (good / warn / crit regions)
- progress bar complete vs low

A mix donut that *means* on-track / at-risk must pass those hues in. Occupying slot 0 is not how you get “passing”.

Gates in `charts.test.ts`. SVG fills stay outside `colorContract.ts` (CSS selectors).

## Land

Keep version **0.3.1002**. Do not rebase onto a red `main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

