### PR TITLE
v0.3.1100 — the re-pin the last release said was the right answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1100 (2026-08-25) — the re-pin the last release said was the right answer
+
+v0.3.1098 patched two CRITICAL `libgnutls30` CVEs by name and recorded the fix as a treadmill in the
+same commit: *"every future CRITICAL in the base will red this gate until the shared digest is
+re-pinned to a newer `node:24-slim`. Re-pinning is the right answer and accumulating `--only-upgrade`
+lines is not."* This is that re-pin, two releases later rather than left as a note.
+
+    was  sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0
+    now  sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7ea7fbc29df
+
+All three Dockerfiles move together, which is not diligence but arithmetic: `check-fragments-version.mjs`
+B1c (v0.3.1097) asserts they share one base, tag **and** digest, so a partial re-pin fails the build.
+
+### What is verified, and what is deliberately not
+
+The `--only-upgrade libgnutls30` line is **removed**, and whether the new base already carries
+`3.7.9-2+deb12u7` **could not be checked before pushing.** Stated plainly because the alternative is
+implying a confidence that does not exist: there is no Docker daemon in the agent container, and the
+proxy denies image *blob* fetches (`production.cloudfront.docker.com`, 403 at CONNECT), so the layers
+cannot be read either.
+
+What manifests *do* confirm: the digest resolves, and it still covers `linux/amd64` — the platform
+every Docker build here targets. The new index drops `armv7` and `s390x`, which nothing in this
+repository builds for, and that narrowing is itself consistent with a newer Node build.
+
+So the removal is a **hypothesis with Trivy as its adjudicator**, not a guess dressed as a fix. If the
+CRITICAL returns, the line comes back carrying the scan output as evidence and the treadmill becomes a
+measured fact rather than a prediction. Either outcome is knowledge; leaving a stopgap in place
+indefinitely is the only option that produces none.
+
+**And the scan can answer it at all only because of v0.3.1098.** Before that release this image was in
+no build matrix, so re-pinning its base would have been unfalsifiable — the change would have shipped
+to ghcr with nothing able to contradict it. A gate's first value is catching the defect; its second is
+making the *next* change testable.
+
 ## v0.3.1099 (2026-08-25) — the source that gates the build was, for the second time, the source nobody linted
 
 Following v0.3.1098's question — *what else is not covered?* — to the linter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,17 @@ What manifests *do* confirm: the digest resolves, and it still covers `linux/amd
 every Docker build here targets. The new index drops `armv7` and `s390x`, which nothing in this
 repository builds for, and that narrowing is itself consistent with a newer Node build.
 
-So the removal is a **hypothesis with Trivy as its adjudicator**, not a guess dressed as a fix. If the
-CRITICAL returns, the line comes back carrying the scan output as evidence and the treadmill becomes a
-measured fact rather than a prediction. Either outcome is knowledge; leaving a stopgap in place
-indefinitely is the only option that produces none.
+So the removal was a **hypothesis with Trivy as its adjudicator**, not a guess dressed as a fix. It
+was pushed as one and **CI has since ruled: confirmed.**
+
+    massing-converter:pr (debian 12.15)   debian   0   -
+    Legend:  '0': Clean (no security findings detected)   '-': Not scanned
+
+The `debian` row reads **0**, not `-` — the OS scan ran (Trivy, 10.7 s, outcome success) and found
+nothing, so this is a clean scan rather than an absent one. **And the mechanism is legible in that
+line: `debian 12.15`, where the base this replaces was `debian 12.13`.** Two Debian point releases
+forward is what carries the patched `libgnutls30`; the `--only-upgrade` line was doing by hand what a
+current base does by construction.
 
 **And the scan can answer it at all only because of v0.3.1098.** Before that release this image was in
 no build matrix, so re-pinning its base would have been unfalsifiable — the change would have shipped

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,6 +1,6 @@
 # Build the Vite app, then serve the static bundle with nginx.
 # Build context = repo root (this is an npm workspace: the only lockfile is the root package-lock.json).
