### PR TITLE
v0.3.1098 — the one Dockerfile no job has ever built, and the hardening that never ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
         include:
           - { name: api, context: ., dockerfile: services/api/Dockerfile }
           - { name: web, context: ., dockerfile: apps/web/Dockerfile }
+          - { name: converter, context: ., dockerfile: services/converter/Dockerfile }
     steps:
       - uses: actions/checkout@v7
 
@@ -248,13 +249,14 @@ jobs:
     permissions:
       contents: read
     strategy:
-      # Both images, even when one fails: "the api image broke" and "both images broke" are
+      # Every image, even when one fails: "the api image broke" and "all three images broke" are
       # different findings, and fail-fast would report the first as the second.
       fail-fast: false
       matrix:
         include:
           - { name: api, context: ., dockerfile: services/api/Dockerfile }
           - { name: web, context: ., dockerfile: apps/web/Dockerfile }
+          - { name: converter, context: ., dockerfile: services/converter/Dockerfile }
     steps:
       - uses: actions/checkout@v7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,80 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1098 (2026-08-25) — the one Dockerfile no job has ever built, and the hardening that never ran
+
+Following the v0.3.1097 Node-base fix to its cause. **`services/converter/Dockerfile` is built by
+nothing** — not on a pull request, not on a push to `main`, not on any event — and it has not been
+buildable at all since v0.3.936.
+
+### The image cannot be built
+
+v0.3.936 is titled *"drop root in the converter image"*. It added:
+
+    RUN addgroup -S app && adduser -S -G app app && chown -R app:app /app
+    USER app
+
+That is BusyBox/Alpine syntax. This image is `node:24-slim`, which is Debian, and Debian's
+`adduser` is a Perl script whose short options are Getopt::Long abbreviations. Run on the Debian
+family:
+
+    $ addgroup -S app
+    Option s is ambiguous (shell, stderrmsglevel, stdoutmsglevel, system)
+    $ adduser -S -G app app
+    Option s is ambiguous (...)   Option g is ambiguous (gecos, gid, group)
+
+Both exit non-zero, so the `RUN` fails and the build stops there. **The hardening that commit
+describes has never run anywhere, because the image it hardens has never been produced.** The file
+was never Alpine-based — checked back to the initial commit — so this was wrong on the day it
+landed. Now `useradd -m -u 10001 appuser`, the same idiom and the same uid as
+`services/api/Dockerfile`, which is Debian too and does build.
+
+### Why nothing said so, and it is the same shape again
+
+`ci.yml`'s container matrices listed `api` and `web`. `docker-scope`'s path filter is
+`(^|/)Dockerfile$|...`, which **does** match `services/converter/Dockerfile`. So editing that file
+*triggers* the container jobs, and those jobs then build the two images it did not change:
+
+    apps/web/Dockerfile              filter-matches=True   in-matrix=True
+    services/api/Dockerfile          filter-matches=True   in-matrix=True
+    services/converter/Dockerfile    filter-matches=True   in-matrix=False
+
+`test_container_pr_gate.py` exists to keep the filter and the matrix in sync and asked one
+direction: *does the filter match every Dockerfile in the matrix?* That catches a Dockerfile that
+**moved**. It cannot catch one that **exists and was never added**, because such a file is in
+neither list being compared — outside the population entirely. Its own rule 1 anticipated *"a third
+image added to the publish matrix"*: a third image entering the **matrix**, not a third Dockerfile
+entering the **repository**.
+
+**This is the fifth instance of one shape in this release range**, and they are worth reading
+together rather than as five coincidences — a check whose population was defined so that the failure
+it exists for could not appear in it:
+
+| gate | the population it chose | what that excluded |
+|---|---|---|
+| `test_lock_satisfies_requirements` (2026-08-01) | `requirements.in` | the floors in `services/data` |
+| `test_lock_satisfies_requirements` (2026-08-07) | pin ≥ floor | a floor that is too **low** |
+| `docsCurrent.test.ts` (v0.3.1096) | README rows present in the manifest | a row for a **removed** package |
+| `check-fragments-version.mjs` (v0.3.1097) | the two version ARGs | the `FROM` line above them |
+| `test_container_pr_gate.py` (here) | Dockerfiles in the matrix | a Dockerfile **not** in the matrix |
+
+Four of the five filtered their input by the very thing they were checking it against.
+
+### The fix
+
+`converter` is in both matrices, so the image is built on every PR that touches a Dockerfile and
+built, scanned and published on `main`. Rule 3 gains its converse, derived from `git ls-files` so a
+hardcoded list cannot rot: **every Dockerfile the filter triggers on must be one the matrix
+actually builds.** Anti-vacuity guarded on the `git ls-files` result.
+
+Mutation-verified two ways. Reverting the matrices to their previous state — the live defect — fails
+the new assertion **and nothing else in the file**, which is the claim about invisibility stated as
+a test result. Adding `converter` to the publish matrix only fails rule 1 instead.
+
+**CI builds this image for the first time in this pull request**, which is the real verification and
+could not be done locally: this container has no Docker daemon. If the build reveals more than the
+`RUN` line, that is the point of building it.
+
 ## v0.3.1097 (2026-08-25) — a floor that is too low satisfies every check written to catch a floor that is too high
 
 The dependency half of the full branch/PR review. **272 of 340 pull requests merged; 68 closed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,37 @@ the `node` binary and the resolved `node_modules`, which is all the ENTRYPOINT i
 state the other two reach by being multi-stage, and a smaller attack surface besides, which is what
 v0.3.936 was reaching for when it added the non-root user it could not build.
 
