### PR TITLE
v0.3.1003 — R24-MONO-DATA: the last ui-monospace literal is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1003 (2026-08-19) — one mono face, including paste-from-spreadsheet
+
+R24-MONO-DATA. The last hand-rolled `ui-monospace` stack was the register paste textarea, left
+when the renderer still lived in a Lane A file. It now reads `var(--mono)`. The ratchet
+allowance is 0.
+
 ## v0.3.1002 (2026-08-19) — a series is not a traffic light
 
 R24-CHARTS-GRAMMAR ③ closes the item. `chartColor` is a seven-slot categorical ramp that does not

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.3.1002",
+  "version": "0.3.1003",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1002",
+  "version": "0.3.1003",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/portal/register/register.ts
+++ b/apps/web/src/portal/register/register.ts
@@ -1213,7 +1213,7 @@ export class RegisterUI {
     ta.placeholder = "name\tstatus\tamount\nFooting F-1\topen\t1200\n…";
     ta.setAttribute("aria-label", "Pasted spreadsheet rows");
     ta.style.cssText = "width:100%;min-height:150px;margin:8px 0;padding:8px;border:1px solid var(--line);"
-      + "border-radius:6px;background:var(--bg);color:inherit;font-family:ui-monospace,monospace;font-size:12px;white-space:pre;overflow:auto";
+      + "border-radius:6px;background:var(--bg);color:inherit;font-family:var(--mono);font-size:12px;white-space:pre;overflow:auto";
     const row = document.createElement("div");
     row.style.cssText = "display:flex;gap:8px;justify-content:flex-end;margin-top:4px";
     const cancel = document.createElement("button"); cancel.textContent = "Cancel"; cancel.className = "file-btn";

--- a/apps/web/src/ui/monoData.test.ts
+++ b/apps/web/src/ui/monoData.test.ts
@@ -75,15 +75,12 @@ function hardCodedMono(): { file: string; line: number }[] {
 /**
  * Remaining hand-rolled stacks, and why each survives.
  *
- * The survivor is `pasteRows`, and its history is the point. It was left because `portal/portal.ts`
- * was held by another session's in-flight work when this landed — converting it would have meant
- * editing a file two people had open. That was not bad luck: `R24-MONO-DATA` is a Lane B item and
- * `portal.ts` was a Lane A file, so the collision was structural and permanent. v0.3.850 moved the
- * register renderer to `portal/register/register.ts`, which Lane B owns, and this line went with it.
- * It is now a one-line change inside the lane that wants it — and this number going UP is a build
- * failure either way.
+ * There are none. The last survivor was the paste-from-spreadsheet textarea in
+ * `portal/register/register.ts`, left because `portal.ts` used to hold the renderer and a Lane A
+ * session had that file open. v0.3.850 moved the renderer into this lane; v0.3.1003 converted the
+ * literal. ALLOWANCE is 0 so the next `ui-monospace` in first-party source fails the build.
  */
-const ALLOWANCE = 1;
+const ALLOWANCE = 0;
 
 describe("the mono face is decided once", () => {
   it("style.css defines the token", () => {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -653,7 +653,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/portal/portal.ts`, `main.ts` | R24-RUNS-INBOX · REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-MONO-DATA · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R31-CITE-HIGHLIGHT · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R39-UPLOAD-CAP-APP ①◧ · R41-UPLOAD-WARK · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | R38-ARRAY-LIVE ③ · R21-4D-CLASH · R28-BUNDLE ② — **the three that landed in PRs #176/#178/#179 on 2026-08-02** (R28-ICDD, R23-STOREY-LOD, R28-UNIFY) are shipped and pending archive. **Corrected 2026-08-06: this read "all SHIPPED and MERGED", which was false for 8 of the 11 codes beside it** — SEC-PLUGIN-SANDBOX is ◧ with its `setrlimit` half explicitly REFUSED, R38-SYNC-VIEW and R21-4D-CLASH are ◧, and five carry no marker at all. A row-level word like "all" has no defined scope, so it drifts the moment the row grows; the item markers are the authority and this sentence is not. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · R28-VIEWER ④ · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* · R41-MODEL-ALIGN · R43-VIEWER-CONFORMANCE |
@@ -1565,7 +1565,10 @@ refute one, so this goes first even though it is the least visible.
   open and click through. Making it a *scheduled deliverable* — assembled on a date, sent to a
   recipient, with a record that it went — is the larger half and wants `routers/jobs.py` (now wired
   to the UI by R24-JOB-TRAY) plus a delivery surface. That is a real feature, not a grouping change.
-- **R24-TERMS** *(S)* · **R24-MONO-DATA** *(S)* — the remaining long tail.
+- **R24-TERMS** *(S)* — the remaining long tail (element/component and estimate/budget/cost pairs
+  are a user decision; storey/floor settled v0.3.945).
+- ✅ **R24-MONO-DATA** *(S — **SHIPPED v0.3.1003**)* — `var(--mono)` is the only first-party face;
+  the paste-rows textarea was the last `ui-monospace` literal. Allowance is 0.
 
 **Explicitly NOT in scope: the audit's visual identity** (ink canvas `#080C12`, IBM Plex Sans/Mono,
 the 24 px/192 px brand grid at 5–7%). It is the most seductive item in the document and the least

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1002",
+      "version": "0.3.1003",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R24-MONO-DATA — **stacked on #298** (`cursor/charts-series-colour-6e15` / v0.3.1002). Land #297 → #298 → this.

## What

The last first-party `ui-monospace` stack was the register **paste-from-spreadsheet** textarea, left when the renderer still lived in Lane A `portal.ts`. It now uses `var(--mono)`. `monoData.test.ts` allowance is **0**.

Does not grow `register.ts` (string swap on one line). Pin stays 2,516.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