-FROM node:24-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS build
+FROM node:24-slim@sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7ea7fbc29df AS build
 WORKDIR /repo
 # Manifests + lockfile first, so `npm ci` is a reproducible, cache-friendly layer that only re-runs when
 # deps change — not on every source edit. `npm ci` (vs `npm install`) installs EXACTLY the locked tree

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1099",
+    "version": "0.3.1100",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1099",
+  "version": "0.3.1100",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1099",
+      "version": "0.3.1100",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -8,7 +8,7 @@
 # Node 24 LTS, same pinned digest as apps/web/Dockerfile — one Node runtime across the product.
 # The previous pin was node:25-slim, an EOL major: no security patches, and a converter runtime out
 # of step with the supported web runtime (both manifests declare engines.node >= 24, CI runs 24).
-FROM node:24-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS converter
+FROM node:24-slim@sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7ea7fbc29df AS converter
 WORKDIR /conv
 ARG FRAGMENTS_VERSION=3.4.7
 ARG WEBIFC_VERSION=0.0.77

--- a/services/converter/Dockerfile
+++ b/services/converter/Dockerfile
@@ -23,10 +23,13 @@ FROM node:24-slim@sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7e
 # CONNECT), so the layers cannot be read either. Manifests resolve, which confirms only that the
 # digest is real and still covers `linux/amd64`.
 #
-# So the `--only-upgrade` line is removed as a **hypothesis under test, with Trivy as the
-# adjudicator** — the scan that v0.3.1098 made possible by putting this image in the build matrix in
-# the first place. If the CRITICAL returns, the line comes back with the scan output as its evidence,
-# and the treadmill is then a measured fact rather than a prediction.
+# So the `--only-upgrade` line was removed as a hypothesis under test, with Trivy as the adjudicator
+# — the scan v0.3.1098 made possible by putting this image in the build matrix in the first place.
+#
+# **CI ruled: confirmed.** `massing-converter:pr (debian 12.15) | debian | 0` — a clean scan, not an
+# absent one ('-' means not scanned; this reads 0). The base this replaces was `debian 12.13`, so two
+# point releases forward is what carries the patched `libgnutls30`: the removed line was doing by hand
+# what a current base does by construction.
 
 WORKDIR /app
 

--- a/services/converter/Dockerfile
+++ b/services/converter/Dockerfile
@@ -5,33 +5,28 @@
 # both converter images together, the api one was reverted to 24 four days later for that reason,
 # and this file was not. `scripts/check-fragments-version.mjs` gates the two ARGs below across
 # both Dockerfiles and stops one line short of the base image.
-FROM node:24-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0
+FROM node:24-slim@sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7ea7fbc29df
 
-# Security updates for the base OS, which a digest pin deliberately freezes.
+# The `libgnutls30` upgrade this file carried is GONE, and the base digest moved instead.
 #
-# Pinning by digest (SEC F4) buys reproducibility and costs currency: the apt packages inside a
-# pinned image are as old as the day it was built, and they keep accruing CVEs while the digest
-# stays honest. The other two images never had to reckon with that — they are multi-stage, so the
-# Debian layers of the node base stay in a build stage and are never published. This one publishes
-# its base, so it inherits the base's CVEs.
+# v0.3.1098 patched two CRITICAL CVEs by name — the only way to fix them without moving the pin, and
+# recorded in the same commit as a treadmill: *"every future CRITICAL in the base will red this gate
+# until the shared digest is re-pinned to a newer node:24-slim. Re-pinning is the right answer and
+# accumulating `--only-upgrade` lines is not."* This is that re-pin.
 #
-# The second Trivy scan this image has ever had found them:
+#     was  sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0
+#     now  sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7ea7fbc29df
 #
-#     libgnutls30  CVE-2026-33845  CRITICAL  fixed  3.7.9-2+deb12u6 -> 3.7.9-2+deb12u7
-#     libgnutls30  CVE-2026-42010  CRITICAL  fixed  3.7.9-2+deb12u6 -> 3.7.9-2+deb12u7
+# **Whether the new base already carries `libgnutls30 3.7.9-2+deb12u7` could not be checked before
+# pushing**, and that is worth stating rather than implying. There is no Docker daemon in the agent
+# container, and the proxy denies image *blob* fetches (`production.cloudfront.docker.com`, 403 at
+# CONNECT), so the layers cannot be read either. Manifests resolve, which confirms only that the
+# digest is real and still covers `linux/amd64`.
 #
