### PR TITLE
v0.3.1008 — field mode hides the seven rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1008 (2026-08-19) — field mode hides the seven rooms
+
+R24-FIELD-MODE ④. With field mode on, `#workspaces` (the room tablist) is `display:none`, so
+it is also out of the tab order. Capture stays the landing (③); Office restores the spine.
+Replacing the portal home itself is still Lane A.
+
 ## v0.3.1007 (2026-08-19) — Tab to the room's job, then land
 
 R39-A11Y-JOURNEYS ②. Each of the seven rooms has one keyboard primary: Design is its tab; the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1007",
+    "version": "0.3.1008",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1007",
+  "version": "0.3.1008",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/field/fieldMode.css
+++ b/apps/web/src/field/fieldMode.css
@@ -73,3 +73,9 @@ html[data-field-mode="1"] .field-sheet button {
   min-height: 56px;
   font-size: 16px;
 }
+
+/* Slice ④ — field mode is capture-first. The seven-room tablist is office IA; display:none
+   drops it from the tab order as well as the screen. Leave Field → Office to get it back. */
+html[data-field-mode="1"] #workspaces {
+  display: none !important;
+}

--- a/apps/web/src/field/fieldMode.test.ts
+++ b/apps/web/src/field/fieldMode.test.ts
@@ -115,4 +115,8 @@ describe("fieldMode.css stays off the accent contract", () => {
     expect(css).toMatch(/#field-fab[\s\S]*bottom:\s*72px\s*!important/);
     expect(css).toMatch(/min-height:\s*56px/);
   });
+
+  it("hides the seven-room tablist in field mode so capture is the home, not a spine overlay", () => {
+    expect(css).toMatch(/html\[data-field-mode="1"\]\s+#workspaces\s*\{[^}]*display:\s*none\s*!important/);
+  });
 });

--- a/apps/web/src/field/fieldMode.ts
+++ b/apps/web/src/field/fieldMode.ts
@@ -5,6 +5,7 @@
  * IA: a 52 px FAB, a queue you only see after opening the sheet, and notes that cannot be spoken.
  * This file is the mode flag plus the copy the always-visible strip uses. Contrast and 56 px
  * targets live in `fieldMode.css`, scoped to field chrome so office density is untouched.
