### PR TITLE
v0.3.1099 — the source that gates the build was, for the second time, the source nobody linted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
       - name: Fragments/web-ifc version guard
         run: node scripts/check-fragments-version.mjs
 
+      # The root `scripts/` and `services/converter/src/` were covered by no ESLint config until
+      # v0.3.1099 — `apps/web`'s config reaches `apps/web/scripts/` and cannot reach above its own
+      # base path. The step below is the one that lints the program the step ABOVE runs.
+      - name: Lint (ESLint — root scripts + converter)
+        run: npm run lint
+
       - name: Lint (ESLint)
         run: npm run lint --workspace apps/web
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,16 @@ service"*. So the root `scripts/` was covered by nothing — and it holds
 `scripts/check-fragments-version.mjs`, the program CI runs to gate the fragments/web-ifc pin and, as
 of v0.3.1097, the shared Node base image.
 
-**That is verbatim PR #219's finding of 2026-08-06, one directory up and eleven weeks later:** *"the
+**That is verbatim PR #219's finding of 2026-08-06, one directory up and _nineteen days_ later:** *"the
 only web source nobody linted was the source that gates the build."* Its note is the part that
 matters — the directory was ignored *"rather than a decision anyone made about linting build
 scripts."* An accident of configuration reads, from outside, exactly like a choice.
+
+*(This entry first said "eleven weeks later", which was simply wrong — 2026-08-06 to 2026-08-25 is
+**19 days**. Caught in review. The correction sharpens the point rather than softening it: the same
+structural defect recurred inside three weeks, in a repository that had just written the lesson down.
+A recurrence at eleven weeks is drift; a recurrence at nineteen days is a pattern the prose could not
+prevent — which is the argument for the check.)*
 
 ### Enumerating the population found three more, in the same service as yesterday's
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,22 @@ mutation run is the only thing that told the two drafts apart; their PASS lines 
 Mutation-verified three ways: dropping the converter globs now names all three files, deleting the
 root config fails, and narrowing the population to one tree trips the span guard.
 
+### The check's first CI run failed, on the config that was added with it
+
+`eslint.config.mjs` is tracked JavaScript, and no config linted it — which would have made the root
+ESLint config **the one file in the repository exempt from the rule it exists to enforce.** It now
+appears in its own `files` list.
+
+**The local run had missed it for a reason worth generalising.** The population is `git ls-files`, so
+it contains *tracked* files, and `eslint.config.mjs` had been written but not yet `git add`ed when the
+suite was run. CI checks out a tree where everything is tracked, so it saw immediately what the local
+run structurally could not. The test was right; the local run was under-populated.
+
+**A `git ls-files` gate cannot see the change being made until it is staged**, so a green from one
+before `git add` is weaker than it looks. That applies to most of the gates in this repository —
+`test_claude_md_gates`, `roadmapLanes.test.ts`, `test_file_sizes` and this one all derive their
+population the same way.
+
 ### Also
 
 `npm run lint` at the repo root, wired into CI immediately before the existing web lint — the step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,69 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1099 (2026-08-25) — the source that gates the build was, for the second time, the source nobody linted
