### PR TITLE
fix(auth): the domain allowlist governs the massing.cloud door too

### DIFF
--- a/services/api/src/aec_api/oauth.py
+++ b/services/api/src/aec_api/oauth.py
@@ -171,3 +171,26 @@ def email_from_login(provider: str, code: str, redirect_uri: str) -> str | None:
     info = fetch_userinfo(provider, access)
     email = PROVIDERS[provider]["email"](info)
     return email.strip().lower() if email else None
+
+
+def domain_allowed(email: str) -> bool:
+    """Is this email's domain permitted to sign in? (`AEC_OAUTH_ALLOWED_DOMAINS`, empty = any.)
+
+    Lives here, shared, because it was inline in the direct-IdP callback and **the massing.cloud
+    broker path did not carry it** — so an operator who had restricted sign-in to their own domain
+    got that enforced on Google/Microsoft/Procore/Autodesk and silently bypassed by the fifth door.
+    A control that is true for four sign-in paths and false for the fifth is worse than no control,
+    because the operator believes it holds.
+
+    The flag is named `AEC_OAUTH_*` and reads as if it were scoped to the direct providers, which is
+    part of how it was missed; it is not — it governs **who may sign in**, whichever provider proved
+    the address. Any future sign-in path must call this rather than re-deriving it, which is the
+    reason it is a function and not a copied five lines.
+    """
+    import os as _os
+    domains = [d.strip().lower().lstrip("@") for d in
+               _os.environ.get("AEC_OAUTH_ALLOWED_DOMAINS", "").split(",") if d.strip()]
+    if not domains:
+        return True
+    dom = email.rsplit("@", 1)[-1].lower() if "@" in email else ""
+    return dom in domains

