### PR TITLE
v0.3.1007 — Tab to the room's job, then land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1007 (2026-08-19) — Tab to the room's job, then land
+
+R39-A11Y-JOURNEYS ②. Each of the seven rooms has one keyboard primary: Design is its tab; the
+other six put `[data-room-primary]` on the landing (Open RFIs / budget lines / activities / the
+next Deal gate / the first work-queue row / Open work orders). Tests Tab to it, operate it, and
+assert focus did not fall on `document.body`.
+
 ## v0.3.1006 (2026-08-19) — field mode lands on capture when a project is open
 
 R24-FIELD-MODE ③. If field mode is on and a project is selected, the capture sheet opens

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-  "version": "0.3.1006",
+    "version": "0.3.1007",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1006",
+  "version": "0.3.1007",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/portal/panels/costBrief.ts
+++ b/apps/web/src/portal/panels/costBrief.ts
@@ -1,6 +1,6 @@
 import { usd } from "../../ui/charts";
 import type { PanelContext } from "../panelContext";
-import { fail, mountBrief } from "./roomBriefChrome";
+import { briefPrimary, fail, mountBrief, openRoomModule } from "./roomBriefChrome";
 
 /**
  * R36-ROOM-BRIEFS — Cost (PM / estimator).
@@ -70,5 +70,6 @@ export async function renderCostBrief(ctx: PanelContext): Promise<HTMLElement> {
         + (exp != null ? ` · exposure ${exp > 0 ? "+" : ""}${exp.toFixed(1)}%` : "");
   }
 
+  briefPrimary(gmpCard, "cost", "Open budget lines", () => openRoomModule(ctx, "budget"));
   return wrap;
 }

--- a/apps/web/src/portal/panels/dealBrief.ts
+++ b/apps/web/src/portal/panels/dealBrief.ts
@@ -1,6 +1,6 @@
 import type { PanelContext } from "../panelContext";
 import { firstOpenStep, type ReadinessStep } from "./readinessStrip";
-import { fail, mountBrief } from "./roomBriefChrome";
+import { briefPrimary, fail, mountBrief } from "./roomBriefChrome";
 
 /**
  * R36-ROOM-BRIEFS — Deal (developer).
@@ -84,15 +84,15 @@ export async function renderDealBrief(ctx: PanelContext): Promise<HTMLElement> {
         gateCard.body.appendChild(g);
       }
       if (ctx.hasDest(next.dest)) {
-        const b = document.createElement("button");
-        b.className = "tool-btn";
-        b.style.marginTop = "6px";
-        b.textContent = "Open";
-        b.onclick = () => ctx.navigate(next.dest);
-        gateCard.root.appendChild(b);
+        briefPrimary(gateCard, "deal", "Open", () => ctx.navigate(next.dest));
+      } else {
+        briefPrimary(gateCard, "deal", "See the book", () => ctx.navigate("__portfolio__"));
       }
     }
   }
 
+  if (!wrap.querySelector("[data-room-primary]")) {
+    briefPrimary(gateCard, "deal", "See the book", () => ctx.navigate("__portfolio__"));
+  }
   return wrap;
 }

--- a/apps/web/src/portal/panels/operateBrief.ts
+++ b/apps/web/src/portal/panels/operateBrief.ts
@@ -1,5 +1,5 @@
 import type { PanelContext } from "../panelContext";
-import { fail, mountBrief } from "./roomBriefChrome";
+import { briefPrimary, fail, mountBrief, openRoomModule } from "./roomBriefChrome";
 
 /**
  * R36-ROOM-BRIEFS — Operate (facility / CMMS).
@@ -58,5 +58,6 @@ export async function renderOperateBrief(ctx: PanelContext): Promise<HTMLElement
       + ` · ${fca.value.open_deficiencies} open deficiencies`;
   }
 
+  briefPrimary(odCard, "operate", "Open work orders", () => openRoomModule(ctx, "work_order"));
   return wrap;
 }

--- a/apps/web/src/portal/panels/planningBrief.ts
+++ b/apps/web/src/portal/panels/planningBrief.ts
@@ -1,5 +1,5 @@
 import type { PanelContext } from "../panelContext";
-import { fail, mountBrief } from "./roomBriefChrome";
+import { briefPrimary, fail, mountBrief, openRoomModule } from "./roomBriefChrome";
 
 /**
  * R36-ROOM-BRIEFS — Planning (PM).
@@ -73,5 +73,6 @@ export async function renderPlanningBrief(ctx: PanelContext): Promise<HTMLElemen
     }
   }
 
+  briefPrimary(rfiCard, "planning", "Open RFIs", () => openRoomModule(ctx, "rfi"));
   return wrap;
 }

--- a/apps/web/src/portal/panels/roomBriefChrome.ts
+++ b/apps/web/src/portal/panels/roomBriefChrome.ts
@@ -4,6 +4,10 @@
  * Each room still owns its three questions and its engines. This file only builds the three
  * cards so a fourth room does not copy the markup a third time.
  */
