### PR TITLE
v0.3.1012 — a pin on a wall is that wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1012 (2026-08-20) — a pin on a wall is that wall
+
+R38-SHEET-MARKUP ③ ①. Generated-sheet markup in the Drawings room now reads `data-guid` from the
+SVG (same hit-twins as the plan pane). A pin dropped on linework stores the GlobalId and
+reselects it in 3D. Empty paper is still a coordinate pin. PDF markup on generated
+plans/elevations (not only composed `sheet.pdf`) is still open.
+
 ## v0.3.1011 (2026-08-20) — box one symbol on the sheet, get the rest
 
 R23-SYMBOL-COUNT ②. Takeoff **⌘ Match** boxes one instance on the pdf.js-rendered page;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1011",
+    "version": "0.3.1012",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1011",
+  "version": "0.3.1012",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -92,6 +92,8 @@ export interface DrawingMarkupItem {
   id: string; sheet_id: string; x: number; y: number; note: string | null;
   author: string | null; topic_id: string | null; created_at: string;
   kind?: string; data?: { pts?: { x: number; y: number }[]; value?: number; unit?: string; page?: number; text?: string; nx?: number; ny?: number;
+    /** IFC GlobalId when the pin was dropped on identified linework (R38-SHEET-MARKUP ③). */
+    guid?: string;
     /** MARKUP-2a slip-sheet: the register revision the markup was made against, and (after a sheet
      *  revise) the superseded revision it was carried forward from — "verify against current". */
     rev?: string; carried_from?: string } | null;

--- a/apps/web/src/drawings/drawings.ts
+++ b/apps/web/src/drawings/drawings.ts
@@ -4,6 +4,7 @@ import { noProjectHtml } from "../ui/empty";
 import { askText } from "../ui/prompt";
 import { sanitizeSvg } from "../ui/sanitizeSvg";
 import { escapeHtml } from "../ui/feedback";
+import { addHitTargets, guidFromEvent, guidFromMarkupData, postSheetPin, selectInViewer, syncPlanHighlight } from "../ui/sheetGuid";
 
 /** 2D Drawings Set — a sheet-set browser for the server-generated plans / elevations / sections
  *  (a plan room, a PDF markup layer and field pins in one view). Left: a sheet register;
@@ -169,6 +170,7 @@ export class DrawingsUI {
       this.svgHost.innerHTML = sanitizeSvg(await res.text());
       const svg = this.svgHost.querySelector("svg");
       if (svg) { svg.removeAttribute("width"); svg.removeAttribute("height"); svg.style.display = "block"; }
+      addHitTargets(this.svgHost);
       this.fit();
       await this.loadPins();
       this.host_.setStatus(`drawing: ${sheet.label}`);
@@ -269,7 +271,12 @@ export class DrawingsUI {
       const x = (e.clientX - r.left - this.tx) / this.scale;
       const y = (e.clientY - r.top - this.ty) / this.scale;
       const note = await askText("Add markup", { label: "Markup note:" }); if (note == null) return;
-      try { await this.host_.api.addDrawingMarkup(pid, this.current.id, x, y, note); await this.loadPins(); }
+      const guid = guidFromEvent(e);
+      try {
+        await postSheetPin(this.host_.api, pid, this.current.id, x, y, note, guid);
+        if (guid) selectInViewer(guid);
+        await this.loadPins();
+      }
       catch { this.host_.setStatus("markup needs reviewer access"); }
     });
   }
@@ -300,18 +307,25 @@ export class DrawingsUI {
     const ch = rect && this.scale ? rect.height / this.scale : 0;
     this.markup.forEach((p, i) => {
       const takeoff = p.kind && p.kind !== "pin" && p.data?.nx != null;
+      const tied = guidFromMarkupData(p.data);
       const carried = !!p.data?.carried_from;        // MARKUP-2a: predates the current sheet revision
       const el = document.createElement("div");
-      el.className = "dwg-pin" + (p.topic_id ? " linked" : "") + (takeoff ? " takeoff" : "") + (carried ? " carried" : "");
+      el.className = "dwg-pin" + (p.topic_id ? " linked" : "") + (takeoff ? " takeoff" : "") + (carried ? " carried" : "") + (tied ? " tied" : "");
       el.textContent = takeoff ? "◆" : String(i + 1);
       const left = takeoff && cw ? p.data!.nx! * cw : p.x;
       const top = takeoff && ch ? p.data!.ny! * ch : p.y;
       el.style.left = `${left}px`; el.style.top = `${top}px`;
       const meas = takeoff && p.data?.value ? ` — ${p.data.value} ${p.data.unit || ""}` : "";
-      el.title = (p.note || (takeoff ? p.kind! : "")) + meas + (p.topic_id ? "  · linked to RFI" : "")
+      el.title = (p.note || (takeoff ? p.kind! : "")) + meas
+        + (tied ? `  · ${tied}` : "")
+        + (p.topic_id ? "  · linked to RFI" : "")
         + (carried ? `  · carried from Rev ${p.data!.carried_from} — verify against the current revision` : "");
-      el.onclick = async (e) => {
-        e.stopPropagation();
+      el.onclick = async (ev) => {
+        ev.stopPropagation();
+        if (tied) {
+          selectInViewer(tied);
+          syncPlanHighlight(this.svgHost, tied);
+        }
         if (!pid) return;
         const linked = p.topic_id ? " (already an RFI)" : "";
         const choice = await askText(`Markup #${i + 1}`, {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -779,6 +779,7 @@ body[data-cap-admin="off"] [data-cap="admin"] * { pointer-events: none; }
 .dwg-pin.takeoff.linked { background: #33d17a; }
 /* MARKUP-2a slip-sheet: markup carried forward from a superseded revision — verify against current */
 .dwg-pin.carried { border: 2px dashed #ff8c1a; opacity: 0.75; }
+.dwg-pin.tied { box-shadow: 0 0 0 2px #111; }   /* dropped on data-guid linework */
 
 /* phones: tighten chrome + reflow grids so the portal/proforma are usable in the field.
    Placed last so these win over the base .kpi-grid/.pf-form rules (media queries add no specificity). */

--- a/apps/web/src/ui/sheetGuid.test.ts
+++ b/apps/web/src/ui/sheetGuid.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { guidFromEvent, guidFromMarkupData, postSheetPin, selectInViewer } from "./sheetGuid";
+
+describe("R38-SHEET-MARKUP ③ ① — guid on generated sheets", () => {
+  it("reads the GlobalId from linework, not from a wrapper", () => {
+    const svg = document.createElement("div");
+    svg.innerHTML = '<svg><polyline data-guid="1kP9xAbCdEf7Qa" points="0,0 1,1"/></svg>';
+    const poly = svg.querySelector("polyline")!;
+    const e = { target: poly } as unknown as Event;
+    expect(guidFromEvent(e)).toBe("1kP9xAbCdEf7Qa");
+  });
+
+  it("empty paper is null, never a guessed guid", () => {
+    const paper = document.createElement("div");
+    const e = { target: paper } as unknown as Event;
+    expect(guidFromEvent(e)).toBeNull();
+  });
+
+  it("markup data.guid is the stored key; other shapes are ignored", () => {
+    expect(guidFromMarkupData({ guid: "WALL_A" })).toBe("WALL_A");
+    expect(guidFromMarkupData({ guid: "  " })).toBeNull();
+    expect(guidFromMarkupData({ guid: 12 })).toBeNull();
+    expect(guidFromMarkupData(null)).toBeNull();
+  });
+
+  it("selectInViewer uses the viewer hook, not a transient node id", () => {
+    const selectByGuid = vi.fn();
+    (window as unknown as { __viewer: { selectByGuid: typeof selectByGuid } }).__viewer = { selectByGuid };
+    selectInViewer("DOOR_5F");
+    expect(selectByGuid).toHaveBeenCalledWith("DOOR_5F", true);
+  });
+
+  it("postSheetPin sends data.guid only when the click hit linework", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    const api = { url: (p: string) => `http://api${p}`, authHeaders: () => ({ Authorization: "Bearer t" }) };
+    await postSheetPin(api, "p1", "plan:L1", 10, 20, "crack", "WALL_A");
+    expect(fetchMock.mock.calls[0]).toBeTruthy();
+    const tied = JSON.parse(String((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].body));
+    expect(tied).toEqual({
+      sheet_id: "plan:L1", x: 10, y: 20, note: "crack", kind: "pin", data: { guid: "WALL_A" },
+    });
+    fetchMock.mockClear();
+    await postSheetPin(api, "p1", "plan:L1", 1, 2, "note", null);
+    const paper = JSON.parse(String((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].body));
+    expect(paper.data).toBeUndefined();
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/ui/sheetGuid.ts
+++ b/apps/web/src/ui/sheetGuid.ts
@@ -1,0 +1,46 @@
+/**
+ * R38-SHEET-MARKUP ③ ① — a pin on a generated sheet is a GlobalId, not a pixel.
+ *
+ * The SVG already carries `data-guid` (R38-PLAN-IDENTITY). The Drawings room was dropping
+ * coordinate-only pins, so a wall that moved left the markup pointing at empty paper. Hit-twins
+ * and highlight live in `viewer/planPane.ts`; this file is the drawing-room seam: read the guid
+ * from the event, persist it on the pin, and hand it to the 3D viewer.
+ */
+import { addHitTargets, syncPlanHighlight } from "../viewer/planPane";
+
+export { addHitTargets, syncPlanHighlight };
+
+/** IFC GlobalId on the clicked linework, or null if the click was empty paper. */
+export function guidFromEvent(e: Event): string | null {
+  const el = (e.target as Element | null)?.closest?.("[data-guid]");
+  const g = el?.getAttribute("data-guid")?.trim();
+  return g || null;
+}
+
+export function guidFromMarkupData(data: { guid?: unknown } | null | undefined): string | null {
+  const g = data?.guid;
+  return typeof g === "string" && g.trim() ? g.trim() : null;
+}
+
+/** Same `__viewer` hook the Cost/Deal rooms use — drawings must not import `app.ts`. */
+export function selectInViewer(guid: string): void {
+  const v = (window as unknown as {
+    __viewer?: { selectByGuid?: (g: string, fit?: boolean) => void };
+  }).__viewer;
+  v?.selectByGuid?.(guid, true);
+}
+
+export async function postSheetPin(
+  api: { url: (p: string) => string; authHeaders: () => Record<string, string> },
+  pid: string, sheetId: string, x: number, y: number, note: string, guid: string | null,
+): Promise<void> {
+  const res = await fetch(api.url(`/projects/${pid}/drawings/markup`), {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...api.authHeaders() },
+    body: JSON.stringify({
+      sheet_id: sheetId, x, y, note, kind: "pin",
+      ...(guid ? { data: { guid } } : {}),
+    }),
+  });
+  if (!res.ok) throw new Error(`markup ${res.status}`);
+}

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-20, after v0.3.1011
+# Runway for Claude Code — 2026-08-20, after v0.3.1012
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security
@@ -27,7 +27,8 @@ memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still
 | 12 | [#304](https://github.com/ibuilder/massing/pull/304) | `cursor/field-hide-spine-6e15` | **1008** vs #303 |
 | 13 | [#305](https://github.com/ibuilder/massing/pull/305) | `cursor/weekly-gantt-6e15` | **1009** vs #304 |
 | 14 | [#306](https://github.com/ibuilder/massing/pull/306) | `cursor/symbol-count-6e15` | **1010** vs #305 |
-| 15 | this | `cursor/symbol-takeoff-6e15` | **1011** vs #306 |
+| 15 | [#307](https://github.com/ibuilder/massing/pull/307) | `cursor/symbol-takeoff-6e15` | **1011** vs #306 |
+| 16 | this | `cursor/sheet-guid-pins-6e15` | **1012** vs #307 |
 
 After each merge: rebase the remainder, **keep the later version numbers**. Do not tag onto a red or
 pending `main`. This agent cannot merge.
@@ -52,6 +53,7 @@ pending `main`. This agent cannot merge.
 | 1009 | UX-GANTT closed — weekly hybrid on the Schedule room |
 | 1010 | R23-SYMBOL-COUNT ① — NCC + NMS matcher (`ui/symbolCount.ts`); takeoff wiring open |
 | 1011 | R23-SYMBOL-COUNT ② closed — **⌘ Match** on the takeoff canvas; peaks are `count` marks |
+| 1012 | R38-SHEET-MARKUP ③ ① — pin on generated-sheet linework stores GlobalId; PDF-on-plans still open |
 
 ---
 
@@ -76,7 +78,8 @@ PERSONA-SHAPE; IDENTITY.
 1. **R24-FIELD-MODE remainder** — replacing the portal home (Lane A). ④ only hides the room tabs.
 2. **R24-REPORTS-BY-MOMENT** scheduling (needs a job kind + delivery; larger).
 3. Lane B still open: `R24-TERMS` (user decision), `R22-REPORT-BUILDER` (aggregation/share is backend),
-   `R38-SHEET-MARKUP ③` (generated sheets + GUID pins).
+   `R38-SHEET-MARKUP ③` remainder (PDF markup on generated plans/elevations, not only composed sheet.pdf;
+   promote-to-RFI does not yet copy `data.guid` onto `Topic.element_guids`).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1824,9 +1824,12 @@ server's report stays authoritative on the authored element. Wave 1 and its foll
     the pane had been unreachable (toggle button never appended), its fetch had failed cross-origin
     since v0.3.826 (`credentials:"include"` without a credentials CORS grant), and the live route
     dropped the `storey` param entirely — three defects only a live drive could see.
-- **R38-SHEET-MARKUP ③** *(M, Lane B)* — the vendored markup toolset (clouds, callouts, stamps,
+- ◧ **R38-SHEET-MARKUP ③** *(M, Lane B — **① v0.3.1012**)* — the vendored markup toolset (clouds, callouts, stamps,
   tool sets) opened on the room's OWN generated sheets, markups tied to GUIDs through the existing
-  pin-to-drawing spine.
+  pin-to-drawing spine. ①: a pin dropped on `data-guid` linework in `apps/web/src/drawings/drawings.ts`
+  stores that GlobalId (`apps/web/src/ui/sheetGuid.ts`) and reselects it in 3D; empty paper is
+  still a coordinate pin. PDF markup on generated plans/elevations (not just composed `sheet.pdf`)
+  remains.
 - Consumes: R24-ELEMENT-CARD ② and R31-CITE-HIGHLIGHT (both already coded) as the "everything
   about this thing" surface.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1011",
+      "version": "0.3.1012",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What & why

R38-SHEET-MARKUP ③ ①. Generated sheets already emit `data-guid` on linework. The Drawings room was dropping coordinate-only pins, so a wall that moved left the markup on empty paper. A pin dropped on identified linework now stores that GlobalId (`apps/web/src/ui/sheetGuid.ts`), uses the same hit-twins as the plan pane, and reselects the element in 3D. Empty paper is still a coordinate pin.

Remainder (not this PR): PDF markup on generated plans/elevations (only composed `sheet.pdf` has a PDF twin today); promote-to-RFI does not copy `data.guid` onto `Topic.element_guids` (that lives in `bim.py`).

Stacks on #307. Do not merge until the land order ahead of it has landed; keep this version number.

## Checklist (mirrors CONTRIBUTING.md)

- [x] No Python change
- [x] Web: `npm run typecheck && npm run lint` (Node 24)
- [x] `npx vitest run src/ui/sheetGuid.test.ts src/shell/roadmapLanes.test.ts src/shell/versionConsistency.test.ts`
- [x] CHANGELOG + roadmap (item stays open as ◧ ①)
- [x] Version 0.3.1012
- [ ] Live Drawings markup + 3D reselect not driven
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