-**This is what the gate was for.** A CRITICAL, fixable CVE was sitting in a published-on-`main`
-image, and the reason it went unreported is not that anyone dismissed it — it is that no scan had
-ever been pointed at that image. A finding cannot be triaged by a check that never runs.
+### ...and then two more, in the base OS
+
+With npm gone, the node-package scan came back clean and the **OS** scan failed instead:
+
+    libgnutls30  CVE-2026-33845  CRITICAL  fixed  3.7.9-2+deb12u6 -> 3.7.9-2+deb12u7
+    libgnutls30  CVE-2026-42010  CRITICAL  fixed  3.7.9-2+deb12u6 -> 3.7.9-2+deb12u7
+
+Same root cause as the npm one, one layer down. **Pinning a base image by digest (SEC F4) buys
+reproducibility and costs currency**: the apt packages inside a pinned image are as old as the day
+it was built and keep accruing CVEs while the digest stays perfectly honest. The other two images
+never had to reckon with that, because their Debian layers stay in a build stage and are never
+published. This one publishes its base, so it inherits the base's CVEs.
+
+Upgraded by name rather than by a blanket `apt-get upgrade`: the scanner names the package and the
+fixed version, so the change stays bounded and reviewable, where a blanket upgrade would move an
+unbounded set of packages in an image nobody can build locally.
+
+**Recorded as a treadmill, because that is what it is.** Every future CRITICAL in the base will red
+this gate until the shared digest is re-pinned to a newer `node:24-slim`. Re-pinning is the right
+answer and accumulating `--only-upgrade` lines is not; the digest is shared by all three Dockerfiles
+and asserted by `scripts/check-fragments-version.mjs` B1c, so it is one coordinated change when it
+comes.
+
+### What this says about the gate
+
+Three CRITICAL, fixable CVEs — one vendored inside npm, two in the base OS — were sitting in an
+image that `main` publishes to ghcr. **Nobody triaged them and decided they were acceptable. No scan
+had ever been pointed at that image.** A finding cannot be dismissed, or accepted, or even seen, by a
+check that never runs; and the check never ran because the file was in the trigger's population and
+not in the matrix's. That is the whole argument for the assertion this release adds, stated in CVEs
+rather than in principle.
 
 ## v0.3.1097 (2026-08-25) — a floor that is too low satisfies every check written to catch a floor that is too high
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,9 +74,34 @@ Mutation-verified two ways. Reverting the matrices to their previous state — t
 the new assertion **and nothing else in the file**, which is the claim about invisibility stated as
 a test result. Adding `converter` to the publish matrix only fails rule 1 instead.
 
