### PR TITLE
v0.3.1006 — R24-FIELD-MODE ③: land on capture when a project is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1006 (2026-08-19) — field mode lands on capture when a project is open
+
+R24-FIELD-MODE ③. If field mode is on and a project is selected, the capture sheet opens
+(on load and when you flip the Field toggle). No project → no sheet (that would only toast).
+The seven-room spine is unchanged; this is not a second portal home.
+
 ## v0.3.1005 (2026-08-19) — a citation boxes the passage, not a new browser tab
 
 R31-CITE-HIGHLIGHT. Opening a source used `window.open` on a blob URL, so `citeLocate` had no

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.3.1005",
+  "version": "0.3.1006",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1005",
+  "version": "0.3.1006",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/field/field.ts
+++ b/apps/web/src/field/field.ts
@@ -8,7 +8,7 @@ import type { ApiClient } from "../api/client";
 import { currentIdentity, ownedByMe } from "../api/identity";
 import { toast } from "./../ui/feedback";
 import { attachDictation } from "./dictate";
-import { mountFieldChrome } from "./fieldMode";
+import { mountFieldChrome, readFieldMode, shouldOpenCaptureHome } from "./fieldMode";
 import "./fieldMode.css";
 
 const QKEY = "aec-field-queue";
@@ -101,9 +101,15 @@ export class FieldCapture {
     const chrome = mountFieldChrome({
       queueCount: () => loadQueue().length,
       onOpenQueue: () => this.openQueue(),
+      onFieldModeChange: (on) => {
+        if (shouldOpenCaptureHome(on, this.projectId())) this.openSheet();
+      },
     });
     this.refreshStrip = chrome.refreshStrip;
     this.refreshBadge();
+    if (shouldOpenCaptureHome(readFieldMode(), this.projectId())) {
+      setTimeout(() => this.openSheet(), 400);
+    }
     // flush any queued captures now and whenever connectivity returns
     window.addEventListener("online", () => void this.flush());
     void this.flush();

--- a/apps/web/src/field/fieldMode.test.ts
+++ b/apps/web/src/field/fieldMode.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   FIELD_MODE_KEY, applyFieldMode, honourFieldQuery, mountFieldChrome, readFieldMode,
-  setFieldMode, syncStripText,
+  setFieldMode, shouldOpenCaptureHome, syncStripText,
 } from "./fieldMode";
 
 beforeEach(() => {
@@ -85,6 +85,21 @@ describe("field chrome", () => {
     mountFieldChrome({ queueCount: () => 0, onOpenQueue: () => undefined });
     expect(document.querySelectorAll("#field-mode-toggle")).toHaveLength(1);
     expect(document.querySelectorAll("#field-sync-strip")).toHaveLength(1);
+  });
+});
+
+describe("capture-first landing", () => {
+  it("needs both field mode and a project — otherwise the sheet would only toast", () => {
+    expect(shouldOpenCaptureHome(true, "p1")).toBe(true);
+    expect(shouldOpenCaptureHome(true, null)).toBe(false);
+    expect(shouldOpenCaptureHome(false, "p1")).toBe(false);
+  });
+
+  it("notifies when the mode flips so capture can become the landing", () => {
+    const onFieldModeChange = vi.fn();
+    mountFieldChrome({ queueCount: () => 0, onOpenQueue: () => undefined, onFieldModeChange });
+    (document.getElementById("field-mode-toggle") as HTMLButtonElement).click();
+    expect(onFieldModeChange).toHaveBeenCalledWith(true);
   });
 });
 

