### PR TITLE
v0.3.1013 — a pin on a wall raises an RFI on that wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1013 (2026-08-20) — a pin on a wall raises an RFI on that wall
+
+R38-SHEET-MARKUP ③ ②. Promoting a drawing pin copies `data.guid` onto
+`Topic.element_guids`, so the RFI is the same GlobalId the sheet and the 3D view
+already share. A pin on empty paper still raises a coordinate-only RFI.
+
 ## v0.3.1012 (2026-08-20) — a pin on a wall is that wall
 
 R38-SHEET-MARKUP ③ ①. Generated-sheet markup in the Drawings room now reads `data-guid` from the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1012",
+    "version": "0.3.1013",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1012",
+  "version": "0.3.1013",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-20, after v0.3.1012
+# Runway for Claude Code — 2026-08-20, after v0.3.1013
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security
@@ -28,7 +28,8 @@ memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still
 | 13 | [#305](https://github.com/ibuilder/massing/pull/305) | `cursor/weekly-gantt-6e15` | **1009** vs #304 |
 | 14 | [#306](https://github.com/ibuilder/massing/pull/306) | `cursor/symbol-count-6e15` | **1010** vs #305 |
 | 15 | [#307](https://github.com/ibuilder/massing/pull/307) | `cursor/symbol-takeoff-6e15` | **1011** vs #306 |
-| 16 | this | `cursor/sheet-guid-pins-6e15` | **1012** vs #307 |
+| 16 | [#308](https://github.com/ibuilder/massing/pull/308) | `cursor/sheet-guid-pins-6e15` | **1012** vs #307 |
+| 17 | this | `cursor/markup-promote-guid-6e15` | **1013** vs #308 |
 
 After each merge: rebase the remainder, **keep the later version numbers**. Do not tag onto a red or
 pending `main`. This agent cannot merge.
@@ -54,6 +55,7 @@ pending `main`. This agent cannot merge.
 | 1010 | R23-SYMBOL-COUNT ① — NCC + NMS matcher (`ui/symbolCount.ts`); takeoff wiring open |
 | 1011 | R23-SYMBOL-COUNT ② closed — **⌘ Match** on the takeoff canvas; peaks are `count` marks |
 | 1012 | R38-SHEET-MARKUP ③ ① — pin on generated-sheet linework stores GlobalId; PDF-on-plans still open |
+| 1013 | R38-SHEET-MARKUP ③ ② — promote-to-RFI copies `data.guid` onto `Topic.element_guids` |
 
 ---
 
@@ -78,8 +80,7 @@ PERSONA-SHAPE; IDENTITY.
 1. **R24-FIELD-MODE remainder** — replacing the portal home (Lane A). ④ only hides the room tabs.
 2. **R24-REPORTS-BY-MOMENT** scheduling (needs a job kind + delivery; larger).
 3. Lane B still open: `R24-TERMS` (user decision), `R22-REPORT-BUILDER` (aggregation/share is backend),
-   `R38-SHEET-MARKUP ③` remainder (PDF markup on generated plans/elevations, not only composed sheet.pdf;
-   promote-to-RFI does not yet copy `data.guid` onto `Topic.element_guids`).
+   `R38-SHEET-MARKUP ③` remainder (PDF markup on generated plans/elevations, not only composed sheet.pdf).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1824,12 +1824,13 @@ server's report stays authoritative on the authored element. Wave 1 and its foll
     the pane had been unreachable (toggle button never appended), its fetch had failed cross-origin
     since v0.3.826 (`credentials:"include"` without a credentials CORS grant), and the live route
     dropped the `storey` param entirely — three defects only a live drive could see.
-- ◧ **R38-SHEET-MARKUP ③** *(M, Lane B — **① v0.3.1012**)* — the vendored markup toolset (clouds, callouts, stamps,
+- ◧ **R38-SHEET-MARKUP ③** *(M, Lane B — **① v0.3.1012 · ② v0.3.1013**)* — the vendored markup toolset (clouds, callouts, stamps,
   tool sets) opened on the room's OWN generated sheets, markups tied to GUIDs through the existing
   pin-to-drawing spine. ①: a pin dropped on `data-guid` linework in `apps/web/src/drawings/drawings.ts`
   stores that GlobalId (`apps/web/src/ui/sheetGuid.ts`) and reselects it in 3D; empty paper is
-  still a coordinate pin. PDF markup on generated plans/elevations (not just composed `sheet.pdf`)
-  remains.
+  still a coordinate pin. ②: promote-to-RFI copies that GlobalId onto `Topic.element_guids`
+  (`services/api/src/aec_api/routers/bim.py`). PDF markup on generated plans/elevations (not just
+  composed `sheet.pdf`) remains.
 - Consumes: R24-ELEMENT-CARD ② and R31-CITE-HIGHLIGHT (both already coded) as the "everything
   about this thing" surface.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1012",
+      "version": "0.3.1013",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/src/aec_api/routers/bim.py
+++ b/services/api/src/aec_api/routers/bim.py
@@ -301,16 +301,25 @@ def promote_markup(pid: str, mid: str, db: Session = Depends(get_db),
     detail = m.note or ""
     if m.data and m.data.get("value"):                       # takeoff markup — include the measurement
         detail = f"{detail}\n{m.kind}: {m.data.get('value')} {m.data.get('unit', '')}".strip()
+    guid = None
+    if isinstance(m.data, dict):
+        raw = m.data.get("guid")
+        if isinstance(raw, str) and raw.strip():
+            guid = raw.strip()
+    if guid:
+        detail = f"{detail}\nGlobalId: {guid}".strip()
     t = Topic(project_id=pid, type="rfi", status="open", author=actor,
               title=(m.note or f"Drawing {m.kind or 'RFI'}")[:80],
-              description=f"Raised from a {m.kind or 'pin'} markup on sheet '{m.sheet_id}'.\n\n{detail}")
+              description=f"Raised from a {m.kind or 'pin'} markup on sheet '{m.sheet_id}'.\n\n{detail}",
+              element_guids=[guid] if guid else None)
     db.add(t)
     db.flush()
     m.topic_id = t.id
     audit.record(db, action="markup.promote", actor=actor, method="POST", topic_id=t.id,
                  path=f"/projects/{pid}/drawings/markup/{mid}/promote", detail={"sheet": m.sheet_id})
     db.commit()
-    return {"markup": _markup_out(m), "topic": {"id": t.id, "type": t.type, "title": t.title, "status": t.status}}
+    return {"markup": _markup_out(m), "topic": {"id": t.id, "type": t.type, "title": t.title,
+                                                "status": t.status, "element_guids": t.element_guids}}
 
 
 @router.get("/projects/{pid}/members")

--- a/services/api/test_markup.py
+++ b/services/api/test_markup.py
@@ -55,6 +55,19 @@ with TestClient(app) as c:
     mid = next(m["id"] for m in pdfm if m["kind"] == "area")
     pr = c.post(f"/projects/{pid}/drawings/markup/{mid}/promote", headers=H)
     assert pr.status_code == 201 and pr.json()["topic"]["type"] == "rfi", pr.text
+    assert pr.json()["topic"].get("element_guids") in (None, []), pr.json()
+
+    # R38-SHEET-MARKUP ③ ② — a pin on identified linework copies that GlobalId onto the RFI
+    pin = c.post(f"/projects/{pid}/drawings/markup", headers=H, json={
+        "sheet_id": "plan:L1", "x": 4, "y": 8, "note": "crack at jamb",
+        "kind": "pin", "data": {"guid": "1kP9xAbCdEf7Qa"}}).json()
+    pr2 = c.post(f"/projects/{pid}/drawings/markup/{pin['id']}/promote", headers=H)
+    assert pr2.status_code == 201, pr2.text
+    assert pr2.json()["topic"]["element_guids"] == ["1kP9xAbCdEf7Qa"], pr2.json()
+    tid = pr2.json()["topic"]["id"]
+    topic = c.get(f"/projects/{pid}/topics/{tid}", headers=H).json()
+    assert topic["element_guids"] == ["1kP9xAbCdEf7Qa"], topic
+    assert "1kP9xAbCdEf7Qa" in (topic.get("description") or "")
 
     # a promoted markup survives a subsequent replace (topic_id set → kept)
     c.post(f"/projects/{pid}/drawings/markup/bulk", headers=H,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What & why

R38-SHEET-MARKUP ③ ②. Promoting a drawing pin copies `data.guid` onto `Topic.element_guids`, so the RFI is the same GlobalId the sheet and the 3D view already share. Empty paper still raises a coordinate-only RFI.

Stacks on #308. Do not merge until the land order ahead of it has landed; keep this version number.

## Checklist

- [x] `python3 -m ruff check src/aec_api/routers/bim.py` from `services/api`
- [x] `PYTHONPATH=src:../data/src python3 test_markup.py`
- [x] CHANGELOG + roadmap
- [x] Version 0.3.1013
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