+
+Following v0.3.1098's question — *what else is not covered?* — to the linter.
+
+### The gap
+
+`apps/web/eslint.config.js` lints `scripts/**/*.mjs` **relative to its own base path**, so it reaches
+`apps/web/scripts/` and *structurally cannot* reach the repository-root `scripts/`. A flat config
+cannot lint above its own directory; pointing it there fails with *"was not found by the project
+service"*. So the root `scripts/` was covered by nothing — and it holds
+`scripts/check-fragments-version.mjs`, the program CI runs to gate the fragments/web-ifc pin and, as
+of v0.3.1097, the shared Node base image.
+
+**That is verbatim PR #219's finding of 2026-08-06, one directory up and eleven weeks later:** *"the
+only web source nobody linted was the source that gates the build."* Its note is the part that
+matters — the directory was ignored *"rather than a decision anyone made about linting build
+scripts."* An accident of configuration reads, from outside, exactly like a choice.
+
+### Enumerating the population found three more, in the same service as yesterday's
+
+Every tracked `.mjs`/`.js` outside `apps/web` is four files: one in `scripts/`, and
+`services/converter/src/{cli,ifcToFrag,rvtToIfc}.mjs` — **the IFC→Fragments conversion named in the
+first non-negotiable at the top of CLAUDE.md**, read by no linter.
+
+Which makes the converter the least-covered corner of this repository in two independent ways found
+hours apart: **its image was built by no CI job (v0.3.1098) and its source was read by no linter.**
+Neither caused the other. Both are the same absence, and the second was found only because fixing the
+first prompted the question.
+
+The first lint of that source found one issue — `no-useless-escape` on
+`objectName.replace(/[^\w.\-]/g, "_")`, the sanitiser for a filename sent to Autodesk APS. **It is
+cosmetic**: `\-` and `-` are identical inside a character class, verified across 8,192 code points
+with zero behavioural differences before touching it. Reported as what it is rather than dressed up —
+the value here is that a linter now reads these files at all, not that this one found a bug.
+
+### The check, and how its own first draft failed
+
+A recurring gap does not want a third careful config; it wants **a check that fails**.
+`apps/web/src/shell/lintCoverage.test.ts` asserts every tracked JavaScript file resolves an ESLint
+config carrying at least one rule.
+
+**Its first draft ran `eslint . --format json` and treated every path in the output as covered — and
+it passed its own mutation.** Removing `services/converter/src/**` from the root config, reproducing
+the exact defect the file was written for, left those three files linted by nothing and the test
+still went green: ESLint emits a zero-message result for a file it merely *walked past* without
+matching any `files` entry, so *"appears in the output"* and *"had rules applied to it"* are
+different questions, and the draft asked the easier one.
+
+**A measurement whose population quietly includes the failure case — reproduced inside the test
+written to catch that exact shape.** The fix asks ESLint's own config resolution
+(`calculateConfigForFile`) for a rule count, which a file ESLint declined to lint cannot satisfy. The
+mutation run is the only thing that told the two drafts apart; their PASS lines were identical.
+
+Mutation-verified three ways: dropping the converter globs now names all three files, deleting the
+root config fails, and narrowing the population to one tree trips the span guard.
+
+### Also
+
+`npm run lint` at the repo root, wired into CI immediately before the existing web lint — the step
+that lints the program the step above it runs. And `apps/web/public/coi-serviceworker.js` (Guido
+Zuidhof, MIT) joins the excluded list beside `src/vendor/`: third-party source vendored verbatim is
+not ours to restyle. **That entry exists because the check found the file on its first execution.**
+
 ## v0.3.1098 (2026-08-25) — the one Dockerfile no job has ever built, and the hardening that never ran
 
 Following the v0.3.1097 Node-base fix to its cause. **`services/converter/Dockerfile` is built by

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1098",
+    "version": "0.3.1099",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1098",
+  "version": "0.3.1099",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/shell/lintCoverage.test.ts
+++ b/apps/web/src/shell/lintCoverage.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Every tracked JavaScript file in this repository is read by some ESLint config.
+ *
+ * ## Why this exists
+ *
+ * It has now happened twice, in two different directories, for the same structural reason.
+ *
+ * On 2026-08-06 (PR #219) `apps/web/scripts/` was in `ignores`, so — in that PR's own words — **"the
+ * only web source nobody linted was the source that gates the build"**: `check-vite-version.mjs`,
+ * `check-licences.mjs`, `bundle-budget.mjs`. Its note is the part worth keeping: the directory was
+ * ignored *"rather than a decision anyone made about linting build scripts"*. An accident of
+ * configuration reads, from outside, exactly like a choice.
+ *
+ * On 2026-08-25 the same sentence was true one directory up. `apps/web/eslint.config.js` matches
+ * `scripts/**‌/*.mjs` relative to **its own base path**, so it covers `apps/web/scripts/` and
+ * *structurally cannot* reach the repository-root `scripts/` — a flat config cannot lint above its own
+ * directory, and pointing it there fails with "was not found by the project service". So the root
+ * `scripts/` was covered by nothing, and it holds `check-fragments-version.mjs`, the program CI runs
+ * to gate the fragments/web-ifc pin and the shared Node base image.
+ *
+ * Enumerating the population then turned up three more: `services/converter/src/{cli,ifcToFrag,
+ * rvtToIfc}.mjs` — the IFC→Fragments conversion named in the first non-negotiable of CLAUDE.md.
+ *
+ * **The fix for a recurring gap is not a third careful config; it is a check that fails.** A rule held
+ * as prose — "new JS should be linted" — is what drifted twice.
+ *
+ * ## What is asserted, and how the first draft of this file got it wrong
+ *
+ * Coverage is **measured through ESLint's own config resolution**, not inferred from globs: each
+ * tracked file is put to `isPathIgnored` and `calculateConfigForFile`, and counts as covered only if
+ * it is not ignored AND resolves a config carrying at least one rule. ESLint 10 finds the governing
+ * config by walking up from *the file*, so one instance answers for both trees — `apps/web/**`
+ * resolves `apps/web/eslint.config.js`, everything else resolves the root `eslint.config.mjs`.
+ *
+ * **The first draft ran `eslint . --format json` and treated every path in the output as covered.
+ * That draft passed its own mutation.** Removing `services/converter/src/**` from the root config —
+ * reconstructing the exact defect this file was written for — left those three files linted by
+ * nothing, and the test still reported green: ESLint emits a zero-message result for a file it merely
+ * *walked past* without matching any `files` entry, so "appears in the output" and "had rules applied
+ * to it" are different questions, and the draft asked the easier one.
+ *
+ * That is the same shape as everything this check is about — a measurement whose population quietly
+ * includes the failure case — reproduced inside the very test written to catch it. A rule *count*
+ * cannot be satisfied by a file ESLint declined to lint, so that is the question worth asking.
+ * **The mutation run is the only thing that told the difference; the PASS lines were identical.**
+ */
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const REPO = resolve(process.cwd(), "..", "..");
+
+/** Tracked JS the repo deliberately does not lint, each for a reason written where it is excluded. */
+const EXCLUDED = [
+  /^apps\/web\/src\/vendor\//,      // third-party, vendored verbatim (MIT) — see VENDOR.md
+  // coi-serviceworker v0.1.7 (Guido Zuidhof, MIT), vendored verbatim: the COOP/COEP shim that lets
+  // web-ifc's multithreaded WASM use SharedArrayBuffer on GitHub Pages. Same reason as src/vendor/
+  // and the same `ignores` entry (`public/**`) — third-party source is not ours to restyle.
+  // **This entry was written because the check found the file**, not before: the first run of this
+  // test reported it, which is the check doing its job on its own first execution.
+  /^apps\/web\/public\//,
+  /^apps\/web\/dist\//,
+  /^apps\/web\/src-tauri\//,
+  /\.config\.js$/,                  // *.config.js is in apps/web's ignores
+];
+
+const tracked = execFileSync("git", ["ls-files", "*.mjs", "*.js", "*.cjs"],
+  { cwd: REPO, encoding: "utf8", maxBuffer: 1 << 26 })
+  .split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+  .filter((f) => !EXCLUDED.some((re) => re.test(f)));
+
+describe("ESLint coverage", () => {
+  it("has a non-empty population to check — otherwise every assertion here is vacuous", () => {
+    expect(tracked.length, `tracked JS files found: ${tracked.join(", ")}`).toBeGreaterThanOrEqual(10);
+  });
+
+  it("spans both trees, so neither config is being checked alone", () => {
+    // The population must actually reach the root-governed files AND the apps/web-governed ones.
+    // Without this, a `git ls-files` glob that stopped matching one tree would leave the assertion
+    // below true over the other tree alone — green, and blind to exactly one config.
+    expect(tracked.some((f) => f.startsWith("apps/web/")), "no apps/web JS in the population").toBe(true);
+    expect(tracked.some((f) => !f.startsWith("apps/web/")), "no root-tree JS in the population").toBe(true);
+  });
+
+  it("lints every tracked JavaScript file", async () => {
+    const { ESLint } = await import("eslint");
+    const eslint = new ESLint({ cwd: REPO });
+
+    const results = await Promise.all(tracked.map(async (file) => {
+      const abs = resolve(REPO, file);
+      if (await eslint.isPathIgnored(abs)) return [file, 0] as const;
+      const cfg = (await eslint.calculateConfigForFile(abs)) as { rules?: object } | null;
+      return [file, Object.keys(cfg?.rules ?? {}).length] as const;
+    }));
+
+    const uncovered = results.filter(([, n]) => n === 0).map(([f]) => f);
+    expect(uncovered, "these tracked JavaScript files are linted by no ESLint config — add them to "
+      + "eslint.config.mjs at the repo root, or to apps/web's config").toEqual([]);
+  }, 60_000);
+});

--- a/apps/web/src/shell/lintCoverage.test.ts
+++ b/apps/web/src/shell/lintCoverage.test.ts
@@ -43,6 +43,19 @@
  * includes the failure case — reproduced inside the very test written to catch it. A rule *count*
  * cannot be satisfied by a file ESLint declined to lint, so that is the question worth asking.
  * **The mutation run is the only thing that told the difference; the PASS lines were identical.**
+ *
+ * ## A local green that CI was right to reject
+ *
+ * The population is `git ls-files`, so it contains **tracked** files — and on the run that produced
+ * this file's own commit, `eslint.config.mjs` had been written but not yet `git add`ed. It was
+ * therefore invisible to the check locally, and CI, which checks out a tree where everything is
+ * tracked, immediately reported it: the root ESLint config was itself JavaScript that no config
+ * linted, which would have made it the one file in the repository exempt from the rule it exists to
+ * enforce.
+ *
+ * **The test was right and the local run was under-populated.** A `git ls-files` gate does not see
+ * the change being made until it is staged, so a green from it before `git add` is weaker than it
+ * looks — worth knowing for every check in this repository built the same way, which is most of them.
  */
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,12 @@ export default [
     // discovered hours apart: **its image was built by no CI job (v0.3.1098) and its source was read
     // by no linter.** Neither fact caused the other; both are the same absence of coverage, and the
     // second was found only because fixing the first prompted the question "what else is uncovered?"
-    files: ["scripts/**/*.mjs", "scripts/**/*.js",
+    // `eslint.config.mjs` lints ITSELF. It is tracked JavaScript like any other, and leaving it out
+    // would make this file the one piece of JavaScript in the repository exempt from the rule it
+    // exists to enforce. `lintCoverage.test.ts` caught the omission on its first CI run — see the
+    // note there about why a local run did not.
+    files: ["eslint.config.mjs",
+            "scripts/**/*.mjs", "scripts/**/*.js",
             "services/converter/src/**/*.mjs", "services/converter/src/**/*.js"],
     languageOptions: {
       ecmaVersion: "latest",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@
 // source nobody linted.**
 //
 // That is verbatim the finding PR #219 recorded about `apps/web/scripts/` on 2026-08-06, one
-// directory up and eleven weeks later. Its note is worth re-reading rather than paraphrasing: the
+// directory up and NINETEEN DAYS later. Its note is worth re-reading rather than paraphrasing: the
 // directory was ignored "rather than a decision anyone made about linting build scripts" — an
 // accident of configuration that reads, from the outside, exactly like a choice.
 //

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,56 @@
+// ESLint (flat config) for the repository-root `scripts/` directory.
+//
+// `apps/web/eslint.config.js` already lints `scripts/**/*.mjs` — but relative to ITS base path, so it
+// reaches `apps/web/scripts/` and structurally cannot reach this one. Pointing it here fails with
+// "was not found by the project service": a flat config cannot lint above its own directory.
+//
+// So the repo root had a `scripts/` directory that no ESLint config covered, and it holds
+// `check-fragments-version.mjs` — a program CI runs to gate the build (the fragments/web-ifc pin, and
+// as of v0.3.1097 the shared Node base image). **The source that gates the build was, again, the
+// source nobody linted.**
+//
+// That is verbatim the finding PR #219 recorded about `apps/web/scripts/` on 2026-08-06, one
+// directory up and eleven weeks later. Its note is worth re-reading rather than paraphrasing: the
+// directory was ignored "rather than a decision anyone made about linting build scripts" — an
+// accident of configuration that reads, from the outside, exactly like a choice.
+//
+// Type-aware parsing is off for the same reason it is off in that block: these are standalone Node
+// programs run by `node scripts/x.mjs`, not part of any TypeScript compilation unit.
+import js from "@eslint/js";
+import globals from "globals";
+
+export default [
+  // Everything not explicitly selected below is ignored. `js.configs.recommended` carries no `files`
+  // of its own, so applied at top level it lints EVERY file ESLint can reach — which here meant
+  // `services/api/.venv/lib/python3.12/site-packages/coverage/htmlfiles/coverage_html.js`, third-party
+  // browser JS vendored inside a Python virtualenv, reported with hundreds of `no-undef` errors for
+  // `localStorage` and `setTimeout`. A config whose population is "whatever is on disk" finds other
+  // people's files; its rules are scoped to the globs below instead.
+  {
+    ignores: ["**/node_modules/**", "**/.venv/**", "**/site-packages/**", "**/dist/**",
+              "apps/**", "docs/**", ".claude/**"],
+  },
+  {
+    // `services/converter/src/**` is here for the same reason as `scripts/` and was found the same
+    // way: enumerating every tracked `.mjs`/`.js` outside `apps/web` turned up four files, one in
+    // `scripts/` and three that ARE the converter service — `cli.mjs`, `ifcToFrag.mjs`,
+    // `rvtToIfc.mjs`. The IFC→Fragments conversion is a non-negotiable at the top of CLAUDE.md, and
+    // nothing had ever linted it.
+    //
+    // Which makes the converter the least-covered corner of this repository, in two independent ways
+    // discovered hours apart: **its image was built by no CI job (v0.3.1098) and its source was read
+    // by no linter.** Neither fact caused the other; both are the same absence of coverage, and the
+    // second was found only because fixing the first prompted the question "what else is uncovered?"
+    files: ["scripts/**/*.mjs", "scripts/**/*.js",
+            "services/converter/src/**/*.mjs", "services/converter/src/**/*.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: { ...globals.node },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1098",
+      "version": "0.3.1099",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspace apps/web",
-    "build": "npm run build --workspace apps/web"
+    "build": "npm run build --workspace apps/web",
+    "lint": "eslint ."
   },
   "engines": {
     "node": ">=24"

--- a/services/converter/src/rvtToIfc.mjs
+++ b/services/converter/src/rvtToIfc.mjs
@@ -117,7 +117,7 @@ export async function rvtToIfc(rvtBytes, objectName, onStage = () => {}) {
   const token = await getToken();
   const auth = { Authorization: `Bearer ${token}` };
   const bucketKey = process.env.APS_BUCKET || "aec-bim-rvt";
-  const name = objectName.replace(/[^\w.\-]/g, "_");
+  const name = objectName.replace(/[^\w.-]/g, "_");
 
   onStage("bucket");
   await ensureBucket(auth, bucketKey);


### PR DESCRIPTION
# What & why

Following #341's question — *what else is not covered?* — to the linter.

## The gap

`apps/web/eslint.config.js` lints `scripts/**/*.mjs` **relative to its own base path**, so it reaches `apps/web/scripts/` and *structurally cannot* reach the repository-root `scripts/`. A flat config cannot lint above its own directory; pointing it there fails with *"was not found by the project service"*.

So the root `scripts/` was covered by nothing — and it holds `scripts/check-fragments-version.mjs`, the program CI runs to gate the fragments/web-ifc pin and, as of v0.3.1097, the shared Node base image.

**That is verbatim PR #219's finding of 2026-08-06, one directory up and _nineteen days_ later:** *"the only web source nobody linted was the source that gates the build."* Its note is the part that matters — the directory was ignored *"rather than a decision anyone made about linting build scripts."* An accident of configuration reads, from outside, exactly like a choice.

*(This PR first said "eleven weeks later", which was simply wrong; caught in review. The correction sharpens the point rather than softening it — the same structural defect recurred inside three weeks, in a repository that had just written the lesson down. A recurrence at eleven weeks is drift; at nineteen days it is a pattern prose could not prevent, which is the argument for the check.)*

## Enumerating the population found three more, in the same service as #341's

Every tracked `.mjs`/`.js` outside `apps/web` is four files — one in `scripts/`, and `services/converter/src/{cli,ifcToFrag,rvtToIfc}.mjs`, **the IFC→Fragments conversion named in the first non-negotiable at the top of CLAUDE.md**, read by no linter.

Which makes the converter the least-covered corner of this repository in two independent ways found hours apart: **its image was built by no CI job (#341) and its source was read by no linter.** Neither caused the other; both are the same absence, and the second was found only because fixing the first prompted the question.

The first lint of that source found one issue — `no-useless-escape` on `objectName.replace(/[^\w.\-]/g, "_")`, the sanitiser for a filename sent to Autodesk APS. **It is cosmetic**: `\-` and `-` are identical inside a character class, verified across 8,192 code points with zero behavioural differences before touching it. Reported as what it is rather than dressed up — the value is that a linter now reads these files at all, not that this one found a bug.

## The check, and how its own first draft failed

`apps/web/src/shell/lintCoverage.test.ts` asserts every tracked JavaScript file resolves an ESLint config carrying at least one rule.

**Its first draft ran `eslint . --format json` and treated every path in the output as covered — and it passed its own mutation.** Removing `services/converter/src/**` from the root config, reproducing the exact defect the file was written for, left those three files linted by nothing and the test still went green: ESLint emits a zero-message result for a file it merely *walked past* without matching any `files` entry. *"Appears in the output"* and *"had rules applied to it"* are different questions, and the draft asked the easier one.

**A measurement whose population quietly includes the failure case — reproduced inside the test written to catch that exact shape.** It now asks `calculateConfigForFile` for a rule count, which a file ESLint declined to lint cannot satisfy.

| mutation | result |
|---|---|
| drop `services/converter/**` from the root config *(the one the first draft survived)* | fails, naming all three files |
| delete the root config entirely | fails |
| narrow the population to one tree | trips the span guard |

## Then it failed on CI, on the config added with it

`eslint.config.mjs` is itself tracked JavaScript that no config linted — which would have made the root ESLint config **the one file in the repository exempt from the rule it exists to enforce.** Fixed in `8bac895`; it now appears in its own `files` list.

**The local run missed it for a reason worth generalising.** The population is `git ls-files`, so it holds *tracked* files, and `eslint.config.mjs` had been written but not yet `git add`ed when the suite ran. CI checks out a tree where everything is tracked and saw immediately what the local run structurally could not. The test was right; the local run was under-populated.

**A `git ls-files` gate cannot see the change being made until it is staged, so a green from one before `git add` is weaker than it looks.** That applies to most gates here — `test_claude_md_gates`, `roadmapLanes.test.ts`, `test_file_sizes` and this one all derive their population the same way. Verification for the fix commits was run after staging.

## Also

`npm run lint` at the repo root, wired into CI immediately before the existing web lint — the step that lints the program the step above it runs. And `apps/web/public/coi-serviceworker.js` (Guido Zuidhof, MIT) joins the excluded list beside `src/vendor/`: third-party source vendored verbatim is not ours to restyle. **That entry exists because the check found the file on its first execution.**

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `ruff check src/ ../data/src/` clean; `test_changelog_current`, `test_claude_md_gates`, `test_file_sizes`, `test_container_pr_gate` pass. No new Python test, so no `run_tests.py` change
- [x] Web: **2,010 tests / 197 files pass**; `tsc --noEmit` clean; both ESLint runs clean; fragments/Node-base guard green
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added (newest at top)
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` and `package-lock.json` → 0.3.1099
- [x] No secrets; no competitor names

## Note on the one behavioural change

`services/converter/src/rvtToIfc.mjs` is the only non-config source touched, and the edit is provably a no-op. Everything else is configuration, a test, and the changelog.