-**CI builds this image for the first time in this pull request**, which is the real verification and
-could not be done locally: this container has no Docker daemon. If the build reveals more than the
-`RUN` line, that is the point of building it.
+### What the first build revealed — a CRITICAL CVE, shipped by the base image
+
+**CI built this image for the first time in this pull request, and that first build immediately
+earned its keep.** The `useradd` fix was correct — the build ran to completion — and then the Trivy
+gate, also running against this image for the first time, failed it:
+
+    tar (package.json)  CVE-2026-59873  CRITICAL  fixed  installed 6.2.1  fixed in 7.5.19
+    node-tar: Denial of Service via crafted gzip bomb
+
+**Nothing this Dockerfile installs is `tar`.** A clean `npm install` of `@thatopen/fragments@3.4.7`
+and `web-ifc@0.0.77` resolves seven packages, none of them tar — verified by running it. The
+vulnerable copy is `/usr/local/lib/node_modules/npm/node_modules/tar`, **vendored inside npm**, which
+`node:24-slim` ships.
+
+The reason the other two images are clean is structural, and it is the same reason they were never
+caught by this: **the converter is the only single-stage image in the repository.** Its base *is* its
+runtime, so the whole toolchain publishes with it. `services/api/Dockerfile` takes exactly two things
+out of its node stage — `/usr/local/bin/node` and `/conv/node_modules` — and `apps/web/Dockerfile`
+ships nginx with only `dist`. Neither has ever shipped npm.
+
+So npm, corepack and the npm cache are removed in the same layer that uses them. The runtime keeps
+the `node` binary and the resolved `node_modules`, which is all the ENTRYPOINT invokes — the same end
+state the other two reach by being multi-stage, and a smaller attack surface besides, which is what
+v0.3.936 was reaching for when it added the non-root user it could not build.
+
+**This is what the gate was for.** A CRITICAL, fixable CVE was sitting in a published-on-`main`
+image, and the reason it went unreported is not that anyone dismissed it — it is that no scan had
+ever been pointed at that image. A finding cannot be triaged by a check that never runs.
 
 ## v0.3.1097 (2026-08-25) — a floor that is too low satisfies every check written to catch a floor that is too high
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1097",
+    "version": "0.3.1098",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1097",
+  "version": "0.3.1098",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1097",
+      "version": "0.3.1098",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/test_container_pr_gate.py
+++ b/services/api/test_container_pr_gate.py
@@ -13,6 +13,13 @@ This file is the part that keeps it honest, and the assertions are ordered by wh
 1.  **The two matrices stay equal.** This is the ratchet. A third image added to the publish matrix
     and not to the PR matrix would restore the original hole for that image alone, silently, and
     every other assertion here would still pass. Derived from both jobs, never listed here.
+
+    **That was written about an image entering the MATRIX, and the gap was an image entering the
+    REPOSITORY.** `services/converter/Dockerfile` existed in neither list, so it was invisible to
+    every assertion here: the path filter matched it (editing it started the container jobs) while
+    the matrix did not build it. No job had ever built that image on any event, which is why a
+    non-root `RUN` written in BusyBox syntax on a Debian base -- a build failure, not a warning --
+    shipped green in v0.3.936 and survived. Rule 3 now closes it from the `git ls-files` side.
 2.  **The PR job cannot push.** No `docker/login-action`, no write permission, no `docker push`,
     and every `build-push-action` step sets `push: false`. A build job that acquires registry
     credentials on a fork PR is a worse problem than the one this item fixes.
@@ -34,6 +41,7 @@ from __future__ import annotations
 
 import pathlib
 import re
+import subprocess
 import sys
 
 import yaml
@@ -121,6 +129,39 @@ if pat:
           not unmatched, ", ".join(unmatched) or f"all {len(pub_images)} matched")
     check("...and it matches ci.yml itself, so an action bump triggers a build",
           bool(rx.search(".github/workflows/ci.yml")))
+
+    # ...AND THE CONVERSE, which is the half this rule did not have.
+    #
+    # Above asks "does the filter match every Dockerfile in the matrix?". That direction catches a
+    # Dockerfile that MOVED. It cannot catch a Dockerfile that EXISTS and was never added, because
+    # such a file appears in neither list being compared — it is outside the population entirely.
+    #
+    # `services/converter/Dockerfile` sat in exactly that gap. The filter matched it, so editing it
+    # TRIGGERED the container jobs; the matrix did not list it, so those jobs built the other two
+    # images and never the one that changed. **No job has ever built it, on any event.** The cost
+    # was not hypothetical: v0.3.936 added a non-root user to it in BusyBox syntax on a Debian base,
+    # which fails the build outright, and that shipped green and stayed for months. A separate
+    # 25-day EOL Node base in the same file has the same explanation.
+    #
+    # The file docstring's rule 1 anticipated "a third image added to the publish matrix and not to
+    # the PR matrix" — a third image entering the MATRIX. It did not anticipate a third Dockerfile
+    # entering the REPOSITORY. **A gate's population is part of its claim**, which is the sentence
+    # `test_lock_satisfies_requirements` had to learn twice, and the same shape as
+    # `docsCurrent.test.ts` filtering README rows by the manifest it was checking them against.
+    #
+    # Derived from `git ls-files`, never listed here: a hardcoded list would rot the same way.
+    tracked = subprocess.run(["git", "ls-files"], cwd=ROOT, capture_output=True, text=True,
+                             check=True).stdout.split("\n")
+    dockerfiles = sorted(f.strip() for f in tracked
+                         if f.strip().endswith("Dockerfile") or f.strip() == "Dockerfile")
+    check("git ls-files finds the Dockerfiles -- otherwise the converse below is vacuous",
+          len(dockerfiles) >= 2, f"{len(dockerfiles)}: {', '.join(dockerfiles)}")
+    unbuilt = sorted(d for d in dockerfiles if rx.search(d) and d not in set(pub_images.values()))
+    check("...and every Dockerfile the filter TRIGGERS on is one the matrix actually BUILDS",
+          not unbuilt,
+          ", ".join(unbuilt) + " -- editing it starts the container jobs and no job builds it; "
+          "add it to both matrices, or stop the filter matching it" if unbuilt
+          else f"all {len(dockerfiles)} tracked Dockerfiles are in the matrix")
     decoys = ["README.md", "docs/roadmap.md", "apps/web/src/viewer/app.ts",
               ".github/workflows/codeql.yml"]
     wrong = sorted(d for d in decoys if rx.search(d))

