### PR TITLE
v0.3.1106 — sheet markups were keyed on a name the user can change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1106 (2026-08-26) — markups were keyed on a name the user can change
+
+R36-VIEWER-SUBAPP's sprint row asks for a premise-check before starting. This is the third row in a
+row whose premise-check found the row wrong, and the first where what it found was a live defect
+rather than a stale sentence.
+
+**Slice 6 shipped keyed on the storey NAME.** Both surfaces — the Drawings room and the viewer's plan
+pane — stored sheet markups under `plan:<storeyName>`. Rename a level and every pin on it orphans
+silently: the plan renders, nothing is marked, and it reads as *"there was never anything here."*
+
+What makes it worth writing down is how thoroughly the correct answer was already present:
+
+* **the roadmap entry specified it** — *"keying on the storey NAME would look natural and is wrong…
+  the key is the storey's GlobalId"*, three paragraphs above the shipped code;
+* **the first non-negotiable says it** — reference by IFC GlobalId, never a transient id;
+* **the payload always carried it** — `storey_elevations` returns `{name, elevation, guid}` from
+  `s.GlobalId`, through `drawingStoreys` and `modelGrid` alike;
+* **the client type had been widened to expose it for this exact fix**, with a comment arguing
+  against declaring it optional because *"that is precisely where a `?? level.name` fallback gets
+  written, reintroducing the rename orphan this field exists to prevent."*
+
+Four statements of the right answer, and the code did the other thing. **A specification written in
+the same entry as the work is not a check on the work — only a test is.** So the fallback that
+comment predicted is now a test that fails when it is written.
+
+**The key is `plan:<storeyGuid>`.** `modelGrid` already served `levels[].guid`; the level `<select>`
+now carries it, and it reaches `PlanPane` as an accessor rather than a value, for the reason
+`drawingsSection.ts` documents — a value freezes at panel-build time, before any level exists.
+
+**Nothing already stored disappears.** The pre-GUID key is read alongside the new one and merged.
+Switching the key without that would have "fixed" the bug by hiding every markup already saved, which
+is the same data loss arriving through the front door. Nothing is written to the legacy key and
+nothing is rewritten.
+
+**Residual limitation, stated rather than buried:** a markup created before this release is still
+name-keyed and still orphans if its level is renamed. Rekeying it needs a name→GlobalId map that only
+the source IFC holds, so it is a backfill rather than a code change. Every new markup is immune.
+
+The test stub was part of the defect's cover. It ignored the key and served the same rows for every
+id — modelling an API that does not exist, since `sheet_id` is a column — so the legacy read appeared
+to double every pin. Fixed by making the stub key-aware rather than by adding a dedupe to the layer,
+which would have hidden the unrealistic fixture behind correct-looking code. Both halves are
+mutation-checked: reverting the key fails six tests, and re-adding `?? activeStorey()` fails the one
+written for it.
+
 ## v0.3.1105 (2026-08-26) — a saved view that cannot be replayed is worse than one that was refused
 
 Review follow-up on R22-REPORT-BUILDER. `validate_view_config`'s docstring promised that **a view is

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1105",
+    "version": "0.3.1106",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1105",
+  "version": "0.3.1106",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/drawings/drawings.test.ts
+++ b/apps/web/src/drawings/drawings.test.ts
@@ -20,6 +20,9 @@ interface FakeOpts {
   storeys?: Array<{ name: string | null; elevation: number; guid: string }>;
   pins?: unknown[];
   takeoff?: unknown[];
+  /** Markups stored under the PRE-GUID key `plan:<storeyName>` — read-only legacy rows. */
+  legacyPins?: unknown[];
+  legacyTakeoff?: unknown[];
   failStoreys?: boolean;
   failMarkup?: boolean;
 }
@@ -44,9 +47,21 @@ function mount(opts: FakeOpts = {}) {
       if (opts.failStoreys) throw new Error("no source IFC");
       return opts.storeys ?? [{ name: "L1", elevation: 0, guid: "g1" }];
     },