--- a/apps/web/src/field/fieldMode.ts
+++ b/apps/web/src/field/fieldMode.ts
@@ -34,6 +34,7 @@ export function applyFieldMode(root: HTMLElement = document.documentElement): vo
 export function mountFieldChrome(opts: {
   queueCount: () => number;
   onOpenQueue: () => void;
+  onFieldModeChange?: (on: boolean) => void;
 }): { refreshStrip: () => void } {
   honourFieldQuery();
   applyFieldMode();
@@ -75,6 +76,7 @@ export function mountFieldChrome(opts: {
   toggle.onclick = () => {
     setFieldMode(!readFieldMode());
     refreshStrip();
+    opts.onFieldModeChange?.(readFieldMode());
   };
 
   window.addEventListener("online", refreshStrip);
@@ -90,4 +92,10 @@ export function syncStripText(n: number, online: boolean): string {
     return n ? `Offline · ${n} waiting to sync` : "Offline · queue empty";
   }
   return n ? `${n} waiting to sync` : "Queue empty — all caught up";
+}
+
+/** Capture-first: the sheet is the landing when field mode is on AND a project is open.
+ *  No project means no sheet — openSheet would toast, which is not a home. */
+export function shouldOpenCaptureHome(fieldMode: boolean, projectId: string | null | undefined): boolean {
+  return fieldMode && Boolean(projectId);
 }

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-19, after v0.3.1005
+# Runway for Claude Code — 2026-08-19, after v0.3.1006
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1437,7 +1437,7 @@ is recorded. Filed under Decisions below.
 | 09 | tools panel mixes verbs with analyses | *(none)* | ✅ **v0.3.848** — `R24-TOOLS-SPLIT` cut the 1087-line `qa` section in two; Analyse is its own rail item |
 | 10 | finance numbers have no provenance | R24-TRACE-UI | 🟡 v0.3.775 shipped trace for *cost coverage*; the proforma chain (IRR ← NOI ← rent roll ← area ← GUID) — the audit's actual demo — is not built |
 | 11 | density | R24-DENSITY | ✅ **SHIPPED v0.3.996** — three steps on registers (`DENSITY_ROW_PX`), not dashboards only |
-| 12 | mobile is a bottom sheet in a desktop IA | R24-FIELD-MODE | ◧ **v0.3.1001 + v0.3.1004** — mode, 56 px (now actually applied over inline FAB styles), outdoor contrast, always-visible sync strip, dictation, strip not under the FAB. Capture-first home is still open |
+| 12 | mobile is a bottom sheet in a desktop IA | R24-FIELD-MODE | ◧ **v0.3.1001–1006** — mode, 56 px (applied), strip, dictation, capture sheet as landing when a project is open. Seven-room spine still exists |
 | 13 | search is scoped to modules | R24-CMDK-VERBS | ✅ **v0.3.946** — verbs, elements, reports and an assistant fallback; `apps/web/src/ui/paletteProviders.ts`. Fixed a second defect on the way: async hits were `concat`ed onto an already-grouped list, so a record landed under a **second** RECORDS heading below Modules |
 | 14 | empty states | R24-EMPTY-GUIDE | ✅ **verified done 2026-08-14** — the "24 lines, 'no project' only" reading is stale by a wide margin. `apps/web/src/ui/empty.ts` is 156 lines and R36-EMPTY-STATE shipped the hard part: a register with no rows distinguishes **none / filtered / failed**, because those send a reader to three different places and rendering them identically was the defect. Plus acronym-safe nouns ("No rfis yet" was the bug), `textContent` throughout since the name and the error body are untrusted, and `data-empty` so a test can assert WHICH kind was decided. Curated hints in `apps/web/src/ui/emptyGuide.ts` (157 lines), wired at two `register.ts` call sites, covered by `apps/web/src/ui/empty.test.ts` and `apps/web/src/ui/emptyGuide.test.ts` |
 | 15 | charts have no grammar | *(none)* | ✅ **SHIPPED v0.3.1002** — no-data, ticks/legend/currency, then series vs status (`SERIES_PALETTE` / `STATUS_*` in `apps/web/src/ui/charts.ts`) |
@@ -1540,11 +1540,12 @@ refute one, so this goes first even though it is the least visible.
 
 ### Sprint 4 — field, and the long tail
 
-- ◧ **R24-FIELD-MODE** *(L — **slice ① SHIPPED v0.3.1001; slice ② SHIPPED v0.3.1004**)* — a mode, not a breakpoint.
+- ◧ **R24-FIELD-MODE** *(L — **① v0.3.1001 · ② v0.3.1004 · ③ v0.3.1006**)* — a mode, not a breakpoint.
   `?field=1` / `aec-field-mode`, 56 px targets and ~7:1 on field chrome only (`apps/web/src/field/fieldMode.css`),
   always-visible sync strip, dictation when the browser has SpeechRecognition (`apps/web/src/field/dictate.ts`).
-  Slice ②: field-mode CSS beats the FAB's inline 52 px / `bottom:18px` (`!important`) so the queue
-  strip is not under the camera button; strip is `aria-live="polite"`. Capture-first *home* is still open.
+  Slice ②: field-mode CSS beats the FAB's inline 52 px. Slice ③: with a project open, field mode
+  **lands on the capture sheet** (`shouldOpenCaptureHome`) — the seven-room spine is still there;
+  this is not a second portal home.
 - ✅ **R24-CHARTS-GRAMMAR** *(**SHIPPED v0.3.1002**)* — no-data (v0.3.783), ticks/legend/currency
   (v0.3.948), **series vs status (v0.3.1002)**. `chartColor` is `SERIES_PALETTE` (seven categorical
   slots, none of them a traffic-light hue or `--accent`). Signed magnitude, the CPI–SPI quadrant, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1005",
+      "version": "0.3.1006",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R24-FIELD-MODE ③ — **stacked on #301**. Land #297 → … → #300 → #301 → this.

## What

If field mode is on **and** a project is selected, the capture sheet is the landing (on load, and when you flip Field). No project → no sheet (that would only toast). The seven-room spine is unchanged; this is not a second portal home.

`shouldOpenCaptureHome` is the gate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

