### PR TITLE
v0.3.1015 — assemble the package, don't click it one by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1015 (2026-08-20) — assemble the package, don't click it one by one
+
+R24-REPORTS-BY-MOMENT ②. Each package has **Assemble**: a `report_package` job builds the
+named reports into one PDF and parks it in the job tray. Unknown ids fail the job rather than
+quietly shortening the pack. Email-on-a-date is still open (needs a recipient and SMTP).
+
 ## v0.3.1014 (2026-08-20) — markup the plan you are looking at
 
 R38-SHEET-MARKUP ③ closed. Every generated sheet (plan / elevation / section) has

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1014",
+    "version": "0.3.1015",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1014",
+  "version": "0.3.1015",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/reportCenter.ts
+++ b/apps/web/src/reportCenter.ts
@@ -3,7 +3,7 @@ import { money } from "./ui/charts";
 import { toast, escapeHtml } from "./ui/feedback";
 import { modalShell } from "./ui/modal";
 import { askText } from "./ui/prompt";
-import { REPORT_MOMENTS, missingReportIds, resolveMoment } from "./ui/reportMoments";
+import { REPORT_MOMENTS, REPORT_PACKAGE_KIND, missingReportIds, packageJobParams, resolveMoment } from "./ui/reportMoments";
 import { showResult } from "./ui/result";
 
 /** REL-4 leaf — the Report Center modal: every exportable report (PDF/Excel/markup) plus the
@@ -66,7 +66,16 @@ export async function openReportCenter(api: ApiClient, projectId: string | null,
     const why = document.createElement("div");
     why.className = "meta"; why.style.cssText = "font-size:11px;margin:2px 0 4px";
     why.textContent = m.occasion;                 // the line that makes it a moment, not a category
-    det.append(sum, why);
+    const assemble = document.createElement("button");
+    assemble.className = "tool-btn"; assemble.textContent = "Assemble";
+    assemble.title = "Build this package in the background; the job tray holds the PDF. Email on a date is still open.";
+    assemble.onclick = async () => {
+      try {
+        await api.enqueueJob(pid, REPORT_PACKAGE_KIND, packageJobParams(m));
+        toast("Package queued — watch the job tray", "success");
+      } catch (e) { toast((e as Error).message, "error"); }
+    };
+    det.append(sum, why, assemble);
     for (const rep of rows) det.appendChild(reportRow(rep));
     card.appendChild(det);
   }

--- a/apps/web/src/ui/jobTray.test.ts
+++ b/apps/web/src/ui/jobTray.test.ts
@@ -95,6 +95,7 @@ describe("times say only what is true", () => {
 describe("labels and artifacts do not guess", () => {
   it("a registered kind gets its name; an unknown kind renders raw, not a fabricated label", () => {
     expect(jobLabel("compiled_set_pdf")).toBe("Compiled drawing set");
+    expect(jobLabel("report_package")).toBe("Report package");
     expect(jobLabel("some_plugin_kind")).toBe("some_plugin_kind");
   });
 

--- a/apps/web/src/ui/jobTray.ts
+++ b/apps/web/src/ui/jobTray.ts
@@ -42,6 +42,7 @@ const KIND_LABEL: Record<string, string> = {
   echo: "Echo (test job)",
   cobie_export: "COBie export",
   compiled_set_pdf: "Compiled drawing set",
+  report_package: "Report package",
   model_export: "Model export",
   clash_detect: "Clash detection",
   escalation_scan: "Escalation scan",

--- a/apps/web/src/ui/reportMoments.test.ts
+++ b/apps/web/src/ui/reportMoments.test.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
-  type CatalogEntry, REPORT_MOMENTS, missingReportIds, resolveMoment, unclaimedReports,
+  type CatalogEntry, REPORT_MOMENTS, missingReportIds, packageJobParams, resolveMoment, unclaimedReports,
 } from "./reportMoments";
 
 /**
@@ -122,5 +122,12 @@ describe("the long tail is visible rather than pretended away", () => {
     // named or never-due report findable later.
     expect(Array.isArray(tail)).toBe(true);
     expect(tail.length).toBeLessThan(pythonCatalog().length);
+  });
+});
+
+describe("assembling a package does not invent reports", () => {
+  it("the job params are the moment's own ids, in order", () => {
+    const m = REPORT_MOMENTS[0]!;
+    expect(packageJobParams(m)).toEqual({ moment_id: m.id, reports: m.reports });
   });
 });

--- a/apps/web/src/ui/reportMoments.ts
+++ b/apps/web/src/ui/reportMoments.ts
@@ -136,3 +136,10 @@ export function unclaimedReports(
   const claimed = new Set(moments.flatMap((m) => m.reports));
   return catalog.map((r) => r.id).filter((id) => !claimed.has(id));
 }
+
+/** Job kind + params for assembling a moment. The server rejects unknown ids rather than shortening. */
+export const REPORT_PACKAGE_KIND = "report_package";
+
+export function packageJobParams(m: ReportMoment): { moment_id: string; reports: string[] } {
+  return { moment_id: m.id, reports: [...m.reports] };
+}