--- a/services/converter/Dockerfile
+++ b/services/converter/Dockerfile
@@ -18,10 +18,28 @@ RUN npm init -y >/dev/null 2>&1 \
 COPY services/converter /app/services/converter
 
 # Drop root. This image is a CLI entrypoint — it binds no port, so there is no privileged-port
-# problem and nothing to trade away. `--chown` on the app tree so the non-root user can read
-# what it was given and write nothing it was not.
-RUN addgroup -S app && adduser -S -G app app && chown -R app:app /app
-USER app
+# problem and nothing to trade away. `chown` on the app tree so the non-root user can read what it
+# was given and write nothing it was not.
+#
+# `useradd`, NOT `adduser -S`. This line read `addgroup -S app && adduser -S -G app app` from
+# v0.3.936 — BusyBox/Alpine syntax on a Debian base. Debian's adduser is a Perl script whose short
+# options are Getopt::Long abbreviations, and both of those are ambiguous there:
+#
+#     $ addgroup -S app
+#     Option s is ambiguous (shell, stderrmsglevel, stdoutmsglevel, system)
+#     $ adduser -S -G app app
+#     Option s is ambiguous (...)   Option g is ambiguous (gecos, gid, group)
+#
+# Both exit non-zero, so this RUN failed and **the image could not be built at all**. The commit
+# that introduced it is titled "drop root in the converter image": the hardening it describes has
+# never run anywhere, because nothing has ever built this file. See ci.yml's container matrix —
+# until this change it listed api and web only, so `services/converter/Dockerfile` was the one
+# Dockerfile in the repo that no job built, on any event.
+#
+# Same idiom and same uid as `services/api/Dockerfile`, which is Debian too and does build.
+RUN useradd -m -u 10001 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
 
 # usage: docker compose run --rm converter /data/model.ifc /data/model.frag
 ENTRYPOINT ["node", "services/converter/src/cli.mjs"]

--- a/services/converter/Dockerfile
+++ b/services/converter/Dockerfile
@@ -6,6 +6,33 @@
 # and this file was not. `scripts/check-fragments-version.mjs` gates the two ARGs below across
 # both Dockerfiles and stops one line short of the base image.
 FROM node:24-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0
+
+# Security updates for the base OS, which a digest pin deliberately freezes.
+#
+# Pinning by digest (SEC F4) buys reproducibility and costs currency: the apt packages inside a
+# pinned image are as old as the day it was built, and they keep accruing CVEs while the digest
+# stays honest. The other two images never had to reckon with that — they are multi-stage, so the
+# Debian layers of the node base stay in a build stage and are never published. This one publishes
+# its base, so it inherits the base's CVEs.
+#
+# The second Trivy scan this image has ever had found them:
+#
+#     libgnutls30  CVE-2026-33845  CRITICAL  fixed  3.7.9-2+deb12u6 -> 3.7.9-2+deb12u7
+#     libgnutls30  CVE-2026-42010  CRITICAL  fixed  3.7.9-2+deb12u6 -> 3.7.9-2+deb12u7
+#
+# Upgraded by name rather than by a blanket `apt-get upgrade`: the scanner names the package and the
+# fixed version, so the change is bounded and reviewable, where a blanket upgrade would move an
+# unbounded set of packages in an image no one can build locally (no Docker daemon in the agent
+# container — CI is the only place this is exercised).
+#
+# **This is a treadmill and should be named as one.** Every future CRITICAL in the base will red this
+# gate until the shared digest is re-pinned to a newer node:24-slim. That is the correct direction —
+# re-pin, don't accumulate `--only-upgrade` lines — and the digest is shared by all three Dockerfiles
+# (`scripts/check-fragments-version.mjs` B1c), so re-pinning is one coordinated change.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --only-upgrade libgnutls30 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # install just what the converter needs; web-ifc ships its own WASM. Pin to the SAME versions as the

