### PR TITLE
v0.3.1014 — markup the plan you are looking at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1014 (2026-08-20) — markup the plan you are looking at
+
+R38-SHEET-MARKUP ③ closed. Every generated sheet (plan / elevation / section) has
+**🖊 PDF markup**. Composed sheets still use `sheet.pdf`; the others wrap the live SVG
+in pdf-lib (`apps/web/src/ui/svgPdf.ts`) so the takeoff tools open on the room's own
+drawings.
+
 ## v0.3.1013 (2026-08-20) — a pin on a wall raises an RFI on that wall
 
 R38-SHEET-MARKUP ③ ②. Promoting a drawing pin copies `data.guid` onto

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1013",
+    "version": "0.3.1014",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1013",
+  "version": "0.3.1014",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/drawings/drawings.ts
+++ b/apps/web/src/drawings/drawings.ts
@@ -5,6 +5,7 @@ import { askText } from "../ui/prompt";
 import { sanitizeSvg } from "../ui/sanitizeSvg";
 import { escapeHtml } from "../ui/feedback";
 import { addHitTargets, guidFromEvent, guidFromMarkupData, postSheetPin, selectInViewer, syncPlanHighlight } from "../ui/sheetGuid";
+import { pdfFromPng, pngFromSvgElement } from "../ui/svgPdf";
 
 /** 2D Drawings Set — a sheet-set browser for the server-generated plans / elevations / sections
  *  (a plan room, a PDF markup layer and field pins in one view). Left: a sheet register;
@@ -206,27 +207,47 @@ export class DrawingsUI {
       btn("☰ Markups", "All markups across every sheet — totals, revisions, RFI links", () => void this.showMarkupGrid()),
       // MARKUP-2c: light-table overlay compare — the live sheet (blue) under an uploaded prior
       // revision (red); differences pop where the tints don't cancel.
-      btn("⧉ Compare", "Overlay a prior revision (SVG/PDF) on this sheet — light-table compare", () => void this.startCompare(), !!this.compareLayer));
-    if (sheet.pdf) bar.append(btn("🖊 PDF markup", "Open the sheet PDF in the 2D editor — measure / mark up / persist to the sheet (promotable to RFI)", async () => {
-      const api = this.host_.api, pid = this.host_.projectId();
-      const { openPdfUrl, saveToDocuments } = await import("./openPdf");
-      const sid = `${sheet.id}#pdf`;                          // shares the markup store; own coord space
-      await openPdfUrl(api, api.url(sheet.pdf!), "sheet.pdf", !pid ? {} : {
-        saveLabel: "Save to Documents", onSave: saveToDocuments(api, pid),
-        persist: {
-          load: async (): Promise<Measure[]> => (await api.drawingMarkup(pid, sid))
-            .filter((m) => m.data?.pts?.length)
-            .map((m) => ({ id: 0, kind: (m.kind as Measure["kind"]) || "text", pts: m.data!.pts!,
-              value: m.data!.value ?? 0, unit: m.data!.unit ?? "", label: m.note ?? "",
-              page: m.data!.page ?? 1, text: m.data!.text })),
-          save: async (ms: Measure[], norm) => { await api.saveDrawingMarkups(pid, sid, ms.map((mm) => {
-            const n = norm(mm);                                // page-normalized (0..1) shared anchor
-            return { x: mm.pts[0]?.x ?? 0, y: mm.pts[0]?.y ?? 0, note: mm.label, kind: mm.kind,
-              data: { pts: mm.pts, value: mm.value, unit: mm.unit, page: mm.page, text: mm.text, nx: n.nx, ny: n.ny } };
-          })); await this.loadPins(); },   // refresh so the new markups appear on the SVG view too
-        },
-      });
-    }));
+      btn("⧉ Compare", "Overlay a prior revision (SVG/PDF) on this sheet — light-table compare", () => void this.startCompare(), !!this.compareLayer),
+      btn("🖊 PDF markup", "Open this sheet in the 2D editor — measure / mark up / persist (promotable to RFI)", () => void this.openPdfMarkup()));
+  }
+
+  /** Composed sheets use the server PDF; generated plans/elevations/sections wrap the live SVG. */
+  private async openPdfMarkup() {
+    const sheet = this.current;
+    const api = this.host_.api, pid = this.host_.projectId();
+    if (!sheet) return;
+    const { openPdfUrl, openPdfTakeoff, saveToDocuments } = await import("./openPdf");
+    const sid = `${sheet.id}#pdf`;
+    const persist = !pid ? undefined : {
+      load: async (): Promise<Measure[]> => (await api.drawingMarkup(pid, sid))
+        .filter((m) => m.data?.pts?.length)
+        .map((m) => ({ id: 0, kind: (m.kind as Measure["kind"]) || "text", pts: m.data!.pts!,
+          value: m.data!.value ?? 0, unit: m.data!.unit ?? "", label: m.note ?? "",
+          page: m.data!.page ?? 1, text: m.data!.text })),
+      save: async (ms: Measure[], norm: (m: Measure) => { nx: number; ny: number }) => {
+        await api.saveDrawingMarkups(pid, sid, ms.map((mm) => {
+          const n = norm(mm);
+          return { x: mm.pts[0]?.x ?? 0, y: mm.pts[0]?.y ?? 0, note: mm.label, kind: mm.kind,
+            data: { pts: mm.pts, value: mm.value, unit: mm.unit, page: mm.page, text: mm.text, nx: n.nx, ny: n.ny } };
+        }));
+        await this.loadPins();
+      },
+    };
+    const opts = !pid ? {} : { saveLabel: "Save to Documents", onSave: saveToDocuments(api, pid), persist };
+    if (sheet.pdf) {
+      await openPdfUrl(api, api.url(sheet.pdf), "sheet.pdf", opts);
+      return;
+    }
+    const svg = this.svgHost.querySelector("svg");
+    if (!svg) { this.host_.setStatus("render a sheet first"); return; }
+    try {
+      const { png, w, h } = await pngFromSvgElement(svg);
+      const bytes = await pdfFromPng(png, w, h);
+      const file = new File([bytes.slice()], `${sheet.label}.pdf`, { type: "application/pdf" });
+      await openPdfTakeoff(file, opts);
+    } catch (e) {
+      this.host_.setStatus(`couldn't open PDF markup (${(e as Error).message})`);
+    }
   }
 
   // --- pan / zoom ------------------------------------------------------------