+import type { RoomId } from "../../ui/a11yJourney";
+import { markPrimary } from "../../ui/a11yJourney";
+import type { PanelContext } from "../panelContext";
+
 export type BriefQuestion = { key: string; title: string };
 
 export type BriefCard = { root: HTMLElement; body: HTMLElement };
@@ -45,4 +49,34 @@ export function mountBrief(
     }),
   );
   return { wrap, byKey };
+}
+
+/** Open a register from a room landing. No-ops when the catalog has not loaded that module. */
+export function openRoomModule(ctx: PanelContext, moduleKey: string): void {
+  const m = ctx.mods.find((x) => x.key === moduleKey);
+  if (!m) return;
+  ctx.activeKey = moduleKey;
+  void ctx.openModule(m);
+  ctx.buildNav();
+}
+
+/**
+ * The room's one keyboard primary — a real button on a brief card, not a clickable card.
+ * Exactly one of these should exist per room landing.
+ */
+export function briefPrimary(
+  card: BriefCard,
+  room: RoomId,
+  label: string,
+  onClick: () => void,
+): HTMLButtonElement {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = "tool-btn";
+  b.style.marginTop = "6px";
+  b.textContent = label;
+  b.onclick = onClick;
+  markPrimary(b, room);
+  card.root.appendChild(b);
+  return b;
 }

--- a/apps/web/src/portal/panels/scheduleBrief.ts
+++ b/apps/web/src/portal/panels/scheduleBrief.ts
@@ -1,6 +1,6 @@
 import { escapeHtml as esc } from "../../ui/feedback";
 import type { PanelContext } from "../panelContext";