--- a/services/converter/Dockerfile
+++ b/services/converter/Dockerfile
@@ -13,7 +13,28 @@ WORKDIR /app
 ARG FRAGMENTS_VERSION=3.4.7
 ARG WEBIFC_VERSION=0.0.77
 RUN npm init -y >/dev/null 2>&1 \
-    && npm install @thatopen/fragments@${FRAGMENTS_VERSION} web-ifc@${WEBIFC_VERSION}
+    && npm install --no-audit --no-fund \
+       @thatopen/fragments@${FRAGMENTS_VERSION} web-ifc@${WEBIFC_VERSION} \
+    && npm cache clean --force \
+    && rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+              /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /root/.npm
+
+# npm is a BUILD tool here and must not ship. This image is the only single-stage one in the repo:
+# `node:24-slim` is its runtime, so everything the base carries — including npm and the copy of
+# node-tar npm bundles — lands in the published image. The first Trivy scan this file has ever had
+# failed on exactly that:
+#
+#     tar (package.json)  CVE-2026-59873  CRITICAL  fixed  installed 6.2.1  fixed in 7.5.19
+#
+# Nothing in the two lines above installs `tar`; a clean `npm install` of these two packages pulls
+# seven packages and none of them is tar. It is `/usr/local/lib/node_modules/npm/node_modules/tar`,
+# vendored inside npm itself.
+#
+# The other two images never had this problem and never had to solve it either — they are
+# multi-stage, so npm stays in a build stage. `services/api/Dockerfile` takes exactly two things out
+# of its node stage, `/usr/local/bin/node` and `/conv/node_modules`; `apps/web/Dockerfile` ships
+# nginx and copies only `dist`. Removing npm here reaches the same end state: the runtime keeps the
+# `node` binary and the resolved `node_modules`, which is all the ENTRYPOINT below uses.
 
 COPY services/converter /app/services/converter
 


### PR DESCRIPTION
# What & why

Following #340's Node-base fix to its cause. **`services/converter/Dockerfile` was built by nothing** — not on a pull request, not on a push to `main`, not on any event — and it had not been buildable at all since v0.3.936.

Building it for the first time then turned up **three CRITICAL, fixable CVEs in an image `main` publishes to ghcr.**

## 1. The image could not be built

v0.3.936 is titled *"drop root in the converter image"*. It added:

```dockerfile
RUN addgroup -S app && adduser -S -G app app && chown -R app:app /app
```

That is BusyBox/Alpine syntax. The image is `node:24-slim`, which is Debian, and Debian's `adduser` is a Perl script whose short options are Getopt::Long abbreviations:

```
$ addgroup -S app
Option s is ambiguous (shell, stderrmsglevel, stdoutmsglevel, system)
$ adduser -S -G app app
Option s is ambiguous (...)   Option g is ambiguous (gecos, gid, group)
```

Both exit non-zero, so the `RUN` failed and the build stopped. **The hardening that commit describes has never run anywhere, because the image it hardens has never been produced.** The file was never Alpine-based — checked to the initial commit — so it was wrong the day it landed. Now `useradd -m -u 10001 appuser`, the same idiom and uid as `services/api/Dockerfile`.

## 2. Why nothing said so

`ci.yml`'s container matrices listed `api` and `web`. `docker-scope`'s path filter **does** match `services/converter/Dockerfile`, so editing it *triggers* the container jobs — which then build the two images it did not change:

```
apps/web/Dockerfile              filter-matches=True   in-matrix=True
services/api/Dockerfile          filter-matches=True   in-matrix=True
services/converter/Dockerfile    filter-matches=True   in-matrix=False
```

`test_container_pr_gate.py` asked one direction: *does the filter match every Dockerfile in the matrix?* That catches a Dockerfile that **moved**; it cannot catch one that **exists and was never added**, because such a file is in neither list being compared. Its rule 1 anticipated *"a third image added to the publish matrix"* — a third image entering the **matrix**, not a third Dockerfile entering the **repository**.