-# Upgraded by name rather than by a blanket `apt-get upgrade`: the scanner names the package and the
-# fixed version, so the change is bounded and reviewable, where a blanket upgrade would move an
-# unbounded set of packages in an image no one can build locally (no Docker daemon in the agent
-# container — CI is the only place this is exercised).
-#
-# **This is a treadmill and should be named as one.** Every future CRITICAL in the base will red this
-# gate until the shared digest is re-pinned to a newer node:24-slim. That is the correct direction —
-# re-pin, don't accumulate `--only-upgrade` lines — and the digest is shared by all three Dockerfiles
-# (`scripts/check-fragments-version.mjs` B1c), so re-pinning is one coordinated change.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends --only-upgrade libgnutls30 \
-    && rm -rf /var/lib/apt/lists/*
+# So the `--only-upgrade` line is removed as a **hypothesis under test, with Trivy as the
+# adjudicator** — the scan that v0.3.1098 made possible by putting this image in the build matrix in
+# the first place. If the CRITICAL returns, the line comes back with the scan output as its evidence,
+# and the treadmill is then a measured fact rather than a prediction.
 
 WORKDIR /app
 


### PR DESCRIPTION
# What & why

#341 patched two CRITICAL `libgnutls30` CVEs by name and recorded the fix as a treadmill in the same commit:

> *"every future CRITICAL in the base will red this gate until the shared digest is re-pinned to a newer `node:24-slim`. Re-pinning is the right answer and accumulating `--only-upgrade` lines is not."*

This is that re-pin, rather than the note sitting there until the next CVE forces it.

```
was  sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0
now  sha256:a9f5f7c91a432850b2a8a7797adf5eadb6c733ceed61167806cee7ea7fbc29df
```

All three Dockerfiles move together — not diligence, arithmetic: `check-fragments-version.mjs` B1c (#341) asserts they share one base, tag **and** digest, so a partial re-pin fails the build.

## What is verified, and what deliberately is not

The `--only-upgrade libgnutls30` line is **removed**, and **whether the new base already carries `3.7.9-2+deb12u7` could not be checked before pushing.**

Stated plainly, because the alternative is implying a confidence that does not exist:

- no Docker daemon in the agent container, so the image cannot be built or run;
- the proxy denies image **blob** fetches — `production.cloudfront.docker.com`, 403 at CONNECT — so the layers cannot be read either.

What manifests *do* confirm: the digest resolves, and it still covers `linux/amd64`, the platform every Docker build here targets. The new index drops `armv7` and `s390x`, which nothing in this repository builds for, and that narrowing is itself consistent with a newer Node build.

So the removal is a **hypothesis with Trivy as its adjudicator**, not a guess dressed as a fix:

| Trivy outcome | what it means | what happens |
|---|---|---|
| clean | the new base carries `deb12u7` | the treadmill is retired, and the stopgap is gone with it |
| CRITICAL returns | it does not | the line comes back carrying the scan output as evidence, and the treadmill is measured fact rather than prediction |

Either outcome is knowledge. Leaving a stopgap in place indefinitely is the only option that produces none.

**And the scan can answer it at all only because of #341.** Before that PR this image was in no build matrix, so re-pinning its base would have been *unfalsifiable* — the change would have shipped to ghcr with nothing able to contradict it. A gate's first value is catching the defect; its second is making the next change testable.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `test_changelog_current`, `test_container_pr_gate`, `test_claude_md_gates` pass. No Python source touched, so no `run_tests.py` change
- [x] Web: `tsc --noEmit` clean; root and web ESLint clean; shell suite 384 tests / 27 files
- [x] The base-image gate (`check-fragments-version.mjs` B1c) passes — all three Dockerfiles agree on tag and digest
- [x] No import cycles introduced — no source module touched
- [x] `CHANGELOG.md` entry added (newest at top)
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` and `package-lock.json` → 0.3.1100
- [x] No secrets; no competitor names

## Left in draft on purpose

The one thing this PR asserts is the thing only CI can check. It goes ready for review once the container scan has ruled — same reason #341 was drafted, and the same reason it earned its keep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to 0.3.1100.

* **Security & Maintenance**
  * Refreshed pinned container images to include current base-image updates.
  * Removed a redundant package upgrade step.
  * Verified the Debian-based image with a Trivy security scan.

* **Documentation**
  * Added release notes covering image updates, platform coverage, and security verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->