+ * Slice ④ hides `#workspaces` (the seven-room tablist) while the mode is on.
  */
 export const FIELD_MODE_KEY = "aec-field-mode";
 

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-19, after v0.3.1007
+# Runway for Claude Code — 2026-08-19, after v0.3.1008
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security
@@ -23,7 +23,8 @@ memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still
 | 8 | [#300](https://github.com/ibuilder/massing/pull/300) | `cursor/field-mode-chrome-6e15` | **1004** vs #299 |
 | 9 | [#301](https://github.com/ibuilder/massing/pull/301) | `cursor/cite-highlight-6e15` | **1005** vs #300 |
 | 10 | [#302](https://github.com/ibuilder/massing/pull/302) | `cursor/field-capture-home-6e15` | **1006** vs #301 |
-| 11 | this | `cursor/a11y-journeys-6e15` | **1007** vs #302 |
+| 11 | [#303](https://github.com/ibuilder/massing/pull/303) | `cursor/a11y-journeys-6e15` | **1007** vs #302 |
+| 12 | this | `cursor/field-hide-spine-6e15` | **1008** vs #303 |
 
 After each merge: rebase the remainder, **keep the later version numbers**. Do not tag onto a red or
 pending `main`. This agent cannot merge.
@@ -44,6 +45,7 @@ pending `main`. This agent cannot merge.
 | 1005 | R31-CITE-HIGHLIGHT closed — in-app viewer + PageWords box |
 | 1006 | R24-FIELD-MODE ③ — capture sheet lands when field mode + project |
 | 1007 | R39-A11Y-JOURNEYS ② closed — Tab to `[data-room-primary]` (Design tab for Design) |
+| 1008 | R24-FIELD-MODE ④ — hide `#workspaces` while field mode is on |
 
 ---
 
@@ -65,9 +67,9 @@ PERSONA-SHAPE; IDENTITY.
 
 ## Next slices
 
-1. **R24-FIELD-MODE remainder** — replacing the seven-room home (Lane A). Slice ③ only opens the sheet.
-2. **R24-REPORTS-BY-MOMENT** scheduling (needs jobs/delivery; larger).
-3. Lane B still open: `R24-TERMS`, `UX-GANTT`, `R22-REPORT-BUILDER`, `R23-SYMBOL-COUNT`, `R38-SHEET-MARKUP ③`.
+1. **R24-FIELD-MODE remainder** — replacing the portal home (Lane A). ④ only hides the room tabs.
+2. **R24-REPORTS-BY-MOMENT** scheduling (needs a job kind + delivery; larger).
+3. Lane B still open: `R24-TERMS` (user decision), `UX-GANTT`, `R22-REPORT-BUILDER`, `R23-SYMBOL-COUNT`, `R38-SHEET-MARKUP ③`.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1437,7 +1437,7 @@ is recorded. Filed under Decisions below.
 | 09 | tools panel mixes verbs with analyses | *(none)* | ✅ **v0.3.848** — `R24-TOOLS-SPLIT` cut the 1087-line `qa` section in two; Analyse is its own rail item |
 | 10 | finance numbers have no provenance | R24-TRACE-UI | 🟡 v0.3.775 shipped trace for *cost coverage*; the proforma chain (IRR ← NOI ← rent roll ← area ← GUID) — the audit's actual demo — is not built |
 | 11 | density | R24-DENSITY | ✅ **SHIPPED v0.3.996** — three steps on registers (`DENSITY_ROW_PX`), not dashboards only |
-| 12 | mobile is a bottom sheet in a desktop IA | R24-FIELD-MODE | ◧ **v0.3.1001–1006** — mode, 56 px (applied), strip, dictation, capture sheet as landing when a project is open. Seven-room spine still exists |
+| 12 | mobile is a bottom sheet in a desktop IA | R24-FIELD-MODE | ◧ **v0.3.1001–1008** — mode, 56 px, strip, dictation, capture landing, **room tabs hidden in field mode**. Portal home rewrite still Lane A |
 | 13 | search is scoped to modules | R24-CMDK-VERBS | ✅ **v0.3.946** — verbs, elements, reports and an assistant fallback; `apps/web/src/ui/paletteProviders.ts`. Fixed a second defect on the way: async hits were `concat`ed onto an already-grouped list, so a record landed under a **second** RECORDS heading below Modules |
 | 14 | empty states | R24-EMPTY-GUIDE | ✅ **verified done 2026-08-14** — the "24 lines, 'no project' only" reading is stale by a wide margin. `apps/web/src/ui/empty.ts` is 156 lines and R36-EMPTY-STATE shipped the hard part: a register with no rows distinguishes **none / filtered / failed**, because those send a reader to three different places and rendering them identically was the defect. Plus acronym-safe nouns ("No rfis yet" was the bug), `textContent` throughout since the name and the error body are untrusted, and `data-empty` so a test can assert WHICH kind was decided. Curated hints in `apps/web/src/ui/emptyGuide.ts` (157 lines), wired at two `register.ts` call sites, covered by `apps/web/src/ui/empty.test.ts` and `apps/web/src/ui/emptyGuide.test.ts` |
 | 15 | charts have no grammar | *(none)* | ✅ **SHIPPED v0.3.1002** — no-data, ticks/legend/currency, then series vs status (`SERIES_PALETTE` / `STATUS_*` in `apps/web/src/ui/charts.ts`) |
@@ -1540,12 +1540,12 @@ refute one, so this goes first even though it is the least visible.
 
 ### Sprint 4 — field, and the long tail
 
-- ◧ **R24-FIELD-MODE** *(L — **① v0.3.1001 · ② v0.3.1004 · ③ v0.3.1006**)* — a mode, not a breakpoint.
+- ◧ **R24-FIELD-MODE** *(L — **① v0.3.1001 · ② v0.3.1004 · ③ v0.3.1006 · ④ v0.3.1008**)* — a mode, not a breakpoint.
   `?field=1` / `aec-field-mode`, 56 px targets and ~7:1 on field chrome only (`apps/web/src/field/fieldMode.css`),
   always-visible sync strip, dictation when the browser has SpeechRecognition (`apps/web/src/field/dictate.ts`).
   Slice ②: field-mode CSS beats the FAB's inline 52 px. Slice ③: with a project open, field mode
-  **lands on the capture sheet** (`shouldOpenCaptureHome`) — the seven-room spine is still there;
-  this is not a second portal home.
+  **lands on the capture sheet** (`shouldOpenCaptureHome`). Slice ④: `#workspaces` is hidden while
+  the mode is on, so the seven-room tablist is not field home. Replacing the portal shell is Lane A.
 - ✅ **R24-CHARTS-GRAMMAR** *(**SHIPPED v0.3.1002**)* — no-data (v0.3.783), ticks/legend/currency
   (v0.3.948), **series vs status (v0.3.1002)**. `chartColor` is `SERIES_PALETTE` (seven categorical
   slots, none of them a traffic-light hue or `--accent`). Signed magnitude, the CPI–SPI quadrant, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1007",
+      "version": "0.3.1008",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R24-FIELD-MODE ④. Stack on #303. Keep **0.3.1008**. Do not merge until the earlier stack lands.

## What
Field mode hid the FAB collision and opened capture, but the seven-room tablist (`#workspaces`) stayed on screen. It is now `display:none` (and therefore out of the tab order) while field mode is on. Office restores it.

Replacing the portal home is still Lane A.

## Verify
`npx vitest run src/field/fieldMode.test.ts src/shell/roadmapLanes.test.ts src/shell/versionConsistency.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