**Fifth instance of one shape across #340 and this PR** — a check whose population was defined so the failure it exists for could not appear in it:

| gate | population it chose | what that excluded |
|---|---|---|
| `test_lock_satisfies_requirements` (2026-08-01) | `requirements.in` | the floors in `services/data` |
| `test_lock_satisfies_requirements` (2026-08-07) | pin ≥ floor | a floor that is too **low** |
| `docsCurrent.test.ts` (v0.3.1096) | README rows present in the manifest | a row for a **removed** package |
| `check-fragments-version.mjs` (v0.3.1097) | the two version ARGs | the `FROM` line above them |
| `test_container_pr_gate.py` (here) | Dockerfiles in the matrix | a Dockerfile **not** in the matrix |

Four of the five filtered their input by the very thing they were checking it against.

## 3. What the first build found

**Build 1 — the `useradd` fix was correct, the build completed, and Trivy failed it:**

```
tar (package.json)  CVE-2026-59873  CRITICAL  fixed  6.2.1 -> 7.5.19
node-tar: Denial of Service via crafted gzip bomb
```

Nothing this Dockerfile installs is `tar` — a clean `npm install` of these two packages resolves seven, none of them tar (verified by running it). The vulnerable copy is `/usr/local/lib/node_modules/npm/node_modules/tar`, **vendored inside npm**. The converter is the only single-stage image in the repo, so its base *is* its runtime and npm publishes with it; `services/api` lifts only `/usr/local/bin/node` and `/conv/node_modules` out of its node stage, and `apps/web` ships nginx. npm, corepack and the npm cache are now removed in the same layer that uses them.

**Build 2 — node-package scan clean, OS scan failed:**

```
libgnutls30  CVE-2026-33845  CRITICAL  fixed  3.7.9-2+deb12u6 -> deb12u7
libgnutls30  CVE-2026-42010  CRITICAL  fixed  3.7.9-2+deb12u6 -> deb12u7
```

Same cause, one layer down. **A digest pin buys reproducibility and costs currency** — the apt packages inside a pinned image are as old as the day it was built. The other two images never reckon with it because their Debian layers stay in a build stage. Upgraded by name, not a blanket `apt-get upgrade`: the scanner names the package and fixed version, so the change stays bounded in an image nobody can build locally.

**Build 3 — green.** All three container images build and pass the CRITICAL gate.

## The fix

`converter` is in both matrices, so the image is built on every PR that touches a Dockerfile and built, scanned and published on `main`. Rule 3 gains its converse, derived from `git ls-files` so a hardcoded list cannot rot: **every Dockerfile the filter triggers on must be one the matrix actually builds.** Anti-vacuity guarded.

Mutation-verified two ways:

| mutation | result |
|---|---|
| revert both matrices to their previous state (the live defect) | fails the new assertion **and nothing else in the file** — the invisibility claim, as a test result |
| add `converter` to the publish matrix only | fails rule 1 instead |

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `ruff check src/ ../data/src/` clean
- [x] Backend: affected `test_*.py` pass — `test_container_pr_gate`, `test_changelog_current`, `test_claude_md_gates`, `test_file_sizes`. No new test file, so no `run_tests.py` change
- [x] Web: 2,007 tests / 196 files pass; `ci.yml` parses as YAML
- [x] No import cycles introduced — no source module touched
- [x] `CHANGELOG.md` entry added (newest at top)
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` and `package-lock.json` → 0.3.1098
- [x] No secrets; no competitor names

## One thing for you

**The gnutls patch is a treadmill, and I've named it as one in both the Dockerfile and the CHANGELOG.** Every future CRITICAL in the base will red this gate until the shared `node:24-slim` digest is re-pinned to a current build. Re-pinning is the right answer; accumulating `--only-upgrade` lines is not. The digest is shared by all three Dockerfiles and asserted by B1c, so it is one coordinated change when it comes — and Dependabot already proposes those bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the converter service image to automated container builds and pull-request validation.
* **Bug Fixes**
  * Fixed converter image builds by using compatible user creation commands.
  * Addressed reported runtime image security vulnerabilities by upgrading affected system packages and removing unnecessary npm tooling.
* **Release**
  * Updated the application version to 0.3.1098.
* **Tests**
  * Added validation to ensure all relevant Dockerfiles are included in container build checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->