-import { fail, mountBrief } from "./roomBriefChrome";
+import { briefPrimary, fail, mountBrief, openRoomModule } from "./roomBriefChrome";
 
 /**
  * R36-ROOM-BRIEFS — Schedule (superintendent).
@@ -102,5 +102,6 @@ export async function renderScheduleBrief(ctx: PanelContext): Promise<HTMLElemen
     }
   }
 
+  briefPrimary(laCard, "schedule", "Open activities", () => openRoomModule(ctx, "schedule_activity"));
   return wrap;
 }

--- a/apps/web/src/portal/panels/workQueue.ts
+++ b/apps/web/src/portal/panels/workQueue.ts
@@ -1,4 +1,5 @@
 import { escapeHtml as esc, toast } from "../../ui/feedback";
+import { markPrimary } from "../../ui/a11yJourney";
 import type { PanelContext } from "../panelContext";
 import type { QueueItem } from "../../api/types";
 
@@ -39,6 +40,11 @@ export async function renderWorkQueue(ctx: PanelContext) {
     catch (e) { body.innerHTML = `<div class="meta">Couldn't load the queue: ${esc((e as Error).message)}</div>`; return; }
     body.replaceChildren();
 
+    const restoreFocus = () => {
+      const p = body.querySelector<HTMLElement>("[data-room-primary]");
+      if (p && !body.contains(document.activeElement)) p.focus();
+    };
+
     const head = document.createElement("div");
     head.className = "dash-card"; head.style.marginBottom = "10px";
     // "You have 14 things" and "14 things, 3 of them waiting on somebody else" are different
@@ -53,10 +59,20 @@ export async function renderWorkQueue(ctx: PanelContext) {
       const none = document.createElement("div");
       none.className = "dash-card";
       none.innerHTML = `<div class="meta">Nothing is in your court right now.</div>`;
+      const refresh = document.createElement("button");
+      refresh.type = "button";
+      refresh.className = "tool-btn";
+      refresh.style.marginTop = "8px";
+      refresh.textContent = "Refresh queue";
+      refresh.onclick = () => void load();
+      markPrimary(refresh, "work");
+      none.appendChild(refresh);
       body.appendChild(none);
+      restoreFocus();
       return;
     }
 
+    let marked = false;
     for (const b of q.buckets) {
       // An empty bucket is skipped EXCEPT overdue: rendering "Overdue 0" is worth the line, because
       // a missing heading makes the reader check whether it was hidden or genuinely clear.
@@ -79,7 +95,9 @@ export async function renderWorkQueue(ctx: PanelContext) {
 
         const main = document.createElement("button");
         main.className = "wq-open";
+        main.type = "button";
         main.title = `Open ${it.ref}`;
+        if (!marked) { markPrimary(main, "work"); marked = true; }
         main.innerHTML = `<span class="ic">${esc(it.icon || "•")}</span> `
           + `<b>${esc(it.ref)}</b> ${esc(it.title || "(untitled)")}`
           + `<span class="meta"> — ${esc(it.module_name)} · ${esc(it.state)}`
@@ -128,6 +146,7 @@ export async function renderWorkQueue(ctx: PanelContext) {
       }
       body.appendChild(card);
     }
+    restoreFocus();
   }
 
   await load();

--- a/apps/web/src/ui/a11yJourney.test.ts
+++ b/apps/web/src/ui/a11yJourney.test.ts
@@ -1,0 +1,203 @@
+/**
+ * R39-A11Y-JOURNEYS ② — a journey is Tab → operate → land, not an aria attribute.
+ *
+ * Each room is mounted from the renderer that actually ships (briefs, work queue, room tabs).
+ * jsdom does not walk the browser tab order; we walk the same focusable set `result.ts` / `modal.ts`
+ * use, which is the claim the product makes about what a keyboard can reach.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ModuleDef } from "../api/types";
+import type { PanelContext } from "../portal/panelContext";
+import { renderCostBrief } from "../portal/panels/costBrief";
+import { renderDealBrief } from "../portal/panels/dealBrief";
+import { renderOperateBrief } from "../portal/panels/operateBrief";
+import { renderPlanningBrief } from "../portal/panels/planningBrief";
+import { renderScheduleBrief } from "../portal/panels/scheduleBrief";
+import { renderWorkQueue } from "../portal/panels/workQueue";
+import { buildRoomTabs, renderRoomTabs } from "../shell/roomTabs";
+import { ROOM_IDS } from "../shell/spine";
+import {
+  ROOM_PRIMARY, focusIsSane, operate, tabReach, type RoomId,
+} from "./a11yJourney";
+
+function mod(key: string): ModuleDef {
+  return {
+    key, name: key, section: "x", icon: "•", pinnable: false, fields: [],
+    workflow: { initial: "open", states: ["open"], transitions: [] },
+  };
+}
+
+function land(root: HTMLElement, name: string): void {
+  const pane = document.createElement("div");
+  pane.dataset.landed = name;
+  pane.setAttribute("role", "region");
+  pane.setAttribute("aria-label", name);
+  const inp = document.createElement("input");
+  inp.setAttribute("aria-label", `Search ${name}`);
+  pane.appendChild(inp);
+  root.appendChild(pane);
+  inp.focus();
+}
+
+function ctx(api: Record<string, unknown>, mods: ModuleDef[]): PanelContext {
+  const root = document.createElement("div");
+  const host: PanelContext = {
+    root,
+    host: { projectId: () => "p1", api } as unknown as PanelContext["host"],
+    mods,
+    activeKey: null,
+    bar: (title) => {
+      const bar = document.createElement("div");
+      const back = document.createElement("button");
+      back.type = "button";
+      back.textContent = "←";
+      const t = document.createElement("strong");
+      t.textContent = title;
+      bar.append(back, t);
+      return bar;
+    },
+    buildNav: () => undefined,
+    renderHome: async () => undefined,
+    openModule: async (m) => { land(root, m.key); },
+    navigate: (key) => { land(root, key); },
+    hasDest: () => true,
+  };
+  return host;
+}
+
+function rates() {
+  return {
+    rfi: { total: 4, open: 1, overdue: 0, overdue_pct: 0, avg_turnaround_days: 3 },
+    submittal: { total: 2, open: 1, overdue: 0, overdue_pct: 0, avg_turnaround_days: 5 },
+  };
+}
+
+async function mountRoom(room: RoomId): Promise<HTMLElement> {
+  const chrome = document.createElement("div");
+  document.body.appendChild(chrome);
+  const tabs = document.createElement("div");
+  chrome.appendChild(tabs);
+  renderRoomTabs(tabs, buildRoomTabs(), room, (id) => {
+    const t = tabs.querySelector<HTMLElement>(`[data-room="${id}"]`);
+    t?.focus();
+  });
+  const pane = document.createElement("div");
+  chrome.appendChild(pane);
+
+  if (room === "design") return chrome;
+
+  if (room === "planning") {
+    const host = ctx({
+      benchmarkResponseRates: vi.fn().mockResolvedValue(rates()),
+      benchmarkCosts: vi.fn().mockResolvedValue({ cost_codes: [], code_count: 0, min_samples: 3 }),
+    }, [mod("rfi")]);
+    pane.appendChild(await renderPlanningBrief(host));
+    return chrome;
+  }
+  if (room === "cost") {
+    const host = ctx({
+      gmpBudget: vi.fn().mockResolvedValue({
+        gmp: { contract_value: 1, computed: 1 },
+        totals: { budget: 1 },
+        completion: { eac: 1, projected_over_under: 0 },
+        buyout: { packages: 1, bought_out: 0, budget: 1, awarded: 0, savings: 0 },
+      }),
+      projectPulse: vi.fn().mockResolvedValue({ cost: { unpricedChanges: 0, exposurePct: 0 } }),
+    }, [mod("budget")]);
+    pane.appendChild(await renderCostBrief(host));
+    return chrome;
+  }
+  if (room === "schedule") {
+    const host = ctx({
+      scheduleLookahead: vi.fn().mockResolvedValue({ count: 0, weeks_detail: [] }),
+      scheduleAlerts: vi.fn().mockResolvedValue({ alerts: [], counts: { high: 0, medium: 0, low: 0 } }),
+      scheduleVariance: vi.fn().mockResolvedValue({
+        captured_at: "2026-08-18", baseline_count: 0,
+        summary: { slipped: 0, max_slip_days: 0 }, activities: [],
+      }),
+    }, [mod("schedule_activity")]);
+    pane.appendChild(await renderScheduleBrief(host));
+    return chrome;
+  }
+  if (room === "deal") {
+    const host = ctx({
+      projectPulse: vi.fn().mockResolvedValue({ deal: { irrPct: 14, band: [12, 18] } }),
+      diligenceReadiness: vi.fn().mockResolvedValue({
+        go: true,
+        due_diligence: { total: 1, cleared: 1, flagged: 0 },
+        entitlements: { pending: 0, approved: 1, denied: 0, total: 1 },
+      }),
+      masterBuilderBrief: vi.fn().mockResolvedValue({
+        steps: [{ n: 1, key: "place", title: "Place", dest: "__land__", status: "gap", gaps: [] }],
+      }),
+    }, []);
+    pane.appendChild(await renderDealBrief(host));
+    return chrome;
+  }
+  if (room === "operate") {
+    const host = ctx({
+      cmmsKpis: vi.fn().mockResolvedValue({
+        total: 1, open: 1, completed: 0, overdue: 0, pm_compliance_pct: 90, mttr_days: 2,
+      }),
+      fcaIndex: vi.fn().mockResolvedValue({
+        elements: 1, open_deficiencies: 0, fci_pct: 4, band: "good", note: "",
+      }),
+    }, [mod("work_order")]);
+    pane.appendChild(await renderOperateBrief(host));
+    return chrome;
+  }
+  const host = ctx({
+    workQueue: vi.fn().mockResolvedValue({
+      total: 1, actionable: 1, no_action: 0,
+      buckets: [{
+        key: "today", label: "Today", means: "due today", count: 1,
+        items: [{
+          module: "rfi", module_name: "RFIs", icon: "R", id: "1", ref: "RFI-1",
+          title: "Clash", state: "open", assignee: "you", reason: "assigned",
+          due: "2026-08-19", bucket: "today", actions: [], blocked_actions: [],
+        }],
+      }],
+    }),
+  }, [mod("rfi")]);
+  pane.appendChild(host.root);
+  await renderWorkQueue(host);
+  return chrome;
+}
+
+afterEach(() => { document.body.innerHTML = ""; });
+
+describe("R39-A11Y-JOURNEYS ② — one primary per room", () => {
+  it("names every room exactly once", () => {
+    expect(Object.keys(ROOM_PRIMARY).sort()).toEqual([...ROOM_IDS].sort());
+  });
+
+  it.each([...ROOM_IDS])("%s: Tab reaches the primary, operating it lands focus", async (room) => {
+    const chrome = await mountRoom(room);
+    const primary = chrome.querySelector<HTMLElement>(ROOM_PRIMARY[room].selector);
+    expect(primary, `${room} has no ${ROOM_PRIMARY[room].selector}`).toBeTruthy();
+    expect(chrome.querySelectorAll("[data-room-primary]").length, `${room} must have one primary`)
+      .toBe(room === "design" ? 0 : 1);
+    expect(tabReach(chrome, primary!)).toBe(true);
+    operate(primary!);
+    expect(focusIsSane(chrome), `${room} dropped focus onto ${document.activeElement?.nodeName}`)
+      .toBe(true);
+  });
+
+  it("an empty work queue still has a keyboard primary", async () => {
+    const chrome = document.createElement("div");
+    document.body.appendChild(chrome);
+    const host = ctx({
+      workQueue: vi.fn().mockResolvedValue({
+        total: 0, actionable: 0, no_action: 0, buckets: [],
+      }),
+    }, []);
+    chrome.appendChild(host.root);
+    await renderWorkQueue(host);
+    const primary = chrome.querySelector<HTMLElement>(ROOM_PRIMARY.work.selector);
+    expect(primary?.textContent).toBe("Refresh queue");
+    expect(tabReach(chrome, primary!)).toBe(true);
+    operate(primary!);
+    expect(focusIsSane(chrome)).toBe(true);
+  });
+});

--- a/apps/web/src/ui/a11yJourney.ts
+++ b/apps/web/src/ui/a11yJourney.ts
@@ -1,0 +1,103 @@
+/**
+ * R39-A11Y-JOURNEYS ② — keyboard journeys for the seven rooms.
+ *
+ * Attribute sweeps already ran. A keyboard user does not experience an attribute: they Tab to the
+ * thing they came to do, operate it, and land somewhere they can keep going. This file is that
+ * journey as code — one primary per room, the same focusable query the rest of the app uses, and
+ * a check that focus did not fall on `document.body`.
+ *
+ * Design has no portal home (`ROOM_HOME.design` is null — the viewer *is* the room). Its primary
+ * is the Design tab. The other six mark `[data-room-primary]` on the landing the room already
+ * renders.
+ */
+import { ROOM_IDS } from "../shell/spine";
+
+/** Native + explicit tab stops. Matches `ui/result.ts` / `ui/modal.ts`. */
+export const FOCUSABLE_SEL =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export type RoomId = (typeof ROOM_IDS)[number];
+
+export interface RoomPrimary {
+  room: RoomId;
+  /** Query from the room chrome (tablist + pane). */
+  selector: string;
+}
+
+/**
+ * One primary per room. Labels are not duplicated here — the renderer owns the visible verb so a
+ * test that copied the string would agree with itself while the button drifted.
+ */
+export const ROOM_PRIMARY: Record<RoomId, RoomPrimary> = {
+  design: { room: "design", selector: '[data-room="design"]' },
+  planning: { room: "planning", selector: '[data-room-primary="planning"]' },
+  schedule: { room: "schedule", selector: '[data-room-primary="schedule"]' },
+  cost: { room: "cost", selector: '[data-room-primary="cost"]' },
+  deal: { room: "deal", selector: '[data-room-primary="deal"]' },
+  work: { room: "work", selector: '[data-room-primary="work"]' },
+  operate: { room: "operate", selector: '[data-room-primary="operate"]' },
+};
+
+export function markPrimary(el: HTMLElement, room: RoomId): void {
+  el.dataset.roomPrimary = room;
+}
+
+export function focusables(root: ParentNode): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>(FOCUSABLE_SEL)].filter((el) => isOperable(el));
+}
+
+/** Hidden, `inert`, or `aria-hidden` is not a stop. `offsetParent` is a layout lie in jsdom. */
+export function isOperable(el: HTMLElement): boolean {
+  if (el.hidden || el.getAttribute("aria-hidden") === "true") return false;
+  if (el.closest("[hidden], [inert], [aria-hidden='true']")) return false;
+  const tn = el.tagName;
+  if (tn === "BUTTON" || tn === "SELECT" || tn === "TEXTAREA" || tn === "INPUT") {
+    if ((el as HTMLButtonElement).disabled) return false;
+  }
+  return true;
+}
+
+/** Tab to the next operable control inside `root`. Returns the newly focused node. */
+export function tabForward(root: ParentNode): HTMLElement | null {
+  const items = focusables(root);
+  if (!items.length) return null;
+  const active = document.activeElement;
+  const i = items.findIndex((el) => el === active);
+  const next = i < 0 ? items[0]! : items[(i + 1) % items.length]!;
+  next.focus();
+  return next;
+}
+
+export function tabReach(root: ParentNode, target: HTMLElement): boolean {
+  const items = focusables(root);
+  if (!items.includes(target)) return false;
+  const start = items[0]!;
+  start.focus();
+  if (document.activeElement === target) return true;
+  for (let n = 0; n < items.length; n++) {
+    if (tabForward(root) === target) return true;
+  }
+  return false;
+}
+
+/** Enter / Space activate a control the way a keyboard user does — then click for jsdom. */
+export function operate(el: HTMLElement): void {
+  el.focus();
+  el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+  el.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter", bubbles: true }));
+  el.click();
+}
+
+/**
+ * Focus after operate is sane when it is still a real control the user can keep using:
+ * inside the room chrome, or inside an opened dialog / region that the action created.
+ */
+export function focusIsSane(root: ParentNode): boolean {
+  const el = document.activeElement;
+  if (!(el instanceof HTMLElement)) return false;
+  if (el === document.body || el === document.documentElement) return false;
+  if (!isOperable(el)) return false;
+  if (root.contains(el)) return true;
+  if (el.closest('[role="dialog"], [role="region"]')) return true;
+  return false;
+}

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-19, after v0.3.1006
+# Runway for Claude Code — 2026-08-19, after v0.3.1007
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security
@@ -21,7 +21,9 @@ memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still
 | 6 | [#298](https://github.com/ibuilder/massing/pull/298) | `cursor/charts-series-colour-6e15` | **1002** vs #297 |
 | 7 | [#299](https://github.com/ibuilder/massing/pull/299) | `cursor/mono-data-token-6e15` | **1003** vs #298 |
 | 8 | [#300](https://github.com/ibuilder/massing/pull/300) | `cursor/field-mode-chrome-6e15` | **1004** vs #299 |
-| 9 | this | `cursor/cite-highlight-6e15` | **1005** vs #300 |
+| 9 | [#301](https://github.com/ibuilder/massing/pull/301) | `cursor/cite-highlight-6e15` | **1005** vs #300 |
+| 10 | [#302](https://github.com/ibuilder/massing/pull/302) | `cursor/field-capture-home-6e15` | **1006** vs #301 |
+| 11 | this | `cursor/a11y-journeys-6e15` | **1007** vs #302 |
 
 After each merge: rebase the remainder, **keep the later version numbers**. Do not tag onto a red or
 pending `main`. This agent cannot merge.
@@ -40,6 +42,8 @@ pending `main`. This agent cannot merge.
 | 1003 | R24-MONO-DATA closed — paste textarea uses `var(--mono)`; allowance 0 |
 | 1004 | R24-FIELD-MODE ② — field CSS beats FAB inline size/position; strip `aria-live` |
 | 1005 | R31-CITE-HIGHLIGHT closed — in-app viewer + PageWords box |
+| 1006 | R24-FIELD-MODE ③ — capture sheet lands when field mode + project |
+| 1007 | R39-A11Y-JOURNEYS ② closed — Tab to `[data-room-primary]` (Design tab for Design) |
 
 ---
 
@@ -61,9 +65,9 @@ PERSONA-SHAPE; IDENTITY.
 
 ## Next slices
 
-1. **R24-FIELD-MODE remainder** — capture-first *home* (not another density control, not Lane J CSS).
+1. **R24-FIELD-MODE remainder** — replacing the seven-room home (Lane A). Slice ③ only opens the sheet.
 2. **R24-REPORTS-BY-MOMENT** scheduling (needs jobs/delivery; larger).
-3. **R39-A11Y-JOURNEYS ②** — keyboard journeys; attributes already swept.
+3. Lane B still open: `R24-TERMS`, `UX-GANTT`, `R22-REPORT-BUILDER`, `R23-SYMBOL-COUNT`, `R38-SHEET-MARKUP ③`.
 
 ---
 
@@ -80,8 +84,9 @@ PERSONA-SHAPE; IDENTITY.
 
 ```
 cd apps/web && npm run typecheck && npm run lint
-npx vitest run src/ui/charts.test.ts src/ui/monoData.test.ts src/field/fieldMode.test.ts \
-  src/drawings/citeLocate.test.ts src/portal/panels/citationControl.test.ts \
+npx vitest run src/ui/a11yJourney.test.ts src/portal/panels/planningBrief.test.ts \
+  src/portal/panels/costBrief.test.ts src/portal/panels/scheduleBrief.test.ts \
+  src/portal/panels/dealBrief.test.ts src/portal/panels/operateBrief.test.ts \
   src/shell/roadmapLanes.test.ts src/shell/versionConsistency.test.ts
 cd ../services/api && PYTHONPATH=src:../data/src python3 test_file_sizes.py && python3 test_claude_md_gates.py
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -650,7 +650,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/portal/portal.ts`, `main.ts` | R24-RUNS-INBOX · REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R38-SHEET-MARKUP ③ · R39-A11Y-JOURNEYS ② |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · UX-GANTT · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R38-SHEET-MARKUP ③ |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R39-UPLOAD-CAP-APP ①◧ · R41-UPLOAD-WARK · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | R38-ARRAY-LIVE ③ · R21-4D-CLASH · R28-BUNDLE ② — **the three that landed in PRs #176/#178/#179 on 2026-08-02** (R28-ICDD, R23-STOREY-LOD, R28-UNIFY) are shipped and pending archive. **Corrected 2026-08-06: this read "all SHIPPED and MERGED", which was false for 8 of the 11 codes beside it** — SEC-PLUGIN-SANDBOX is ◧ with its `setrlimit` half explicitly REFUSED, R38-SYNC-VIEW and R21-4D-CLASH are ◧, and five carry no marker at all. A row-level word like "all" has no defined scope, so it drifts the moment the row grows; the item markers are the authority and this sentence is not. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · R28-VIEWER ④ · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* · R41-MODEL-ALIGN · R43-VIEWER-CONFORMANCE |
@@ -2074,10 +2074,11 @@ refusal (`services/api/src/aec_api/main.py`), and full-history checkout for the 
   end. **Two entries, one mechanism** — fix either in isolation and the other still holds the memory
   open.
 
-- **R39-A11Y-JOURNEYS ②** *(M, Lane B)* — keyboard-only acceptance journeys for the seven rooms,
+- ✅ **R39-A11Y-JOURNEYS ②** *(M, Lane B — **SHIPPED v0.3.1007**)* — keyboard-only acceptance journeys for the seven rooms,
   encoded as tests rather than an audit doc: for each room, tab-reach the primary action, operate it,
-  and land focus somewhere sane. The a11y sweeps so far checked *attributes*; nothing yet checks a
-  *journey*, and a journey is what a keyboard user actually has.
+  and land focus somewhere sane (`apps/web/src/ui/a11yJourney.ts`). Design's primary is the Design tab;
+  the other six mark `[data-room-primary]` on the room brief (or the first work-queue row). The a11y
+  sweeps so far checked *attributes*; this checks a *journey*.
 - **R39-VIEWER-OBS ②** *(M, Lane E)* — the viewer has no timing record: "loads slowly" arrives as a
   feeling, not a number. Instrument the load journey (fetch → parse → first frame, keyed by model
   size) and POST the timings to the platform's own API — no third-party telemetry, nothing new to

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1006",
+      "version": "0.3.1007",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R39-A11Y-JOURNEYS ②. Stack this on #302 (`cursor/field-capture-home-6e15`). Do not merge until 294 → 292 → 295 → 297–302 land; keep **0.3.1007**.

## What & why

Attribute sweeps already ran. A keyboard user Tabs to the thing they came to do, operates it, and lands somewhere they can keep going. This encodes that journey as tests.

Each of the seven rooms has one keyboard primary:

- **Design** — the Design tab (`ROOM_HOME.design` is still null; no Design brief)
- **Planning / Cost / Schedule / Operate** — `[data-room-primary]` on the room brief (`Open RFIs`, `Open budget lines`, `Open activities`, `Open work orders`)
- **Deal** — Open the next protocol gate, or See the book
- **Work** — first queue row, or Refresh queue when empty

`apps/web/src/ui/a11yJourney.ts` walks the same focusable set as `result.ts` / `modal.ts`, operates the primary, and asserts focus did not fall on `document.body`.

## Checklist

- [x] Web: typecheck + lint + vitest (journeys, briefs, roadmap lanes, version, import cycles)
- [x] `test_file_sizes.py` / `test_claude_md_gates.py`
- [ ] `npm run build` not run in this pass
- [x] CHANGELOG + roadmap + version triple 0.3.1007
- [ ] Live keyboard pass in the running app — not driven

## Verify

```
cd apps/web && npm run typecheck && npm run lint
npx vitest run src/ui/a11yJourney.test.ts src/portal/panels/*Brief.test.ts src/shell/roadmapLanes.test.ts
cd ../services/api && PYTHONPATH=src:../data/src python3 test_file_sizes.py && python3 test_claude_md_gates.py
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

