### PR TITLE
v0.3.1011 — box one symbol on the sheet, get the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1011 (2026-08-20) — box one symbol on the sheet, get the rest
+
+R23-SYMBOL-COUNT ②. Takeoff **⌘ Match** boxes one instance on the pdf.js-rendered page;
+`countOnRgba` in `apps/web/src/ui/symbolCount.ts` downsamples, NCC-matches, and places
+existing count marks. A too-small or too-large box is a sentence, never a guessed quantity.
+
 ## v0.3.1010 (2026-08-19) — count a symbol by matching it, not guessing
 
 R23-SYMBOL-COUNT ①. Normalised cross-correlation plus non-maximum suppression in

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1010",
+    "version": "0.3.1011",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1010",
+  "version": "0.3.1011",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/drawings/pdfTakeoff.ts
+++ b/apps/web/src/drawings/pdfTakeoff.ts
@@ -10,6 +10,7 @@ import { PdfDocument, configureWorker } from "@massingcloud/pdf-viewer";
 import workerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 import { toast } from "../ui/feedback";
 import { askText } from "../ui/prompt";
+import { countOnRgba } from "../ui/symbolCount";
 import { documentWords, locatePassage, paintCiteBox } from "./citeLocate";
 
 // PDF-ADOPT slice 1 of 3: opening and page access now go through the vendored drawing-review engine
@@ -20,7 +21,7 @@ import { documentWords, locatePassage, paintCiteBox } from "./citeLocate";
 // hazard the hand-rolled `slice(0)` below existed to dodge.
 configureWorker(workerUrl);
 
-type Mode = "pan" | "distance" | "area" | "count" | "rect" | "calibrate" | "text" | "stamp";
+type Mode = "pan" | "distance" | "area" | "count" | "symbol" | "rect" | "calibrate" | "text" | "stamp";
 interface Pt { x: number; y: number }                       // PDF user-space
 export interface Measure { id: number; kind: Mode; pts: Pt[]; value: number; unit: string; label: string; page: number; text?: string }
 
@@ -151,7 +152,8 @@ export async function openPdfTakeoff(source?: PdfSource, opts: TakeoffOpts = {})
       tbtn("📏 Calibrate", calOk() ? `Scale set: 1 unit shown in ${unit}` : "Set the drawing scale (required)", () => setMode("calibrate"), mode === "calibrate"),
       tbtn("📐 Distance", "Measure distance", () => setMode("distance"), mode === "distance"),
       tbtn("▱ Area", "Measure area", () => setMode("area"), mode === "area"),
-      tbtn("# Count", "Count items", () => setMode("count"), mode === "count"),
+      tbtn("# Count", "Count items one by one", () => setMode("count"), mode === "count"),
+      tbtn("⌘ Match", "Box one symbol; matching instances become counts", () => setMode("symbol"), mode === "symbol"),
       tbtn("▭ Rect", "Rectangle annotation", () => setMode("rect"), mode === "rect"),
       tbtn("𝗧 Text", "Text markup", () => setMode("text"), mode === "text"),
       tbtn("🔖 Stamp", "Place the selected stamp", () => setMode("stamp"), mode === "stamp"),
@@ -230,6 +232,7 @@ export async function openPdfTakeoff(source?: PdfSource, opts: TakeoffOpts = {})
     if (mode === "count" || mode === "text" || mode === "stamp") { await commit(); draft = []; }  // single-click placement
     else if (mode === "calibrate" && draft.length === 2) await calibrate();
     else if (mode === "rect" && draft.length === 2) await commit();
+    else if (mode === "symbol" && draft.length === 2) await matchSymbols();
     drawOverlay();
   });
   svg.addEventListener("dblclick", async () => { if ((mode === "distance" && draft.length >= 2) || (mode === "area" && draft.length >= 3)) await commit(); });