--- a/docs/internal/runway-claude-2026-08-19.md
+++ b/docs/internal/runway-claude-2026-08-19.md
@@ -1,4 +1,4 @@
-# Runway for Claude Code — 2026-08-20, after v0.3.1014
+# Runway for Claude Code — 2026-08-20, after v0.3.1015
 
 **Grade: live handoff.** Written so the next session picks up from measured state rather than chat
 memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still is. Security
@@ -30,7 +30,8 @@ memory. It is **not** the work list — [`docs/roadmap.md`](../roadmap.md) still
 | 15 | [#307](https://github.com/ibuilder/massing/pull/307) | `cursor/symbol-takeoff-6e15` | **1011** vs #306 |
 | 16 | [#308](https://github.com/ibuilder/massing/pull/308) | `cursor/sheet-guid-pins-6e15` | **1012** vs #307 |
 | 17 | [#309](https://github.com/ibuilder/massing/pull/309) | `cursor/markup-promote-guid-6e15` | **1013** vs #308 |
-| 18 | this | `cursor/generated-sheet-pdf-6e15` | **1014** vs #309 |
+| 18 | [#310](https://github.com/ibuilder/massing/pull/310) | `cursor/generated-sheet-pdf-6e15` | **1014** vs #309 |
+| 19 | this | `cursor/report-package-job-6e15` | **1015** vs #310 |
 
 After each merge: rebase the remainder, **keep the later version numbers**. Do not tag onto a red or
 pending `main`. This agent cannot merge.
@@ -58,6 +59,7 @@ pending `main`. This agent cannot merge.
 | 1012 | R38-SHEET-MARKUP ③ ① — pin on generated-sheet linework stores GlobalId; PDF-on-plans still open |
 | 1013 | R38-SHEET-MARKUP ③ ② — promote-to-RFI copies `data.guid` onto `Topic.element_guids` |
 | 1014 | R38-SHEET-MARKUP ③ closed — PDF markup on generated sheets (live SVG wrapped when no sheet.pdf) |
+| 1015 | R24-REPORTS-BY-MOMENT ② — Assemble queues `report_package`; email-on-a-date still open |
 
 ---
 
@@ -80,9 +82,9 @@ PERSONA-SHAPE; IDENTITY.
 ## Next slices
 
 1. **R24-FIELD-MODE remainder** — replacing the portal home (Lane A). ④ only hides the room tabs.
-2. **R24-REPORTS-BY-MOMENT** scheduling (needs a job kind + delivery; larger).
+2. **R24-REPORTS-BY-MOMENT** remainder — email on a date (SMTP + recipient). Assemble is shipped.
 3. Lane B still open: `R24-TERMS` (user decision), `R22-REPORT-BUILDER` (aggregation/share is backend),
-   `R24-REPORTS-BY-MOMENT` scheduling (job kind + delivery), `R24-FIELD-MODE` portal home (Lane A).
+   `R24-FIELD-MODE` portal home (Lane A).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1555,17 +1555,17 @@ refute one, so this goes first even though it is the least visible.
   mix donut must pass those hues in; occupying slot 0 is not how you get "passing". SVG fills stay
   outside `ui/colorContract.ts` (that list is CSS selectors). The audit's "four semantic hues" rule
   stays for status and does not apply to series identity.
-- 🟡 **R24-REPORTS-BY-MOMENT** — **grouping SHIPPED v0.3.785; scheduling still open.** The catalog was
+- 🟡 **R24-REPORTS-BY-MOMENT** — **grouping SHIPPED v0.3.785; assemble SHIPPED v0.3.1015; scheduling still open.** The catalog was
   **56 reports under 18 group headings, six holding a single report**. Seven packages now sit above
   them — owner monthly · lender draw · IC · precon/GMP · design issue · closeout · ownership quarter —
   each stating who asks and when, collapsed by default, with every report still under its noun
   heading below. `reportMoments.test.ts` reads `reports.py` and fails the build if a package names an
   id the server no longer defines; without that, a renamed report shortens a package silently on the
   Friday it is due.
-  **Still open: "scheduled and shared, not just downloaded."** A package is currently something you
-  open and click through. Making it a *scheduled deliverable* — assembled on a date, sent to a
-  recipient, with a record that it went — is the larger half and wants `routers/jobs.py` (now wired
-  to the UI by R24-JOB-TRAY) plus a delivery surface. That is a real feature, not a grouping change.
+  **Still open: "scheduled and shared, not just downloaded."** Assemble is a job
+  (`report_package` in `services/api/src/aec_api/jobs.py`, **Assemble** in `apps/web/src/reportCenter.ts`).
+  Making it a *scheduled deliverable* — sent to a recipient on a date — still wants a delivery surface
+  and SMTP. The Job row is already the record that a pack ran.
 - **R24-TERMS** *(S)* — the remaining long tail (element/component and estimate/budget/cost pairs
   are a user decision; storey/floor settled v0.3.945).
 - ✅ **R24-MONO-DATA** *(S — **SHIPPED v0.3.1003**)* — `var(--mono)` is the only first-party face;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1014",
+      "version": "0.3.1015",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/src/aec_api/jobs.py
+++ b/services/api/src/aec_api/jobs.py
@@ -526,6 +526,36 @@ def _echo(db: Session, params: dict) -> dict:
     return {"echo": params}
 
 
+def _report_package(db: Session, params: dict) -> dict:
+    """R24-REPORTS-BY-MOMENT ② — assemble a moment's reports into one PDF off the request thread.
+
+    Params: {project_id, reports: [id, …], moment_id?}. Caps at 16. Unknown ids fail at run, not
+    with a silent shorter package. Delivery (email on a date) is still open; this is the assemble
+    half, and the Job row is the record that it ran.
+    """
+    import uuid
+
+    from . import pdfops, reports, storage
+    pid = str(params.get("project_id") or "")
+    if not pid:
+        raise ValueError("report_package needs a project_id")
+    ids = [str(x) for x in (params.get("reports") or [])]
+    if not ids:
+        raise ValueError("no reports in the package")
+    if len(ids) > 16:
+        raise ValueError("a package is at most 16 reports")
+    unknown = [i for i in ids if i not in reports.REPORTS]
+    if unknown:
+        raise ValueError(f"unknown report(s): {unknown}")
+    parts = [reports.to_pdf(reports.build(db, pid, rid)) for rid in ids]
+    pdf = pdfops.merge(parts)
+    moment = str(params.get("moment_id") or "package")
+    key = f"{pid}/jobs/{uuid.uuid4().hex}-{moment}.pdf"
+    storage.put(key, pdf)
+    return {"artifact_key": key, "media_type": "application/pdf",
+            "filename": f"{moment}.pdf", "bytes": len(pdf), "reports": ids}
+
+
 register_kind("echo", _echo)
 register_kind("cobie_export", _cobie_export)            # read → artifact (no project-state write)
 register_kind("compiled_set_pdf", _compiled_set_pdf)   # read → artifact
@@ -533,3 +563,4 @@ register_kind("model_export", _model_export)           # read → artifact
 register_kind("clash_detect", _clash_detect)           # read-only
 register_kind("escalation_scan", _escalation_scan, mutating=True)   # WRITES records (me.update_record)
 register_kind("model_ci", _model_ci, mutating=True)    # writes the CI report; wants a consistent model read
+register_kind("report_package", _report_package)       # read → artifact

--- a/services/api/test_jobs.py
+++ b/services/api/test_jobs.py
@@ -192,7 +192,22 @@ assert _wait(njid).state == "done"
 
 # the real mutating kinds (write records / republish-adjacent) are flagged; read/artifact kinds aren't
 assert {"escalation_scan", "model_ci"} <= jobs._MUTATING_KINDS, jobs._MUTATING_KINDS
-assert not ({"model_export", "clash_detect", "cobie_export"} & jobs._MUTATING_KINDS), jobs._MUTATING_KINDS
+assert not ({"model_export", "clash_detect", "cobie_export", "report_package"} & jobs._MUTATING_KINDS), jobs._MUTATING_KINDS
+
+# R24-REPORTS-BY-MOMENT ②: assemble named reports into one PDF artifact
+with TestClient(app) as c:
+    pid = c.post("/projects", json={"name": "Pkg"}).json()["id"]
+    r = c.post(f"/projects/{pid}/jobs", json={"kind": "report_package",
+               "params": {"moment_id": "owner_monthly", "reports": ["executive"]}})
+    assert r.status_code == 201, r.text
+    pkg = _wait(r.json()["id"], timeout=60)
+    assert pkg.state == "done", (pkg.state, pkg.error)
+    assert pkg.result and pkg.result.get("artifact_key") and pkg.result.get("reports") == ["executive"], pkg.result
+    bad = c.post(f"/projects/{pid}/jobs", json={"kind": "report_package",
+                 "params": {"reports": ["not_a_report"]}})
+    assert bad.status_code == 201, bad.text
+    failed = _wait(bad.json()["id"], timeout=30)
+    assert failed.state == "error" and "unknown report" in (failed.error or ""), failed.error
 
 print("JOB-QUEUE OK - unknown kind 400s at submit; orphaned running job re-queued on worker start and "
       "completed (crash recovery); echo round-trips with timestamps; handler exception captured on the "


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R24-REPORTS-BY-MOMENT ②. Each Report Center package has **Assemble**: it queues a `report_package` job that builds the named reports into one PDF and parks it in the job tray.

Unknown report ids fail the job rather than silently shortening the pack. The HTTP enqueue path already injects `project_id` into params.

**Still open:** email on a date (SMTP + recipient). The Job row is the record that a pack ran.

Stacked on #310 (`cursor/generated-sheet-pdf-6e15`). Do not merge this stack from here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9982f6a-4df7-40c2-bfe9-c32426246e15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9982f6a-4df7-40c2-bfe9-c32426246e15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

