### PR TITLE
v0.3.1010 — count a symbol by matching it, not guessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1010 (2026-08-19) — count a symbol by matching it, not guessing
+
+R23-SYMBOL-COUNT ①. Normalised cross-correlation plus non-maximum suppression in
+`apps/web/src/ui/symbolCount.ts`. Zero new dependencies. The takeoff-worker wiring is still open.
+
 ## v0.3.1009 (2026-08-19) — this week's Gantt, not a month of bars
 
 UX-GANTT. The Schedule room already had a month-scale SVG. It now opens with a Mon–Sun week:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1009",
+    "version": "0.3.1010",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1009",
+  "version": "0.3.1010",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/ui/symbolCount.test.ts
+++ b/apps/web/src/ui/symbolCount.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { countSymbols, nccAt, nms, scanNcc, stamp } from "./symbolCount";
+
+function plus(): { needle: Float64Array; nw: number; nh: number } {
+  // 3×3 plus on black
+  const n = new Float64Array([
+    0, 1, 0,
+    1, 1, 1,
+    0, 1, 0,
+  ]);
+  return { needle: n, nw: 3, nh: 3 };
+}
+
+describe("R23-SYMBOL-COUNT ① — NCC", () => {
+  it("a stamped copy scores ~1 at the stamp and less beside it", () => {
+    const { needle, nw, nh } = plus();
+    const hw = 10, hh = 10;
+    const hay = new Float64Array(hw * hh);
+    stamp(hay, hw, needle, nw, nh, 4, 5);
+    expect(nccAt(hay, hw, hh, needle, nw, nh, 4, 5)).toBeCloseTo(1, 10);
+    expect(nccAt(hay, hw, hh, needle, nw, nh, 5, 5)).toBeLessThan(0.8);
+  });
+
+  it("a needle larger than the sheet is zero hits, not a throw", () => {
+    expect(scanNcc(new Float64Array(4), 2, 2, new Float64Array(9), 3, 3, 0.5)).toEqual([]);
+  });
+
+  it("a blank needle (zero variance) does not invent a match", () => {
+    const hay = new Float64Array(16);
+    hay[0] = 1;
+    const needle = new Float64Array(4);
+    expect(nccAt(hay, 4, 4, needle, 2, 2, 0, 0)).toBe(0);
+  });
+});
+
+describe("R23-SYMBOL-COUNT ① — NMS + count", () => {
+  it("two well-separated stamps both count", () => {
+    const { needle, nw, nh } = plus();
+    const hw = 16, hh = 8;
+    const hay = new Float64Array(hw * hh);
+    stamp(hay, hw, needle, nw, nh, 1, 2);
+    stamp(hay, hw, needle, nw, nh, 10, 2);
+    const r = countSymbols(hay, hw, hh, needle, nw, nh, { threshold: 0.9, radius: 2 });
+    expect(r.count).toBe(2);
+    expect(r.peaks.map((p) => `${p.x},${p.y}`).sort()).toEqual(["1,2", "10,2"]);
+  });
+
+  it("two peaks a pixel apart collapse to the stronger one", () => {
+    const kept = nms(
+      [{ x: 0, y: 0, score: 0.99 }, { x: 1, y: 0, score: 0.90 }],
+      2,
+    );
+    expect(kept).toEqual([{ x: 0, y: 0, score: 0.99 }]);
+  });
+
+  it("threshold rejects a weak lookalike", () => {
+    const { needle, nw, nh } = plus();
+    const hw = 8, hh = 8;
+    const hay = new Float64Array(hw * hh);
+    // a 2×2 block is not a plus
+    hay[0] = hay[1] = hay[hw] = hay[hw + 1] = 1;
+    const r = countSymbols(hay, hw, hh, needle, nw, nh, { threshold: 0.85, radius: 2 });
+    expect(r.count).toBe(0);
+  });
+});