--- a/apps/web/src/drawings/openPdf.ts
+++ b/apps/web/src/drawings/openPdf.ts
@@ -1,5 +1,6 @@
 import type { ApiClient, DocFolderNode } from "../api/client";
 import { openPdfTakeoff, type TakeoffOpts } from "./pdfTakeoff";
+export { openPdfTakeoff, type TakeoffOpts };
 import { escapeHtml } from "../ui/feedback";
 
 /**

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -245,7 +245,7 @@ describe("the roadmap lane table", () => {
   it("reads a plausible number of lanes and items — else every assertion below is vacuous", () => {
     // The can't-fail shape this repo keeps getting bitten by: a green check over an empty set.
     expect(LANES.length, `parsed ${LANES.length} lane rows`).toBeGreaterThanOrEqual(8);
-    expect(CODES.size, `extracted ${CODES.size} open item codes`).toBeGreaterThanOrEqual(39);
+    expect(CODES.size, `extracted ${CODES.size} open item codes`).toBeGreaterThanOrEqual(38);
   });
 
   it("SEES a closed ⛔ item and then excludes it — both halves, in both spellings", () => {

--- a/apps/web/src/ui/svgPdf.test.ts
+++ b/apps/web/src/ui/svgPdf.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { MAX_PAGE_PT, pageSizeFromViewBox, pdfFromPng, viewBoxOf } from "./svgPdf";
+
+// 1×1 white PNG
+const DOT = Uint8Array.from(atob(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+), (c) => c.charCodeAt(0));
+
+describe("R38-SHEET-MARKUP ③ ③ — generated sheet PDF", () => {
+  it("caps the longest side so a full A1 does not freeze takeoff", () => {
+    const p = pageSizeFromViewBox(10_000, 5_000);
+    expect(Math.max(p.w, p.h)).toBe(MAX_PAGE_PT);
+    expect(p.w / p.h).toBeCloseTo(2, 5);
+  });
+
+  it("a small sheet stays at its own size", () => {
+    expect(pageSizeFromViewBox(200, 100)).toEqual({ w: 200, h: 100 });
+  });
+
+  it("viewBox wins over a missing width/height", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("viewBox", "0 0 800 600");
+    expect(viewBoxOf(svg)).toEqual({ w: 800, h: 600 });
+  });
+
+  it("pdfFromPng writes a real PDF, not an empty blob", async () => {
+    const bytes = await pdfFromPng(DOT, 200, 100);
+    const head = new TextDecoder().decode(bytes.slice(0, 5));
+    expect(head).toBe("%PDF-");
+    expect(bytes.length).toBeGreaterThan(50);
+  });
+});

--- a/apps/web/src/ui/svgPdf.ts
+++ b/apps/web/src/ui/svgPdf.ts
@@ -1,0 +1,65 @@
+/**
+ * R38-SHEET-MARKUP ③ ③ — a generated sheet becomes a PDF the takeoff tools can open.
+ *
+ * Composed sheets already have `sheet.pdf`. Plans/elevations/sections are SVG-only (no Cairo
+ * SVG→PDF in prod). Wrap a PNG of the live sheet in pdf-lib so ⌘ Match / stamps / persist
+ * work on the room's own drawings, not only the titleblock sheet.
+ */
+export const MAX_PAGE_PT = 1440;
+
+export function pageSizeFromViewBox(w: number, h: number): { w: number; h: number } {
+  const aw = Math.max(1, w);
+  const ah = Math.max(1, h);
+  const scale = Math.min(1, MAX_PAGE_PT / Math.max(aw, ah));
+  return { w: aw * scale, h: ah * scale };
+}
+
+export function viewBoxOf(svg: SVGSVGElement): { w: number; h: number } {
+  const vb = svg.viewBox?.baseVal;
+  if (vb && vb.width > 0 && vb.height > 0) return { w: vb.width, h: vb.height };
+  const w = Number(svg.getAttribute("width")) || svg.clientWidth || 1000;
+  const h = Number(svg.getAttribute("height")) || svg.clientHeight || 800;
+  return { w: Math.max(1, w), h: Math.max(1, h) };
+}
+
+export async function pdfFromPng(png: Uint8Array, w: number, h: number): Promise<Uint8Array> {
+  const { PDFDocument } = await import("pdf-lib");
+  const doc = await PDFDocument.create();
+  const img = await doc.embedPng(png);
+  const size = pageSizeFromViewBox(w, h);
+  const page = doc.addPage([size.w, size.h]);
+  page.drawImage(img, { x: 0, y: 0, width: size.w, height: size.h });
+  return doc.save();
+}
+
+/** Rasterise the live SVG. Empty paper is refused rather than a blank PDF that looks like a sheet. */
+export async function pngFromSvgElement(svg: SVGSVGElement): Promise<{ png: Uint8Array; w: number; h: number }> {
+  const { w, h } = viewBoxOf(svg);
+  const xml = new XMLSerializer().serializeToString(svg);
+  if (!xml.includes("<svg")) throw new Error("not a sheet");
+  const blob = new Blob([xml], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image();
+      el.onload = () => resolve(el);
+      el.onerror = () => reject(new Error("couldn't rasterise the sheet"));
+      el.src = url;
+    });
+    const canvas = document.createElement("canvas");
+    const size = pageSizeFromViewBox(w, h);
+    canvas.width = Math.max(1, Math.round(size.w));
+    canvas.height = Math.max(1, Math.round(size.h));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("couldn't rasterise the sheet");
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    const blobOut = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("couldn't rasterise the sheet"))), "image/png");
+    });
+    return { png: new Uint8Array(await blobOut.arrayBuffer()), w, h };
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-20, after v0.3.1013
+# Runway for Claude Code — 2026-08-20, after v0.3.1014
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security
@@ -29,7 +29,8 @@ memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still
 | 14 | [#306](https://github.com/ibuilder/massing/pull/306) | `cursor/symbol-count-6e15` | **1010** vs #305 |
 | 15 | [#307](https://github.com/ibuilder/massing/pull/307) | `cursor/symbol-takeoff-6e15` | **1011** vs #306 |
 | 16 | [#308](https://github.com/ibuilder/massing/pull/308) | `cursor/sheet-guid-pins-6e15` | **1012** vs #307 |
-| 17 | this | `cursor/markup-promote-guid-6e15` | **1013** vs #308 |
+| 17 | [#309](https://github.com/ibuilder/massing/pull/309) | `cursor/markup-promote-guid-6e15` | **1013** vs #308 |
+| 18 | this | `cursor/generated-sheet-pdf-6e15` | **1014** vs #309 |
 
 After each merge: rebase the remainder, **keep the later version numbers**. Do not tag onto a red or
 pending `main`. This agent cannot merge.
@@ -56,6 +57,7 @@ pending `main`. This agent cannot merge.
 | 1011 | R23-SYMBOL-COUNT ② closed — **⌘ Match** on the takeoff canvas; peaks are `count` marks |
 | 1012 | R38-SHEET-MARKUP ③ ① — pin on generated-sheet linework stores GlobalId; PDF-on-plans still open |
 | 1013 | R38-SHEET-MARKUP ③ ② — promote-to-RFI copies `data.guid` onto `Topic.element_guids` |
+| 1014 | R38-SHEET-MARKUP ③ closed — PDF markup on generated sheets (live SVG wrapped when no sheet.pdf) |
 
 ---
 
@@ -80,7 +82,7 @@ PERSONA-SHAPE; IDENTITY.
 1. **R24-FIELD-MODE remainder** — replacing the portal home (Lane A). ④ only hides the room tabs.
 2. **R24-REPORTS-BY-MOMENT** scheduling (needs a job kind + delivery; larger).
 3. Lane B still open: `R24-TERMS` (user decision), `R22-REPORT-BUILDER` (aggregation/share is backend),
-   `R38-SHEET-MARKUP ③` remainder (PDF markup on generated plans/elevations, not only composed sheet.pdf).
+   `R24-REPORTS-BY-MOMENT` scheduling (job kind + delivery), `R24-FIELD-MODE` portal home (Lane A).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -650,7 +650,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/portal/portal.ts`, `main.ts` | R24-RUNS-INBOX · REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · R22-REPORT-BUILDER · R38-SHEET-MARKUP ③ |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · R22-REPORT-BUILDER |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · R24-PERF-BUDGET · SEC-PLUGIN-LOADER · PERF-WORKERS ① · PERF-THREADS ③ · R35-DEAL-MEMORY · R37-TRIAGE · R39-UPLOAD-CAP-APP ①◧ · R41-UPLOAD-WARK · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/` | R38-ARRAY-LIVE ③ · R21-4D-CLASH · R28-BUNDLE ② — **the three that landed in PRs #176/#178/#179 on 2026-08-02** (R28-ICDD, R23-STOREY-LOD, R28-UNIFY) are shipped and pending archive. **Corrected 2026-08-06: this read "all SHIPPED and MERGED", which was false for 8 of the 11 codes beside it** — SEC-PLUGIN-SANDBOX is ◧ with its `setrlimit` half explicitly REFUSED, R38-SYNC-VIEW and R21-4D-CLASH are ◧, and five carry no marker at all. A row-level word like "all" has no defined scope, so it drifts the moment the row grows; the item markers are the authority and this sentence is not. **Three carried defects a post-merge review then found, all fixed v0.3.843**: the array editor repositioned nothing on a pitch change, the ICDD writer left a truncated container when it refused, and the guided cut dropped linework silently. *Merged is not verified — that is the argument for the review pass, not against it.* |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts` | A29-GUIDE-UNDERLAY ③ *(in flight, PR #199)* · R28-VIEWER ④ · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R38-SYNC-VIEW ③ *(mostly built; only cursor sync left)* · R38-SOLVER-LOCKS ③ · R23-BATCH-OVERLAYS · R39-VIEWER-OBS ② · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R38-SYNC-SELECT ③ *(SHIPPED v0.3.829, pending archive)* · R41-MODEL-ALIGN · R43-VIEWER-CONFORMANCE |
@@ -748,11 +748,10 @@ that lanes do not *overlap*; nothing asserts they *cover*, and they do not. `app
 `proforma/`, `studio/`, `tools/`, `tree/`, `pins/`, `kernel/`, `account/`, `connections/` and the
 `portal/` root files (`prefs.ts`, `offlineQueue.ts`, `panelContext.ts`) belong to no lane, which the
 carve-out check in `roadmapLanes.test.ts` correctly calls "editable by everyone" when it happens
-deliberately. The live case: **`R38-SHEET-MARKUP ③` is Lane B and lands in
-`apps/web/src/drawings/`, while `R36-DRAWINGS-RETURN` is Lane A and lands there too** — so `drawings/`
-is contested by two lanes right now, the same shape as the register with the extra twist that nobody
-owns it. It needs its own premise-check and possibly the same answer. It is deliberately left open:
-guessing an owner for a directory two lanes are already aimed at is how the register problem was made.
+deliberately. The live case: **`R36-DRAWINGS-RETURN` is Lane A and lands in
+`apps/web/src/drawings/`**, so `drawings/` remains unowned rather than assigned by guess.
+It needs its own premise-check; guessing an owner for a directory a lane is already aimed at
+is how the register problem was made.
 
 **Shared files that need a heads-up before editing.** Every multi-session conflict so far has been one
 of these: `services/api/run_tests.py` · `services/api/src/aec_api/main.py` · `docs/roadmap.md` ·
@@ -1824,13 +1823,10 @@ server's report stays authoritative on the authored element. Wave 1 and its foll
     the pane had been unreachable (toggle button never appended), its fetch had failed cross-origin
     since v0.3.826 (`credentials:"include"` without a credentials CORS grant), and the live route
     dropped the `storey` param entirely — three defects only a live drive could see.
-- ◧ **R38-SHEET-MARKUP ③** *(M, Lane B — **① v0.3.1012 · ② v0.3.1013**)* — the vendored markup toolset (clouds, callouts, stamps,
-  tool sets) opened on the room's OWN generated sheets, markups tied to GUIDs through the existing
-  pin-to-drawing spine. ①: a pin dropped on `data-guid` linework in `apps/web/src/drawings/drawings.ts`
-  stores that GlobalId (`apps/web/src/ui/sheetGuid.ts`) and reselects it in 3D; empty paper is
-  still a coordinate pin. ②: promote-to-RFI copies that GlobalId onto `Topic.element_guids`
-  (`services/api/src/aec_api/routers/bim.py`). PDF markup on generated plans/elevations (not just
-  composed `sheet.pdf`) remains.
+- ✅ **R38-SHEET-MARKUP ③** *(M, Lane B — **SHIPPED ① v0.3.1012 · ② v0.3.1013 · ③ v0.3.1014**)* —
+  generated-sheet pins store GlobalId (`apps/web/src/ui/sheetGuid.ts`); promote copies it onto
+  `Topic.element_guids` (`services/api/src/aec_api/routers/bim.py`); PDF markup opens on every
+  generated sheet (`apps/web/src/ui/svgPdf.ts` wraps the live SVG when there is no `sheet.pdf`).
 - Consumes: R24-ELEMENT-CARD ② and R31-CITE-HIGHLIGHT (both already coded) as the "everything
   about this thing" surface.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1013",
+      "version": "0.3.1014",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What & why

R38-SHEET-MARKUP ③ closed. Every generated sheet has **🖊 PDF markup**. Composed sheets still use `sheet.pdf`. Plans / elevations / sections wrap the live SVG in pdf-lib (`apps/web/src/ui/svgPdf.ts`) so takeoff tools open on the room's own drawings.

Stacks on #309. Do not merge until the land order ahead of it has landed; keep this version number.

## Checklist

- [x] `npm run typecheck && npm run lint`
- [x] `npx vitest run src/ui/svgPdf.test.ts src/shell/roadmapLanes.test.ts src/shell/versionConsistency.test.ts`
- [x] CHANGELOG + roadmap (item closed; Lane B cell drops R38-SHEET-MARKUP ③)
- [x] Version 0.3.1014
- [ ] Live rasterise of a generated plan not driven (pdfFromPng is unit-tested)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