@@ -247,6 +250,36 @@ export async function openPdfTakeoff(source?: PdfSource, opts: TakeoffOpts = {})
     unit = m?.[2] || "m"; unitsPerPt = +numStr / px;
     toast(`scale set — 1 ${unit} = ${(1 / unitsPerPt).toFixed(1)} pt`, "success");
     buildBar(); renderList();
+  }
+
+  /** R23-SYMBOL-COUNT ② — box one instance on the rendered pdf.js canvas; NCC places the rest. */
+  async function matchSymbols() {
+    const [a, b] = draft;
+    draft = [];
+    if (!a || !b) { drawOverlay(); return; }
+    // Reuse the context already created in `render` — a second getContext with different
+    // attributes can return null.
+    const ctx2d = canvas.getContext("2d");
+    if (!ctx2d) { toast("couldn't read the page", "error"); return; }
+    const x0 = Math.round(Math.min(a.x, b.x) * scale);
+    const y0 = Math.round(Math.min(a.y, b.y) * scale);
+    const tw = Math.round(Math.abs(b.x - a.x) * scale);
+    const th = Math.round(Math.abs(b.y - a.y) * scale);
+    let img: ImageData;
+    try { img = ctx2d.getImageData(0, 0, canvas.width, canvas.height); }
+    catch { toast("couldn't read the page pixels", "error"); return; }
+    const found = countOnRgba(img.data, img.width, img.height, { x: x0, y: y0, w: tw, h: th });
+    if (found.reason) { toast(found.reason, "info"); drawOverlay(); return; }
+    if (!found.count) { toast("no matches for that symbol", "info"); drawOverlay(); return; }
+    for (const p of found.peaks) {
+      measures.push({
+        id: ++seq, kind: "count",
+        pts: [{ x: (p.x + tw / 2) / scale, y: (p.y + th / 2) / scale }],
+        value: 1, unit: "ea", label: `symbol ${seq}`, page: pageNum,
+      });
+    }
+    toast(`${found.count} match${found.count === 1 ? "" : "es"}`, "success");
+    drawOverlay(); renderList();
   }
   async function commit() {
     const needsCal = mode === "distance" || mode === "area";
@@ -277,7 +310,7 @@ export async function openPdfTakeoff(source?: PdfSource, opts: TakeoffOpts = {})
     const S = (p: Pt) => [p.x * scale, p.y * scale] as const;
     const drawShape = (kind: Mode, pts: Pt[], color: string, dash = false) => {
       if (kind === "count") { for (const p of pts) { const [x, y] = S(p); svg.append(el("circle", { cx: `${x}`, cy: `${y}`, r: "5", fill: color, "fill-opacity": "0.8" })); } return; }
-      if (kind === "rect" && pts.length === 2) { const [x0, y0] = S(pts[0]!), [x1, y1] = S(pts[1]!); svg.append(el("rect", { x: `${Math.min(x0, x1)}`, y: `${Math.min(y0, y1)}`, width: `${Math.abs(x1 - x0)}`, height: `${Math.abs(y1 - y0)}`, fill: color, "fill-opacity": "0.15", stroke: color, "stroke-width": "1.5" })); return; }  // safe: length === 2
+      if ((kind === "rect" || kind === "symbol") && pts.length === 2) { const [x0, y0] = S(pts[0]!), [x1, y1] = S(pts[1]!); svg.append(el("rect", { x: `${Math.min(x0, x1)}`, y: `${Math.min(y0, y1)}`, width: `${Math.abs(x1 - x0)}`, height: `${Math.abs(y1 - y0)}`, fill: color, "fill-opacity": "0.15", stroke: color, "stroke-width": "1.5" })); return; }  // safe: length === 2
       const d = pts.map((p, i) => `${i ? "L" : "M"}${S(p)[0]},${S(p)[1]}`).join(" ") + (kind === "area" ? " Z" : "");
       svg.append(el("path", { d, fill: kind === "area" ? color : "none", "fill-opacity": "0.15", stroke: color, "stroke-width": "1.8", ...(dash ? { "stroke-dasharray": "5 4" } : {}) }));
       for (const p of pts) { const [x, y] = S(p); svg.append(el("circle", { cx: `${x}`, cy: `${y}`, r: "3", fill: color })); }
@@ -425,7 +458,7 @@ export async function openPdfTakeoff(source?: PdfSource, opts: TakeoffOpts = {})
   const avail = viewport.clientWidth - 40; if (canvas.width > avail) setScale(scale * (avail / canvas.width));
   // test hook (mirrors __viewer): drive modes/clicks/commit from preview_eval
   (window as unknown as Record<string, unknown>).__takeoff = {
-    setMode, click: async (xPdf: number, yPdf: number) => { draft.push({ x: xPdf, y: yPdf }); if (mode === "count") { await commit(); draft = []; } else if (mode === "calibrate" && draft.length === 2) await calibrate(); else if (mode === "rect" && draft.length === 2) await commit(); drawOverlay(); },
+    setMode, click: async (xPdf: number, yPdf: number) => { draft.push({ x: xPdf, y: yPdf }); if (mode === "count") { await commit(); draft = []; } else if (mode === "calibrate" && draft.length === 2) await calibrate(); else if (mode === "rect" && draft.length === 2) await commit(); else if (mode === "symbol" && draft.length === 2) await matchSymbols(); drawOverlay(); },
     commit, measures, calibrated: () => calOk(), exportPdf, saveSet,
     placeText: (t: string, x: number, y: number) => { measures.push({ id: ++seq, kind: "text", pts: [{ x, y }], value: 0, unit: "", label: t, page: pageNum, text: t }); drawOverlay(); renderList(); },
     placeStamp: async (tpl: string, x: number, y: number) => { const t = await resolveStamp(tpl); measures.push({ id: ++seq, kind: "stamp", pts: [{ x, y }], value: 0, unit: "", label: t, page: pageNum, text: t }); drawOverlay(); renderList(); },

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -245,7 +245,7 @@ describe("the roadmap lane table", () => {
   it("reads a plausible number of lanes and items — else every assertion below is vacuous", () => {
     // The can't-fail shape this repo keeps getting bitten by: a green check over an empty set.
     expect(LANES.length, `parsed ${LANES.length} lane rows`).toBeGreaterThanOrEqual(8);
-    expect(CODES.size, `extracted ${CODES.size} open item codes`).toBeGreaterThanOrEqual(40);
+    expect(CODES.size, `extracted ${CODES.size} open item codes`).toBeGreaterThanOrEqual(39);
   });
 
   it("SEES a closed ⛔ item and then excludes it — both halves, in both spellings", () => {

--- a/apps/web/src/ui/symbolCount.test.ts
+++ b/apps/web/src/ui/symbolCount.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { countSymbols, nccAt, nms, scanNcc, stamp } from "./symbolCount";
+import { countOnRgba, countSymbols, nccAt, nms, scanNcc, stamp } from "./symbolCount";
 
 function plus(): { needle: Float64Array; nw: number; nh: number } {
   // 3×3 plus on black
@@ -62,5 +62,44 @@ describe("R23-SYMBOL-COUNT ① — NMS + count", () => {
     hay[0] = hay[1] = hay[hw] = hay[hw + 1] = 1;
     const r = countSymbols(hay, hw, hh, needle, nw, nh, { threshold: 0.85, radius: 2 });
     expect(r.count).toBe(0);
+  });
+});
+
+function grayToRgba(gray: ArrayLike<number>, w: number, h: number): Uint8ClampedArray {
+  const d = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    const v = Math.round((gray[i] ?? 0) * 255);
+    d[i * 4] = v; d[i * 4 + 1] = v; d[i * 4 + 2] = v; d[i * 4 + 3] = 255;
+  }
+  return d;
+}
+
+describe("R23-SYMBOL-COUNT ② — rgba page", () => {
+  it("a 3 px box is a reason, never a guessed count", () => {
+    const d = new Uint8ClampedArray(20 * 20 * 4);
+    const r = countOnRgba(d, 20, 20, { x: 1, y: 1, w: 3, h: 3 });
+    expect(r.count).toBe(0);
+    expect(r.reason).toMatch(/larger instance/);
+  });
+
+  it("a region bigger than one symbol is refused", () => {
+    const d = new Uint8ClampedArray(200 * 200 * 4);
+    const r = countOnRgba(d, 200, 200, { x: 0, y: 0, w: 120, h: 10 });
+    expect(r.count).toBe(0);
+    expect(r.reason).toMatch(/too large/);
+  });
+
+  it("two stamped 6×6 pluses both come back in original pixel space", () => {
+    const nw = 6, nh = 6;
+    const needle = new Float64Array(nw * nh);
+    for (let i = 0; i < nw; i++) { needle[2 * nw + i] = 1; needle[i * nw + 2] = 1; needle[i * nw + 3] = 1; }
+    const hw = 40, hh = 20;
+    const hay = new Float64Array(hw * hh);
+    stamp(hay, hw, needle, nw, nh, 2, 4);
+    stamp(hay, hw, needle, nw, nh, 24, 4);
+    const r = countOnRgba(grayToRgba(hay, hw, hh), hw, hh, { x: 2, y: 4, w: nw, h: nh }, { threshold: 0.9 });
+    expect(r.reason).toBeUndefined();
+    expect(r.count).toBe(2);
+    expect(r.peaks.map((p) => `${p.x},${p.y}`).sort()).toEqual(["2,4", "24,4"]);
   });
 });

--- a/apps/web/src/ui/symbolCount.ts
+++ b/apps/web/src/ui/symbolCount.ts
@@ -1,10 +1,10 @@
 /**
- * R23-SYMBOL-COUNT ① — normalised cross-correlation + non-maximum suppression.
+ * R23-SYMBOL-COUNT — normalised cross-correlation + non-maximum suppression.
  *
  * Mark one instance, find the others. No new dependencies, offline, auditable — quantities
- * that feed a bid cannot be a black-box detector. This file is the matcher. Wiring it into
- * the pdf.js takeoff worker is the next slice; a matcher nobody can unit-test on a known
- * patch is how a count becomes a guess.
+ * that feed a bid cannot be a black-box detector. ① is the matcher (unit-tested on known
+ * patches). ② is the takeoff page: `countOnRgba` reads the pdf.js canvas, downsamples so a
+ * sheet stays interactive, and returns peaks in the original pixel space.
  *
  * Buffers are row-major grayscale in 0..1. Coordinates are top-left of the needle.
  */
@@ -51,11 +51,13 @@ export function scanNcc(
   hay: ArrayLike<number>, hw: number, hh: number,
   needle: ArrayLike<number>, nw: number, nh: number,
   threshold: number,
+  step = 1,
 ): Peak[] {
   if (nw < 1 || nh < 1 || nw > hw || nh > hh) return [];
+  const stride = Math.max(1, Math.floor(step));
   const out: Peak[] = [];
-  for (let y = 0; y <= hh - nh; y++) {
-    for (let x = 0; x <= hw - nw; x++) {
+  for (let y = 0; y <= hh - nh; y += stride) {
+    for (let x = 0; x <= hw - nw; x += stride) {
       const score = nccAt(hay, hw, hh, needle, nw, nh, x, y);
       if (score >= threshold) out.push({ x, y, score });
     }
@@ -100,4 +102,86 @@ export function stamp(
     const nr = j * nw;
     for (let i = 0; i < nw; i++) hay[hr + i] = needle[nr + i]!;
   }
+}
+
+/** Largest side we scan. A full-res A1 canvas is tens of billions of NCC ops; 480 keeps a sheet interactive. */
+export const MAX_SCAN_DIM = 480;
+export const MAX_NEEDLE_PX = 96;
+export const MAX_MATCHES = 250;
+
+export function rgbaToGray(data: ArrayLike<number>, w: number, h: number): Float64Array {
+  const out = new Float64Array(w * h);
+  for (let i = 0, p = 0; i < out.length; i++, p += 4) {
+    out[i] = (data[p]! * 0.299 + data[p + 1]! * 0.587 + data[p + 2]! * 0.114) / 255;
+  }
+  return out;
+}
+
+export function cropGray(
+  buf: ArrayLike<number>, w: number, x: number, y: number, nw: number, nh: number,
+): Float64Array {
+  const out = new Float64Array(nw * nh);
+  for (let j = 0; j < nh; j++) {
+    const src = (y + j) * w + x;
+    const dst = j * nw;
+    for (let i = 0; i < nw; i++) out[dst + i] = buf[src + i]!;
+  }
+  return out;
+}
+
+/** Average 2×2 blocks. Odd leftover columns/rows are dropped, not invented. */
+export function downsample2(buf: ArrayLike<number>, w: number, h: number): { buf: Float64Array; w: number; h: number } {
+  const nw = Math.floor(w / 2), nh = Math.floor(h / 2);
+  const out = new Float64Array(nw * nh);
+  for (let j = 0; j < nh; j++) {
+    for (let i = 0; i < nw; i++) {
+      const s = (j * 2) * w + (i * 2);
+      out[j * nw + i] = (buf[s]! + buf[s + 1]! + buf[s + w]! + buf[s + w + 1]!) / 4;
+    }
+  }
+  return { buf: out, w: nw, h: nh };
+}
+
+export type PixelRect = { x: number; y: number; w: number; h: number };
+
+export type RgbaCount = { count: number; peaks: Peak[]; factor: number; reason?: string };
+
+/**
+ * Count a boxed template on an RGBA page. Peaks are top-left in the *original* pixel space.
+ * A too-small or too-large box is a reason, never a guessed count.
+ */
+export function countOnRgba(
+  data: ArrayLike<number>, w: number, h: number,
+  rect: PixelRect,
+  opts?: { threshold?: number },
+): RgbaCount {
+  const x = Math.max(0, Math.floor(rect.x));
+  const y = Math.max(0, Math.floor(rect.y));
+  const nw = Math.min(Math.floor(rect.w), w - x);
+  const nh = Math.min(Math.floor(rect.h), h - y);
+  if (nw < 4 || nh < 4) return { count: 0, peaks: [], factor: 1, reason: "box a larger instance" };
+  if (nw > MAX_NEEDLE_PX || nh > MAX_NEEDLE_PX) {
+    return { count: 0, peaks: [], factor: 1, reason: "template too large — box one symbol, not a region" };
+  }
+
+  let gray = rgbaToGray(data, w, h);
+  let gw = w, gh = h, gx = x, gy = y, gnW = nw, gnH = nh, factor = 1;
+  while (Math.max(gw, gh) > MAX_SCAN_DIM && gnW >= 6 && gnH >= 6) {
+    const d = downsample2(gray, gw, gh);
+    gray = d.buf; gw = d.w; gh = d.h;
+    gx = Math.floor(gx / 2); gy = Math.floor(gy / 2);
+    gnW = Math.floor(gnW / 2); gnH = Math.floor(gnH / 2);
+    factor *= 2;
+  }
+  if (gnW < 3 || gnH < 3) return { count: 0, peaks: [], factor, reason: "box a larger instance" };
+
+  const needle = cropGray(gray, gw, gx, gy, gnW, gnH);
+  const threshold = opts?.threshold ?? 0.85;
+  const found = countSymbols(gray, gw, gh, needle, gnW, gnH, {
+    threshold, radius: Math.max(gnW, gnH) / 2,
+  });
+  const peaks = found.peaks.slice(0, MAX_MATCHES).map((p) => ({
+    x: p.x * factor, y: p.y * factor, score: p.score,
+  }));
+  return { count: peaks.length, peaks, factor };
 }

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-19, after v0.3.1010
+# Runway for Claude Code — 2026-08-20, after v0.3.1011
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security
@@ -26,7 +26,8 @@ memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still
 | 11 | [#303](https://github.com/ibuilder/massing/pull/303) | `cursor/a11y-journeys-6e15` | **1007** vs #302 |
 | 12 | [#304](https://github.com/ibuilder/massing/pull/304) | `cursor/field-hide-spine-6e15` | **1008** vs #303 |
 | 13 | [#305](https://github.com/ibuilder/massing/pull/305) | `cursor/weekly-gantt-6e15` | **1009** vs #304 |
-| 14 | this | `cursor/symbol-count-6e15` | **1010** vs #305 |
+| 14 | [#306](https://github.com/ibuilder/massing/pull/306) | `cursor/symbol-count-6e15` | **1010** vs #305 |
+| 15 | this | `cursor/symbol-takeoff-6e15` | **1011** vs #306 |
 
 After each merge: rebase the remainder, **keep the later version numbers**. Do not tag onto a red or
 pending `main`. This agent cannot merge.
@@ -50,6 +51,7 @@ pending `main`. This agent cannot merge.
 | 1008 | R24-FIELD-MODE ④ — hide `#workspaces` while field mode is on |
 | 1009 | UX-GANTT closed — weekly hybrid on the Schedule room |
 | 1010 | R23-SYMBOL-COUNT ① — NCC + NMS matcher (`ui/symbolCount.ts`); takeoff wiring open |
+| 1011 | R23-SYMBOL-COUNT ② closed — **⌘ Match** on the takeoff canvas; peaks are `count` marks |
 
 ---
 
@@ -74,7 +76,7 @@ PERSONA-SHAPE; IDENTITY.
 1. **R24-FIELD-MODE remainder** — replacing the portal home (Lane A). ④ only hides the room tabs.
 2. **R24-REPORTS-BY-MOMENT** scheduling (needs a job kind + delivery; larger).
 3. Lane B still open: `R24-TERMS` (user decision), `R22-REPORT-BUILDER` (aggregation/share is backend),
-   `R23-SYMBOL-COUNT` takeoff wiring, `R38-SHEET-MARKUP ③` (generated sheets + GUID pins).
+   `R38-SHEET-MARKUP ③` (generated sheets + GUID pins).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -650,7 +650,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/portal/portal.ts`, `main.ts` | R24-RUNS-INBOX · REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · R22-REPORT-BUILDER · R23-SYMBOL-COUNT · R38-SHEET-MARKUP ③ |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · R22-REPORT-BUILDER · R38-SHEET-MARKUP ③ |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R39-UPLOAD-CAP-APP ①◧ · R41-UPLOAD-WARK · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | R38-ARRAY-LIVE ③ · R21-4D-CLASH · R28-BUNDLE ② — **the three that landed in PRs #176/#178/#179 on 2026-08-02** (R28-ICDD, R23-STOREY-LOD, R28-UNIFY) are shipped and pending archive. **Corrected 2026-08-06: this read "all SHIPPED and MERGED", which was false for 8 of the 11 codes beside it** — SEC-PLUGIN-SANDBOX is ◧ with its `setrlimit` half explicitly REFUSED, R38-SYNC-VIEW and R21-4D-CLASH are ◧, and five carry no marker at all. A row-level word like "all" has no defined scope, so it drifts the moment the row grows; the item markers are the authority and this sentence is not. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · R28-VIEWER ④ · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* · R41-MODEL-ALIGN · R43-VIEWER-CONFORMANCE |
@@ -748,7 +748,7 @@ that lanes do not *overlap*; nothing asserts they *cover*, and they do not. `app
 `proforma/`, `studio/`, `tools/`, `tree/`, `pins/`, `kernel/`, `account/`, `connections/` and the
 `portal/` root files (`prefs.ts`, `offlineQueue.ts`, `panelContext.ts`) belong to no lane, which the
 carve-out check in `roadmapLanes.test.ts` correctly calls "editable by everyone" when it happens
-deliberately. The live case: **`R23-SYMBOL-COUNT` and `R38-SHEET-MARKUP ③` are Lane B and land in
+deliberately. The live case: **`R38-SHEET-MARKUP ③` is Lane B and lands in
 `apps/web/src/drawings/`, while `R36-DRAWINGS-RETURN` is Lane A and lands there too** — so `drawings/`
 is contested by two lanes right now, the same shape as the register with the extra twist that nobody
 owns it. It needs its own premise-check and possibly the same answer. It is deliberately left open:
@@ -1370,10 +1370,12 @@ exists: the repo has a 220 KB bundle budget and **zero** runtime perf assertions
 
   The `MeshStandardMaterial` clause needs no work — every remaining use is GIS context, not the BIM
   pass.
-- ◧ **R23-SYMBOL-COUNT** *(M — **① v0.3.1010**)* — deterministic template-match symbol counting:
-  mark one instance, normalised cross-correlation, non-maximum suppression
-  (`apps/web/src/ui/symbolCount.ts`). **Zero new dependencies**, offline, auditable.
-  Takeoff-worker wiring (the existing pdf.js takeoff) is the remainder.
+- ✅ **R23-SYMBOL-COUNT** *(M — **SHIPPED ① v0.3.1010 / ② v0.3.1011**)* — deterministic
+  template-match symbol counting: mark one instance, normalised cross-correlation, non-maximum
+  suppression (`apps/web/src/ui/symbolCount.ts`). **Zero new dependencies**, offline, auditable.
+  ② boxes one instance on the pdf.js takeoff canvas (`apps/web/src/drawings/pdfTakeoff.ts`);
+  matching peaks become existing `count` marks. Matching is on the rendered pixels, not inside
+  the pdf.js worker.
 
 **Watch, not work:** WebGPU (`WebGPURenderer` exists in the pinned three, but Fragments targets WebGL
 — 2–3 year horizon) · browser-side IFC parsing (a streaming WASM parser now exists; server-side
@@ -2289,8 +2291,9 @@ taxonomy should be derived from those same rooms rather than invented again.
 
 **One external measurement worth keeping**, because it puts a number on an item we already hold:
 current models score **40–55% on object-counting from drawing sets**, with symbols and linework the
-weakest part. That is direct corroboration of **R23-SYMBOL-COUNT** (Lane B) and a reason to treat it as
-higher-value than its size suggests — it is the measurable floor under every takeoff claim.
+weakest part. That is direct corroboration of **R23-SYMBOL-COUNT** (Lane B; **SHIPPED v0.3.1011**)
+and a reason it was higher-value than its size suggested — it is the measurable floor under every
+takeoff claim.
 
 The framing worth adopting even though it is not a feature: **reduce verification cost, not just
 production cost.** Several items already do this without saying so; it is the sharper way to argue for

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1010",
+      "version": "0.3.1011",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What & why

R23-SYMBOL-COUNT ②. Takeoff **⌘ Match** boxes one instance on the pdf.js-rendered page. `countOnRgba` in `apps/web/src/ui/symbolCount.ts` downsamples so a sheet stays interactive, NCC-matches, and places existing `count` marks. A too-small or too-large box is a sentence, never a guessed quantity. Matching is on the rendered canvas, not inside the pdf.js worker.

Stacks on #306 (v0.3.1010 matcher). Do not merge until the land order ahead of it has landed; keep this version number.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: ruff not required (no Python change)
- [x] Web: `npm run typecheck && npm run lint` clean (Node 24)
- [x] `npx vitest run src/ui/symbolCount.test.ts src/shell/roadmapLanes.test.ts src/shell/versionConsistency.test.ts`
- [x] `test_file_sizes.py` / `test_claude_md_gates.py`
- [x] CHANGELOG + roadmap (item closed; Lane B cell drops R23-SYMBOL-COUNT)
- [x] Version 0.3.1011 in package.json, tauri.conf.json, package-lock.json
- [ ] Live takeoff Match not driven (unit tests on RGBA patches only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