--- a/apps/web/src/ui/symbolCount.ts
+++ b/apps/web/src/ui/symbolCount.ts
@@ -1,0 +1,103 @@
+/**
+ * R23-SYMBOL-COUNT ① — normalised cross-correlation + non-maximum suppression.
+ *
+ * Mark one instance, find the others. No new dependencies, offline, auditable — quantities
+ * that feed a bid cannot be a black-box detector. This file is the matcher. Wiring it into
+ * the pdf.js takeoff worker is the next slice; a matcher nobody can unit-test on a known
+ * patch is how a count becomes a guess.
+ *
+ * Buffers are row-major grayscale in 0..1. Coordinates are top-left of the needle.
+ */
+export type Peak = { x: number; y: number; score: number };
+
+function meanPatch(
+  buf: ArrayLike<number>, w: number, x: number, y: number, nw: number, nh: number,
+): number {
+  let s = 0;
+  for (let j = 0; j < nh; j++) {
+    const row = (y + j) * w + x;
+    for (let i = 0; i < nw; i++) s += buf[row + i]!;
+  }
+  return s / (nw * nh);
+}
+
+/** NCC of `needle` against `hay` at top-left `(x, y)`. 1 is identical (up to scale). */
+export function nccAt(
+  hay: ArrayLike<number>, hw: number, hh: number,
+  needle: ArrayLike<number>, nw: number, nh: number,
+  x: number, y: number,
+): number {
+  if (x < 0 || y < 0 || x + nw > hw || y + nh > hh) return 0;
+  const hm = meanPatch(hay, hw, x, y, nw, nh);
+  const nm = meanPatch(needle, nw, 0, 0, nw, nh);
+  let dot = 0, hn = 0, nn = 0;
+  for (let j = 0; j < nh; j++) {
+    const hr = (y + j) * hw + x;
+    const nr = j * nw;
+    for (let i = 0; i < nw; i++) {
+      const hv = hay[hr + i]! - hm;
+      const nv = needle[nr + i]! - nm;
+      dot += hv * nv;
+      hn += hv * hv;
+      nn += nv * nv;
+    }
+  }
+  const den = Math.sqrt(hn * nn);
+  if (den === 0) return 0;
+  return dot / den;
+}
+
+export function scanNcc(
+  hay: ArrayLike<number>, hw: number, hh: number,
+  needle: ArrayLike<number>, nw: number, nh: number,
+  threshold: number,
+): Peak[] {
+  if (nw < 1 || nh < 1 || nw > hw || nh > hh) return [];
+  const out: Peak[] = [];
+  for (let y = 0; y <= hh - nh; y++) {
+    for (let x = 0; x <= hw - nw; x++) {
+      const score = nccAt(hay, hw, hh, needle, nw, nh, x, y);
+      if (score >= threshold) out.push({ x, y, score });
+    }
+  }
+  return out;
+}
+
+/** Keep the highest peak in each `radius` neighbourhood. */
+export function nms(peaks: readonly Peak[], radius: number): Peak[] {
+  const sorted = [...peaks].sort((a, b) => b.score - a.score || a.y - b.y || a.x - b.x);
+  const kept: Peak[] = [];
+  const r2 = radius * radius;
+  for (const p of sorted) {
+    if (kept.some((k) => {
+      const dx = k.x - p.x, dy = k.y - p.y;
+      return dx * dx + dy * dy <= r2;
+    })) continue;
+    kept.push(p);
+  }
+  return kept;
+}
+
+export function countSymbols(
+  hay: ArrayLike<number>, hw: number, hh: number,
+  needle: ArrayLike<number>, nw: number, nh: number,
+  opts?: { threshold?: number; radius?: number },
+): { count: number; peaks: Peak[] } {
+  const threshold = opts?.threshold ?? 0.85;
+  const radius = opts?.radius ?? Math.max(nw, nh) / 2;
+  const peaks = nms(scanNcc(hay, hw, hh, needle, nw, nh, threshold), radius);
+  return { count: peaks.length, peaks };
+}
+
+/** Stamp `needle` into `hay` at `(x, y)` — test helper and takeoff preview. */
+export function stamp(
+  hay: Float64Array, hw: number,
+  needle: ArrayLike<number>, nw: number, nh: number,
+  x: number, y: number,
+): void {
+  for (let j = 0; j < nh; j++) {
+    const hr = (y + j) * hw + x;
+    const nr = j * nw;
+    for (let i = 0; i < nw; i++) hay[hr + i] = needle[nr + i]!;
+  }
+}

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-19, after v0.3.1009
+# Runway for Claude Code — 2026-08-19, after v0.3.1010
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security
@@ -25,7 +25,8 @@ memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still
 | 10 | [#302](https://github.com/ibuilder/massing/pull/302) | `cursor/field-capture-home-6e15` | **1006** vs #301 |
 | 11 | [#303](https://github.com/ibuilder/massing/pull/303) | `cursor/a11y-journeys-6e15` | **1007** vs #302 |
 | 12 | [#304](https://github.com/ibuilder/massing/pull/304) | `cursor/field-hide-spine-6e15` | **1008** vs #303 |
-| 13 | this | `cursor/weekly-gantt-6e15` | **1009** vs #304 |
+| 13 | [#305](https://github.com/ibuilder/massing/pull/305) | `cursor/weekly-gantt-6e15` | **1009** vs #304 |
+| 14 | this | `cursor/symbol-count-6e15` | **1010** vs #305 |
 
 After each merge: rebase the remainder, **keep the later version numbers**. Do not tag onto a red or
 pending `main`. This agent cannot merge.
@@ -48,6 +49,7 @@ pending `main`. This agent cannot merge.
 | 1007 | R39-A11Y-JOURNEYS ② closed — Tab to `[data-room-primary]` (Design tab for Design) |
 | 1008 | R24-FIELD-MODE ④ — hide `#workspaces` while field mode is on |
 | 1009 | UX-GANTT closed — weekly hybrid on the Schedule room |
+| 1010 | R23-SYMBOL-COUNT ① — NCC + NMS matcher (`ui/symbolCount.ts`); takeoff wiring open |
 
 ---
 
@@ -71,7 +73,8 @@ PERSONA-SHAPE; IDENTITY.
 
 1. **R24-FIELD-MODE remainder** — replacing the portal home (Lane A). ④ only hides the room tabs.
 2. **R24-REPORTS-BY-MOMENT** scheduling (needs a job kind + delivery; larger).
-3. Lane B still open: `R24-TERMS` (user decision), `R22-REPORT-BUILDER`, `R23-SYMBOL-COUNT`, `R38-SHEET-MARKUP ③`.
+3. Lane B still open: `R24-TERMS` (user decision), `R22-REPORT-BUILDER` (aggregation/share is backend),
+   `R23-SYMBOL-COUNT` takeoff wiring, `R38-SHEET-MARKUP ③` (generated sheets + GUID pins).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1370,9 +1370,10 @@ exists: the repo has a 220 KB bundle budget and **zero** runtime perf assertions
 
   The `MeshStandardMaterial` clause needs no work — every remaining use is GIS context, not the BIM
   pass.
-- **R23-SYMBOL-COUNT** *(M)* — deterministic template-match symbol counting in the **existing** pdf.js
-  takeoff worker: mark one instance, normalised cross-correlation, non-maximum suppression.
-  **Zero new dependencies**, offline, auditable — which matters for quantities that feed a bid.
+- ◧ **R23-SYMBOL-COUNT** *(M — **① v0.3.1010**)* — deterministic template-match symbol counting:
+  mark one instance, normalised cross-correlation, non-maximum suppression
+  (`apps/web/src/ui/symbolCount.ts`). **Zero new dependencies**, offline, auditable.
+  Takeoff-worker wiring (the existing pdf.js takeoff) is the remainder.
 
 **Watch, not work:** WebGPU (`WebGPURenderer` exists in the pinned three, but Fragments targets WebGL
 — 2–3 year horizon) · browser-side IFC parsing (a streaming WASM parser now exists; server-side

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1009",
+      "version": "0.3.1010",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R23-SYMBOL-COUNT ①. Stack on #305. Keep **0.3.1010**.

## What
Deterministic template match: normalised cross-correlation + non-maximum suppression in `apps/web/src/ui/symbolCount.ts`. Zero new dependencies. Two well-separated stamps count as two; neighbours collapse; a blank needle does not invent a hit.

The existing pdf.js takeoff worker is **not** wired yet — that is the remainder.

## Left closed / not this PR
- R24-TERMS — user decision on remaining pairs
- R22-REPORT-BUILDER — aggregation / shared views need `SavedView` schema (backend)
- R24-REPORTS-BY-MOMENT scheduling — needs a job kind + delivery
- R38-SHEET-MARKUP ③ — generated sheets + GUID pins (drawings/viewer)

## Verify
`npx vitest run src/ui/symbolCount.test.ts src/ui/a11yJourney.test.ts src/field/fieldMode.test.ts src/portal/panels/weeklyGantt.test.ts`
`npm run typecheck && npm run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