+    // KEY-AWARE on purpose. This stub used to ignore `id` and serve the same rows for every key,
+    // which modelled an API that does not exist: `sheet_id` is a column, so two keys never return
+    // the same row. That mattered the moment plans gained a legacy key — the layer reads
+    // `plan:<guid>` and `plan:<name>`, and a key-blind stub reported every pin twice, which looks
+    // exactly like a merge bug in code that is correct.
     drawingMarkup: async (_pid: string, id: string) => {
       calls.push(`markup:${id}`);
       if (opts.failMarkup) throw new Error("markup down");
+      const base = id.replace(/#pdf$/, "");
+      const storeys = opts.storeys ?? [{ name: "L1", elevation: 0, guid: "g1" }];
+      // The pre-GUID form for this project's storeys. Derived from the same list the sheet builder
+      // uses, so renaming the fixture cannot make the two disagree.
+      if (storeys.some((st) => base === `plan:${st.name}`)) {
+        return (id.endsWith("#pdf") ? opts.legacyTakeoff : opts.legacyPins) ?? [];
+      }
       return (id.endsWith("#pdf") ? opts.takeoff : opts.pins) ?? [];
     },
     markupStream: (_pid: string, _cb: () => void) => {
@@ -155,6 +170,44 @@ describe("the markup layer, as it behaves today", () => {
     await ui.open();
     await settle();
     // t2 has no `nx`, so it cannot be placed and is dropped.
+    expect(host.querySelectorAll(".dwg-pin")).toHaveLength(2);
+  });
+
+  // R36 premise-check, 2026-08-26. Slice 6 shipped keyed on the storey NAME. The entry itself had
+  // specified the GlobalId ("levels can be renamed here, and every markup on that level would orphan
+  // silently"), the project's first non-negotiable says the same, and `drawingStoreys` had been
+  // serving `guid` beside `name` all along. The key was the one thing that did not follow.
+  it("keys a storey plan's markups on the storey GUID, never its renameable name", async () => {
+    const { ui, calls } = mount({ storeys: [{ name: "Level 1", elevation: 0, guid: "3aB7xQ" }] });
+    await ui.open();
+    await settle();
+    const keys = calls.filter((c) => c.startsWith("markup:") && !c.endsWith("#pdf"));
+    expect(keys, "the GUID is the key new markups are written under").toContain("markup:plan:3aB7xQ");
+  });
+
+  it("still reads markups stored under the pre-GUID name key, so none disappear", async () => {
+    const { ui, host, calls } = mount({
+      storeys: [{ name: "Level 1", elevation: 0, guid: "3aB7xQ" }],
+      pins: [{ id: "new", data: {} }],
+      legacyPins: [{ id: "old", data: {} }],
+    });
+    await ui.open();
+    await settle();
+    expect(calls.filter((c) => c.startsWith("markup:"))).toContain("markup:plan:Level 1");
+    // Both sources on one surface. Switching the key WITHOUT this read would have "fixed" the
+    // rename bug by hiding every markup already stored, which is the same data loss by other means.
+    expect(host.querySelectorAll(".dwg-pin"), "the new GUID-keyed pin and the legacy one").toHaveLength(2);
+  });
+
+  // The inverse. Reading two keys is only correct if it does not double-count: a stub that served
+  // every key the same rows reported 4 pins for 2 and looked exactly like this feature misbehaving.
+  it("does not double-count when the legacy key holds nothing", async () => {
+    const { ui, host } = mount({
+      storeys: [{ name: "Level 1", elevation: 0, guid: "3aB7xQ" }],
+      pins: [{ id: "p1", data: {} }, { id: "p2", data: {} }],
+    });
+    await ui.open();
+    await settle();
     expect(host.querySelectorAll(".dwg-pin")).toHaveLength(2);
   });
 

--- a/apps/web/src/drawings/drawings.ts
+++ b/apps/web/src/drawings/drawings.ts
@@ -20,6 +20,13 @@ interface DrawingsHost {
 
 interface Sheet {
   id: string;                 // stable key (also the markup key)
+  /**
+   * The pre-GUID markup key, when this sheet used to have a different one. Read-only: markups found
+   * under it are shown, nothing is written or moved there. Only storey plans have one — they were
+   * keyed `plan:<storeyName>` until the R36 premise-check found that a rename orphans every pin on
+   * the level, against the GlobalId non-negotiable.
+   */
+  legacyId?: string;
   label: string;
   type: "plan" | "elevation" | "section" | "sheet";
   path: string;               // SVG endpoint (query string included)
@@ -121,7 +128,11 @@ export class DrawingsUI {
     try { storeys = await this.host_.api.drawingStoreys(pid); } catch { /* no source IFC */ }
     for (const s of storeys) {
       const q = pq({ elevation: s.elevation, cut_height: 1.2, title: `PLAN - ${s.name}` });
-      sheets.push({ id: `plan:${s.name}`, label: `Plan — ${s.name}`, type: "plan",
+      // Keyed on the storey's IFC GlobalId, never its name. `drawingStoreys` has always returned
+      // `guid` beside `name`; keying on the name meant a level rename silently orphaned every markup
+      // on it. The LABEL still shows the name, because that is what a person reads.
+      sheets.push({ id: `plan:${s.guid}`, legacyId: `plan:${s.name}`,
+                    label: `Plan — ${s.name}`, type: "plan",
                     path: `/projects/${pid}/drawings/plan.svg?${q}` });
     }
     for (const d of DIRS) {
@@ -313,6 +324,7 @@ export class DrawingsUI {
       api: this.host_.api,
       projectId: () => this.host_.projectId(),
       sheetId: () => this.current?.id ?? null,
+      legacySheetId: () => this.current?.legacyId ?? null,
       setStatus: (m) => this.host_.setStatus(m),
       // This room reveals in BOTH places: the 3D viewer selects the element and the plan lights it.
       onReveal: (g) => { selectInViewer(g); syncPlanHighlight(this.svgHost, g); },

--- a/apps/web/src/drawings/markupLayer.ts
+++ b/apps/web/src/drawings/markupLayer.ts
@@ -59,8 +59,28 @@ export interface MarkupLayerDeps {
   readonly getScale: () => number;
   readonly api: MarkupApi;
   readonly projectId: () => string | null;
-  /** The markup key for what is on screen — `plan:L1`, `elev:north`… `null` when nothing is shown. */
+  /**
+   * The markup key for what is on screen — `plan:<storeyGuid>`, `elev:north`… `null` when nothing
+   * is shown. **New markups are always written under this key.**
+   */
   readonly sheetId: () => string | null;
+  /**
+   * The pre-GUID key the same surface used to be stored under, READ-ONLY and merged into the
+   * displayed set. `null` when there is no legacy form (elevations and sections were never keyed on
+   * a renameable thing).
+   *
+   * Storey plans were keyed `plan:<storeyName>` until the R36 premise-check found that keying markup
+   * on a renameable name orphans every pin on the level the moment somebody renames it — against the
+   * project's first non-negotiable, *reference by GlobalId, never a transient id*. Switching the key
+   * without reading the old one would have "fixed" the bug by hiding every markup already stored,
+   * which is the same data loss arriving through the front door.
+   *
+   * Nothing is written here and nothing is rewritten: a markup stored under the legacy key stays
+   * there and stays visible. **The residual limitation is real and stated rather than hidden** — a
+   * pin created before this change still orphans if its level is renamed, because rekeying it needs
+   * a name→GlobalId map that only the source IFC holds. New pins are immune from here on.
+   */
+  readonly legacySheetId?: () => string | null;
   readonly setStatus: (message: string) => void;
   /** Called after every render with the number of markups, for a host that shows a count. */
   readonly onCount?: (n: number) => void;
@@ -99,12 +119,24 @@ export class MarkupLayer {
     const pid = this.d.projectId();
     const id = this.d.sheetId();
     if (!pid || !id) { this.items = []; this.render(); return; }
+    // The legacy key is read only when it is genuinely a DIFFERENT key. Comparing rather than
+    // assuming matters: a host that wires `legacySheetId` to the same accessor as `sheetId` would
+    // otherwise fetch every markup twice and render each pin twice, which reads as duplicated work
+    // by the user rather than as a bug in the wiring.
+    const legacyKey = ((k) => (k && k !== id ? k : null))(this.d.legacySheetId?.() ?? null);
+    const none = Promise.resolve([] as DrawingMarkupItem[]);
     try {
-      const [pins, takeoff] = await Promise.all([
+      // The PRIMARY fetch is the only one without a catch, deliberately: an unreachable API still
+      // empties the layer exactly as it did before the legacy read existed. Both legacy fetches
+      // swallow their own failures, so a missing or unreadable legacy key can never take down the
+      // markups that are stored correctly.
+      const [pins, takeoff, oldPins, oldTakeoff] = await Promise.all([
         this.d.api.drawingMarkup(pid, id),
         this.d.api.drawingMarkup(pid, `${id}#pdf`).catch(() => [] as DrawingMarkupItem[]),
+        legacyKey ? this.d.api.drawingMarkup(pid, legacyKey).catch(() => []) : none,
+        legacyKey ? this.d.api.drawingMarkup(pid, `${legacyKey}#pdf`).catch(() => []) : none,
       ]);
-      this.items = placeable(pins, takeoff);
+      this.items = placeable([...pins, ...oldPins], [...takeoff, ...oldTakeoff]);
     } catch {
       this.items = [];                 // see the header: a legible drawing beats an error banner
     }

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -894,6 +894,11 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   let cadPick: ((at: readonly [number, number]) => boolean) | null = null;
   let activeStorey: string | null = null;       // name passed to Draft recipes; sets the work-plane Z
   let activeStoreyZ = 0;
+  // The active level's IFC GlobalId — the markup key for its plan. Tracked BESIDE the name rather
+  // than instead of it: Draft recipes and the AI author take the human name, markups take the GUID.
+  // `modelGrid` has served `levels[].guid` since it shipped; nothing here read it until R36's
+  // premise-check found markups keyed on the renameable name.
+  let activeStoreyGuid: string | null = null;
   // R38-SYNC-VIEW + R38-SYNC-SELECT — the plan docked beside the model, following the active level,
   // and now selection-synced both ways: PLAN-IDENTITY carried the GlobalId through the bake, the
   // SVG carries it as data-guid, so a click on plan linework is a real selection and a 3D pick
@@ -902,6 +907,9 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     url: (p) => api.url(p),
     projectId: () => projectId,
     activeStorey: () => activeStorey,
+    // Accessor, not a value: `activeStoreyGuid` is a `let` reassigned by the level selector, and the
+    // pane is built before any level exists.
+    activeStoreyGuid: () => activeStoreyGuid,
     notify,
     onPick: (guid) => { void selectByGuid(guid, true); },
     headers: () => api.authHeaders(), markupApi: api,   // R36 slice 6: pins on the Sheets canvas
@@ -1872,6 +1880,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
       const applyLevel = () => {
         const opt = levelSel.selectedOptions[0]; if (!opt) return;
         activeStorey = opt.dataset.name || null; activeStoreyZ = Number(opt.dataset.z || 0);
+        activeStoreyGuid = opt.dataset.guid || null;
         groundPlane.constant = -activeStoreyZ;                       // draft on the active level's plane
         if (gridOverlay.data) gridOverlay.set(gridOverlay.data, activeStoreyZ);
         setStatus(`active level: ${activeStorey ?? "—"} (Z ${activeStoreyZ.toFixed(2)} m)`);
@@ -1886,7 +1895,8 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
           for (const lv of g.levels) {
             const o = document.createElement("option");
             o.textContent = `${lv.name ?? "Level"} (${lv.elevation.toFixed(2)} m)`;
-            o.dataset.name = lv.name ?? ""; o.dataset.z = String(lv.elevation); levelSel.appendChild(o);
+            o.dataset.name = lv.name ?? ""; o.dataset.z = String(lv.elevation);
+            o.dataset.guid = lv.guid; levelSel.appendChild(o);
           }
           if (g.levels.length) applyLevel();
           status.textContent = `grid: ${g.grid.source} · ${g.grid.axes.length} axes · `

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -893,12 +893,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   // Set when the CAD bar mounts; a viewport click answers an armed point prompt through it.
   let cadPick: ((at: readonly [number, number]) => boolean) | null = null;
   let activeStorey: string | null = null;       // name passed to Draft recipes; sets the work-plane Z
-  let activeStoreyZ = 0;
-  // The active level's IFC GlobalId — the markup key for its plan. Tracked BESIDE the name rather
-  // than instead of it: Draft recipes and the AI author take the human name, markups take the GUID.
-  // `modelGrid` has served `levels[].guid` since it shipped; nothing here read it until R36's
-  // premise-check found markups keyed on the renameable name.
-  let activeStoreyGuid: string | null = null;
+  let activeStoreyZ = 0; let activeStoreyGuid: string | null = null;   // GUID: the plan's markup key (names are renameable)
   // R38-SYNC-VIEW + R38-SYNC-SELECT — the plan docked beside the model, following the active level,
   // and now selection-synced both ways: PLAN-IDENTITY carried the GlobalId through the bake, the
   // SVG carries it as data-guid, so a click on plan linework is a real selection and a 3D pick
@@ -906,10 +901,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   const planPane = new PlanPane({
     url: (p) => api.url(p),
     projectId: () => projectId,
-    activeStorey: () => activeStorey,
-    // Accessor, not a value: `activeStoreyGuid` is a `let` reassigned by the level selector, and the
-    // pane is built before any level exists.
-    activeStoreyGuid: () => activeStoreyGuid,
+    activeStorey: () => activeStorey, activeStoreyGuid: () => activeStoreyGuid,
     notify,
     onPick: (guid) => { void selectByGuid(guid, true); },
     headers: () => api.authHeaders(), markupApi: api,   // R36 slice 6: pins on the Sheets canvas
@@ -1879,8 +1871,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
       levelSel.style.cssText = "width:100%;margin:4px 0"; levelSel.setAttribute("aria-label", "Active level");
       const applyLevel = () => {
         const opt = levelSel.selectedOptions[0]; if (!opt) return;
-        activeStorey = opt.dataset.name || null; activeStoreyZ = Number(opt.dataset.z || 0);
-        activeStoreyGuid = opt.dataset.guid || null;
+        activeStorey = opt.dataset.name || null; activeStoreyZ = Number(opt.dataset.z || 0); activeStoreyGuid = opt.dataset.guid || null;
         groundPlane.constant = -activeStoreyZ;                       // draft on the active level's plane
         if (gridOverlay.data) gridOverlay.set(gridOverlay.data, activeStoreyZ);
         setStatus(`active level: ${activeStorey ?? "—"} (Z ${activeStoreyZ.toFixed(2)} m)`);
@@ -1895,8 +1886,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
           for (const lv of g.levels) {
             const o = document.createElement("option");
             o.textContent = `${lv.name ?? "Level"} (${lv.elevation.toFixed(2)} m)`;
-            o.dataset.name = lv.name ?? ""; o.dataset.z = String(lv.elevation);
-            o.dataset.guid = lv.guid; levelSel.appendChild(o);
+            o.dataset.name = lv.name ?? ""; o.dataset.z = String(lv.elevation); o.dataset.guid = lv.guid; levelSel.appendChild(o);
           }
           if (g.levels.length) applyLevel();
           status.textContent = `grid: ${g.grid.source} · ${g.grid.axes.length} axes · `

--- a/apps/web/src/viewer/planPane.test.ts
+++ b/apps/web/src/viewer/planPane.test.ts
@@ -120,6 +120,59 @@ describe("syncPlanHighlight — one element is MANY loops", () => {
   });
 });
 
+describe("the markup key is the storey's GlobalId", () => {
+  /**
+   * R36 premise-check, 2026-08-26. This pane keyed its markups `plan:<activeStorey()>` — the human
+   * level NAME — so renaming a level orphaned every pin on it. The GUID was already reachable:
+   * `modelGrid` serves `levels[].guid` and its own type comment says why it matters, warning in
+   * as many words against the `?? level.name` fallback that would put the bug back.
+   */
+  function keysFetched(deps: { storey: string | null; guid?: string | null }) {
+    const asked: string[] = [];
+    const svg = '<svg data-plan-scale="1" data-plan-ox="0" data-plan-oy="0" '
+      + 'data-plan-minx="0" data-plan-miny="0" data-plan-drawh="10"></svg>';
+    vi.stubGlobal("fetch", async () => new Response(svg, { status: 200 }));
+    const pane = new PlanPane({
+      url: (p) => p, projectId: () => "p1",
+      activeStorey: () => deps.storey,
+      activeStoreyGuid: deps.guid === undefined ? undefined : () => deps.guid ?? null,
+      notify: () => {},
+      markupApi: {
+        drawingMarkup: async (_pid: string, id: string) => { asked.push(id); return []; },
+        promoteDrawingMarkup: async () => ({ topic: { title: "t" } }),
+        deleteDrawingMarkup: async () => undefined,
+      },
+    });
+    document.body.appendChild(pane.el);
+    pane.dock("full");
+    return { pane, asked };
+  }
+
+  it("asks for the GUID key, not the name", async () => {
+    const { pane, asked } = keysFetched({ storey: "Level 1", guid: "3aB7xQ" });
+    await pane.refresh(true);
+    expect(asked, "the key new markups are written under").toContain("plan:3aB7xQ");
+    vi.unstubAllGlobals();
+  });
+
+  it("also reads the pre-GUID name key, so existing pins still show", async () => {
+    const { pane, asked } = keysFetched({ storey: "Level 1", guid: "3aB7xQ" });
+    await pane.refresh(true);
+    expect(asked).toContain("plan:Level 1");
+    vi.unstubAllGlobals();
+  });
+
+  // The important negative. A host that has not wired the GUID must show NOTHING rather than fall
+  // back to the name — a fallback would be indistinguishable from the fixed code while carrying the
+  // exact defect, and it is the one line the client type's comment predicted somebody would write.
+  it("shows no pins at all when the host has not wired a GUID — it does not fall back to the name", async () => {
+    const { pane, asked } = keysFetched({ storey: "Level 1" });
+    await pane.refresh(true);
+    expect(asked, "no markup fetch is better than one keyed on a renameable name").toEqual([]);
+    vi.unstubAllGlobals();
+  });
+});
+
 describe("ground cursor survives an SVG refresh", () => {
   it("re-paints the last ground point after the drawing is replaced", async () => {
     const svg = '<svg data-plan-scale="1" data-plan-ox="0" data-plan-oy="0" '

--- a/apps/web/src/viewer/planPane.ts
+++ b/apps/web/src/viewer/planPane.ts
@@ -105,6 +105,17 @@ export interface PlanPaneDeps {
   projectId: () => string | null;
   /** The storey the modeler is working in, or null for the whole model. */
   activeStorey: () => string | null;
+  /**
+   * The active storey's IFC GlobalId — the markup key. An ACCESSOR for the same reason
+   * `activeStorey` is one: both are `let` in `app.ts` and change with the level selector, so a value
+   * would freeze at panel-build time, before any level exists.
+   *
+   * Optional so a host that has not wired it keeps the pane it had; without it the pane shows no
+   * pins rather than falling back to the name. **The fallback is what is being removed** — keying on
+   * a renameable name is what orphaned markups on rename, and `?? activeStorey()` here would
+   * reintroduce it in the one place nobody would look.
+   */
+  activeStoreyGuid?: () => string | null;
   notify: (msg: string, kind: "info" | "success" | "error") => void;
   /** SYNC-SELECT: a click on identified linework names an element; the viewer selects it. */
   onPick?: (guid: string) => void;
@@ -148,9 +159,11 @@ export class PlanPane {
       getScale: () => this.zoomPct / 100,
       api,
       projectId: () => this.d.projectId(),
-      // The same key the Drawings room writes: `plan:<storey>`. A pane showing the whole model has no
-      // sheet to key against, so it shows no pins rather than guessing one.
-      sheetId: () => { const st = this.d.activeStorey(); return st ? `plan:${st}` : null; },
+      // The same key the Drawings room writes: `plan:<storeyGuid>`. A pane showing the whole model
+      // has no sheet to key against, so it shows no pins rather than guessing one.
+      sheetId: () => { const g = this.d.activeStoreyGuid?.(); return g ? `plan:${g}` : null; },
+      // Read-only, so markups stored before the key became a GlobalId still appear here.
+      legacySheetId: () => { const st = this.d.activeStorey(); return st ? `plan:${st}` : null; },
       setStatus: (m) => this.d.notify(m, "info"),
       // The pane already has a pick handler and its own highlighter — it does not need the viewer
       // hook the Drawings room uses, which is precisely why this is injected rather than imported.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -655,7 +655,7 @@ entry demanded a premise-check before starting. **That is now the first line of 
 | # | Sprint | Why here | Size | Premise to check FIRST |
 |---|---|---|---|---|
 | 1 | ~~**A correctness sweep** — refill Band 1~~ **DONE 2026-08-25 (v0.3.1091–1095)** | **Struck rather than deleted, because the prediction is the part worth checking.** All three axes it named were run: **authz** (43 routes, no live hole, `services/api/test_resource_id_authz.py` is the finding), **concurrency** (a 500 on concurrent first sign-in at all three SSO doors), **money** (52 of 399 JV distribution periods whose parts did not sum to their own total). Its premise-check was the load-bearing part — "pick the axis before starting" is what made two of the three produce a defect. Records in §Band 1 above. | M | — |
-| 2 | ~~**R22-REPORT-BUILDER — items 2–5**~~ **COMPLETE 2026-08-26 (v0.3.1101–1104)** | All four remaining items shipped: a validated config schema (which exposed a live alert miscount), shareable views, cross-module reports along declared reference edges, and one report catalog. **The premise-check this row demanded is what found that FOUR remained rather than three** — the row was written when the entry listed four items and was never re-derived after it grew to five. Full record in [`roadmap-completed.md`](roadmap-completed.md). | S/M → M/L | — |
+| 2 | ~~**R22-REPORT-BUILDER — items 2–5**~~ **COMPLETE 2026-08-26 (v0.3.1101–1105)** | All four remaining items shipped: a validated config schema (which exposed a live alert miscount), shareable views, cross-module reports along declared reference edges, and one report catalog. **The premise-check this row demanded is what found that FOUR remained rather than three** — the row was written when the entry listed four items and was never re-derived after it grew to five. Full record in [`roadmap-completed.md`](roadmap-completed.md). | S/M → M/L | — |
 | 3 | **R36-VIEWER-SUBAPP** — the canvas switches 2D/3D in place, including PRINT | The remaining half of the rail arc, and a **user directive** rather than an agent's idea — the rooms "must each be a product". It is also the largest thing standing between the drawing surface and the roadmap's own headline judgement at the top of this file: *what is thin now is the drawing*. | L | The R43 collision. `@massing/embed` was evaluated and **declined** on 2026-08-23 for an architectural reason (its load path is IFC text into a browser tessellator, against two non-negotiables), and two breaking changes are still coming: async viewport creation, and add/remove replacing `showModel`. Build behind the existing seams, not into `apps/web/src/viewer/app.ts`. |
 
 **Why not the obvious candidates.** Stated so that disagreeing with the omission is as cheap as
@@ -2483,7 +2483,10 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
   element is a property of the surface, not of the markup**, and a layer that reached for one host's
   hook could only ever be mounted where that hook was right.
 
-  **Re-checked 2026-08-23 — slice 6 is still open, and "an INTEGRATION, not a build" understates it.**
+  **Re-checked 2026-08-23 — slice 6 was still open THEN, and "an INTEGRATION, not a build" understated
+  it.** *(Past tense as of 2026-08-26: it shipped in v0.3.1071, which the ✅ line above records. Left
+  in place because its prediction was right and that is the part worth keeping — but re-read it as
+  history, not as status. This entry has now had a stale present-tense paragraph twice.)*
   The five client methods and their callers are all present, exactly as measured. But every caller
   lives inside the `DrawingsRoom` class in `apps/web/src/drawings/drawings.ts`, and the markup layer
   is *class state coupled to that room's DOM* — `markupOn`, the `markup[]` array, `buildToolbar()`,
@@ -2507,8 +2510,22 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
   the codebase already namespaces markup stores by suffix, so `plan:<storeyGuid>` fits the pattern
   that is there.
 
+  **PREMISE-CHECK 2026-08-26, before starting the sprint row — and it found the row's own subject
+  half-wrong.** Slice 6 had shipped, so "and slice 6 as specified above" was stale here too. But it
+  shipped **keyed on the storey NAME**, which this entry had specified against three paragraphs
+  earlier (*"keying on the storey NAME would look natural and is wrong"*), which the project's first
+  non-negotiable forbids, and which `drawingStoreys` had never required — it has served `guid` beside
+  `name` since it shipped. `apps/web/src/api/authoring.ts` had even been widened to expose
+  `levels[].guid` **for this exact purpose**, with a comment warning against the `?? level.name`
+  fallback. The groundwork was laid and the consumer never used it. *A specification written in the
+  same entry as the work is not a check — only a test is.* Fixed in v0.3.1106: the key is
+  `plan:<storeyGuid>`, the pre-GUID key is read so nothing already stored disappears, and the
+  forbidden fallback is now a failing test in `apps/web/src/viewer/planPane.test.ts`.
+
   Remaining: the **keynote → spec section** link (the spec surface now exists; keynotes do not yet
-  carry their section code), and slice 6 as specified above. **Print paper picker (v0.3.993):**
+  carry their section code). **One residual limitation, stated rather than buried:** a markup created
+  before v0.3.1106 is still name-keyed and still orphans on rename — rekeying it needs a
+  name→GlobalId map only the source IFC holds, so it is a backfill, not a code change. **Print paper picker (v0.3.993):**
   Issue / Sheet PDF / Place and the paper-space editor share `drawings.py` `PAGES` — ARCH-C/D/B/A and
   ISO A0–A4. Default is **ARCH-C (24×18 in)**; that is not an ISO A size. ARCH-D is full-size US
   CDs (36×24), ARCH-B is half of D, ARCH-A is the next ARCH step (often called quarter of D).

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1105",
+      "version": "0.3.1106",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
# What & why

R36-VIEWER-SUBAPP's sprint row asks for a premise-check before starting. **This is the third row running whose premise-check found the row wrong — and the first where it found a live defect rather than a stale sentence.**

## The defect

Slice 6 shipped keyed on the storey **NAME**. Both surfaces — the Drawings room and the viewer's plan pane — stored sheet markups under `plan:<storeyName>`.

Rename a level, and every pin on it orphans silently. The plan renders, nothing is marked, and it reads as *"there was never anything here"* — the failure shape this codebase keeps meeting.

## What makes it worth writing down

The correct answer was already present **four times over**:

| where | what it said |
|---|---|
| the roadmap entry, 3 paragraphs above | *"keying on the storey NAME would look natural and is wrong … the key is the storey's GlobalId"* |
| the first non-negotiable | reference by IFC GlobalId, never a transient id |
| the payload | `storey_elevations` returns `s.GlobalId`, through `drawingStoreys` **and** `modelGrid` |
| the client type | widened to expose `levels[].guid` **for this exact fix**, arguing against `guid?:` because *"that is precisely where a `?? level.name` fallback gets written, reintroducing the rename orphan this field exists to prevent"* |

Four statements of the right answer, and the code did the other thing.

**A specification written in the same entry as the work is not a check on the work — only a test is.** So the fallback that comment predicted is now a test that fails when somebody writes it.

## The fix

The key is `plan:<storeyGuid>`. `modelGrid` already served `levels[].guid`; the level `<select>` now carries it, and it reaches `PlanPane` as an **accessor rather than a value** — for the reason `drawingsSection.ts` documents at length: a value freezes at panel-build time, which is before any level exists.

**Nothing already stored disappears.** The pre-GUID key is read alongside the new one and merged. Switching the key without that would have "fixed" the bug by hiding every markup already saved — the same data loss arriving through the front door. Nothing is written to the legacy key and nothing is rewritten.

## Residual limitation, stated rather than buried

A markup created **before** this release is still name-keyed and still orphans if its level is renamed. Rekeying it needs a name→GlobalId map that only the source IFC holds, so it is a **backfill, not a code change**. Every new markup is immune from here on. Flagged so the gap is yours to schedule rather than mine to assume.

## The test stub was part of the cover

It ignored the key and served the same rows for every id — modelling an API that does not exist, since `sheet_id` is a column and two keys never return the same row. So the legacy read appeared to double every pin.

Fixed by making the stub **key-aware**, not by adding a dedupe to the layer: a dedupe would have hidden an unrealistic fixture behind correct-looking code, and would have made the layer pass for the wrong reason.

## Mutation-checked, both halves

* revert the key to `plan:${s.name}` → **6 tests fail**, including all three new ones
* re-add `?? activeStorey()` in the pane → the negative test written for it fails, alone

## Also corrected

Two stale status claims the check turned up in the same entry: the *"slice 6 is still open"* paragraph (true on 2026-08-23, false since v0.3.1071) and the `Remaining:` line that still listed slice 6. Plus the sprint row's version range, `1101–1104` → `1101–1105`.

## Checklist

- [x] Web: **2,016 tests / 197 files** (6 new); `tsc --noEmit` clean; web + root ESLint clean
- [x] `test_claude_md_gates.py` passes — every backticked citation resolves to a tracked file
- [x] Roadmap gates (lanes, self-consistency, stale, docs-current) pass — 53 tests
- [x] `CHANGELOG.md` entry added (newest at top); roadmap entry corrected
- [x] Version bumped in all three files → 0.3.1106
- [x] No backend change — no migration, no API change
- [x] No secrets; no competitor names

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Markups now remain associated with the correct storey when its name changes.
  - Existing name-based markups continue to appear without creating duplicate pins.
  - New markups use stable storey identifiers for improved reliability.

- **Documentation**
  - Updated the changelog and roadmap with the markup key migration and known limitations.

- **Chores**
  - Updated the application version to 0.3.1106.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->