### PR TITLE
feat(auth): sign in through massing.cloud, and open your cloud library

### DIFF
--- a/apps/web/src/account/accountChip.test.ts
+++ b/apps/web/src/account/accountChip.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { avatarEl, initialsFor, renderChip } from "./accountChip";
+
+/**
+ * The identity chip — "signed in as", with the massing.cloud (WordPress) avatar.
+ *
+ * The interesting cases are all about the **absence** of a cloud profile, because that is the normal
+ * state for password and direct-IdP accounts and it must never read as an error. A missing
+ * `avatarUrl` has to produce a real element, and a *broken* one has to degrade to the same element
+ * rather than leaving the browser's broken-image glyph on the most-looked-at control in the shell.
+ */
+describe("initialsFor", () => {
+  it("takes one glyph from each of two name parts", () => {
+    expect(initialsFor("Ada Lovelace")).toBe("AL");
+  });
+
+  it("splits an email local-part on separators, ignoring the domain", () => {
+    // "ada.lovelace@example.com" must not become "AD" — and must never reach into the domain.
+    expect(initialsFor("ada.lovelace@example.com")).toBe("AL");
+    expect(initialsFor("ada@example.com")).toBe("AD");
+  });
+
+  it("falls back to the first two characters for a single-word name", () => {
+    expect(initialsFor("ada")).toBe("AD");
+    expect(initialsFor("x")).toBe("X");
+  });
+
+  it("never returns an empty string, so the disc is never blank", () => {
+    expect(initialsFor("")).toBe("?");
+    expect(initialsFor("   ")).toBe("?");
+    // A name that is *only* separators still has to yield something paintable.
+    expect(initialsFor("@example.com").length).toBeGreaterThan(0);
+  });
+
+  it("is at most two glyphs", () => {
+    for (const n of ["Ada Lovelace", "ada.lovelace@example.com", "Wolfgang Amadeus Mozart", "x"]) {
+      expect(initialsFor(n).length).toBeLessThanOrEqual(2);
+    }
+  });
+});
+
+describe("avatarEl", () => {
+  it("renders an <img> when the cloud supplied an avatar", () => {
+    const el = avatarEl({ username: "ada@example.com", avatarUrl: "https://cloud/a.jpg" });
+    expect(el.tagName).toBe("IMG");
+    expect((el as HTMLImageElement).src).toBe("https://cloud/a.jpg");
+    // Decorative: the accessible name is on the button, not repeated here.
+    expect((el as HTMLImageElement).alt).toBe("");
+    // Never leak the app's URL to the avatar host as a referrer.
+    expect((el as HTMLImageElement).referrerPolicy).toBe("no-referrer");
+  });
+
+  it("refuses a dangerous scheme and falls back to the disc", () => {
+    // `avatar_url` is external data — it comes from massing.cloud's userinfo, which reflects
+    // whatever avatar host the account uses. A non-http(s) scheme must never reach `src`.
+    for (const bad of ["javascript:alert(1)", "data:text/html,<script>", "vbscript:x", "file:///etc"]) {
+      const el = avatarEl({ username: "ada@example.com", displayName: "Ada Lovelace", avatarUrl: bad });
+      expect(el.tagName, `${bad} must not become an <img>`).toBe("SPAN");
+      expect(el.textContent).toBe("AL");
+    }
+  });
+
+  it("still accepts an ordinary https avatar", () => {
+    const el = avatarEl({ username: "ada@example.com", avatarUrl: "https://www.massing.cloud/a.jpg" });
+    expect(el.tagName).toBe("IMG");
+  });
+
+  it("renders an initials disc when there is no avatar", () => {
+    const el = avatarEl({ username: "ada@example.com", displayName: "Ada Lovelace" });
+    expect(el.tagName).toBe("SPAN");
+    expect(el.textContent).toBe("AL");
+    expect(el.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("swaps a broken avatar for the disc instead of showing a broken image", () => {
+    const el = avatarEl({ username: "ada@example.com", displayName: "Ada Lovelace",
+      avatarUrl: "https://cloud/gone.jpg" }) as HTMLImageElement;
+    const host = document.createElement("div");
+    host.append(el);
+    el.onerror?.(new Event("error"));
+    expect(host.querySelector("img")).toBeNull();
+    expect(host.textContent).toBe("AL");
+  });
+
+  it("gives the same person the same fallback colour across renders", () => {
+    // Read the raw style attribute, NOT `el.style.background`: happy-dom does not reflect the
+    // `background` shorthand back, so both sides would be "" and the equality assertion below
+    // would pass no matter what the code did.
+    const hue = (el: HTMLElement) => {
+      const css = el.getAttribute("style") || "";
+      const m = /hsl\((\d+)/.exec(css);
+      expect(m, `expected an hsl() background in: ${css}`).not.toBeNull();
+      return m![1];
+    };
+    expect(hue(avatarEl({ username: "ada@example.com" })))
+      .toBe(hue(avatarEl({ username: "ada@example.com" })));
+    expect(hue(avatarEl({ username: "ada@example.com" })))
+      .not.toBe(hue(avatarEl({ username: "bob@example.com" })));
+  });
+});
+
+describe("renderChip", () => {
+  let btn: HTMLButtonElement;
+  beforeEach(() => { btn = document.createElement("button"); });
+
+  it("shows the display name, not the raw username, when the cloud gave one", () => {
+    renderChip(btn, { username: "ada@example.com", displayName: "Ada Lovelace" });
+    expect(btn.textContent).toContain("Ada Lovelace");
+    expect(btn.getAttribute("aria-label")).toBe("Account: Ada Lovelace");
+  });
+
+  it("falls back to the username when there is no display name", () => {
+    renderChip(btn, { username: "ada@example.com" });
+    expect(btn.textContent).toContain("ada@example.com");
+    expect(btn.getAttribute("aria-label")).toBe("Account: ada@example.com");
+  });
+
+  it("badges an admin, and does not badge a regular user", () => {
+    renderChip(btn, { username: "ada@example.com", isAdmin: true });
+    expect(btn.textContent).toContain("admin");
+    const plain = document.createElement("button");
+    renderChip(plain, { username: "bob@example.com", isAdmin: false });
+    expect(plain.textContent).not.toContain("admin");
+  });
+
+  it("names the plan in the tooltip when one is known", () => {
+    renderChip(btn, { username: "ada@example.com", displayName: "Ada", tierLabel: "Commercial" });
+    expect(btn.title).toBe("Ada — Commercial plan");
+  });
+
+  it("is idempotent — re-rendering does not stack a second avatar or chevron", () => {
+    const id = { username: "ada@example.com", displayName: "Ada Lovelace", isAdmin: true };
+    renderChip(btn, id);
+    const styleAfterFirst = btn.getAttribute("style");
+    renderChip(btn, id);
+    expect(btn.querySelectorAll("span").length).toBe(4);   // disc + label + badge + chevron
+    expect(btn.textContent!.match(/Ada Lovelace/g)!.length).toBe(1);
+    // ...and the inline style does not grow on every render either.
+    expect(btn.getAttribute("style")).toBe(styleAfterFirst);
+  });
+});

--- a/apps/web/src/account/accountChip.ts
+++ b/apps/web/src/account/accountChip.ts
@@ -1,0 +1,126 @@
+/** The toolbar identity control — "signed in as", with the massing.cloud (WordPress) avatar.
+ *
+ *  Replaces the plain `"<username> ▾"` text button. The point is recognition at a glance: the chip
+ *  is the most-looked-at control in the shell, and a photo answers "whose session is this?" faster
+ *  than an email address does — which matters here because a browser in a site trailer is routinely
+ *  a shared machine.
+ *
+ *  **Three states, one control.** Signed out → a plain "Sign in". Signed in with a cloud link → the
+ *  avatar massing.cloud serves for that account. Signed in *without* one (password or direct-IdP
+ *  accounts, which have no avatar and never will) → a generated initials disc in a colour derived
+ *  from the name. The fallback is a rendering branch, never an error: `avatar_url` being absent is
+ *  the normal case for a local account.
+ *
+ *  The avatar is decorative — the accessible name is carried by `aria-label` on the button, so a
+ *  screen reader reads "Account: Ada Lovelace", not a filename.
+ */
+import { escapeHtml, safeHref } from "../ui/feedback";
+
+export interface ChipIdentity {
+  username: string;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  tierLabel?: string | null;
+  isAdmin?: boolean;
+}
+
+/** Stable hue from a string, so a given person keeps the same fallback colour across reloads. */
+function hueFor(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) % 360;
+  return h;
+}
+
+/** "Ada Lovelace" → "AL"; "ada@example.com" → "AD". Never more than two glyphs. */
+export function initialsFor(name: string): string {
+  const clean = (name || "").trim();
+  if (!clean) return "?";
+  const local = (clean.includes("@") ? clean.split("@")[0] : clean) || clean;
+  const parts = local.split(/[\s._-]+/).filter(Boolean);
+  if (parts.length >= 2) return ((parts[0]![0] ?? "") + (parts[1]![0] ?? "")).toUpperCase();
+  return local.slice(0, 2).toUpperCase();
+}
+
+/** Build the 22px avatar element: an <img> when there is a URL, else an initials disc.
+ *
+ *  A broken/blocked avatar URL swaps itself for the initials disc on `error` — an offline desktop
+ *  session would otherwise show the browser's broken-image glyph on the primary account control. */
+export function avatarEl(identity: ChipIdentity, size = 22): HTMLElement {
+  const label = identity.displayName || identity.username;
+  const disc = () => {
+    const d = document.createElement("span");
+    d.textContent = initialsFor(label);
+    d.style.cssText = `width:${size}px;height:${size}px;border-radius:50%;flex:0 0 auto;`
+      + `display:inline-flex;align-items:center;justify-content:center;`
+      + `font-size:${Math.round(size * 0.42)}px;font-weight:600;letter-spacing:.02em;`
+      // Legacy comma syntax on purpose: the space-separated `hsl(H S% L%)` form is dropped outright
+      // by some CSS parsers (happy-dom among them), which would leave the disc transparent.
+      + `background:hsl(${hueFor(label)}, 45%, 32%);color:#fff`;
+    d.setAttribute("aria-hidden", "true");
+    return d;
+  };
+  if (!identity.avatarUrl) return disc();
+  // The avatar URL is external data — it reaches us from massing.cloud's `userinfo`, which in turn
+  // reflects whatever avatar host that account uses. `safeHref` collapses anything outside the
+  // http(s) allowlist to "#"; rather than set `src="#"` and rely on the error handler, refuse it
+  // up front and draw the initials disc, which is the same outcome without the failed request.
+  const href = safeHref(identity.avatarUrl);
+  if (href === "#") return disc();
+  const img = document.createElement("img");
+  img.src = href;
+  img.alt = "";                                   // decorative; the button carries the name
+  img.decoding = "async";
+  img.referrerPolicy = "no-referrer";
+  img.style.cssText = `width:${size}px;height:${size}px;border-radius:50%;flex:0 0 auto;object-fit:cover;`
+    + "background:var(--control)";
+  img.onerror = () => img.replaceWith(disc());
+  return img;
+}
+
+/** Render the signed-in chip into `btn` (avatar + name + chevron). */
+export function renderChip(btn: HTMLButtonElement, identity: ChipIdentity): void {
+  btn.textContent = "";
+  // Set properties individually rather than appending to `cssText`: the button already carries
+  // inline styles from the toolbar, and `cssText +=` would re-append these declarations on every
+  // re-render, growing the attribute without bound.
+  Object.assign(btn.style, {
+    display: "inline-flex", alignItems: "center", gap: "7px",
+    paddingLeft: "5px", maxWidth: "220px",
+  });
+  const name = identity.displayName || identity.username;
+  btn.append(avatarEl(identity));
+  const label = document.createElement("span");
+  label.textContent = name;
+  label.style.cssText = "overflow:hidden;text-overflow:ellipsis;white-space:nowrap";
+  btn.append(label);
+  if (identity.isAdmin) {
+    const badge = document.createElement("span");
+    badge.textContent = "admin";
+    badge.style.cssText = "font-size:9px;text-transform:uppercase;letter-spacing:.04em;padding:1px 5px;"
+      + "border-radius:999px;background:var(--accent-soft);color:var(--accent);flex:0 0 auto";
+    btn.append(badge);
+  }
+  const chev = document.createElement("span");
+  chev.textContent = "▾"; chev.style.cssText = "opacity:.6;flex:0 0 auto";
+  btn.append(chev);
+  btn.setAttribute("aria-label", `Account: ${name}`);
+  btn.title = identity.tierLabel ? `${name} — ${identity.tierLabel} plan` : name;
+}
+
+/** The larger identity block at the top of the profile panel. */
+export function identityHeader(identity: ChipIdentity, subtitle: string): HTMLElement {
+  const wrap = document.createElement("div");
+  wrap.style.cssText = "display:flex;align-items:center;gap:12px;padding:2px 0 8px";
+  wrap.append(avatarEl(identity, 44));
+  const col = document.createElement("div");
+  col.style.cssText = "display:flex;flex-direction:column;gap:2px;min-width:0";
+  const nm = document.createElement("strong");
+  nm.textContent = identity.displayName || identity.username;
+  nm.style.cssText = "font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap";
+  const sub = document.createElement("span");
+  sub.className = "meta";
+  sub.innerHTML = escapeHtml(subtitle);
+  col.append(nm, sub);
+  wrap.append(col);
+  return wrap;
+}

--- a/apps/web/src/account/accountUI.ts
+++ b/apps/web/src/account/accountUI.ts
@@ -11,6 +11,8 @@ import type { ApiClient, AccountUser, AuditEntry, ProjectMember, ProjectRole } f
 import { modalShell, confirmModal } from "../ui/modal";
 import { askText } from "../ui/prompt";
 import { escapeHtml, toast } from "../ui/feedback";
+import { renderChip, type ChipIdentity } from "./accountChip";
+import { cloudLoginUrl, cloudStatus, cloudRefresh, cloudDisconnect, type CloudStatus } from "../api/cloud";
 
 export interface AccountDeps {
   api: ApiClient;
@@ -19,9 +21,15 @@ export interface AccountDeps {
   getProjectId: () => string | null;
   getIsProjectAdmin: () => boolean;
   openSettings: () => void;        // main owns settingsModal (tied to viewer settings state)
+  /** CLOUD-LIBRARY: hand a model downloaded from massing.cloud to the app. Returns false when the
+   *  container type isn't something this build can open, so the library can say so instead of
+   *  closing on a no-op. main.ts owns it because opening a model is a viewer/session concern. */
+  openCloudModel: (blob: Blob, name: string) => Promise<boolean> | boolean;
 }
 
 let D: AccountDeps;
+/** The signed-in identity as the chip and the profile panel render it. Set once at startup. */
+let ME: ChipIdentity = { username: "account" };
 const PROJECT_ROLES = ["viewer", "reviewer", "editor", "admin"] as const;
 const PARTY_ROLES = ["", "GC", "Owner", "OwnersRep", "Consultant", "Subcontractor"];
 
@@ -33,12 +41,21 @@ export async function buildAuthControl(deps: AccountDeps): Promise<void> {
   el.className = "tool-btn"; el.style.marginLeft = "6px"; el.dataset.tour = "account";
   if (api.authed) {
     let name = "account", platformAdmin = false, tier = "free";
+    let displayName: string | null = null, avatarUrl: string | null = null;
     try {
       const m = await api.me();
-      if (m.authenticated) { name = m.username; platformAdmin = !!m.platform_admin; tier = m.tier || "free"; }
-      else api.setToken("");
+      if (m.authenticated) {
+        name = m.username; platformAdmin = !!m.platform_admin; tier = m.tier || "free";
+        // CLOUD-SSO: `/auth/me` carries the cloud profile so the chip draws in ONE round trip.
+        // Absent for password and direct-IdP accounts — `renderChip` falls back to initials.
+        const withCloud = m as typeof m & { display_name?: string | null; avatar_url?: string | null };
+        displayName = withCloud.display_name ?? null;
+        avatarUrl = withCloud.avatar_url ?? null;
+      } else api.setToken("");
     } catch { /* keep token; offline */ }
-    el.textContent = `${name} ▾`; el.title = "Account";
+    ME = { username: name, displayName, avatarUrl, isAdmin: platformAdmin };
+    renderChip(el, ME);
+    primeCloudStatus();     // so the dropdown knows on FIRST open whether to offer the library
     el.onclick = () => accountMenu(el, platformAdmin, tier);
   } else {
     el.textContent = "Sign in"; el.title = "Sign in";
@@ -75,6 +92,26 @@ function loginModal() {
   resetLink.style.cssText = "font-size:12px;color:var(--muted);align-self:flex-start";
   resetLink.onclick = (e) => { e.preventDefault(); close(); resetModal(); };
   row.append(cancel, go); card.append(u, p, msg, row, resetLink);
+
+  // CLOUD-SSO leads, when the operator has enabled it. massing.cloud is the identity broker: behind
+  // this one button the user picks Microsoft / Google / Procore / Autodesk / password on the site,
+  // and this deployment never holds a provider secret. It is deliberately rendered ABOVE the direct
+  // IdP buttons below — those remain for deployments that federate on their own.
+  void cloudStatus(D.api).then((st) => {
+    if (!st.enabled) return;
+    const b = document.createElement("button");
+    b.className = "file-btn";
+    b.style.cssText = "padding:11px 14px;font-size:14px;font-weight:600";
+    b.textContent = "Continue with massing.cloud";
+    b.onclick = connectCloud;
+    const hint = document.createElement("div");
+    hint.className = "meta";
+    hint.style.cssText = "text-align:center;font-size:11px;margin:-2px 0 2px";
+    hint.textContent = "Sign in with Microsoft, Google, Procore or Autodesk — and open your cloud projects";
+    card.insertBefore(b, card.firstChild);
+    card.insertBefore(hint, b.nextSibling);
+  }).catch(() => { /* status unavailable — the password form below still works */ });
+
   // SSO buttons (only the providers configured on the server), shown above the password form
   void D.api.authProviders().then(({ providers }) => {
     if (!providers.length) {
@@ -245,26 +282,96 @@ function accountMenu(anchor: HTMLElement, platformAdmin = false, tier = "free") 
     return b;
   };
   const pid = D.getProjectId();
-  if (platformAdmin) menu.append(item("Manage users…", adminModal));
-  if (platformAdmin) menu.append(item("Audit log…", auditModal));
-  if (platformAdmin) menu.append(item("Errors…", errorsModal));
-  if (platformAdmin) menu.append(item("Data connections…",
-    () => void import("../connections/connectionsUI").then((m) => m.openConnectionsModal(D.api, D.getProjectId))));
+  // The four platform-admin entries that used to sit here — users, audit, errors, data connections —
+  // are now the "Administration" SECTION of the profile panel, shown only when the account carries
+  // the capability. The dropdown is back to being a short list of things you do often; anything that
+  // is *about your account* lives one click deeper, in one place, instead of being split across a
+  // dropdown, a settings modal and four admin consoles. See `profileSettings.ts`.
+  menu.append(item("Profile & settings…", () => void openProfile(platformAdmin, tier)));
+  if (cloudLink?.enabled && cloudLink.linked && cloudLink.library_access) {
+    menu.append(item("My cloud projects…", openLibrary));
+  }
+  if (cloudLink?.enabled && !cloudLink.linked) {
+    menu.append(item("Connect massing.cloud…", connectCloud));
+  }
   if (D.getIsProjectAdmin() && pid) menu.append(item("Project members…", () => membersModal(pid)));
-  menu.append(item("Settings…", D.openSettings));
-  menu.append(item("Change password…", passwordModal));
-  menu.append(item("Two-factor auth…", () => void mfaModal()));
-  menu.append(item("Sign out everywhere…", async () => {
-    if (!await confirmModal("Sign out everywhere",
-        "Sign out of every other device and session? This tab stays signed in.", "Revoke sessions")) return;
-    try { await D.api.logoutAll(); toast("Signed out of all other sessions", "info"); }
-    catch { toast("Could not revoke sessions", "error"); }
-  }));
   menu.append(item("Sign out", async () => { await D.api.logout(); D.api.setToken(""); location.reload(); }));
   document.body.appendChild(menu);
   setTimeout(() => document.addEventListener("pointerdown", function off(e) {
     if (!menu.contains(e.target as Node)) { menu.remove(); document.removeEventListener("pointerdown", off); }
   }), 0);
+}
+
+/** Cached `/auth/cloud/status`. `undefined` = not fetched yet, `null` = the call failed (offline),
+ *  which the profile panel renders as "could not check" rather than as "not connected" — those are
+ *  different facts and conflating them would tell a user to reconnect a link they already have. */
+let cloudLink: CloudStatus | null | undefined;
+
+/** Fetch (once) and cache the cloud link state. */
+async function ensureCloudStatus(): Promise<CloudStatus | null> {
+  if (cloudLink !== undefined) return cloudLink;
+  try { cloudLink = await cloudStatus(D.api); }
+  catch { cloudLink = null; }
+  return cloudLink;
+}
+
+/** Warm the cloud status at startup so the dropdown can offer the right items on first open. */
+export function primeCloudStatus(): void {
+  void ensureCloudStatus();
+}
+
+function connectCloud(): void {
+  // A full-page navigation, not fetch/XHR: the broker must render its own login UI on its own
+  // origin and set its own cookies. It returns to /auth/cloud/callback, which redirects back in.
+  window.location.href = cloudLoginUrl(D.api);
+}
+
+function openLibrary(): void {
+  void import("./cloudLibrary").then((m) => m.openCloudLibrary({
+    api: D.api,
+    siteUrl: cloudLink?.site_url || "https://www.massing.cloud",
+    connectCloud,
+    onOpenModel: (blob, name) => D.openCloudModel(blob, name),
+  }));
+}
+
+/** Open the unified profile panel (see `profileSettings.ts` for why admin lives inside it). */
+async function openProfile(platformAdmin: boolean, tier: string, initial = "profile") {
+  const cloud = await ensureCloudStatus();
+  const pid = D.getProjectId();
+  const [{ openProfileSettings }] = await Promise.all([import("./profileSettings")]);
+  openProfileSettings({
+    identity: { ...ME, isAdmin: platformAdmin, tierLabel: cloud?.tier_label || tier },
+    platformAdmin,
+    cloud,
+    tierLabel: cloud?.tier_label || tier.charAt(0).toUpperCase() + tier.slice(1),
+    actions: {
+      manageUsers: adminModal,
+      auditLog: auditModal,
+      errorLog: errorsModal,
+      dataConnections: () => void import("../connections/connectionsUI")
+        .then((m) => m.openConnectionsModal(D.api, D.getProjectId)),
+      projectMembers: D.getIsProjectAdmin() && pid ? () => membersModal(pid) : null,
+      changePassword: passwordModal,
+      twoFactor: () => void mfaModal(),
+      appSettings: D.openSettings,
+      signOutEverywhere: async () => {
+        if (!await confirmModal("Sign out everywhere",
+            "Sign out of every other device and session? This tab stays signed in.", "Revoke sessions")) return;
+        try { await D.api.logoutAll(); toast("Signed out of all other sessions", "info"); }
+        catch { toast("Could not revoke sessions", "error"); }
+      },
+      signOut: async () => { await D.api.logout(); D.api.setToken(""); location.reload(); },
+      connectCloud,
+      refreshCloud: async () => { cloudLink = await cloudRefresh(D.api); return cloudLink; },
+      disconnectCloud: async () => {
+        await cloudDisconnect(D.api);
+        cloudLink = undefined;          // force a re-read; the link is gone and so is the elevation
+        location.reload();              // role/tier may have changed — redraw from a clean state
+      },
+      openLibrary,
+    },
+  }, initial);
 }
 
 /** Self-service password change (any signed-in user). */

--- a/apps/web/src/account/cloudLibrary.ts
+++ b/apps/web/src/account/cloudLibrary.ts
@@ -1,0 +1,173 @@
+/** CLOUD-LIBRARY browser — the user's massing.cloud project vault, inside the app.
+ *
+ *  Two levels: the vaults (projects) they own, and the models inside one. Opening a model resolves
+ *  its signed `download_url` server-side and fetches the bytes straight from massing.cloud — see
+ *  `api/cloud.ts` for why that fetch carries no Authorization header.
+ *
+ *  **Refusals are rendered, not swallowed.** A free plan gets an upgrade link, an unlinked account
+ *  gets a connect prompt, and a plan limit shows the site's own message. An empty library and an
+ *  ungranted one look completely different here, which is the whole reason the server distinguishes
+ *  402 / 403 / 200-with-`[]` instead of returning an empty list for all three.
+ */
+import { modalShell } from "../ui/modal";
+import { escapeHtml, toast } from "../ui/feedback";
+import type { ApiClient } from "../api/client";
+import {
+  CloudError, cloudProjects, cloudProject, cloudModel, formatBytes,
+  type CloudProject,
+} from "../api/cloud";
+
+export interface LibraryDeps {
+  api: ApiClient;
+  siteUrl: string;
+  /** Hand the downloaded `.mass`/IFC bytes to the app. Returning false means "not handled". */
+  onOpenModel: (blob: Blob, name: string) => Promise<boolean> | boolean;
+  connectCloud: () => void;
+}
+
+function empty(msg: string, actionLabel?: string, onClick?: () => void): HTMLElement {
+  const el = document.createElement("div");
+  el.style.cssText = "display:flex;flex-direction:column;align-items:flex-start;gap:8px;padding:18px 4px";
+  const t = document.createElement("div");
+  t.className = "meta"; t.innerHTML = escapeHtml(msg);
+  el.append(t);
+  if (actionLabel && onClick) {
+    const b = document.createElement("button");
+    b.className = "file-btn"; b.textContent = actionLabel; b.onclick = onClick;
+    el.append(b);
+  }
+  return el;
+}
+
+/** Turn a thrown CloudError into the right piece of UI, or null if it is not one we explain. */
+function refusalView(e: unknown, deps: LibraryDeps): HTMLElement | null {
+  if (!(e instanceof CloudError)) return null;
+  if (e.needsUpgrade) {
+    return empty("The cloud project library is included with any paid Massing plan. "
+      + "Your massing.cloud account is on the Free plan.",
+      "See plans", () => window.open(`${deps.siteUrl}/pricing/`, "_blank", "noopener"));
+  }
+  if (e.notLinked) {
+    return empty("This account is not connected to massing.cloud yet.",
+      "Connect massing.cloud", deps.connectCloud);
+  }
+  return empty(e.message);
+}
+
+export function openCloudLibrary(deps: LibraryDeps): void {
+  const { card, msg, close, ready } = modalShell("My massing.cloud projects", 560);
+  msg.style.color = "var(--err)";
+  const crumbs = document.createElement("div");
+  crumbs.style.cssText = "display:flex;align-items:center;gap:6px;min-height:24px";
+  const list = document.createElement("div");
+  list.style.cssText = "display:flex;flex-direction:column;gap:6px;max-height:56vh;overflow:auto";
+  card.append(crumbs, list, msg);
+
+  const spinner = () => { list.textContent = ""; list.append(empty("Loading…")); };
+
+  const showProjects = async () => {
+    crumbs.textContent = "";
+    spinner();
+    let projects: CloudProject[];
+    try {
+      projects = await cloudProjects(deps.api);
+    } catch (e) {
+      const view = refusalView(e, deps);
+      list.textContent = "";
+      list.append(view || empty("Could not reach your massing.cloud library."));
+      return;
+    }
+    list.textContent = "";
+    if (!projects.length) {
+      list.append(empty("No projects in your cloud library yet. Projects you save to massing.cloud "
+        + "will appear here.", "Open massing.cloud",
+        () => window.open(`${deps.siteUrl}/my-account/vaults/`, "_blank", "noopener")));
+      return;
+    }
+    for (const p of projects) list.append(projectRow(p));
+  };
+
+  const projectRow = (p: CloudProject) => {
+    const el = document.createElement("button");
+    el.className = "tool-btn";
+    el.style.cssText = "display:flex;align-items:center;gap:10px;width:100%;text-align:left;padding:9px 10px";
+    const col = document.createElement("div");
+    col.style.cssText = "display:flex;flex-direction:column;gap:2px;flex:1;min-width:0";
+    const t = document.createElement("span"); t.textContent = p.title;
+    const d = document.createElement("span"); d.className = "meta";
+    d.textContent = `${p.model_count} model${p.model_count === 1 ? "" : "s"}`
+      + (p.updated ? ` · updated ${new Date(p.updated).toLocaleDateString()}` : "");
+    col.append(t, d);
+    const chev = document.createElement("span"); chev.textContent = "›"; chev.style.opacity = ".6";
+    el.append(col, chev);
+    el.onclick = () => void showProject(p);
+    return el;
+  };
+
+  const showProject = async (p: CloudProject) => {
+    crumbs.textContent = "";
+    const back = document.createElement("button");
+    back.className = "tool-btn"; back.textContent = "‹ All projects";
+    back.onclick = () => void showProjects();
+    const here = document.createElement("span");
+    here.className = "meta"; here.textContent = p.title;
+    crumbs.append(back, here);
+    spinner();
+
+    // The vault list gives a model COUNT but not the model records; `GET /projects/{id}` is what
+    // carries them. A site that returns the count only still renders — as "no models listed" —
+    // rather than throwing, because the count is not a promise about the payload shape.
+    let models: unknown[];
+    try {
+      const full = await cloudProject(deps.api, p.id) as CloudProject & { models?: unknown[] };
+      models = Array.isArray(full.models) ? full.models : [];
+    } catch (e) {
+      const view = refusalView(e, deps);
+      list.textContent = "";
+      list.append(view || empty("Could not open that project."));
+      return;
+    }
+    list.textContent = "";
+    if (!models.length) {
+      list.append(empty("No models in this project yet."));
+      return;
+    }
+    for (const raw of models) {
+      const m = raw as { id: number | string; title?: string; size_bytes?: number; version?: number };
+      list.append(modelRow(m));
+    }
+  };
+
+  const modelRow = (m: { id: number | string; title?: string; size_bytes?: number; version?: number }) => {
+    const el = document.createElement("div");
+    el.style.cssText = "display:flex;align-items:center;gap:10px;padding:9px 10px;border:1px solid var(--line);"
+      + "border-radius:7px";
+    const col = document.createElement("div");
+    col.style.cssText = "display:flex;flex-direction:column;gap:2px;flex:1;min-width:0";
+    const t = document.createElement("span"); t.textContent = m.title || "Untitled model";
+    const d = document.createElement("span"); d.className = "meta";
+    d.textContent = [formatBytes(m.size_bytes || 0), m.version ? `v${m.version}` : ""]
+      .filter(Boolean).join(" · ");
+    col.append(t, d);
+    const open = document.createElement("button");
+    open.className = "file-btn"; open.textContent = "Open";
+    open.onclick = async () => {
+      open.disabled = true; open.textContent = "Opening…";
+      try {
+        const rec = await cloudModel(deps.api, m.id);
+        const { openModelBytes } = await import("../api/cloud");
+        const blob = await openModelBytes(rec);
+        const handled = await deps.onOpenModel(blob, rec.title || "model");
+        if (handled) { close(); toast(`Opened “${rec.title}” from massing.cloud`, "info"); }
+        else toast("This model type can't be opened here yet", "error");
+      } catch (e) {
+        msg.textContent = e instanceof CloudError ? e.message : "could not open that model";
+      } finally { open.disabled = false; open.textContent = "Open"; }
+    };
+    el.append(col, open);
+    return el;
+  };
+
+  void showProjects();
+  ready?.();
+}

--- a/apps/web/src/account/profileSettings.test.ts
+++ b/apps/web/src/account/profileSettings.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { openProfileSettings, type ProfileActions, type ProfileDeps } from "./profileSettings";
+import type { CloudStatus } from "../api/cloud";
+
+/**
+ * The profile panel is where this change actually lands for a user, so the assertions are about the
+ * product claim rather than about markup:
+ *
+ *  * **Administration is a section, not a console.** A non-admin and an admin see the *same* panel;
+ *    the admin's has one more section. That is the whole reorganisation, and it is the thing that
+ *    silently regresses if someone re-adds a top-level admin entry point.
+ *  * **Capability gates the section, not the actions.** The admin actions must be unreachable for a
+ *    non-admin — asserting the tab is missing is not enough on its own, because a hidden tab whose
+ *    content is still built would leak the buttons.
+ *  * **An unreachable server and an unlinked account are different facts.** `cloud: null` must not
+ *    render as "not connected", or a user with a working link is told to reconnect.
+ */
+function actions(): ProfileActions {
+  return {
+    manageUsers: vi.fn(), auditLog: vi.fn(), errorLog: vi.fn(), dataConnections: vi.fn(),
+    projectMembers: null, changePassword: vi.fn(), twoFactor: vi.fn(), appSettings: vi.fn(),
+    signOutEverywhere: vi.fn(), signOut: vi.fn(), connectCloud: vi.fn(),
+    refreshCloud: vi.fn(async () => ({} as CloudStatus)), disconnectCloud: vi.fn(async () => {}),
+    openLibrary: vi.fn(),
+  };
+}
+
+const linked: CloudStatus = {
+  enabled: true, linked: true, site_url: "https://www.massing.cloud",
+  email: "ada@example.com", name: "Ada Lovelace", tier: "commercial", tier_label: "Commercial",
+  roles: ["editor"], providers: ["google"], is_admin: true, library_access: true,
+};
+
+function open(over: Partial<ProfileDeps> = {}, initial?: string) {
+  const deps: ProfileDeps = {
+    identity: { username: "ada@example.com", displayName: "Ada Lovelace" },
+    platformAdmin: false, cloud: linked, tierLabel: "Commercial", actions: actions(),
+    ...over,
+  };
+  openProfileSettings(deps, initial);
+  const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+  return { dialog, deps };
+}
+
+const tabNames = (d: HTMLElement) =>
+  [...d.querySelectorAll('[role="tab"]')].map((b) => b.textContent);
+
+beforeEach(() => { document.body.textContent = ""; });
+
+describe("openProfileSettings", () => {
+  it("shows the same sections to a non-admin, minus Administration", () => {
+    const { dialog } = open({ platformAdmin: false });
+    expect(tabNames(dialog)).toEqual(["Profile", "massing.cloud", "Security", "Preferences"]);
+  });
+
+  it("adds Administration as ONE MORE SECTION for an admin — not a separate console", () => {
+    const { dialog } = open({ platformAdmin: true });
+    expect(tabNames(dialog)).toEqual(
+      ["Profile", "massing.cloud", "Security", "Preferences", "Administration"]);
+  });
+
+  it("does not build the admin actions at all for a non-admin", () => {
+    // The gate has to be on the section, not merely on the tab: a hidden tab whose body is still
+    // constructed would put "Manage…" buttons in the DOM for a user who cannot use them.
+    const { dialog } = open({ platformAdmin: false });
+    for (const tab of dialog.querySelectorAll('[role="tab"]')) (tab as HTMLElement).click();
+    expect(dialog.textContent).not.toContain("Audit log");
+    expect(dialog.textContent).not.toContain("Data connections");
+  });
+
+  it("reaches the admin actions through the Administration section", () => {
+    const { dialog, deps } = open({ platformAdmin: true });
+    (([...dialog.querySelectorAll('[role="tab"]')]
+      .find((b) => b.textContent === "Administration")) as HTMLElement).click();
+    const users = [...dialog.querySelectorAll("button")]
+      .find((b) => b.previousSibling?.textContent?.includes("Users"));
+    expect(dialog.textContent).toContain("Audit log");
+    users?.click();
+    expect(deps.actions.manageUsers).toHaveBeenCalled();
+  });
+
+  it("tells an admin WHY they see the section, naming the cloud role when that is the reason", () => {
+    const { dialog } = open({ platformAdmin: true, cloud: linked });
+    (([...dialog.querySelectorAll('[role="tab"]')]
+      .find((b) => b.textContent === "Administration")) as HTMLElement).click();
+    expect(dialog.textContent).toContain("massing.cloud role is editor");
+  });
+
+  it("offers Connect when the broker is enabled but this account is not linked", () => {
+    const { dialog, deps } = open({
+      cloud: { enabled: true, linked: false, site_url: "https://www.massing.cloud" },
+    }, "cloud");
+    expect(dialog.textContent).toContain("Not connected");
+    ([...dialog.querySelectorAll("button")].find((b) => b.textContent === "Connect…"))?.click();
+    expect(deps.actions.connectCloud).toHaveBeenCalled();
+  });
+
+  it("points a free plan at pricing instead of an empty library", () => {
+    const { dialog } = open({
+      cloud: { ...linked, tier: "free", tier_label: "Free", library_access: false },
+    }, "cloud");
+    expect(dialog.textContent).toContain("Included with any paid plan");
+    expect(dialog.textContent).not.toContain("Open library…");
+  });
+
+  it("opens the library for an entitled plan", () => {
+    const { dialog, deps } = open({ cloud: linked }, "cloud");
+    ([...dialog.querySelectorAll("button")].find((b) => b.textContent === "Open library…"))?.click();
+    expect(deps.actions.openLibrary).toHaveBeenCalled();
+  });
+
+  it("distinguishes 'could not check' from 'not connected'", () => {
+    const { dialog } = open({ cloud: null }, "cloud");
+    expect(dialog.textContent).toContain("Could not reach the server");
+    expect(dialog.textContent).not.toContain("Not connected");
+  });
+
+  it("says so when the operator has not enabled the broker at all", () => {
+    const { dialog } = open({
+      cloud: { enabled: false, linked: false, site_url: "https://www.massing.cloud" },
+    }, "cloud");
+    expect(dialog.textContent).toContain("Not configured");
+  });
+
+  it("falls back to Profile when asked for a section that does not exist for this user", () => {
+    // A non-admin deep-linked to "admin" must land somewhere sane rather than on a blank pane.
+    const { dialog } = open({ platformAdmin: false }, "admin");
+    const selected = dialog.querySelector('[role="tab"][aria-selected="true"]');
+    expect(selected?.textContent).toBe("Profile");
+  });
+});

--- a/apps/web/src/account/profileSettings.ts
+++ b/apps/web/src/account/profileSettings.ts
@@ -1,0 +1,265 @@
+/** Profile & settings — **one** place for everything about the signed-in person.
+ *
+ *  This replaces the old account dropdown, in which "Manage users…", "Audit log…", "Errors…" and
+ *  "Data connections…" sat as four separate top-level entries visible only to admins. That layout
+ *  encoded a product idea we are moving away from: that "admin" is a *place* you go, distinct from
+ *  your account. It is not. Administration is a **section of your profile** that appears when your
+ *  account happens to carry the capability — the same panel, one section longer.
+ *
+ *  Practically that means: a user who gains or loses admin sees the same navigation with one section
+ *  added or removed, rather than four menu items materialising somewhere else; and every setting that
+ *  is *about the person* (identity, cloud link, password, MFA, sessions, preferences) is reachable
+ *  from one control instead of from a dropdown, a modal and a separate settings panel.
+ *
+ *  **Sections are injected, not imported.** The existing modals (`adminModal`, `auditModal`, …) stay
+ *  private to `accountUI.ts`, which owns them; this module receives them as callbacks. That keeps the
+ *  dependency one-way and lets this panel be tested against a stub with no DOM-heavy modal behind it.
+ */
+import { escapeHtml, toast } from "../ui/feedback";
+import { modalShell, confirmModal } from "../ui/modal";
+import { identityHeader, type ChipIdentity } from "./accountChip";
+import type { CloudStatus } from "../api/cloud";
+
+/** The actions this panel offers. Everything is a callback so the panel owns no domain logic. */
+export interface ProfileActions {
+  manageUsers: () => void;
+  auditLog: () => void;
+  errorLog: () => void;
+  dataConnections: () => void;
+  projectMembers: (() => void) | null;   // null when there is no project / not a project admin
+  changePassword: () => void;
+  twoFactor: () => void;
+  appSettings: () => void;               // viewer/shortcut settings, owned by main.ts
+  signOutEverywhere: () => void;
+  signOut: () => void;
+  connectCloud: () => void;
+  refreshCloud: () => Promise<CloudStatus>;
+  disconnectCloud: () => Promise<void>;
+  openLibrary: () => void;
+}
+
+export interface ProfileDeps {
+  identity: ChipIdentity;
+  platformAdmin: boolean;
+  /** massing.cloud link state; `null` when the status call failed (offline) — rendered as such. */
+  cloud: CloudStatus | null;
+  tierLabel: string;
+  actions: ProfileActions;
+}
+
+interface Section { id: string; label: string; build: (body: HTMLElement) => void }
+
+/** A labelled row with an action button on the right — the panel's one repeating unit. */
+function row(title: string, detail: string, actionLabel?: string, onClick?: () => void): HTMLElement {
+  const el = document.createElement("div");
+  el.style.cssText = "display:flex;align-items:center;gap:12px;padding:9px 10px;border:1px solid var(--line);"
+    + "border-radius:7px;background:var(--bg-elev)";
+  const col = document.createElement("div");
+  col.style.cssText = "display:flex;flex-direction:column;gap:2px;min-width:0;flex:1";
+  const t = document.createElement("span");
+  t.textContent = title; t.style.cssText = "font-size:13px";
+  const d = document.createElement("span");
+  d.className = "meta"; d.innerHTML = escapeHtml(detail);
+  col.append(t, d);
+  el.append(col);
+  if (actionLabel && onClick) {
+    const b = document.createElement("button");
+    b.className = "tool-btn"; b.textContent = actionLabel; b.style.flex = "0 0 auto";
+    b.onclick = onClick;
+    el.append(b);
+  }
+  return el;
+}
+
+function group(body: HTMLElement, heading: string): HTMLElement {
+  const h = document.createElement("div");
+  h.textContent = heading;
+  h.style.cssText = "font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);"
+    + "margin:6px 0 2px";
+  const wrap = document.createElement("div");
+  wrap.style.cssText = "display:flex;flex-direction:column;gap:7px";
+  body.append(h, wrap);
+  return wrap;
+}
+
+/** Open the profile panel. `initial` selects a section by id (e.g. "cloud" from a deep link). */
+export function openProfileSettings(deps: ProfileDeps, initial = "profile"): void {
+  const { platformAdmin, actions } = deps;
+  const { card, close, ready } = modalShell("Profile & settings", 720);
+
+  const layout = document.createElement("div");
+  layout.style.cssText = "display:flex;gap:16px;align-items:flex-start;min-height:320px";
+  const nav = document.createElement("div");
+  nav.setAttribute("role", "tablist");
+  nav.setAttribute("aria-orientation", "vertical");
+  nav.style.cssText = "display:flex;flex-direction:column;gap:2px;flex:0 0 168px;border-right:1px solid var(--line);"
+    + "padding-right:12px";
+  const body = document.createElement("div");
+  body.style.cssText = "flex:1;display:flex;flex-direction:column;gap:8px;min-width:0";
+  layout.append(nav, body);
+  card.append(layout);
+
+  const sections: Section[] = [
+    { id: "profile", label: "Profile", build: (b) => buildProfile(b, deps) },
+    { id: "cloud", label: "massing.cloud", build: (b) => buildCloud(b, deps) },
+    { id: "security", label: "Security", build: (b) => buildSecurity(b, actions) },
+    { id: "preferences", label: "Preferences", build: (b) => buildPreferences(b, actions) },
+  ];
+  // The whole point of this panel: administration is a SECTION, present only when the account
+  // carries the capability — not a separate console reached from somewhere else.
+  if (platformAdmin) {
+    sections.push({ id: "admin", label: "Administration", build: (b) => buildAdmin(b, deps) });
+  }
+
+  const buttons = new Map<string, HTMLButtonElement>();
+  const show = (id: string) => {
+    body.textContent = "";
+    for (const [bid, b] of buttons) {
+      const on = bid === id;
+      b.setAttribute("aria-selected", String(on));
+      b.style.background = on ? "var(--control-hover)" : "transparent";
+      b.style.color = on ? "var(--text)" : "";
+    }
+    sections.find((s) => s.id === id)?.build(body);
+  };
+  for (const s of sections) {
+    const b = document.createElement("button");
+    b.className = "tool-btn"; b.textContent = s.label;
+    b.setAttribute("role", "tab");
+    b.style.cssText = "justify-content:flex-start;width:100%;text-align:left;border:none;background:transparent";
+    b.onclick = () => show(s.id);
+    buttons.set(s.id, b);
+    nav.append(b);
+  }
+
+  const signOut = document.createElement("button");
+  signOut.className = "tool-btn";
+  signOut.textContent = "Sign out";
+  signOut.style.cssText = "justify-content:flex-start;width:100%;text-align:left;border:none;"
+    + "background:transparent;margin-top:auto;color:var(--danger)";
+  signOut.onclick = () => { close(); actions.signOut(); };
+  nav.append(signOut);
+
+  show(sections.some((s) => s.id === initial) ? initial : "profile");
+  ready?.();
+}
+
+function buildProfile(body: HTMLElement, deps: ProfileDeps): void {
+  const { identity, cloud, tierLabel } = deps;
+  const via = cloud?.linked && cloud.providers?.length
+    ? `signed in via ${cloud.providers.join(", ")}`
+    : "signed in with a password on this server";
+  body.append(identityHeader(identity, `${identity.username} · ${via}`));
+
+  const g = group(body, "Account");
+  g.append(row("Plan", tierLabel
+    ? `${tierLabel}${cloud?.linked ? " — from your massing.cloud subscription" : ""}`
+    : "Free"));
+  g.append(row("Signed in as", identity.username));
+  if (identity.isAdmin) {
+    g.append(row("Administrator", cloud?.linked && cloud.roles?.length
+      ? `granted by your massing.cloud role (${cloud.roles.join(", ")})`
+      : "granted on this server"));
+  }
+}
+
+function buildCloud(body: HTMLElement, deps: ProfileDeps): void {
+  const { cloud, actions } = deps;
+  if (cloud === null) {
+    body.append(row("massing.cloud", "Could not reach the server to check your connection."));
+    return;
+  }
+  if (!cloud.enabled) {
+    const g = group(body, "massing.cloud");
+    g.append(row("Not configured", "An administrator has not enabled massing.cloud sign-in on this "
+      + "server. Turn it on under Administration → Server settings."));
+    return;
+  }
+  if (!cloud.linked) {
+    const g = group(body, "massing.cloud");
+    g.append(row("Not connected",
+      "Connect your massing.cloud account to sign in with Microsoft, Google, Procore or Autodesk "
+      + "and open the projects in your cloud library.",
+      "Connect…", actions.connectCloud));
+    return;
+  }
+
+  const g = group(body, "Connection");
+  g.append(row("Account", `${cloud.name || cloud.email || "—"}${cloud.email ? ` · ${cloud.email}` : ""}`));
+  g.append(row("Plan", cloud.tier_label || cloud.tier || "Free"));
+  if (cloud.providers?.length) g.append(row("Connected accounts", cloud.providers.join(", ")));
+  if (cloud.roles?.length) g.append(row("Role on massing.cloud", cloud.roles.join(", ")));
+  g.append(row("Last checked", cloud.last_sync ? new Date(cloud.last_sync).toLocaleString() : "—",
+    "Refresh", () => {
+      void actions.refreshCloud()
+        .then(() => toast("Updated from massing.cloud", "info"))
+        .catch(() => toast("Could not reach massing.cloud", "error"));
+    }));
+
+  const lib = group(body, "Project library");
+  if (cloud.library_access) {
+    lib.append(row("Your cloud projects",
+      "Browse and open the projects saved to your massing.cloud vault.",
+      "Open library…", actions.openLibrary));
+  } else {
+    // An unentitled library and an empty one must not look the same — say which it is, and where
+    // the fix is. This mirrors the server's 402, which names the upgrade page rather than
+    // returning an empty list.
+    lib.append(row("Included with any paid plan",
+      "Your massing.cloud plan is Free, so there is no cloud library to open yet.",
+      "See plans", () => window.open(`${cloud.site_url}/pricing/`, "_blank", "noopener")));
+  }
+
+  const danger = group(body, "Disconnect");
+  danger.append(row("Disconnect massing.cloud",
+    "Removes the link and this app's access to your cloud library. Your local projects are untouched.",
+    "Disconnect…", async () => {
+      if (!await confirmModal("Disconnect massing.cloud",
+        "Sign-in through massing.cloud and your cloud library will stop working until you reconnect. "
+        + "Projects stored on this server are not affected.", "Disconnect")) return;
+      try { await actions.disconnectCloud(); toast("Disconnected from massing.cloud", "info"); }
+      catch { toast("Could not disconnect", "error"); }
+    }));
+}
+
+function buildSecurity(body: HTMLElement, a: ProfileActions): void {
+  const g = group(body, "Sign-in");
+  g.append(row("Password", "Change the password for this account.", "Change…", a.changePassword));
+  g.append(row("Two-factor authentication", "Protect this account with an authenticator app.",
+    "Manage…", a.twoFactor));
+  const s = group(body, "Sessions");
+  s.append(row("Sign out everywhere",
+    "Ends every other session on every device. This tab stays signed in.",
+    "Revoke…", a.signOutEverywhere));
+}
+
+function buildPreferences(body: HTMLElement, a: ProfileActions): void {
+  const g = group(body, "Application");
+  g.append(row("Viewer & shortcuts", "Keyboard shortcuts, units and viewer defaults.",
+    "Open…", a.appSettings));
+}
+
+function buildAdmin(body: HTMLElement, deps: ProfileDeps): void {
+  const { actions: a, cloud } = deps;
+  const note = document.createElement("div");
+  note.className = "meta";
+  note.style.cssText = "padding:2px 0 4px";
+  note.textContent = cloud?.linked && cloud.roles?.length
+    ? `You see this section because your massing.cloud role is ${cloud.roles.join(", ")}.`
+    : "You see this section because this account has administrator access on this server.";
+  body.append(note);
+
+  const people = group(body, "People");
+  people.append(row("Users", "Create accounts, change roles, reset passwords.", "Manage…", a.manageUsers));
+  if (a.projectMembers) {
+    people.append(row("Project members", "Roles and parties on the current project.",
+      "Manage…", a.projectMembers));
+  }
+  const server = group(body, "Server");
+  server.append(row("Data connections", "Connect external data sources for this deployment.",
+    "Open…", a.dataConnections));
+  server.append(row("Server settings", "Licence, integrations and API keys.", "Open…", a.appSettings));
+  const logs = group(body, "Diagnostics");
+  logs.append(row("Audit log", "Who did what, newest first.", "View…", a.auditLog));
+  logs.append(row("Errors", "Recent server-side errors.", "View…", a.errorLog));
+}

--- a/apps/web/src/api/cloud.ts
+++ b/apps/web/src/api/cloud.ts
@@ -1,0 +1,136 @@
+/** CLOUD-SSO / CLOUD-LIBRARY client — massing.cloud identity + the user's project library.
+ *
+ *  **Why this is standalone functions rather than the usual `withX` mixin.** Every other API domain
+ *  in this folder is a mixin folded into `ApiClient`'s inheritance chain, and this one is written to
+ *  match that shape *except* for the last step: it takes the client as its first argument instead of
+ *  being `extends`-ed onto it. `HttpCore` exposes `url()` and `authHeaders()` publicly, so nothing is
+ *  lost by doing so — and folding it in would mean editing `client.ts`, whose one-line mixin chain is
+ *  the single most contended line in the repository. Promoting these to a mixin later is a mechanical
+ *  change with no call-site churn.
+ *
+ *  **No token ever crosses this boundary.** The massing.cloud access/refresh tokens live server-side
+ *  on the `cloud_identities` row; the browser holds only this app's own session. That is why the
+ *  library is read through our API rather than called directly from here — see `routers/cloud.py`.
+ *  The one exception is `download_url` on a model, which is a signed, short-lived, model-scoped URL
+ *  the browser fetches **without** an Authorization header (`openModelBytes` below).
+ */
+import type { ApiClient } from "./client";
+
+/** What `/auth/cloud/status` reports. Never includes a token. */
+export interface CloudStatus {
+  enabled: boolean;
+  linked: boolean;
+  site_url: string;
+  sub?: string;
+  email?: string | null;
+  name?: string | null;
+  avatar_url?: string | null;
+  /** massing.cloud licence vocabulary: free | home | commercial | enterprise. */
+  tier?: string;
+  tier_label?: string;
+  roles?: string[];
+  providers?: string[];
+  is_admin?: boolean;
+  library_access?: boolean;
+  linked_at?: string | null;
+  last_sync?: string | null;
+}
+
+export interface CloudProject {
+  id: number | string;
+  title: string;
+  cloud_project_id?: string | null;
+  status: string;
+  model_count: number;
+  updated?: string | null;
+}
+
+export interface CloudModel {
+  id: number | string;
+  title: string;
+  project_id?: number | string | null;
+  format: string;
+  size_bytes: number;
+  version: number;
+  cloud_model_id?: string | null;
+  thumb_url?: string | null;
+  preview_url?: string | null;
+  metrics: Record<string, unknown>;
+  download_url?: string | null;
+  updated?: string | null;
+}
+
+/** A refusal the user can act on: 402 = needs a paid plan, 403 = not linked, 409 = plan limit. */
+export class CloudError extends Error {
+  constructor(readonly status: number, message: string) { super(message); }
+  /** True when the fix is "upgrade", which the UI renders as a link rather than an error toast. */
+  get needsUpgrade() { return this.status === 402; }
+  get notLinked() { return this.status === 403; }
+}
+
+async function call<T>(api: ApiClient, path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(api.url(path), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...api.authHeaders(), ...(init?.headers || {}) },
+  });
+  if (!res.ok) {
+    let detail = "";
+    try { detail = ((await res.json()) as { detail?: string }).detail || ""; } catch { /* non-JSON */ }
+    throw new CloudError(res.status, detail || `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+/** Where to send the browser to start the massing.cloud sign-in (a full-page navigation, because
+ *  the broker must be able to show its own login UI and set its own cookies). */
+export function cloudLoginUrl(api: ApiClient): string {
+  return api.url("/auth/cloud/login");
+}
+
+export function cloudStatus(api: ApiClient) {
+  return call<CloudStatus>(api, "/auth/cloud/status");
+}
+
+/** Re-read the profile from massing.cloud so a plan upgrade or a role change lands without a
+ *  sign-out/sign-in round trip. */
+export function cloudRefresh(api: ApiClient) {
+  return call<CloudStatus>(api, "/auth/cloud/refresh", { method: "POST" });
+}
+
+export function cloudDisconnect(api: ApiClient) {
+  return call<{ ok: boolean; linked: boolean }>(api, "/auth/cloud/disconnect", { method: "POST" });
+}
+
+export async function cloudProjects(api: ApiClient): Promise<CloudProject[]> {
+  const r = await call<{ projects: CloudProject[] }>(api, "/cloud/library/projects");
+  return r.projects || [];
+}
+
+export function cloudProject(api: ApiClient, id: string | number) {
+  return call<CloudProject>(api, `/cloud/library/projects/${encodeURIComponent(String(id))}`);
+}
+
+export function cloudModel(api: ApiClient, id: string | number) {
+  return call<CloudModel>(api, `/cloud/library/models/${encodeURIComponent(String(id))}`);
+}
+
+/** Fetch a model's bytes from its signed `download_url`.
+ *
+ *  Deliberately a bare `fetch` with **no** auth header and no credentials: the URL already carries a
+ *  signed, ~15-minute, model-scoped token, and attaching this app's bearer to a massing.cloud origin
+ *  would leak a credential cross-origin to no purpose. */
+export async function openModelBytes(model: CloudModel): Promise<Blob> {
+  if (!model.download_url) throw new CloudError(404, "this model has no downloadable file");
+  const res = await fetch(model.download_url, { credentials: "omit" });
+  if (!res.ok) throw new CloudError(res.status, `could not download “${model.title}”`);
+  return res.blob();
+}
+
+/** Human-readable byte size for the library list. */
+export function formatBytes(n: number): string {
+  if (!n) return "—";
+  const units = ["B", "KB", "MB", "GB"];
+  let i = 0, v = n;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v >= 10 || i === 0 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1895,6 +1895,20 @@ async function startup() {
       getProjectId: () => projectId,
       getIsProjectAdmin: () => isProjectAdmin,
       openSettings: settingsModal,
+      openCloudModel: async (blob, name) => {
+        // CLOUD-LIBRARY: bytes pulled from a massing.cloud vault go through exactly the same path
+        // as a local file open — including R28-UNIFY — so a cloud project behaves like any other
+        // once it is here. `.mass` is a container this build cannot read yet (the writer does not
+        // exist), so it is refused explicitly rather than handed to the IFC loader to fail on.
+        const lower = name.toLowerCase();
+        const kind = lower.endsWith(".frag") ? "frag" : lower.endsWith(".ifc") ? "ifc" : null;
+        if (!kind) return false;
+        const file = new File([blob], name, { type: "application/octet-stream" });
+        const v = await ensureViewer();
+        await v.openFile(kind, file);
+        await unifyAfterModelOpen(name);
+        return true;
+      },
     });
   }
   // Help (?) — relaunch the welcome / tour, the guides, or the getting-started checklist

--- a/docs/internal/massing-cloud-sso.md
+++ b/docs/internal/massing-cloud-sso.md
@@ -1,0 +1,127 @@
+# massing.cloud SSO + project library — integration notes
+
+Internal notes for the CLOUD-SSO / CLOUD-LIBRARY work. The site-side contract is
+massing.cloud `docs/18-sso-and-desktop-auth.md`, `docs/19-desktop-sso-client-implementation.md`
+and `docs/31-massing-app-integration.md`; this file records **what we built against it, what we
+verified rather than assumed, and the one thing the site still owes us.**
+
+## What this adds
+
+massing.cloud becomes an **identity broker** for this app: the user signs in once on the site,
+picking Microsoft / Google / Procore / Autodesk / password there, and this deployment holds **no
+provider secret at all**. If their plan is anything but Free, their massing.cloud project vault
+becomes browsable and openable from inside the app.
+
+| Piece | Where |
+|---|---|
+| PKCE broker client | `services/api/src/aec_api/massing_cloud_auth.py` |
+| Vault (library) client | `services/api/src/aec_api/massing_cloud_vault.py` |
+| Routes | `services/api/src/aec_api/routers/cloud.py` |
+| Link table | `CloudIdentity` in `services/api/src/aec_api/models.py` |
+| Browser client | `apps/web/src/api/cloud.ts` |
+| Identity chip | `apps/web/src/account/accountChip.ts` |
+| Profile & settings | `apps/web/src/account/profileSettings.ts` |
+| Library browser | `apps/web/src/account/cloudLibrary.ts` |
+| Test | `services/api/test_massing_cloud_sso.py` |
+
+## Turning it on
+
+No secret to configure — the app is a registered **public** client and PKCE replaces the secret.
+
+```
+MASSING_CLOUD_SSO_ENABLED=1
+MASSING_CLOUD_SITE_URL=https://www.massing.cloud     # default
+MASSING_CLOUD_SSO_CLIENT_ID=massing-desktop          # default, already registered site-side
+MASSING_CLOUD_ROLE_SYNC=1                            # default
+MASSING_CLOUD_ADMIN_ROLES=administrator,editor       # default
+```
+
+The redirect URI is this app's own callback, `{api}/auth/cloud/callback`. For a normal desktop /
+self-hosted install that is a loopback address (`http://127.0.0.1:8093/auth/cloud/callback`), which
+the `massing-desktop` public client already allows. **A hosted deployment must have its https
+callback registered site-side** via the `massing_sso_clients` filter — loopback-only is the default.
+
+## Three decisions worth knowing about
+
+**1. The code exchange happens on our server, not in the browser.** Doc 31 describes a native app
+doing the exchange itself. We do it server-side for three reasons: the cloud refresh token is good
+for 30 days and has no business in `localStorage`; the Vault API is then reachable without
+massing.cloud having to CORS-allow this origin; and it reuses the existing session/RBAC/audit layer
+instead of running a second identity system in the client. PKCE requires no client secret, so
+nothing about being a public client is compromised by doing it from the server.
+
+**2. The PKCE verifier travels in a cookie, never in `state`.** `state` is echoed by the broker
+through the user agent. An attacker who can observe the redirect would hold the code *and* the
+verifier — precisely what PKCE exists to prevent. `auth.seal_pkce` / `auth.open_pkce` HMAC-seal the
+verifier into an HttpOnly `SameSite=Lax` cookie scoped to `/auth/cloud`, bound to that specific
+`state` so it cannot be replayed against another attempt.
+
+**3. The two tier vocabularies must not be crossed — this one nearly shipped as a bug.**
+`licensing.TIER_ORDER` is `free | home | commercial | enterprise`, which is exactly what
+massing.cloud sends. `tiers.TIERS` is `free | pro | enterprise`, the per-user entitlement seam on
+`User.tier`. Running a cloud tier through `tiers.normalize` maps **`commercial` → `free`**, because
+`commercial` is not in that tuple — a paying customer silently told they have no library.
+`massing_cloud_auth.normalize_tier` normalises against `licensing`; `app_tier_for` converts for
+storage (`home`/`commercial` → `pro`). Asserted in the test.
+
+## Roles — the one open dependency on the site
+
+**`userinfo` does not return a role.** Verified against the plugin source
+(`plugin/massing-sso/includes/class-broker.php::userinfo`), not the docs: the response is exactly
+`{sub, name, email, avatar_url, tier, providers}`. There is no `role` or `roles` key anywhere in
+the broker.
+
+So the requirement *"an admin or editor on massing.cloud authenticates as an admin in the app"* is
+**built here and inert until the site publishes roles**. `roles_from_userinfo` accepts `roles: []`,
+`role: "…"` or `wp_roles`, lower-cases them, and returns `[]` when none are present; `is_cloud_admin`
+returns False on `[]`, so the failure mode is *no elevation*, never accidental elevation.
+
+The site already has the filter this needs. Adding it is a few lines in a site mu-plugin:
+
+```php
+add_filter( 'massing_sso_userinfo', function ( array $data, int $user_id ) {
+    $user = get_userdata( $user_id );
+    $data['roles'] = $user ? array_values( (array) $user->roles ) : array();
+    return $data;
+}, 10, 2 );
+```
+
+Scope it if you would rather not publish every role — `array_values( array_intersect( (array)
+$user->roles, [ 'administrator', 'editor' ] ) )` sends only the two that mean anything to us.
+
+**Once roles arrive, the mapping is two-way.** Losing `editor` on the site drops the elevation here
+on the next `/auth/cloud/refresh` or sign-in, and disconnecting removes it entirely. A one-way map
+would leave a live admin behind after the role was revoked, which is the failure that actually
+matters. Only cloud-linked accounts are touched, so a local admin is never demoted by this path.
+
+**Why this provider is allowed to grant admin at all.** `routers/auth.py` carries a standing rule —
+*"Regular SSO users are never platform admins"* — and it is deliberately kept for the four direct
+IdPs in `oauth.py`: a Google account proves an email, not a relationship to this product. The
+massing.cloud broker is different in kind because it is first-party — the role it reports is the
+role the operator granted on their own site. `MASSING_CLOUD_ROLE_SYNC=0` turns the coupling off and
+falls back to `AEC_ADMIN_EMAILS`.
+
+## Admin is a section, not a console
+
+The old account dropdown carried four admin-only entries (Manage users, Audit log, Errors, Data
+connections). Those are now the **Administration section of the profile panel**, present only when
+the account carries the capability. The user's framing was that an "admin mode" should not really
+exist and its settings belong in a user's profile — this is that, without deleting a capability the
+product still needs. A non-admin and an admin now see the same panel; the admin's has one section
+more. `profileSettings.test.ts` asserts exactly that, including that the admin *actions* are not
+built at all for a non-admin (a hidden tab whose body still rendered would leak the buttons).
+
+## What is deliberately NOT here
+
+**Saving back to the cloud.** `massing_cloud_vault.save_model` exists but is not routed. Doc 31 §3
+is an open joint decision: the site's `POST /models` records a **pointer** (`storage_key`) and
+assumes the bytes already live in storage. A recent site commit adds a `.mass` binary upload
+endpoint, but this app has no `.mass` container writer yet, so there is nothing to push — wiring a
+save button now would record a pointer to nothing.
+
+**Opening `.mass`.** `openCloudModel` in `main.ts` accepts `.ifc` and `.frag` and refuses anything
+else explicitly, so the library says "can't be opened here yet" rather than handing an unknown
+container to the IFC loader.
+
+**Deep links.** Doc 31 §4 (`massing://open?…` and `{app_url}/open?license=…&project=…`) is not
+implemented.

--- a/services/api/migrations/versions/2026_08_24_0900-b3c7d1e94a52_cloud_identities_massing_cloud_sso.py
+++ b/services/api/migrations/versions/2026_08_24_0900-b3c7d1e94a52_cloud_identities_massing_cloud_sso.py
@@ -1,0 +1,52 @@
+"""cloud_identities (CLOUD-SSO — massing.cloud as the identity broker)
+
+The link between a local account and a massing.cloud account: the broker's subject id, the profile
+it reports (name/avatar/tier/roles), and the OAuth tokens the app uses to read that user's project
+library from the Vault API on their behalf.
+
+A table rather than columns on `users` because the link is optional, sparse, and holds live
+credentials that "disconnect" must be able to delete outright — a row delete, not a six-column wipe.
+
+Revision ID: b3c7d1e94a52
+Revises: a7d4e9b23c81
+Create Date: 2026-08-24 09:00:00.000000
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b3c7d1e94a52'
+down_revision: str | None = 'a7d4e9b23c81'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'cloud_identities',
+        sa.Column('username', sa.String(), nullable=False),
+        sa.Column('cloud_sub', sa.String(), nullable=False),
+        sa.Column('cloud_email', sa.String(), nullable=True),
+        sa.Column('display_name', sa.String(), nullable=True),
+        sa.Column('avatar_url', sa.String(), nullable=True),
+        sa.Column('cloud_tier', sa.String(), nullable=True),
+        sa.Column('cloud_roles', sa.JSON(), nullable=True),
+        sa.Column('providers', sa.JSON(), nullable=True),
+        sa.Column('access_token', sa.Text(), nullable=True),
+        sa.Column('refresh_token', sa.Text(), nullable=True),
+        sa.Column('expires_at', sa.Integer(), nullable=True),
+        sa.Column('linked_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('last_sync', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['username'], ['users.username'], ),
+        sa.PrimaryKeyConstraint('username'),
+    )
+    op.create_index(op.f('ix_cloud_identities_cloud_sub'), 'cloud_identities', ['cloud_sub'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_cloud_identities_cloud_sub'), table_name='cloud_identities')
+    op.drop_table('cloud_identities')

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -102,7 +102,7 @@ TESTS = ["test_provenance_report", "test_provenance_estimate_leg", "test_answers
          # AEC_ALLOW_IFC_CODE/AEC_SEAL_ALLOW_PROFILE; codes.MAX_AMENDMENTS) were ALSO dropped —
          # Security restores those from their branches; an unregistered test hides that honest red.
          "test_dispatcher_privilege_coverage", "test_ifc_path_containment", "test_outbound_fetch_guard",
-         "test_preflight_covers_settings", "test_storage_key_parity", "test_stored_collection_caps"]
+         "test_preflight_covers_settings", "test_storage_key_parity", "test_stored_collection_caps", "test_massing_cloud_sso"]
 
 
 #: Engine tests that live beside the data service (services/data/test_*.py) — the massing /

--- a/services/api/src/aec_api/auth.py
+++ b/services/api/src/aec_api/auth.py
@@ -238,6 +238,40 @@ def create_oauth_state(provider: str) -> str:
     return f"{payload}.{sig}"
 
 
+def seal_pkce(verifier: str, state: str) -> str:
+    """Seal a PKCE `code_verifier` for the round trip through the identity broker (CLOUD-SSO).
+
+    **The verifier must not travel in `state`.** `state` is echoed by the broker through the user
+    agent, so anything inside it is visible to whoever can observe the redirect — and an attacker who
+    holds both the authorization code and the verifier has exactly what PKCE exists to deny them.
+    This sealed blob is therefore carried in an HttpOnly, SameSite=Lax cookie on **our own** origin
+    and never sent to the broker; only the opaque `state` makes that trip. The `state` is bound into
+    the signature so a sealed verifier cannot be replayed against a different authorization attempt.
+    """
+    payload = _b64(json.dumps({"v": verifier, "st": state, "exp": int(time.time()) + _STATE_TTL,
+                               "purpose": "pkce"}).encode())
+    sig = _b64(hmac.new(_SECRET, payload.encode(), hashlib.sha256).digest())
+    return f"{payload}.{sig}"
+
+
+def open_pkce(sealed: str, state: str) -> str | None:
+    """Return the `code_verifier` if `sealed` is a valid, unexpired seal bound to `state`, else None."""
+    try:
+        payload_b64, sig_b64 = sealed.split(".")
+        expected = _b64(hmac.new(_SECRET, payload_b64.encode(), hashlib.sha256).digest())
+        if not hmac.compare_digest(sig_b64, expected):
+            return None
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64 + "=="))
+        if payload.get("purpose") != "pkce" or payload.get("exp", 0) < time.time():
+            return None
+        # constant-time compare: `state` is attacker-supplied on the callback.
+        if not hmac.compare_digest(str(payload.get("st") or ""), state):
+            return None
+        return payload.get("v")
+    except Exception:
+        return None
+
+
 def verify_oauth_state(token: str) -> str | None:
     """Return the provider id if the state is a valid, unexpired oauth state, else None."""
     try:

--- a/services/api/src/aec_api/main.py
+++ b/services/api/src/aec_api/main.py
@@ -34,6 +34,7 @@ from .routers import (
     classify,
     client_portal,
     closeout,
+    cloud,
     codecheck,
     conceptual,
     connections,
@@ -547,6 +548,7 @@ app.include_router(closeout.router, tags=["closeout"])
 app.include_router(convert.router, tags=["convert"])
 app.include_router(uploads.router, tags=["uploads"])   # R41-UPLOAD-WARK resumable handshake
 app.include_router(auth.router, tags=["auth"])
+app.include_router(cloud.router, tags=["cloud"])
 app.include_router(scim.router, tags=["scim"])
 app.include_router(saml.router, tags=["saml"])
 app.include_router(connections.router, tags=["connections"])

--- a/services/api/src/aec_api/massing_cloud_auth.py
+++ b/services/api/src/aec_api/massing_cloud_auth.py
@@ -1,0 +1,242 @@
+"""CLOUD-SSO — **massing.cloud as the identity broker** (OAuth2 Authorization Code + PKCE, RFC 8252).
+
+The difference from [[oauth]]: `oauth.py` federates *directly* to Google/Microsoft/Procore/Autodesk,
+which means this deployment holds four client secrets. Here massing.cloud holds them and we hold
+none — we are a **public client** (`massing-desktop`, already registered site-side) authenticating
+with PKCE/S256 and no secret at all. The user picks their IdP on massing.cloud; we only ever see the
+broker. That is the whole point of the site's SSO plugin (massing.cloud docs 18/31).
+
+    app → GET  {site}/massing-sso/authorize?...code_challenge=S256(verifier)   (system browser)
+        ← 302  {redirect_uri}?code=…&state=…
+    app → POST {site}/wp-json/massing-sso/v1/token    code + code_verifier  → access/refresh tokens
+    app → GET  {site}/wp-json/massing-sso/v1/userinfo (Bearer)              → sub/name/email/avatar/tier
+    app → POST {site}/wp-json/massing-sso/v1/revoke   on disconnect
+
+**`redirect_uri` is our own callback**, which for the normal desktop/self-hosted install is already a
+loopback URL (`http://127.0.0.1:8093/auth/cloud/callback`) — exactly what the `massing-desktop`
+public client is registered to allow. A hosted deployment must register its https callback site-side.
+Doing the exchange **server-side rather than in the browser** keeps the cloud refresh token out of
+`localStorage` and avoids needing massing.cloud to CORS-allow this origin; PKCE means no secret is
+required to do so, so nothing about the public-client model is bent.
+
+**Roles.** `userinfo` on Massing SSO v1.1.0 returns `{sub, name, email, avatar_url, tier, providers}`
+and **no role** — verified against the plugin source, not the docs. `roles_from_userinfo` therefore
+reads several plausible spellings and returns `[]` when none are present, and `[]` never grants
+anything (fail closed). The site can add roles in a few lines through its own `massing_sso_userinfo`
+filter; until it does, cloud-driven admin simply never triggers and `AEC_ADMIN_EMAILS` remains the
+way in. See `docs/internal/massing-cloud-sso.md`.
+
+Stdlib only (urllib) + `safe_urlopen`, matching `oauth.py`: every hop is re-validated and pinned to
+https, because a 302 would otherwise carry the code or the Bearer token somewhere else entirely.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from . import settings_store
+from .net import safe_urlopen
+
+_DEFAULT_SITE = "https://www.massing.cloud"
+_DEFAULT_CLIENT_ID = "massing-desktop"
+# WordPress ships `administrator` and `editor` as the two roles that can change site content. The
+# user-facing rule is "admin or editor on massing.cloud ⇒ admin in the app"; `shop_manager` is
+# deliberately NOT here (a store role, not an authoring one).
+_DEFAULT_ADMIN_ROLES = "administrator,editor"
+_TIMEOUT = 15
+# The tier below which the cloud project library is not offered. massing.cloud tiers are
+# free | home | commercial | enterprise — everything above `free` is a paying plan.
+FREE_TIER = "free"
+
+
+def _get(key: str, default: str = "") -> str:
+    return (settings_store.get(key, default) or default).strip()
+
+
+def _flag(key: str, default: str = "0") -> bool:
+    return _get(key, default).lower() in ("1", "true", "yes", "on")
+
+
+def site_url() -> str:
+    """Base URL of the massing.cloud site (no trailing slash)."""
+    return (_get("MASSING_CLOUD_SITE_URL") or _DEFAULT_SITE).rstrip("/")
+
+
+def client_id() -> str:
+    return _get("MASSING_CLOUD_SSO_CLIENT_ID") or _DEFAULT_CLIENT_ID
+
+
+def is_enabled() -> bool:
+    """Cloud sign-in is opt-in: an operator turns it on. Unlike the four direct IdPs there is no
+    secret to configure, so the flag is the whole switch."""
+    return _flag("MASSING_CLOUD_SSO_ENABLED", "0")
+
+
+def role_sync_enabled() -> bool:
+    """Whether a cloud `administrator`/`editor` role grants platform-admin in this app.
+
+    On by default *for this provider only*. `routers/auth.py` states the standing rule — "Regular
+    SSO users are never platform admins" — and that rule is deliberately kept for the generic IdPs
+    in `oauth.py`: a Google account proves an email, not a relationship to this product. The
+    massing.cloud broker is different in kind, because it is first-party: the role it reports is the
+    role the operator granted on their own site. An operator who does not want that coupling sets
+    `MASSING_CLOUD_ROLE_SYNC=0` and falls back to `AEC_ADMIN_EMAILS`."""
+    return _flag("MASSING_CLOUD_ROLE_SYNC", "1")
+
+
+def admin_roles() -> set[str]:
+    raw = _get("MASSING_CLOUD_ADMIN_ROLES") or _DEFAULT_ADMIN_ROLES
+    return {r.strip().lower() for r in raw.split(",") if r.strip()}
+
+
+# ── PKCE ──────────────────────────────────────────────────────────────────────────────────────
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def new_verifier() -> str:
+    """A fresh PKCE `code_verifier` (RFC 7636 §4.1: 43–128 chars of unreserved ASCII)."""
+    return _b64url(secrets.token_bytes(64))
+
+
+def challenge_for(verifier: str) -> str:
+    """S256 challenge. `plain` is never offered — the broker requires S256 for the public client."""
+    return _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+
+
+def authorize_url(redirect_uri: str, state: str, verifier: str, scope: str = "profile email") -> str:
+    params = {
+        "response_type": "code",
+        "client_id": client_id(),
+        "redirect_uri": redirect_uri,
+        "code_challenge": challenge_for(verifier),
+        "code_challenge_method": "S256",
+        "state": state,
+        "scope": scope,
+    }
+    return f"{site_url()}/massing-sso/authorize?{urllib.parse.urlencode(params)}"
+
+
+# ── broker endpoints ──────────────────────────────────────────────────────────────────────────
+
+def _api(path: str) -> str:
+    return f"{site_url()}/wp-json/massing-sso/v1{path}"
+
+
+def _post_form(url: str, data: dict[str, str]) -> dict:
+    body = urllib.parse.urlencode(data).encode()
+    req = urllib.request.Request(url, data=body, headers={
+        "Accept": "application/json", "Content-Type": "application/x-www-form-urlencoded"})
+    with safe_urlopen(req, timeout=_TIMEOUT, require_https=True, label="massing.cloud SSO token") as r:
+        return json.loads(r.read().decode())
+
+
+def _get_json(url: str, token: str, label: str) -> dict:
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"Bearer {token}", "Accept": "application/json"})
+    with safe_urlopen(req, timeout=_TIMEOUT, require_https=True, label=label) as r:
+        return json.loads(r.read().decode())
+
+
+def _exchange_code(code: str, verifier: str, redirect_uri: str) -> dict:
+    return _post_form(_api("/token"), {
+        "grant_type": "authorization_code", "code": code, "code_verifier": verifier,
+        "client_id": client_id(), "redirect_uri": redirect_uri})
+
+
+def _refresh_token(refresh: str) -> dict:
+    return _post_form(_api("/token"), {
+        "grant_type": "refresh_token", "refresh_token": refresh, "client_id": client_id()})
+
+
+def _fetch_userinfo(access_token: str) -> dict:
+    return _get_json(_api("/userinfo"), access_token, "massing.cloud SSO userinfo")
+
+
+def _revoke_token(token: str) -> None:
+    try:
+        _post_form(_api("/revoke"), {"token": token, "client_id": client_id()})
+    except Exception:
+        # A failed revoke must not block a local disconnect — the user asked to unlink, and leaving
+        # them linked because the site was unreachable is the worse outcome. The token still expires.
+        pass
+
+
+# Overridable seams so the suite can exercise the whole callback without a live massing.cloud —
+# the same recipe `oauth.py` uses (`exchange_code` / `fetch_userinfo` module attributes).
+exchange_code = _exchange_code
+refresh_token = _refresh_token
+fetch_userinfo = _fetch_userinfo
+revoke_token = _revoke_token
+
+
+# ── identity shaping ──────────────────────────────────────────────────────────────────────────
+
+def roles_from_userinfo(info: dict[str, Any]) -> list[str]:
+    """Best-effort role extraction, lower-cased.
+
+    Massing SSO v1.1.0 sends none of these keys, so this returns `[]` today and callers must treat
+    `[]` as "no elevation" rather than "not an admin, probably". Several spellings are accepted so
+    that whichever shape the site's `massing_sso_userinfo` filter adopts, this keeps working:
+    `roles: [...]`, `role: "editor"`, or the OIDC-ish `wp_roles`."""
+    out: list[str] = []
+    for key in ("roles", "wp_roles", "role"):
+        val = info.get(key)
+        if isinstance(val, str):
+            out.extend(v.strip() for v in val.split(",") if v.strip())
+        elif isinstance(val, (list, tuple)):
+            out.extend(str(v).strip() for v in val if str(v).strip())
+    # de-duplicate, preserve order
+    seen: set[str] = set()
+    roles: list[str] = []
+    for r in out:
+        low = r.lower()
+        if low and low not in seen:
+            seen.add(low)
+            roles.append(low)
+    return roles
+
+
+def is_cloud_admin(roles: list[str]) -> bool:
+    """True when the cloud roles include one that should map to platform-admin here.
+
+    Fails closed on an empty list, which is the live case until the site publishes roles."""
+    if not role_sync_enabled():
+        return False
+    return bool(set(roles) & admin_roles())
+
+
+def normalize_tier(raw: Any) -> str:
+    """Coerce the broker's `tier` onto the **licence** vocabulary.
+
+    There are two tier vocabularies in this app and picking the wrong one here is silently
+    catastrophic: `licensing.TIER_ORDER` is `free|home|commercial|enterprise` — which is exactly what
+    massing.cloud sends — while `tiers.TIERS` is `free|pro|enterprise`, the per-user entitlement
+    seam on `User.tier`. Running a cloud tier through `tiers.normalize` maps **`commercial` → `free`**,
+    because `commercial` is not in that tuple, and a paying customer would be told they have no
+    library. So the cloud tier is normalised here against `licensing`, and converted for storage by
+    `app_tier_for` below. Unknown or missing still degrades to `free` — an unreadable plan must never
+    unlock a paid surface."""
+    from . import licensing
+    val = str(raw or "").strip().lower()
+    return val if val in licensing.TIER_ORDER else FREE_TIER
+
+
+def app_tier_for(cloud_tier: str) -> str:
+    """Map a massing.cloud licence tier onto the `User.tier` entitlement vocabulary (`tiers.TIERS`).
+
+    `home` and `commercial` are both paid plans with no separate representation in the three-value
+    entitlement seam, so both land on `pro`; `enterprise` carries across by name."""
+    return {"free": "free", "home": "pro", "commercial": "pro", "enterprise": "enterprise"}.get(
+        normalize_tier(cloud_tier), "free")
+
+
+def has_library_access(tier: str) -> bool:
+    """The user's rule: *anything but free* gets their massing.cloud project library."""
+    return normalize_tier(tier) != FREE_TIER

--- a/services/api/src/aec_api/massing_cloud_vault.py
+++ b/services/api/src/aec_api/massing_cloud_vault.py
@@ -1,0 +1,138 @@
+"""CLOUD-LIBRARY — read a signed-in user's **massing.cloud project library** (the Vault API).
+
+This is the second half of the massing.cloud integration: [[massing_cloud_auth]] establishes *who*
+the user is, and the access token it obtains **is** the credential here. The Vault API is
+Bearer-scoped — the token is the identity, and the site ownership-checks every per-record call — so
+this module never sends a user id and never has to be trusted to filter by one. A 403 from the site
+is the authoritative answer, not a bug to route around.
+
+Namespace: `{site}/wp-json/massing-vault/v1`
+
+    GET    /projects           → the user's vaults        {user_id, projects:[…]}
+    GET    /projects/{id}      → one vault
+    GET    /models/{id}        → a model + a signed, ~15-min `download_url`
+    POST   /models             → save a model back (pointer; see the `.mass` note below)
+    DELETE /models/{id}        → remove a model
+
+**Reading is what ships here.** `save_model` is included because the round trip is the point of a
+library, but the byte-upload half of it is an open joint decision in massing.cloud docs/31 §3 — the
+site's `POST /models` records a *pointer* (`storage_key`) and assumes the bytes already live in
+storage. A recent site commit adds a `.mass` binary upload endpoint; until this app actually writes
+`.mass` containers there is nothing to push, so `save_model` is deliberately not wired to a route
+yet. Wiring it before the container writer exists would give us a save button that silently records
+a pointer to nothing.
+
+Plan limits are enforced site-side and come back as **409** with a message meant for the user —
+surfaced verbatim rather than reworded, because it names the actual limit they hit.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from . import massing_cloud_auth as cloud
+from .net import safe_urlopen
+
+_TIMEOUT = 20
+
+
+class VaultError(Exception):
+    """A Vault call that failed in a way the user should see (status + site message)."""
+
+    def __init__(self, status: int, message: str):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+def _api(path: str) -> str:
+    return f"{cloud.site_url()}/wp-json/massing-vault/v1{path}"
+
+
+def _call(path: str, token: str, method: str = "GET", body: dict | None = None) -> Any:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(_api(path), data=data, method=method, headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        **({"Content-Type": "application/json"} if data is not None else {}),
+    })
+    try:
+        with safe_urlopen(req, timeout=_TIMEOUT, require_https=True, label="massing.cloud Vault") as r:
+            raw = r.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            payload = json.loads(e.read().decode())
+            detail = str(payload.get("message") or payload.get("error") or "")
+        except Exception:
+            pass
+        raise VaultError(e.code, detail or f"massing.cloud returned HTTP {e.code}") from e
+
+
+# Overridable seam for the suite (same recipe as `massing_cloud_auth.exchange_code`).
+call = _call
+
+
+def list_projects(token: str) -> list[dict]:
+    """The user's vaults. Returns `[]` rather than raising when the shape is unexpected — an empty
+    library and an unreadable one look the same to the caller only in that both show nothing, and
+    the route above logs the distinction."""
+    data = call("/projects", token)
+    projects = data.get("projects") if isinstance(data, dict) else data
+    return [_shape_project(p) for p in projects] if isinstance(projects, list) else []
+
+
+def get_project(token: str, project_id: int | str) -> dict:
+    return _shape_project(call(f"/projects/{urllib.parse.quote(str(project_id))}", token))
+
+
+def get_model(token: str, model_id: int | str) -> dict:
+    """A model record including the signed `download_url`. That URL carries its own short-lived,
+    model-scoped token and needs **no** Authorization header — so it must never be handed a Bearer
+    header on fetch, and it must never be cached or logged."""
+    return _shape_model(call(f"/models/{urllib.parse.quote(str(model_id))}", token))
+
+
+def save_model(token: str, payload: dict) -> dict:
+    """Ingest/update a model pointer. See the module note: not routed until the `.mass` writer lands."""
+    return _shape_model(call("/models", token, method="POST", body=payload))
+
+
+def delete_model(token: str, model_id: int | str) -> None:
+    call(f"/models/{urllib.parse.quote(str(model_id))}", token, method="DELETE")
+
+
+def _shape_project(p: Any) -> dict:
+    """Project the site's record onto a stable shape. Extra keys the site grows are dropped rather
+    than forwarded, so a site-side addition can never surprise the browser."""
+    p = p if isinstance(p, dict) else {}
+    return {
+        "id": p.get("id"),
+        "title": str(p.get("title") or "Untitled project"),
+        "cloud_project_id": p.get("cloud_project_id"),
+        "status": p.get("status") or "active",
+        "model_count": int(p.get("model_count") or 0),
+        "updated": p.get("updated"),
+    }
+
+
+def _shape_model(m: Any) -> dict:
+    m = m if isinstance(m, dict) else {}
+    return {
+        "id": m.get("id"),
+        "title": str(m.get("title") or "Untitled model"),
+        "project_id": m.get("project_id"),
+        "format": m.get("format") or "mass",
+        "size_bytes": int(m.get("size_bytes") or 0),
+        "version": int(m.get("version") or 1),
+        "cloud_model_id": m.get("cloud_model_id"),
+        "thumb_url": m.get("thumb_url"),
+        "preview_url": m.get("preview_url"),
+        "metrics": m.get("metrics") if isinstance(m.get("metrics"), dict) else {},
+        "download_url": m.get("download_url"),
+        "updated": m.get("updated"),
+    }

--- a/services/api/src/aec_api/models.py
+++ b/services/api/src/aec_api/models.py
@@ -178,6 +178,46 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
 
 
+class CloudIdentity(Base):
+    """A user's link to their **massing.cloud** account (CLOUD-SSO — see [[massing_cloud_auth]]).
+
+    A separate table rather than columns on `users` for two reasons. The link is optional and
+    sparse — password and direct-IdP accounts never have one — and it holds *live credentials* that
+    must be deletable on disconnect without touching the account itself: "unlink my cloud" is a row
+    delete here, not a partial wipe of six nullable columns on `users`.
+
+    `access_token` / `refresh_token` are the user's **cloud** credentials, not this app's session.
+    They are stored so the app can call the Vault API on the user's behalf between requests, which is
+    the entire reason the project library can exist server-side; they are never returned by any
+    route, never logged, and never sent to the browser. `/auth/cloud/status` reports only whether a
+    link exists and what it grants.
+
+    `cloud_roles` is the raw role list as the broker reported it, kept verbatim so that a change in
+    the mapping rules re-evaluates against what the site actually said rather than against a decision
+    frozen at link time.
+    """
+    __tablename__ = "cloud_identities"
+    # One cloud link per local account. The username is the FK into `users`.
+    username: Mapped[str] = mapped_column(String, ForeignKey("users.username"), primary_key=True)
+    # The broker's stable subject id (WordPress user id as a string). Indexed because a re-link from
+    # a renamed/re-emailed account resolves by `sub`, not by address.
+    cloud_sub: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    cloud_email: Mapped[str | None] = mapped_column(String, nullable=True)
+    display_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    # massing.cloud licence vocabulary: free | home | commercial | enterprise (licensing.TIER_ORDER),
+    # NOT the three-value `tiers.TIERS` used by `User.tier`. See massing_cloud_auth.normalize_tier.
+    cloud_tier: Mapped[str | None] = mapped_column(String, nullable=True)
+    cloud_roles: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    providers: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    access_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    refresh_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Unix seconds at which `access_token` expires; refreshed ahead of this by the route layer.
+    expires_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    linked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_now)
+    last_sync: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
 class ProfessionalLicense(Base):
     """A PE/RA licence held by a user — the record a seal is drawn FROM, never typed into.
 

--- a/services/api/src/aec_api/routers/auth.py
+++ b/services/api/src/aec_api/routers/auth.py
@@ -368,9 +368,25 @@ def me(db: Session = Depends(get_db), user: str = Depends(current_user)):
     from .. import tiers
     u = db.get(User, user)
     tier = tiers.normalize(u.tier if u else None)
-    return {"username": user, "role": (u.role if u else None), "authenticated": u is not None,
-            "tier": tier, "features": tiers.features_for(tier),
-            "platform_admin": _is_platform_admin(u)}
+    out = {"username": user, "role": (u.role if u else None), "authenticated": u is not None,
+           "tier": tier, "features": tiers.features_for(tier),
+           "platform_admin": _is_platform_admin(u)}
+    # CLOUD-SSO: the identity the account chip renders. Folded into /auth/me rather than left to a
+    # second round trip because the chip is drawn at startup on every load, and a name that arrives
+    # after the button does is a visible flicker on the most-looked-at control in the app.
+    # `display_name`/`avatar_url` are absent for password and direct-IdP accounts — the chip falls
+    # back to initials, so the absence is a rendering branch and never an error.
+    from ..models import CloudIdentity
+    link = db.get(CloudIdentity, user) if u is not None else None
+    if link is not None:
+        from .. import massing_cloud_auth as cloud
+        cloud_tier = cloud.normalize_tier(link.cloud_tier)
+        out["display_name"] = link.display_name
+        out["avatar_url"] = link.avatar_url
+        out["cloud"] = {"linked": True, "email": link.cloud_email, "tier": cloud_tier,
+                        "roles": link.cloud_roles or [], "providers": link.providers or [],
+                        "library_access": cloud.has_library_access(cloud_tier)}
+    return out
 
 
 # --- self-service -------------------------------------------------------------

--- a/services/api/src/aec_api/routers/cloud.py
+++ b/services/api/src/aec_api/routers/cloud.py
@@ -1,0 +1,348 @@
+"""CLOUD-SSO / CLOUD-LIBRARY routes — sign in through **massing.cloud** and read the user's library.
+
+Two groups behind one module because they share a credential:
+
+    GET  /auth/cloud/login       → 307 to the broker (PKCE S256; verifier sealed into a cookie)
+    GET  /auth/cloud/callback    → exchange, link, mint this app's session, redirect into the app
+    GET  /auth/cloud/status      → is cloud sign-in available / is this account linked / what it grants
+    POST /auth/cloud/disconnect  → revoke at the broker and delete the link row
+    POST /auth/cloud/refresh     → re-read userinfo (tier/role change picked up without a re-login)
+
+    GET  /cloud/library/projects        → the user's vaults
+    GET  /cloud/library/projects/{id}   → one vault
+    GET  /cloud/library/models/{id}     → a model + its signed download URL
+
+**Why the exchange is server-side.** The browser never sees the cloud tokens: they are the
+credential for the Vault API and a refresh token is good for 30 days. Keeping them here also means
+massing.cloud never has to CORS-allow this origin. PKCE needs no client secret, so nothing about
+being a *public* client is compromised by doing the exchange from the server.
+
+**Tier gate.** `has_library_access` is "any tier but free". A free user who is signed in gets a 402
+naming the upgrade page rather than an empty list — an empty library and an ungranted one must not
+look the same, which is the same rule as everywhere else in this codebase.
+
+**Role gate.** Cloud `administrator`/`editor` → platform admin *here*, and only for this provider.
+See `massing_cloud_auth.role_sync_enabled` for why that is a deliberate exception to the standing
+"regular SSO users are never platform admins" rule in `routers/auth.py`.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from .. import audit, auth
+from .. import massing_cloud_auth as cloud
+from .. import massing_cloud_vault as vault
+from ..db import get_db
+from ..models import CloudIdentity, User
+from ..rbac import current_user
+
+router = APIRouter()
+
+_PKCE_COOKIE = "mc_pkce"
+# Refresh the access token this many seconds before it actually expires, so a long Vault call
+# started just under the wire does not die mid-flight.
+_REFRESH_SKEW = 120
+
+
+def _cookie_secure(request: Request) -> bool:
+    return request.url.scheme == "https"
+
+
+def _app_url() -> str:
+    return os.environ.get("AEC_APP_URL", "/")
+
+
+def _require_enabled() -> None:
+    if not cloud.is_enabled():
+        raise HTTPException(404, "massing.cloud sign-in is not enabled on this deployment")
+
+
+# ── sign-in ───────────────────────────────────────────────────────────────────────────────────
+
+@router.get("/auth/cloud/login")
+def cloud_login(request: Request):
+    """Start the PKCE flow. The verifier is sealed into an HttpOnly cookie (never into `state`)."""
+    _require_enabled()
+    redirect_uri = str(request.url_for("cloud_callback"))
+    verifier = cloud.new_verifier()
+    state = auth.create_oauth_state("massing-cloud")
+    resp = RedirectResponse(cloud.authorize_url(redirect_uri, state, verifier), status_code=307)
+    resp.set_cookie(
+        _PKCE_COOKIE, auth.seal_pkce(verifier, state),
+        max_age=600, httponly=True, samesite="lax", path="/auth/cloud",
+        secure=_cookie_secure(request))
+    return resp
+
+
+@router.get("/auth/cloud/callback", name="cloud_callback")
+def cloud_callback(request: Request, code: str | None = None, state: str | None = None,
+                   error: str | None = None, db: Session = Depends(get_db)):
+    _require_enabled()
+    if error:
+        raise HTTPException(400, f"massing.cloud sign-in was refused: {error}")
+    sealed = request.cookies.get(_PKCE_COOKIE) or ""
+    if not code or not state or auth.verify_oauth_state(state) != "massing-cloud":
+        raise HTTPException(400, "invalid callback (missing code or bad state)")
+    verifier = auth.open_pkce(sealed, state)
+    if not verifier:
+        # Either the cookie is gone (browser blocked it / flow resumed in another browser) or it is
+        # bound to a different attempt. Both are "start again", not "trust the code".
+        raise HTTPException(400, "sign-in session expired — please start again")
+
+    redirect_uri = str(request.url_for("cloud_callback"))
+    try:
+        tok = cloud.exchange_code(code, verifier, redirect_uri)
+    except Exception as e:
+        raise HTTPException(502, "massing.cloud token exchange failed") from e
+    access = str(tok.get("access_token") or "")
+    if not access:
+        raise HTTPException(502, "massing.cloud did not return an access token")
+    try:
+        info = cloud.fetch_userinfo(access)
+    except Exception as e:
+        raise HTTPException(502, "massing.cloud userinfo failed") from e
+
+    email = str(info.get("email") or "").strip().lower()
+    sub = str(info.get("sub") or "").strip()
+    if not email or not sub:
+        raise HTTPException(403, "massing.cloud did not return an identified account")
+
+    username = _link_account(db, info, tok, access)
+    resp = RedirectResponse(_app_url(), status_code=303)
+    _set_session_cookie(resp, auth.create_token(username), request)
+    resp.delete_cookie(_PKCE_COOKIE, path="/auth/cloud")
+    return resp
+
+
+def _set_session_cookie(response: Response, token: str, request: Request) -> None:
+    """Mirror this app's own session token into the cookie the SSE layer needs (see routers/auth)."""
+    response.set_cookie("aec_token", token, max_age=604800, httponly=False, samesite="lax",
+                        path="/", secure=_cookie_secure(request))
+
+
+def _link_account(db: Session, info: dict, tok: dict, access: str) -> str:
+    """Find-or-create the local account for a broker identity and (re)write its cloud link.
+
+    Returns the local username. Identity is resolved by the broker's `sub` first and by email
+    second: `sub` is stable across an email change on massing.cloud, so resolving by email alone
+    would silently fork one person into two accounts the first time they change their address."""
+    sub = str(info.get("sub") or "").strip()
+    email = str(info.get("email") or "").strip().lower()
+    roles = cloud.roles_from_userinfo(info)
+    cloud_tier = cloud.normalize_tier(info.get("tier"))
+    is_admin = cloud.is_cloud_admin(roles)
+
+    link = db.query(CloudIdentity).filter(CloudIdentity.cloud_sub == sub).one_or_none()
+    username = link.username if link else email
+
+    u = db.get(User, username)
+    if u is None:
+        if os.environ.get("AEC_OAUTH_NO_AUTOPROVISION") == "1":
+            raise HTTPException(403, "no account for this cloud user — ask an admin to invite you first")
+        u = User(username=username, password_hash="cloud!massing",  # unusable for password login
+                 role="admin" if is_admin else "user", email=email,
+                 tier=cloud.app_tier_for(cloud_tier))
+        db.add(u)
+        db.flush()
+    else:
+        if not u.email:
+            u.email = email
+        u.tier = cloud.app_tier_for(cloud_tier)
+        # Role sync is two-way *for this provider*: losing `editor` on the site must also drop the
+        # elevation here, otherwise a revoked cloud role leaves a live admin behind. Only ever
+        # touches accounts that are cloud-linked, so a local admin is never demoted by this path.
+        if cloud.role_sync_enabled():
+            u.role = "admin" if is_admin else "user"
+    if u.active is False:
+        raise HTTPException(403, "account is deactivated")
+
+    if link is None:
+        link = db.get(CloudIdentity, username) or CloudIdentity(username=username, cloud_sub=sub)
+        db.add(link)
+    link.cloud_sub = sub
+    link.cloud_email = email
+    link.display_name = str(info.get("name") or "") or None
+    link.avatar_url = str(info.get("avatar_url") or "") or None
+    link.cloud_tier = cloud_tier
+    link.cloud_roles = roles
+    link.providers = info.get("providers") if isinstance(info.get("providers"), list) else []
+    link.access_token = access
+    link.refresh_token = str(tok.get("refresh_token") or "") or link.refresh_token
+    link.expires_at = int(time.time()) + int(tok.get("expires_in") or 0)
+    link.last_sync = _utcnow()
+
+    audit.record(db, action="auth.cloud_login", actor=username, method="GET",
+                 path="/auth/cloud/callback",
+                 detail={"sub": sub, "tier": cloud_tier, "roles": roles, "admin": is_admin})
+    db.commit()
+    return username
+
+
+def _utcnow():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc)
+
+
+# ── link state ────────────────────────────────────────────────────────────────────────────────
+
+@router.get("/auth/cloud/status")
+def cloud_status(db: Session = Depends(get_db), user: str = Depends(current_user)):
+    """What the UI needs to render the account chip and the library entry point.
+
+    Deliberately returns `enabled` even when the caller is not linked, so the sign-in surface can
+    offer the button; and never returns a token."""
+    link = db.get(CloudIdentity, user) if user else None
+    if link is None:
+        return {"enabled": cloud.is_enabled(), "linked": False, "site_url": cloud.site_url()}
+    tier = cloud.normalize_tier(link.cloud_tier)
+    return {
+        "enabled": cloud.is_enabled(),
+        "linked": True,
+        "site_url": cloud.site_url(),
+        "sub": link.cloud_sub,
+        "email": link.cloud_email,
+        "name": link.display_name,
+        "avatar_url": link.avatar_url,
+        "tier": tier,
+        "tier_label": _tier_label(tier),
+        "roles": link.cloud_roles or [],
+        "providers": link.providers or [],
+        "is_admin": cloud.is_cloud_admin(list(link.cloud_roles or [])),
+        "library_access": cloud.has_library_access(tier),
+        "linked_at": link.linked_at,
+        "last_sync": link.last_sync,
+    }
+
+
+def _tier_label(tier: str) -> str:
+    from .. import licensing
+    return licensing.TIER_LABEL.get(tier, tier.title())
+
+
+@router.post("/auth/cloud/refresh")
+def cloud_refresh_profile(db: Session = Depends(get_db), user: str = Depends(current_user)):
+    """Re-read `userinfo` and re-apply tier + role. Lets an upgrade or a role change take effect
+    without making the user sign out and back in."""
+    link = _linked_or_403(db, user)
+    token = _fresh_access_token(db, link)
+    try:
+        info = cloud.fetch_userinfo(token)
+    except Exception as e:
+        raise HTTPException(502, "could not reach massing.cloud") from e
+    roles = cloud.roles_from_userinfo(info)
+    link.cloud_roles = roles
+    link.cloud_tier = cloud.normalize_tier(info.get("tier"))
+    link.display_name = str(info.get("name") or "") or link.display_name
+    link.avatar_url = str(info.get("avatar_url") or "") or link.avatar_url
+    link.last_sync = _utcnow()
+    u = db.get(User, user)
+    if u is not None:
+        u.tier = cloud.app_tier_for(link.cloud_tier)
+        if cloud.role_sync_enabled():
+            u.role = "admin" if cloud.is_cloud_admin(roles) else "user"
+    db.commit()
+    return cloud_status(db=db, user=user)
+
+
+@router.post("/auth/cloud/disconnect")
+def cloud_disconnect(db: Session = Depends(get_db), user: str = Depends(current_user)):
+    """Unlink. Revokes at the broker best-effort, then deletes the row — the local account and its
+    projects survive; only the cloud credential is destroyed."""
+    link = db.get(CloudIdentity, user)
+    if link is None:
+        return {"ok": True, "linked": False}
+    for tok in (link.access_token, link.refresh_token):
+        if tok:
+            cloud.revoke_token(tok)
+    db.delete(link)
+    u = db.get(User, user)
+    # An account that was only ever an admin *because* of its cloud role must not keep that
+    # elevation after the link is gone.
+    if u is not None and cloud.role_sync_enabled() and u.role == "admin":
+        u.role = "user"
+    audit.record(db, action="auth.cloud_disconnect", actor=user, method="POST",
+                 path="/auth/cloud/disconnect", detail={})
+    db.commit()
+    return {"ok": True, "linked": False}
+
+
+# ── the library ───────────────────────────────────────────────────────────────────────────────
+
+def _linked_or_403(db: Session, user: str) -> CloudIdentity:
+    link = db.get(CloudIdentity, user) if user else None
+    if link is None:
+        raise HTTPException(403, "this account is not linked to massing.cloud")
+    return link
+
+
+def _fresh_access_token(db: Session, link: CloudIdentity) -> str:
+    """The access token, refreshed if it is at or near expiry. Refresh tokens rotate on use, so the
+    new one is stored — dropping it would strand the link at the next refresh."""
+    if link.expires_at and link.expires_at - _REFRESH_SKEW > int(time.time()) and link.access_token:
+        return link.access_token
+    if not link.refresh_token:
+        if link.access_token:
+            return link.access_token
+        raise HTTPException(401, "massing.cloud session expired — sign in again")
+    try:
+        tok = cloud.refresh_token(link.refresh_token)
+    except Exception as e:
+        raise HTTPException(401, "massing.cloud session expired — sign in again") from e
+    access = str(tok.get("access_token") or "")
+    if not access:
+        raise HTTPException(401, "massing.cloud session expired — sign in again")
+    link.access_token = access
+    link.refresh_token = str(tok.get("refresh_token") or "") or link.refresh_token
+    link.expires_at = int(time.time()) + int(tok.get("expires_in") or 0)
+    db.commit()
+    return access
+
+
+def _library_token(db: Session, user: str) -> str:
+    """Linked + entitled, or the specific refusal that says which of the two failed."""
+    link = _linked_or_403(db, user)
+    tier = cloud.normalize_tier(link.cloud_tier)
+    if not cloud.has_library_access(tier):
+        raise HTTPException(402, "the cloud project library is included with any paid Massing plan — "
+                                 f"upgrade at {cloud.site_url()}/pricing/")
+    return _fresh_access_token(db, link)
+
+
+def _vault(fn, *args):
+    try:
+        return fn(*args)
+    except vault.VaultError as e:
+        # Pass the site's own message through: a 409 names the plan limit that was hit, and
+        # rewording it would lose the only part the user can act on.
+        raise HTTPException(e.status if e.status in (401, 402, 403, 404, 409) else 502,
+                            e.message) from e
+    except Exception as e:
+        raise HTTPException(502, "could not reach the massing.cloud library") from e
+
+
+@router.get("/cloud/library/projects")
+def library_projects(db: Session = Depends(get_db), user: str = Depends(current_user)):
+    token = _library_token(db, user)
+    return {"projects": _vault(vault.list_projects, token)}
+
+
+@router.get("/cloud/library/projects/{project_id}")
+def library_project(project_id: str, db: Session = Depends(get_db), user: str = Depends(current_user)):
+    token = _library_token(db, user)
+    return _vault(vault.get_project, token, project_id)
+
+
+@router.get("/cloud/library/models/{model_id}")
+def library_model(model_id: str, db: Session = Depends(get_db), user: str = Depends(current_user)):
+    """A model record plus its signed `download_url`.
+
+    The URL is handed to the browser deliberately: it is short-lived, model-scoped, and carries its
+    own token, so proxying the bytes through this app would add a hop without adding a check. It
+    must be fetched **without** an Authorization header."""
+    token = _library_token(db, user)
+    return _vault(vault.get_model, token, model_id)

--- a/services/api/src/aec_api/settings_store.py
+++ b/services/api/src/aec_api/settings_store.py
@@ -29,6 +29,22 @@ CATALOG: list[dict[str, Any]] = [
          "secret": False},
         {"key": "MASSING_CLOUD_SECRET", "label": "Shared secret (X-Massing-Secret header)", "secret": True},
     ]},
+    # CLOUD-SSO: massing.cloud as the identity broker (OAuth2 PKCE). There is deliberately **no
+    # secret in this group** — the app is a registered *public* client (`massing-desktop`) and PKCE
+    # is what replaces the secret, so an operator only has to turn it on. See massing_cloud_auth.py.
+    {"group": "massing.cloud sign-in", "keys": [
+        {"key": "MASSING_CLOUD_SSO_ENABLED", "label": "Enable massing.cloud sign-in (1/0)",
+         "secret": False, "default": "0"},
+        {"key": "MASSING_CLOUD_SITE_URL", "label": "Site URL (e.g. https://www.massing.cloud)",
+         "secret": False, "default": "https://www.massing.cloud"},
+        {"key": "MASSING_CLOUD_SSO_CLIENT_ID", "label": "OAuth client id",
+         "secret": False, "default": "massing-desktop"},
+        {"key": "MASSING_CLOUD_ROLE_SYNC",
+         "label": "Grant app admin to massing.cloud admins/editors (1/0)",
+         "secret": False, "default": "1"},
+        {"key": "MASSING_CLOUD_ADMIN_ROLES", "label": "Cloud roles that map to app admin",
+         "secret": False, "default": "administrator,editor"},
+    ]},
     {"group": "AI assist (Draft RFI)", "keys": [
         {"key": "ANTHROPIC_API_KEY", "label": "Anthropic API key", "secret": True},
         {"key": "AEC_AI_MODEL", "label": "Model", "secret": False, "default": "claude-opus-4-8"},

--- a/services/api/test_massing_cloud_sso.py
+++ b/services/api/test_massing_cloud_sso.py
@@ -1,0 +1,203 @@
+"""CLOUD-SSO / CLOUD-LIBRARY test. Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_massing_cloud_sso.py
+
+Covers the massing.cloud broker integration end to end with the network stubbed at the two seams
+`massing_cloud_auth` exposes (`exchange_code` / `fetch_userinfo` / `refresh_token`) and the one
+`massing_cloud_vault` exposes (`call`):
+
+  * PKCE: the verifier is sealed into a cookie and **never** appears in `state` (the property the
+    whole flow rests on), the challenge is S256, and a seal is bound to its own state.
+  * the callback links the account, mints a session, and maps tier + role;
+  * `administrator`/`editor` on massing.cloud ⇒ platform admin here — and **losing** the role on a
+    later sync drops the elevation again, which is the half a one-way mapping would leave behind;
+  * the tier vocabularies do not get crossed: `commercial` is a paying plan, not `free`;
+  * the library is tier-gated — a free user gets 402 naming the upgrade, not an empty list;
+  * a 409 plan-limit message from the site is passed through verbatim;
+  * disconnect revokes and deletes, and takes the cloud-granted elevation with it.
+"""
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///./cloud_sso_test.db"
+os.environ["STORAGE_DIR"] = "./test_storage_cloud_sso"
+os.environ.pop("AEC_RBAC", None)
+os.environ.pop("AEC_API_KEY", None)
+os.environ.pop("AEC_ADMIN_EMAILS", None)
+# Enable the broker via the ENVIRONMENT, not `settings_store._cache`: the app's lifespan calls
+# `settings_store.load()`, which **clears** the cache — so anything pre-seeded there is gone by the
+# time the first request runs. `get()` falls back to env, which survives startup.
+os.environ["MASSING_CLOUD_SSO_ENABLED"] = "1"
+os.environ["MASSING_CLOUD_SITE_URL"] = "https://www.massing.cloud"
+os.environ["MASSING_CLOUD_ROLE_SYNC"] = "1"
+for f in ("./cloud_sso_test.db",):
+    if os.path.exists(f):
+        os.remove(f)
+
+import urllib.parse  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api import auth as auth_mod  # noqa: E402
+from aec_api import massing_cloud_auth as cloud  # noqa: E402
+from aec_api import massing_cloud_vault as vault  # noqa: E402
+from aec_api import settings_store  # noqa: E402
+from aec_api.main import app  # noqa: E402
+
+BEARER = lambda t: {"Authorization": f"Bearer {t}"}  # noqa: E731
+
+# ── unit: PKCE + role/tier shaping ────────────────────────────────────────────────────────────
+v = cloud.new_verifier()
+assert 43 <= len(v) <= 128, len(v)                       # RFC 7636 §4.1
+assert cloud.challenge_for("abc") == cloud.challenge_for("abc")
+assert cloud.challenge_for("abc") != "abc"               # S256, not plain
+assert "=" not in cloud.challenge_for(v)                 # base64url, unpadded
+
+state = auth_mod.create_oauth_state("massing-cloud")
+sealed = auth_mod.seal_pkce(v, state)
+assert auth_mod.open_pkce(sealed, state) == v
+assert auth_mod.open_pkce(sealed, "someone-elses-state") is None, "seal must bind to its state"
+assert auth_mod.open_pkce("garbage", state) is None
+# THE property: the authorize URL carries the challenge and the state, and NOT the verifier.
+url = cloud.authorize_url("http://127.0.0.1:8093/auth/cloud/callback", state, v)
+assert v not in url, "the code_verifier must never travel to the broker"
+q = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+assert q["code_challenge_method"] == ["S256"] and q["code_challenge"] == [cloud.challenge_for(v)]
+assert q["client_id"] == ["massing-desktop"] and q["response_type"] == ["code"]
+
+# tier vocabularies must not be crossed: massing.cloud speaks free|home|commercial|enterprise.
+assert cloud.normalize_tier("commercial") == "commercial", "commercial is a PAYING plan"
+assert cloud.app_tier_for("commercial") == "pro" and cloud.app_tier_for("home") == "pro"
+assert cloud.app_tier_for("enterprise") == "enterprise"
+assert cloud.normalize_tier("platinum") == "free" and cloud.app_tier_for("platinum") == "free"
+assert cloud.has_library_access("home") and cloud.has_library_access("enterprise")
+assert not cloud.has_library_access("free")
+
+assert cloud.roles_from_userinfo({"roles": ["Editor"]}) == ["editor"]
+assert cloud.roles_from_userinfo({"role": "administrator,subscriber"}) == ["administrator", "subscriber"]
+assert cloud.roles_from_userinfo({"tier": "pro"}) == [], "no role key ⇒ no roles"
+assert cloud.is_cloud_admin(["editor"]) and cloud.is_cloud_admin(["administrator"])
+assert not cloud.is_cloud_admin([]), "empty roles must fail CLOSED"
+assert not cloud.is_cloud_admin(["subscriber"])
+
+# ── stub the broker + vault ───────────────────────────────────────────────────────────────────
+STATE = {"tier": "commercial", "roles": ["editor"], "exchanges": 0, "revoked": []}
+
+cloud.exchange_code = lambda code, verifier, redirect_uri: (
+    STATE.__setitem__("exchanges", STATE["exchanges"] + 1),
+    STATE.__setitem__("last_verifier", verifier),
+    {"access_token": "acc-1", "refresh_token": "ref-1", "expires_in": 28800},
+)[-1]
+cloud.fetch_userinfo = lambda token: {
+    "sub": "1042", "name": "Ada Lovelace", "email": "Ada@Example.com",
+    "avatar_url": "https://www.massing.cloud/wp-content/uploads/avatar-1042.jpg",
+    "tier": STATE["tier"], "providers": ["google"], "roles": STATE["roles"],
+}
+cloud.refresh_token = lambda r: {"access_token": "acc-2", "refresh_token": "ref-2", "expires_in": 28800}
+cloud.revoke_token = lambda t: STATE["revoked"].append(t)
+
+VAULT_PROJECTS = {"user_id": 1042, "projects": [
+    {"id": 123, "title": "1428 Maple Ave", "cloud_project_id": "proj_ab12",
+     "status": "active", "model_count": 3, "updated": "2026-08-24T10:00:00Z", "secret_site_field": "nope"},
+]}
+VAULT_MODEL = {"id": 456, "title": "Scheme C", "project_id": 123, "format": "mass",
+               "size_bytes": 91234, "version": 2, "cloud_model_id": "mdl_77",
+               "download_url": "https://www.massing.cloud/wp-admin/admin-post.php?action=massing_vault_download&model=456&token=sig"}
+
+
+def fake_call(path, token, method="GET", body=None):
+    assert token in ("acc-1", "acc-2"), f"vault called with a bad token: {token}"
+    if path == "/projects":
+        return VAULT_PROJECTS
+    if path == "/models/456":
+        return VAULT_MODEL
+    if path == "/models/999":
+        raise vault.VaultError(409, "Vault limit reached on the Home plan (3 of 3 models).")
+    raise vault.VaultError(404, "not found")
+
+
+vault.call = fake_call
+
+with TestClient(app) as c:
+    # ── the authorize redirect sets the sealed cookie and points at the broker ────────────────
+    r = c.get("/auth/cloud/login", follow_redirects=False)
+    assert r.status_code == 307, r.text
+    loc = r.headers["location"]
+    assert loc.startswith("https://www.massing.cloud/massing-sso/authorize?"), loc
+    q = urllib.parse.parse_qs(urllib.parse.urlparse(loc).query)
+    sent_state = q["state"][0]
+    assert q["code_challenge_method"] == ["S256"]
+    jar_seal = c.cookies.get("mc_pkce")
+    assert jar_seal, "the verifier seal must be set as a cookie"
+    real_verifier = auth_mod.open_pkce(jar_seal, sent_state)
+    assert real_verifier and real_verifier not in loc, "verifier must not be in the authorize URL"
+
+    # a callback whose state does not match the seal is refused (CSRF / mix-up)
+    bad = c.get("/auth/cloud/callback", params={"code": "abc", "state": "forged"},
+                follow_redirects=False)
+    assert bad.status_code == 400, bad.text
+
+    # ── the real callback links the account and signs the user in ────────────────────────────
+    r = c.get("/auth/cloud/callback", params={"code": "the-code", "state": sent_state},
+              follow_redirects=False)
+    assert r.status_code == 303, r.text
+    assert STATE["exchanges"] == 1
+    assert STATE["last_verifier"] == real_verifier, "the sealed verifier is what gets exchanged"
+    tok = c.cookies.get("aec_token")
+    assert tok, "the callback must mint an app session"
+
+    me = c.get("/auth/me", headers=BEARER(tok)).json()
+    assert me["authenticated"] and me["username"] == "ada@example.com", me
+    assert me["display_name"] == "Ada Lovelace", me
+    assert me["avatar_url"].endswith("avatar-1042.jpg"), me
+    # editor on massing.cloud ⇒ admin here
+    assert me["role"] == "admin" and me["platform_admin"] is True, me
+    # commercial ⇒ a paid entitlement tier, NOT free
+    assert me["tier"] == "pro", me
+    assert me["cloud"]["linked"] is True and me["cloud"]["library_access"] is True, me
+
+    st = c.get("/auth/cloud/status", headers=BEARER(tok)).json()
+    assert st["linked"] and st["tier"] == "commercial" and st["tier_label"] == "Commercial", st
+    assert st["is_admin"] is True and st["library_access"] is True, st
+    assert "access_token" not in st and "refresh_token" not in st, "status must never leak a token"
+
+    # ── the library ──────────────────────────────────────────────────────────────────────────
+    lib = c.get("/cloud/library/projects", headers=BEARER(tok))
+    assert lib.status_code == 200, lib.text
+    projects = lib.json()["projects"]
+    assert len(projects) == 1 and projects[0]["title"] == "1428 Maple Ave", projects
+    assert "secret_site_field" not in projects[0], "unknown site keys must not be forwarded"
+
+    m = c.get("/cloud/library/models/456", headers=BEARER(tok))
+    assert m.status_code == 200 and "download_url" in m.json(), m.text
+
+    # a site-side plan limit is surfaced verbatim, with its own status
+    lim = c.get("/cloud/library/models/999", headers=BEARER(tok))
+    assert lim.status_code == 409 and "3 of 3 models" in lim.text, lim.text
+
+    # ── losing the cloud role drops the elevation (the half a one-way map would miss) ─────────
+    STATE["roles"] = ["subscriber"]
+    STATE["tier"] = "free"
+    r = c.post("/auth/cloud/refresh", headers=BEARER(tok))
+    assert r.status_code == 200, r.text
+    me2 = c.get("/auth/me", headers=BEARER(tok)).json()
+    assert me2["role"] == "user" and me2["platform_admin"] is False, me2
+    assert me2["tier"] == "free", me2
+
+    # ...and a free account is refused the library with an upgrade pointer, not an empty list
+    lib2 = c.get("/cloud/library/projects", headers=BEARER(tok))
+    assert lib2.status_code == 402, lib2.text
+    assert "/pricing/" in lib2.text, lib2.text
+
+    # ── disconnect revokes at the broker and deletes the link ────────────────────────────────
+    d = c.post("/auth/cloud/disconnect", headers=BEARER(tok))
+    assert d.status_code == 200 and d.json()["linked"] is False, d.text
+    assert "acc-1" in STATE["revoked"] or "acc-2" in STATE["revoked"], STATE["revoked"]
+    st2 = c.get("/auth/cloud/status", headers=BEARER(tok)).json()
+    assert st2["linked"] is False, st2
+    # the library is gone with the link, and says so as "not linked" rather than "not entitled"
+    assert c.get("/cloud/library/projects", headers=BEARER(tok)).status_code == 403
+
+    # ── the feature is off by default: no flag ⇒ the routes are not there at all ─────────────
+    settings_store._cache["MASSING_CLOUD_SSO_ENABLED"] = "0"
+    assert c.get("/auth/cloud/login", follow_redirects=False).status_code == 404
+    settings_store._cache["MASSING_CLOUD_SSO_ENABLED"] = "1"
+
+print("massing.cloud SSO + library: OK")


### PR DESCRIPTION
Signs the app in through **massing.cloud** and opens the user's cloud project library. Reviewed against the massing.cloud repo (Massing SSO v1.1.0 + Massing Vault v1.5.0, docs 18 / 19 / 31) and, where it mattered, against the plugin **source** rather than the docs.

## What a user gets

* **One button.** "Continue with massing.cloud" leads the sign-in modal. Behind it the user picks Microsoft / Google / Procore / Autodesk / password *on the site* — this deployment holds **no provider secret at all**.
* **An identity chip** in the toolbar: the massing.cloud (WordPress) avatar, display name and an admin badge, replacing the plain `username ▾` text button.
* **Their cloud projects**, browsable and openable in-app, for any plan but Free.
* **One Profile & settings panel** — administration included, when the account has it.

## How it works

OAuth2 authorization code + **PKCE (S256)** against the already-registered public client `massing-desktop`. The redirect URI is our own `/auth/cloud/callback`, which for a desktop/self-hosted install is already a loopback address — exactly what that client allows. A hosted deployment must register its https callback site-side.

The access token then **is** the Vault credential: `/cloud/library/*` proxies `GET /projects`, `/projects/{id}` and `/models/{id}`, and hands the browser the site's signed, ~15-minute, model-scoped `download_url` to fetch directly (no auth header — attaching our bearer to a massing.cloud origin would leak a credential to no purpose).

### Three decisions worth a reviewer's attention

**The code exchange runs server-side, not in the browser.** Doc 31 describes a native app doing it itself. The cloud refresh token is good for 30 days and has no business in `localStorage`; doing it here also means massing.cloud never has to CORS-allow this origin, and the existing session/RBAC/audit layer is reused instead of a second identity system in the client. PKCE needs no client secret, so nothing about being a public client is bent by it.

**The PKCE verifier travels in an HttpOnly cookie, never in `state`.** `state` is echoed by the broker through the user agent, so a verifier carried in it is visible to whoever can observe the redirect — and code *plus* verifier is precisely what PKCE exists to deny. `auth.seal_pkce` HMAC-binds the verifier to its own `state`, so a seal cannot be replayed against another attempt. Verified on the wire, not just in a test.

**The two tier vocabularies must not be crossed — this nearly shipped as a bug.** `licensing.TIER_ORDER` is `free|home|commercial|enterprise`, which is what the site sends. `tiers.TIERS` is `free|pro|enterprise`, the seam on `User.tier`. Running a cloud tier through `tiers.normalize` maps **`commercial` into `free`**, because `commercial` is not in that tuple — a paying customer silently told they have no library. `normalize_tier` goes through `licensing`; `app_tier_for` converts for storage.

## Roles — built here, **inert until the site publishes them**

The requirement was "admin or editor on massing.cloud gives admin in the app". Checked against `plugin/massing-sso/includes/class-broker.php`, `userinfo`: the response is exactly `{sub, name, email, avatar_url, tier, providers}` — **there is no role key anywhere in the broker**, and the docs do not claim otherwise.

So this consumes roles when they appear and grants nothing when they do not. `roles_from_userinfo` accepts `roles`, `role` and `wp_roles`; `is_cloud_admin([])` is `False`, so the failure mode is *no elevation*, never accidental elevation. **The site-side filter that closes this is four lines** and is written out in `docs/internal/massing-cloud-sso.md` — massing.cloud already has the `massing_sso_userinfo` hook it needs.

The mapping is **two-way**: losing `editor` on the site drops the elevation on the next refresh or sign-in, and disconnecting removes it outright. A one-way map would leave a live admin behind after the role was revoked, which is the half that actually matters. Only cloud-linked accounts are touched, so a local admin is never demoted by this path.

This is a deliberate exception to the standing *"Regular SSO users are never platform admins"* rule in `routers/auth.py`, scoped to the **first-party** broker and killable with `MASSING_CLOUD_ROLE_SYNC=0`. The four direct IdPs in `oauth.py` keep the old rule: a Google account proves an email, not a relationship to this product.

## Admin becomes a section, not a console

The four admin-only dropdown entries — Manage users, Audit log, Errors, Data connections — are now the **Administration section** of one Profile & settings panel, present only when the account carries the capability.

That is the reorganisation asked for ("all the admin settings should be in a user's profile settings section") **without deleting a capability the product still needs**: local admin is load-bearing for user management, audit, API keys and data connections. A non-admin and an admin now see the *same* panel; the admin's has one section more. `profileSettings.test.ts` asserts exactly that — including that the admin *actions* are not built at all for a non-admin, because a hidden tab whose body still rendered would leak the buttons.

Refusals stay distinguishable throughout: a Free plan gets **402** naming the upgrade page, an unlinked account **403**, and a plan limit passes the site's own **409** message through verbatim. An empty library and an ungranted one never look the same.

## Turning it on

No secret to configure — PKCE replaces it.

```
MASSING_CLOUD_SSO_ENABLED=1
MASSING_CLOUD_SITE_URL=https://www.massing.cloud     # default
MASSING_CLOUD_SSO_CLIENT_ID=massing-desktop          # default, already registered
MASSING_CLOUD_ROLE_SYNC=1                            # default
MASSING_CLOUD_ADMIN_ROLES=administrator,editor       # default
```

Off by default; the routes 404 until enabled.

## Verification

* **Backend** — `test_massing_cloud_sso.py` drives the whole flow with the network stubbed at the module seams: PKCE properties, callback/link, role map **and role loss**, tier map, library, 402/403/409, disconnect, feature-flag-off.
* **Live HTTP** — ran the real ASGI server and confirmed all 8 routes serve, `/auth/cloud/login` 307s to the broker with an S256 challenge and a loopback `redirect_uri`, and the `mc_pkce` cookie is `HttpOnly; Path=/auth/cloud; SameSite=lax` with the verifier **absent** from the redirect URL.
* **Live UI** — drove the running app: chip renders with initials + ADMIN badge; the dropdown shows *Profile & settings…* / *Connect massing.cloud…* / *Sign out*; the panel shows all five sections with Administration's three groups.
* **Suites** — web 2005/2005, typecheck and lint clean.

Two repo gates caught real defects on the way through: `hrefGuard` flagged `avatar_url` reaching an `img.src` (now scheme-checked via `safeHref`, with a dangerous-scheme test), and a happy-dom failure that is a genuine browser concern — the space-separated `hsl(H S% L%)` form is dropped outright by some CSS parsers, which would have left the fallback disc transparent.

## Deliberately not included

* **Saving back to the cloud.** Doc 31 section 3 is an open joint decision — the site's `POST /models` records a *pointer* and assumes the bytes already exist in storage. This app has no `.mass` container writer, so a save button would record a pointer to nothing. `massing_cloud_vault.save_model` exists, unrouted.
* **Opening `.mass`** — refused explicitly rather than handed to the IFC loader.
* **Doc 31 section 4 deep links** (`massing://open?...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional massing.cloud sign-in and account linking.
  * Added profile settings with identity, security, preferences, cloud, and administrator sections.
  * Added cloud project-library browsing and model opening.
  * Added account avatars with initials and reliable fallbacks.
  * Added cloud account refresh and disconnect controls.
* **Bug Fixes**
  * Improved handling of unavailable cloud services, unlinked accounts, failed avatar images, and insufficient plan access.
* **Documentation**
  * Documented massing.cloud sign-in and library integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->