--- a/services/api/src/aec_api/routers/auth.py
+++ b/services/api/src/aec_api/routers/auth.py
@@ -335,11 +335,10 @@ def oauth_callback(provider: str, request: Request, code: str | None = None,
     # Enterprise gate: only self-provision accounts for allowed email domains. Without an allowlist,
     # any verified email at an enabled provider could create an account (and, with cross-tenant reads
     # closed, still see only its own projects — but provisioning itself should be controlled).
+    # Shared with the massing.cloud broker path via `oauth.domain_allowed` — that sharing IS the
+    # fix: this was five inline lines here, and the fifth sign-in door did not carry them.
     import os as _os
-    _domains = [d.strip().lower().lstrip("@") for d in
-                _os.environ.get("AEC_OAUTH_ALLOWED_DOMAINS", "").split(",") if d.strip()]
-    _dom = email.rsplit("@", 1)[-1].lower() if "@" in email else ""
-    if _domains and _dom not in _domains:
+    if not oauth.domain_allowed(email):
         raise HTTPException(403, "this email domain is not permitted to sign in")
 
     u = db.get(User, email)

--- a/services/api/src/aec_api/routers/cloud.py
+++ b/services/api/src/aec_api/routers/cloud.py
@@ -49,7 +49,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
-from .. import audit, auth
+from .. import audit, auth, oauth
 from .. import massing_cloud_auth as cloud
 from .. import massing_cloud_vault as vault
 from ..db import get_db
@@ -131,6 +131,14 @@ def cloud_callback(request: Request, code: str | None = None, state: str | None 
     sub = str(info.get("sub") or "").strip()
     if not email or not sub:
         raise HTTPException(403, "massing.cloud did not return an identified account")
+    # `AEC_OAUTH_ALLOWED_DOMAINS` governs WHO MAY SIGN IN, whichever provider proved the address —
+    # so it applies here too. It did not, originally: the flag reads as if it were scoped to the
+    # four direct IdPs, and this path was written from that callback without carrying it. An
+    # operator who had restricted sign-in to their own domain would have had it enforced on four
+    # doors and silently bypassed by the fifth, which is worse than no control because they believe
+    # it holds. Shared helper rather than a second copy, so the next sign-in path cannot miss it.
+    if not oauth.domain_allowed(email):
+        raise HTTPException(403, "this email domain is not permitted to sign in")
 
     username = _link_account(db, info, tok, access)
     resp = RedirectResponse(_app_url(), status_code=303)

--- a/services/api/test_massing_cloud_sso.py
+++ b/services/api/test_massing_cloud_sso.py
@@ -277,6 +277,37 @@ with TestClient(app) as c:
     assert c.post("/auth/cloud/disconnect", headers=BEARER(chief_tok)).status_code == 200
     assert role_of("chief@example.com") == "user",         "disconnect MUST strip an elevation this path granted"
 
+    # ── AEC_OAUTH_ALLOWED_DOMAINS applies to THIS door too ───────────────────────────────────
+    # It did not originally. The flag reads as if it were scoped to the four direct IdPs, so this
+    # path was written from that callback without carrying it — an operator who had restricted
+    # sign-in to their own domain got it enforced on four doors and bypassed by the fifth. A control
+    # that is true for four paths and false for the fifth is worse than none, because it is believed.
+    os.environ["AEC_OAUTH_ALLOWED_DOMAINS"] = "acme.com"
+    try:
+        cloud.fetch_userinfo = lambda token: {
+            "sub": "9100", "name": "Outsider", "email": "someone@evil.example",
+            "tier": "commercial", "providers": [], "roles": []}
+        c.cookies.clear()
+        lg = c.get("/auth/cloud/login", follow_redirects=False)
+        st5 = urllib.parse.parse_qs(urllib.parse.urlparse(lg.headers["location"]).query)["state"][0]
+        r = c.get("/auth/cloud/callback", params={"code": "d1", "state": st5}, follow_redirects=False)
+        assert r.status_code == 403 and "domain is not permitted" in r.text, r.text
+        assert role_of("someone@evil.example") is None, "...and no account was provisioned"
+
+        # ...and the twin: an ALLOWED domain still gets in, or "it refuses" is satisfied by a door
+        # that refuses everyone.
+        cloud.fetch_userinfo = lambda token: {
+            "sub": "9101", "name": "Insider", "email": "someone@acme.com",
+            "tier": "commercial", "providers": [], "roles": []}
+        c.cookies.clear()
+        lg = c.get("/auth/cloud/login", follow_redirects=False)
+        st6 = urllib.parse.parse_qs(urllib.parse.urlparse(lg.headers["location"]).query)["state"][0]
+        r = c.get("/auth/cloud/callback", params={"code": "d2", "state": st6}, follow_redirects=False)
+        assert r.status_code == 303, r.text
+        assert role_of("someone@acme.com") == "user"
+    finally:
+        os.environ.pop("AEC_OAUTH_ALLOWED_DOMAINS", None)
+
     # ── the feature is off by default: no flag ⇒ the routes are not there at all ─────────────
     settings_store._cache["MASSING_CLOUD_SSO_ENABLED"] = "0"
     assert c.get("/auth/cloud/login", follow_redirects=False).status_code == 404


### PR DESCRIPTION
**A sign-in restriction that held on four doors and not the fifth.**

`AEC_OAUTH_ALLOWED_DOMAINS` was enforced on the four direct-IdP callbacks and **not** on the massing.cloud broker path. An operator who had restricted sign-in to their own domain got it enforced on Google / Microsoft / Procore / Autodesk and silently bypassed by the fifth door — worse than no control, because they believe it holds.

Only bites a deployment with `MASSING_CLOUD_SSO_ENABLED=1` **and** the allowlist set — i.e. precisely the security-conscious operator who bothered to set it.

### How it was missed

The cloud callback was written from the direct-IdP callback. It carried `AEC_OAUTH_NO_AUTOPROVISION` across but not the five inline lines above it. The flag's name works against you: `AEC_OAUTH_*` reads as if scoped to the four providers, when what it governs is *who may sign in*, whichever provider proved the address. Copying the neighbour inherits its shape, not its invariants.

Found by reading v0.3.1089 — the release that documented this flag for the first time is the one that made its gap visible. A hardening control nobody can find is one nobody can check.

### Fixed as a shared helper, not a second copy

`oauth.domain_allowed(email)`, called from both callbacks. Five duplicated lines is exactly how the fifth door came to differ from the first four; a sixth sign-in path now has to call the helper rather than re-derive it.

### Verification

Both directions on the cloud path — a disallowed domain gets **403** and provisions **no account**, and an allowed one still gets in, because "it refuses" is satisfied by a door that refuses everyone.

**Mutation-checked**: removing the gate fails on the 403 assertion.

`test_massing_cloud_sso`, `test_auth`, `test_oauth_providers`, `test_env_documented`, `test_global_authz`, `test_dead_code_population`, `test_route_reachability` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OAuth domain restrictions across standard and massing.cloud sign-ins.
  * Administrators can allow specific email domains using the `AEC_OAUTH_ALLOWED_DOMAINS` setting.
  * Sign-ins from disallowed domains are rejected, while unrestricted access remains the default.

* **Bug Fixes**
  * Ensured massing.cloud sign-ins consistently enforce configured domain restrictions.

* **Tests**
  * Added coverage for permitted and rejected massing.cloud SSO sign-ins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->