### PR TITLE
v0.3.1111 — the viewer could not run offline, and nothing on screen said so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,18 @@ jobs:
       - name: Bundle-size budget (app shell)
         run: npm run budget --workspace apps/web
 
+      # "The viewer must run fully offline" is the fourth non-negotiable in CLAUDE.md, and until
+      # 2026-08-27 nothing enforced it — a headless-browser run found `three-*.js` opening with a
+      # static `import … from "https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm"`, reached through
+      # `@thatopen/components-front` → three's `TTFLoader`. Offline, that chunk never evaluates and
+      # the whole viewer fails to mount with nothing on screen to say why.
+      #
+      # It runs after the build because it greps the OUTPUT: an alias that stops matching after a
+      # dependency bump still builds clean, which is the same trap `vite.config.ts` documents for the
+      # vendor split. Costs about a second.
+      - name: Offline check (no bundled import reaches the network)
+        run: npm run offline --workspace apps/web
+
       # R41-LICENCE-GATE. Runs HERE and not in the API gate on purpose: this job is the one that
       # runs `npm ci`, so `node_modules` exists. The API job does not install it, and a licence scan
       # over an absent tree passes by finding nothing — the vacuous-population failure this repo has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1111 (2026-08-27) — the viewer could not run offline, and nothing on screen said so
+
+**A non-negotiable was being broken by a transitive import, and it was found by opening the app in a
+browser rather than by reading code.** R36-VIEWER-SUBAPP has carried "not verified live" since slice
+4 — `createViewerApp` needs a WebGL context and a Fragments worker, so the tab strip, the spec pane
+and the keynote column had never been seen rendered. A headless Chromium settles it: **WebGL 2.0 is
+available, all three tabs render, and refusing Sheets with no project open both says why and leaves
+the Model tab selected.** The unit tests were right about every one of those.
+
+They could not have caught what the same run found in the first second:
+
+```
+pageerror: Failed to fetch dynamically imported module: .../viewer/app.ts
+REQFAIL https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm :: ERR_CERT_AUTHORITY_INVALID
+```
+
+`three/examples/jsm/loaders/TTFLoader.js` opens with a **static import of a CDN URL**. Rolldown
+cannot bundle a URL specifier, so it emitted it verbatim — as **line 1 of `three-*.js`**, the chunk
+every 3D module depends on, reached because `@thatopen/components-front` imports `TTFLoader` for a
+`DrawingEditor` font loader this app never constructs. A static import is loaded whether or not it is
+used.
+
+The consequence is not a missing font. With no route to jsdelivr the chunk never evaluates, the
+viewer's dynamic import rejects, and **nothing renders and nothing reports it** — which is precisely
+the failure mode an air-gapped deployment has, and the fourth non-negotiable in `CLAUDE.md` says the
+viewer must run fully offline.
+
+`apps/web/src/shims/TTFLoader.ts` is a local stand-in keeping the module's shape and refusing at the
+point of use, aliased in `vite.config.ts`. A stub rather than a vendored font parser because
+`LengthMeasurement`, `AreaMeasurement` and `AngleMeasurement` are the only things this app imports
+from `components-front` and none of them loads a font — so vendoring opentype.js would add a
+dependency to make a path work that nothing enters.
+
+**`apps/web/scripts/check-offline.mjs` is the gate, and it greps the OUTPUT.** `vite.config.ts`
+already carries the reason in as many words for the vendor split next to it: a config that stops
+taking effect still builds, still emits the right filenames, and is wrong. An alias is the same
+shape — bump the dependency, rename the upstream file, and it quietly matches nothing. Measured both
+ways: with the alias, 85 bundled JS files and zero network imports; with it removed, the jsdelivr
+line is back and the check fails on it. It runs in CI after the build, and refuses to pass on a
+directory holding fewer than ten JS files, because "0 remote imports" reads identically whether the
+bundle is clean or absent.
+
+Also fixed, and the same defect class as the rest of this week: the comment introducing the canvas
+mode switch said `specs` **is deliberately NOT registered** — three lines above the registration of
+`specs`. True when written in v0.3.918, false from v0.3.920, and it stood for 190 versions because
+nothing reads a comment. The test beside it proves the tab is real and could not see the prose
+denying it; `canvasMode.test.ts` now fails on a comment that says a registered mode is not
+registered.
+
 ## v0.3.1110 (2026-08-26) — the pre-GUID markups can be moved, and nothing has to guess a level
 
 The residual limitation recorded in v0.3.1106 is now resolved. Storey markups saved before that release

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1110",
+    "version": "0.3.1111",
   "private": true,
   "type": "module",
   "engines": {
@@ -22,6 +22,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "budget": "node scripts/bundle-budget.mjs",
+    "offline": "node scripts/check-offline.mjs",
     "licences": "node scripts/check-licences.mjs",
     "copy-wasm": "node scripts/copy-wasm.mjs",
     "tauri": "tauri",

--- a/apps/web/scripts/check-offline.mjs
+++ b/apps/web/scripts/check-offline.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Fail the build if the shipped bundle imports anything over the network.
+//
+// The fourth non-negotiable in CLAUDE.md is that **the viewer must run fully offline** (local WASM,
+// self-hosted tiles). Nothing enforced it, and on 2026-08-27 a headless-browser run found it broken:
+// `three/examples/jsm/loaders/TTFLoader.js` statically imports
+// `https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm`, Rolldown emitted the URL verbatim, and it
+// landed on line 1 of the `three-*.js` chunk. With no route to jsdelivr the chunk never evaluates,
+// the viewer's dynamic import rejects, and NOTHING renders — no error in the UI, just an empty
+// canvas. `src/shims/TTFLoader.ts` is the fix; this is the thing that fails if it comes back.
+//
+// ## Why this greps the OUTPUT rather than reading the config
+//
+// `vite.config.ts` already carries the lesson in as many words: a vendor split that silently stops
+// splitting still builds, still emits a chunk with the right name, and is wrong. An alias is the
+// same shape — rename the upstream file, bump the dependency, and the alias quietly matches nothing.
+// The bundle is the artefact that gets deployed, so the bundle is what gets checked.
+//
+// ## What counts as a violation
+//
+// A network URL in an *import position* — `import x from "https://…"`, `import("https://…")`, or a
+// bare `require("http://…")`. A URL inside a string that is merely *data* (a docs link, an endpoint
+// the app deliberately fetches, a CSP source list) is not a module the runtime must reach before
+// evaluating the file, and is not flagged: this check is about what the bundle cannot START without.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const DIST = join(process.cwd(), "dist");
+
+const PATTERNS = [
+  /\bfrom\s*["'](https?:\/\/[^"']+)["']/g,
+  /\bimport\s*\(\s*["'](https?:\/\/[^"']+)["']\s*\)/g,
+  /\bimport\s+["'](https?:\/\/[^"']+)["']/g,
+  /\brequire\s*\(\s*["'](https?:\/\/[^"']+)["']\s*\)/g,
+];
+
+function jsFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...jsFiles(p));
+    else if (/\.(js|mjs|cjs)$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+let files;
+try {
+  files = jsFiles(DIST);
+} catch {
+  console.error(`check-offline: ${DIST} not found — run \`vite build\` first.`);
+  process.exit(2);
+}
+
+// Anti-vacuity. A check that scanned an empty directory would pass, and "0 remote imports" reads
+// identically whether the bundle is clean or absent — the one-directional-gate shape this codebase
+// keeps finding, where the population is filtered by the very thing under test.
+if (files.length < 10) {
+  console.error(`check-offline: only ${files.length} JS files under ${DIST} — that is not a built `
+    + "bundle, and passing on it would be a false all-clear.");
+  process.exit(2);
+}
+
+const hits = [];
+for (const f of files) {
+  const src = readFileSync(f, "utf8");
+  for (const re of PATTERNS) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(src)) !== null) hits.push({ file: f.slice(DIST.length + 1), url: m[1] });
+  }
+}
+
+if (hits.length) {
+  console.error(`check-offline: ${hits.length} remote import(s) in the built bundle — the viewer `
+    + "cannot run offline:\n");
+  for (const h of hits) console.error(`  ${h.file}  imports  ${h.url}`);
+  console.error("\nAlias the importing module to a local file (see src/shims/TTFLoader.ts and the "
+    + "`resolve.alias` note in vite.config.ts), or vendor the dependency.");
+  process.exit(1);
+}
+
+console.log(`check-offline OK - ${files.length} bundled JS files, no import reaches the network.`);

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1110",
+  "version": "0.3.1111",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/shims/TTFLoader.ts
+++ b/apps/web/src/shims/TTFLoader.ts
@@ -1,0 +1,59 @@
+/**
+ * Local stand-in for `three/examples/jsm/loaders/TTFLoader.js`, aliased in by `vite.config.ts`.
+ *
+ * ## Why this file exists — a non-negotiable was being broken by a transitive import
+ *
+ * three's own `TTFLoader.js` begins:
+ *
+ *     import opentype from 'https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm';
+ *
+ * a **static import of a CDN URL**, which Rolldown cannot bundle and emits verbatim. Nothing in this
+ * app imports `TTFLoader`; `@thatopen/components-front` does, for a `DrawingEditor` font loader we
+ * never construct. But a static import is loaded whether or not it is used, and because
+ * `components-front` pulls in `three`, that line landed at the **top of the `three-*.js` chunk** —
+ * the chunk every 3D module depends on.
+ *
+ * The consequence is not a missing font. With no route to jsdelivr the chunk never evaluates, the
+ * dynamic `import("./viewer/app")` rejects, and **the viewer does not appear at all** — measured in a
+ * headless Chromium on 2026-08-27: `Failed to fetch dynamically imported module .../viewer/app.ts`,
+ * and no `.canvas-tabs` ever rendered. Against the fourth non-negotiable in CLAUDE.md: *the viewer
+ * must run fully offline (local WASM, self-hosted tiles)*.
+ *
+ * ## Why a stub rather than a bundled opentype.js
+ *
+ * Vendoring opentype.js would add a dependency to make a code path work that this app never enters.
+ * `LengthMeasurement`, `AreaMeasurement` and `AngleMeasurement` are the only things imported from
+ * `components-front` (`apps/web/src/tools/measure.ts`), and none of them loads a font.
+ *
+ * So the stub keeps the module's SHAPE and refuses at the point of use. If somebody later wires up
+ * the drawing editor's text, they get a named error telling them what to do — not a silent blank
+ * label, and not a CDN request that works on their machine and fails in an air-gapped deployment.
+ */
+
+const REASON =
+  "TTFLoader is stubbed out: three's version statically imports opentype.js from a CDN, which breaks "
+  + "the offline-viewer non-negotiable. Bundle a local font parser before using TTF fonts. "
+  + "See apps/web/src/shims/TTFLoader.ts";
+
+export class TTFLoader {
+  /** Mirrors three's `Loader#load(url, onLoad, onProgress, onError)`. */
+  load(
+    _url: string,
+    _onLoad?: (json: unknown) => void,
+    _onProgress?: (e: ProgressEvent) => void,
+    onError?: (err: unknown) => void,
+  ): void {
+    const err = new Error(REASON);
+    // Report through the caller's channel when it has one — a loader that throws synchronously out
+    // of `load()` crashes callers that expect the error on the callback. Rethrow only when there is
+    // nowhere else for it to go, so it can never fail silently.
+    if (onError) onError(err);
+    else throw err;
+  }
+
+  parse(_buffer: ArrayBuffer): never {
+    throw new Error(REASON);
+  }
+}
+
+export default TTFLoader;

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -924,8 +924,8 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   container.appendChild(specPane.el);
 
   // R36-VIEWER-SUBAPP ④ — the canvas is one surface at a time, not 3D with a strip attached.
-  // `specs` is deliberately NOT registered: the spec book is a modal, so a Specs tab would highlight
-  // and show nothing. `canvasMode.test.ts` fails if it is registered without a surface.
+  // All three modes are registered because all three have a surface. `canvasMode.test.ts` fails if one
+  // is registered without one — for `specs` it demands `new SpecPane(` AND the append, not a mention.
   const canvasTabs = document.createElement("div");
   canvasTabs.className = "canvas-tabs";
   canvasTabs.setAttribute("role", "tablist");

--- a/apps/web/src/viewer/canvasMode.test.ts
+++ b/apps/web/src/viewer/canvasMode.test.ts
@@ -126,4 +126,30 @@ describe("a mode cannot exist without a surface", () => {
     }
     expect(MODE_ORDER).toContain("specs");
   });
+
+  it("no comment in app.ts denies registering a mode that IS registered", () => {
+    /**
+     * The comment introducing the switch said `specs` is deliberately NOT registered — three lines
+     * above the registration of `specs`. True when written in v0.3.918, false from v0.3.920, and it
+     * stood for 190 versions because nothing reads a comment.
+     *
+     * The cost is not tidiness. A reader looking for the Specs tab finds a note saying it does not
+     * exist and stops looking; the test above proves the tab is real and could not say the prose
+     * denies it. **A gate on the code cannot see a claim about the code.**
+     *
+     * The trigger is the phrase, not the wording around it: any line saying a named mode is not
+     * registered is checked against whether it actually is. Rewriting the sentence keeps the guard;
+     * only dropping the claim drops it, which is the right way round.
+     */
+    const app = readFileSync(resolve(REPO, "apps/web/src/viewer/app.ts"), "utf8");
+    const denials = app.split("\n")
+      .filter((ln) => /^\s*(\/\/|\*)/.test(ln) && /not\s+registered/i.test(ln));
+    for (const ln of denials) {
+      for (const m of MODE_ORDER) {
+        if (!ln.includes(m)) continue;
+        expect(new RegExp(`key:\\s*"${m}"`).test(app),
+          `a comment says \`${m}\` is not registered, but it is: ${ln.trim()}`).toBe(false);
+      }
+    }
+  });
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,5 @@
 import { brotliCompressSync, gzipSync } from "node:zlib";
+import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { defineConfig, searchForWorkspaceRoot, type Plugin } from "vite";
@@ -122,7 +123,18 @@ return {
     dedupe: ["three"],
     // The vendored massingifc kernel imports its siblings by package name; `vendorAlias` is the one
     // definition of what those names mean (see vendorAlias.ts).
-    alias: { ...vendorAlias },
+    //
+    // TTFLoader is aliased to a local stub because three's own copy STATICALLY imports
+    // `https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm`. Rolldown cannot bundle a URL specifier,
+    // so it was emitted verbatim at the top of the `three-*.js` chunk — and with no route to
+    // jsdelivr that chunk never evaluates and the viewer never mounts. `npm run offline` greps the
+    // built output for exactly this, because a config that is believed rather than checked is how
+    // the vendor split above silently stopped splitting. See apps/web/src/shims/TTFLoader.ts.
+    alias: {
+      ...vendorAlias,
+      "three/examples/jsm/loaders/TTFLoader.js": fileURLToPath(
+        new URL("./src/shims/TTFLoader.ts", import.meta.url)),
+    },
   },
   // web-ifc and the fragments worker ship their own WASM/worker assets; don't let
   // esbuild's dep pre-bundler rewrite them. `three` is excluded too: the @thatopen/*

--- a/docs/roadmap-completed.md
+++ b/docs/roadmap-completed.md
@@ -7505,3 +7505,198 @@ wearing the same glyph.
   **Planning:** `apps/web/src/portal/panels/planningBrief.ts` on `__benchmarks__` — RFI clock, submittal clock, cost history.
   **Operate:** `apps/web/src/portal/panels/operateBrief.ts` on `__operations__` — overdue WOs, PM compliance (`null` is not 0%), FCI (no elements is not 0%).
   **Design is skipped on purpose:** `apps/web/src/shell/spine.ts` sets Design home to null — the 3D viewer is the room. A portal brief would be a second home.
+
+---
+
+## R36-VIEWER-SUBAPP — COMPLETE 2026-08-27 (v0.3.918–920, 1071, 1106–1111)
+
+The canvas became a surface that switches in place — Model ▸ Sheets ▸ Specs — rather than 3D with a
+2D strip attached to it. Seven slices, and the entry is archived intact because **five of them were
+found by a premise-check that contradicted this entry's own prose**, which is the part worth keeping:
+
+* Slice 5's model↔sheet link "already worked" — by the accidental alignment of three unrelated
+  mechanisms, none of them tested.
+* Slice 6 was scoped as "an INTEGRATION, not a build" from a census of *methods with callers*.
+  Reachability and reusability are different properties and a caller census measures only the first.
+* Slice 6 then shipped keyed on the storey **NAME** — which this same entry had specified against,
+  three paragraphs earlier. *A specification written in the same entry as the work is not a check.*
+* The spec surface "now exists" was true and empty: `project_manual` defaulted to MasterFormat while
+  57 of 58 tracked IFC files declare Uniclass, and the test that covered it supplied the very system
+  under test.
+* And the last one is the largest. This entry honestly flagged "not verified live" for 190 versions.
+  When somebody finally opened it in a browser, all the behaviour the unit tests asserted was
+  correct — and the **whole viewer failed to mount**, because a transitive dependency put a CDN
+  import at the top of the `three` chunk. *A suite over the source cannot see a defect the build
+  creates.*
+
+Its lesson, in one line: **an entry cannot check itself.** Every one of those was caught by running
+something — a gate, a browser, a corpus count — and none by re-reading the paragraph above it.
+
+- ✅ **R36-VIEWER-SUBAPP** *(L — Lane E; slice 4 shipped v0.3.918 — `apps/web/src/viewer/canvasMode.ts`)*
+  — **the mode switch is in.** The canvas is now one surface at a time (Model ▸ Sheets) rather than 3D
+  with a strip attached: the plan was `position:absolute; right:0; width:38%`, so 2D was a slice of the
+  model rather than a peer of it. Visibility is DERIVED from the mode, so "both visible" and "neither
+  visible" are unrepresentable rather than merely discouraged, and the old "◫ Plan beside model"
+  toggle now routes through the switch so one thing owns the pane. A refusal carries a reason —
+  Sheets before a project is open says so, because a tab that swallows the click reads as broken.
+
+  Slices 1–3 were the print path this depended on, and the roadmap's own sequencing note was right
+  that it had to come first: `axon` reaching the shipping dispatcher (it had been drawing a plan
+  titled ISO VIEW), the `views=` grammar, and "place this view on a sheet". Without them the switch
+  would have exposed 2D and 3D as non-peers immediately.
+
+  **SPECS SHIPPED v0.3.920 — all three modes are real.** `apps/web/src/viewer/specPane.ts` renders the
+  3-part MasterFormat manual as a canvas surface, and selecting an element reveals its section. It
+  needed **no backend work**: `specmanual.py` has served `elements: [{guid, name, ifc_class}]` per
+  section since it shipped, and the client's return type simply never declared the field — so the
+  section↔element link looked like unbuilt work while sitting in every response. Exact mirror of the
+  sheet-params defect: there the client SENT keys the route ignores, here it IGNORED keys the route
+  sends. A contract believed rather than read, in both directions.
+
+  The `elements` list is **capped at 50 per section** while `element_count` is the true total, so the
+  pane distinguishes *"no spec section"* from *"not in the first 50, so I cannot tell"* — the second
+  reported as the first would be a statement about the payload posing as one about the model.
+
+  The v0.3.918 guard that forbade registering `specs` without a surface now guards the general rule,
+  and a mutation showed it had been **too weak**: it matched the string `specPane` anywhere, which the
+  mode's own `enter`/`leave` satisfy, so a mode wired to a pane that is never built would have passed.
+  It now requires `new SpecPane(` AND the `appendChild` — "built but never appended" being this repo's
+  most repeated defect.
+
+  **Not verified live.** `createViewerApp` needs a WebGL context and a Fragments worker and the
+  dev-preview geometry loader stalls, so the tab strip has not been seen in a browser. 11 unit tests
+  cover the switch's behaviour and `tsc` covers the wiring; the DOM is unverified and said so.
+
+  **Slice 5, measured v0.3.919 — the model↔sheet half ALREADY WORKED, by accident.** Picking in 3D and
+  switching to Sheets does carry the GlobalId, because three unrelated mechanisms happen to line up:
+  `onSelectionChanged` fires whether or not the pane is visible and stores `sel` before touching the
+  DOM; `dock("full")` forces a refresh; `refresh` ends by re-applying `syncPlanHighlight`. Remove any
+  one and the feature vanishes silently — the plan renders, nothing is lit, and it reads as "that
+  element isn't on this level". `PlanPane` had **no instance-level tests at all**, so nothing would
+  have noticed. `apps/web/src/viewer/planPaneSelection.test.ts` is now the thing that fails first.
+
+  **Slice 6 scoped by measurement, 2026-08-09 — it is an INTEGRATION, not a build.** The markup and
+  takeoff layer is already complete and wired: all five client methods (`drawingMarkup`,
+  `addDrawingMarkup`, `saveDrawingMarkups`, `deleteDrawingMarkup`, `promoteDrawingMarkup`) have
+  callers, the read side has four, and every one of them is in `apps/web/src/drawings/drawings.ts`.
+  Nothing needs writing; it needs to be reachable from the Sheets canvas so a drawing is marked up
+  where it is being looked at, rather than in a different room.
+
+  **✅ SLICE 6 SHIPPED v0.3.1071 — and it was a build, as the re-check below predicted.**
+  `apps/web/src/drawings/markupLayer.ts` is the layer, mountable on any surface; the Drawings room and
+  the viewer's plan pane both mount it, and **both key it `plan:<storey>`** — the same key — so a pin
+  dropped in one appears in the other with no syncing and no second store. The identity does the work.
+  Three steps, not one: **characterise, extract, mount.** `apps/web/src/drawings/drawings.test.ts`
+  came first — 13 tests over a 493-line class nothing had ever mounted — because refactoring untested
+  code is how a room quietly loses a feature with every suite still green. Those same tests then
+  proved the extraction changed nothing.
+  **The import-cycle guard caught the design error**: putting the layer under `drawings/` and importing
+  it from `viewer/planPane` closed `markupLayer → ui/sheetGuid → viewer/planPane → markupLayer`. The
+  fix was not a re-route — the layer now takes an `onReveal` dependency, because **how you reveal an
+  element is a property of the surface, not of the markup**, and a layer that reached for one host's
+  hook could only ever be mounted where that hook was right.
+
+  **Re-checked 2026-08-23 — slice 6 was still open THEN, and "an INTEGRATION, not a build" understated
+  it.** *(Past tense as of 2026-08-26: it shipped in v0.3.1071, which the ✅ line above records. Left
+  in place because its prediction was right and that is the part worth keeping — but re-read it as
+  history, not as status. This entry has now had a stale present-tense paragraph twice.)*
+  The five client methods and their callers are all present, exactly as measured. But every caller
+  lives inside the `DrawingsRoom` class in `apps/web/src/drawings/drawings.ts`, and the markup layer
+  is *class state coupled to that room's DOM* — `markupOn`, the `markup[]` array, `buildToolbar()`,
+  `openPdfMarkup()` and a `.dwg-viewport` selector — not a mountable module. So "make it reachable
+  from the Sheets canvas" means **extracting the layer first**, which is a decomposition with the
+  usual seam questions, not a wiring change. The measurement that produced the original framing
+  counted *methods with callers*, which is the right check for "does this exist" and says nothing
+  about whether it can be mounted somewhere else. **Reachability and reusability are different
+  properties, and a caller census only measures the first.**
+
+  **The one real design question, and the non-negotiables answer it.** Markups key on a sheet id — a
+  persisted document record — and the viewer's Sheets mode renders `plan.svg?storey=…&scale=…`, a
+  live cut with no record and no id. So a generated plan needs an identity to attach markups to.
+  Keying on the storey NAME would look natural and is wrong: levels can be renamed here, and every
+  markup on that level would orphan silently. Per the non-negotiable — *reference by IFC GlobalId,
+  never transient ids* — the key is the **storey's GlobalId**. That is a rule the project already
+  holds, not a new decision, and it is the reason this is specified rather than open.
+
+  Cost that follows: `PlanPane` asks for a storey by name (`activeStorey()`), so slice 6 also has to
+  carry the storey's GUID down to the cut request. The existing `${sheet.id}#pdf` convention shows
+  the codebase already namespaces markup stores by suffix, so `plan:<storeyGuid>` fits the pattern
+  that is there.
+
+  **PREMISE-CHECK 2026-08-26, before starting the sprint row — and it found the row's own subject
+  half-wrong.** Slice 6 had shipped, so "and slice 6 as specified above" was stale here too. But it
+  shipped **keyed on the storey NAME**, which this entry had specified against three paragraphs
+  earlier (*"keying on the storey NAME would look natural and is wrong"*), which the project's first
+  non-negotiable forbids, and which `drawingStoreys` had never required — it has served `guid` beside
+  `name` since it shipped. `apps/web/src/api/authoring.ts` had even been widened to expose
+  `levels[].guid` **for this exact purpose**, with a comment warning against the `?? level.name`
+  fallback. The groundwork was laid and the consumer never used it. *A specification written in the
+  same entry as the work is not a check — only a test is.* Fixed in v0.3.1106: the key is
+  `plan:<storeyGuid>`, the pre-GUID key is read so nothing already stored disappears, and the
+  forbidden fallback is now a failing test in `apps/web/src/viewer/planPane.test.ts`.
+
+  **PREMISE-CHECK 2026-08-26 on the last remaining item, and it found the surface that item points at
+  was EMPTY.** "The spec surface now exists" was true and misleading: `project_manual` defaulted to
+  `system="MasterFormat"` and `routers/authoring_docs.spec_manual` passed nothing, while **57 of this
+  repository's 58 tracked IFC files declare Uniclass and none declare MasterFormat**. Every project's
+  manual returned zero sections and reported no error, because an empty manual is also what an
+  unclassified model returns. `services/api/test_specmanual.py` passed throughout — its fixture
+  classifies with MasterFormat, so the population was filtered by the thing under test. Fixed in
+  v0.3.1107, gated by `services/api/test_spec_system.py`, which measures the corpus rather than
+  quoting it.
+
+  ✅ **KEYNOTE → SPEC SECTION — landed in v0.3.1108**, and with it the entry's last named item.
+  *(lowercase "landed" deliberately, as in items 1, 2 and 3 and for the same reason.)* A keynote
+  prefixes the classification code governing the assembly it points at — `04 22 00  200mm MASONRY
+  WALL`. What made it reachable was an identity already present and being discarded:
+  `section_drawing_svg` cut with `cut_baked_classed`, which keeps the class and drops the GlobalId,
+  so the frame building keynotes had nothing to look a classification up by. `cut_baked_guided` has
+  carried `(guid, class, polyline)` since R38-PLAN-IDENTITY and the section path now uses it — which
+  also closes an accounting gap, since the guided cut logs meshes that fail to section where the
+  classed one dropped them silently. **A group cites only when every member agrees**, an unclassified
+  member counting as disagreement: the keynote partition (class + material + thickness) is not the
+  spec partition, and a citation covering only some of the elements a leader points at is a false
+  statement on a construction document. `services/api/test_keynote_spec.py`.
+
+  **Everything this entry named is now shipped**, and the one carried-over limitation with it: the
+  pre-GUID markup backfill landed in v0.3.1110 as
+  `POST /projects/{pid}/drawings/markups/rekey-storeys` — dry-run by default, idempotent, and
+  refusing to resolve a duplicated storey name rather than guessing which level a pin belonged to.
+  `services/api/test_markup_rekey.py`.
+
+  ✅ **THE LIVE DOM VERIFICATION IS DONE — v0.3.1111, and it found a broken non-negotiable.** This
+  entry flagged "not verified live" from slice 4 onward, honestly, on the grounds that
+  `createViewerApp` needs a WebGL context and a Fragments worker. A headless Chromium has both:
+  **WebGL 2.0 reports `OpenGL ES 3.0 Chromium`**, all three tabs render (`model` selected, `sheets`
+  and `specs` beside it), clicking Sheets with no project open answers *"open a project first — a
+  sheet is cut from its model"* and leaves Model selected. The unit tests were right about every one
+  of those, which is the boring half.
+
+  The interesting half is what unit tests could not see. The same run failed at
+  `Failed to fetch dynamically imported module .../viewer/app.ts`, because
+  `three/examples/jsm/loaders/TTFLoader.js` **statically imports opentype.js from jsdelivr** and
+  Rolldown emitted the URL verbatim as line 1 of the `three-*.js` chunk — reached through
+  `@thatopen/components-front`, for a font loader this app never constructs. Offline, that chunk
+  never evaluates and **the viewer does not mount at all, with nothing on screen to say why**:
+  against *the viewer must run fully offline*, the fourth non-negotiable. `apps/web/src/shims/TTFLoader.ts`
+  is the local stand-in, and `apps/web/scripts/check-offline.mjs` greps the built bundle in CI so an
+  alias that stops matching after a dependency bump fails loudly instead of building clean.
+
+  **The lesson is about the shape of the gap, not about fonts.** Everything this entry built was
+  covered by tests that passed, and the thing that made all of it unreachable was in no test's
+  population — it entered through a transitive dependency, survived the bundler, and only exists in
+  the artefact that gets deployed. *A suite over the source cannot see a defect that is created by
+  the build.* That is why the new check reads `dist/` and refuses to pass on a directory too small
+  to be one.
+  *(The sentence that stood here — "one residual limitation … a markup created before v0.3.1106 is
+  still name-keyed and still orphans on rename … it is a backfill, not a code change" — was true
+  when written and false three lines below a paragraph saying the backfill shipped. **The fourth time
+  this entry's prose contradicted its own status**, and the third caught by review rather than by me.
+  A status sentence is not a footnote: it has to be re-read whenever the thing it describes moves.)*
+  **Print paper picker (v0.3.993):**
+  Issue / Sheet PDF / Place and the paper-space editor share `drawings.py` `PAGES` — ARCH-C/D/B/A and
+  ISO A0–A4. Default is **ARCH-C (24×18 in)**; that is not an ISO A size. ARCH-D is full-size US
+  CDs (36×24), ARCH-B is half of D, ARCH-A is the next ARCH step (often called quarter of D).
+  Unknown `page` is 422, never a silent A1/A3. Omitting `page` on `compose()` is still A3 so old
+  links do not change paper. 11×17 is omitted on purpose (not half of 24×36). Live PDF still
+  needs a source IFC — the demo's "no model" cannot exercise the box.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -656,7 +656,7 @@ entry demanded a premise-check before starting. **That is now the first line of 
 |---|---|---|---|---|
 | 1 | ~~**A correctness sweep** — refill Band 1~~ **DONE 2026-08-25 (v0.3.1091–1095)** | **Struck rather than deleted, because the prediction is the part worth checking.** All three axes it named were run: **authz** (43 routes, no live hole, `services/api/test_resource_id_authz.py` is the finding), **concurrency** (a 500 on concurrent first sign-in at all three SSO doors), **money** (52 of 399 JV distribution periods whose parts did not sum to their own total). Its premise-check was the load-bearing part — "pick the axis before starting" is what made two of the three produce a defect. Records in §Band 1 above. | M | — |
 | 2 | ~~**R22-REPORT-BUILDER — items 2–5**~~ **COMPLETE 2026-08-26 (v0.3.1101–1105)** | All four remaining items shipped: a validated config schema (which exposed a live alert miscount), shareable views, cross-module reports along declared reference edges, and one report catalog. **The premise-check this row demanded is what found that FOUR remained rather than three** — the row was written when the entry listed four items and was never re-derived after it grew to five. Full record in [`roadmap-completed.md`](roadmap-completed.md). | S/M → M/L | — |
-| 3 | **R36-VIEWER-SUBAPP** — the canvas switches 2D/3D in place, including PRINT | The remaining half of the rail arc, and a **user directive** rather than an agent's idea — the rooms "must each be a product". It is also the largest thing standing between the drawing surface and the roadmap's own headline judgement at the top of this file: *what is thin now is the drawing*. | L | The R43 collision. `@massing/embed` was evaluated and **declined** on 2026-08-23 for an architectural reason (its load path is IFC text into a browser tessellator, against two non-negotiables), and two breaking changes are still coming: async viewport creation, and add/remove replacing `showModel`. Build behind the existing seams, not into `apps/web/src/viewer/app.ts`. |
+| 3 | ~~**R36-VIEWER-SUBAPP** — the canvas switches 2D/3D in place, including PRINT~~ **COMPLETE 2026-08-27 (v0.3.1106–1111)** | **Struck rather than deleted: this row was sized L and the work left in it was days, which is worth recording.** Its premise-check found the subject half-shipped and then found three live defects in what had shipped — a markup key on the storey NAME against the first non-negotiable, a spec manual answering in a system no tracked model uses, and a keynote with nothing to cite. The row's own stated premise (the R43 collision) was never the thing that mattered; **the entry's description of its own state was**. The last slice — the live DOM verification this entry had flagged for 190 versions — found the viewer did not mount offline at all. Record in [`roadmap-completed.md`](roadmap-completed.md). | L | — |
 
 **Why not the obvious candidates.** Stated so that disagreeing with the omission is as cheap as
 disagreeing with the inclusion. *(Each bullet deliberately opens with "Not X" rather than with the
@@ -719,7 +719,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R35-DEAL-MEMORY · R37-TRIAGE · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
-| **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R36-VIEWER-SUBAPP *(the remaining half of the rail arc — the canvas must switch 2D/3D in place, including PRINT)* · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · UX-3 *(library depth — `apps/web/src/viewer/tools/authoringSection.ts`)* · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* |
+| **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · UX-3 *(library depth — `apps/web/src/viewer/tools/authoringSection.ts`)* · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | — |
@@ -2419,154 +2419,6 @@ in-place, never separate pages); **tool scope follows context** (the palette sho
 verbs, with a command bar as the escape hatch to everything); and **role-shaped landing content**
 (the first screen of a work area answers that role's first question, not a generic dashboard).
 
-- ◧ **R36-VIEWER-SUBAPP** *(L — Lane E; SLICE 4 SHIPPED v0.3.918 — `apps/web/src/viewer/canvasMode.ts`)*
-  — **the mode switch is in.** The canvas is now one surface at a time (Model ▸ Sheets) rather than 3D
-  with a strip attached: the plan was `position:absolute; right:0; width:38%`, so 2D was a slice of the
-  model rather than a peer of it. Visibility is DERIVED from the mode, so "both visible" and "neither
-  visible" are unrepresentable rather than merely discouraged, and the old "◫ Plan beside model"
-  toggle now routes through the switch so one thing owns the pane. A refusal carries a reason —
-  Sheets before a project is open says so, because a tab that swallows the click reads as broken.
-
-  Slices 1–3 were the print path this depended on, and the roadmap's own sequencing note was right
-  that it had to come first: `axon` reaching the shipping dispatcher (it had been drawing a plan
-  titled ISO VIEW), the `views=` grammar, and "place this view on a sheet". Without them the switch
-  would have exposed 2D and 3D as non-peers immediately.
-
-  **SPECS SHIPPED v0.3.920 — all three modes are real.** `apps/web/src/viewer/specPane.ts` renders the
-  3-part MasterFormat manual as a canvas surface, and selecting an element reveals its section. It
-  needed **no backend work**: `specmanual.py` has served `elements: [{guid, name, ifc_class}]` per
-  section since it shipped, and the client's return type simply never declared the field — so the
-  section↔element link looked like unbuilt work while sitting in every response. Exact mirror of the
-  sheet-params defect: there the client SENT keys the route ignores, here it IGNORED keys the route
-  sends. A contract believed rather than read, in both directions.
-
-  The `elements` list is **capped at 50 per section** while `element_count` is the true total, so the
-  pane distinguishes *"no spec section"* from *"not in the first 50, so I cannot tell"* — the second
-  reported as the first would be a statement about the payload posing as one about the model.
-
-  The v0.3.918 guard that forbade registering `specs` without a surface now guards the general rule,
-  and a mutation showed it had been **too weak**: it matched the string `specPane` anywhere, which the
-  mode's own `enter`/`leave` satisfy, so a mode wired to a pane that is never built would have passed.
-  It now requires `new SpecPane(` AND the `appendChild` — "built but never appended" being this repo's
-  most repeated defect.
-
-  **Not verified live.** `createViewerApp` needs a WebGL context and a Fragments worker and the
-  dev-preview geometry loader stalls, so the tab strip has not been seen in a browser. 11 unit tests
-  cover the switch's behaviour and `tsc` covers the wiring; the DOM is unverified and said so.
-
-  **Slice 5, measured v0.3.919 — the model↔sheet half ALREADY WORKED, by accident.** Picking in 3D and
-  switching to Sheets does carry the GlobalId, because three unrelated mechanisms happen to line up:
-  `onSelectionChanged` fires whether or not the pane is visible and stores `sel` before touching the
-  DOM; `dock("full")` forces a refresh; `refresh` ends by re-applying `syncPlanHighlight`. Remove any
-  one and the feature vanishes silently — the plan renders, nothing is lit, and it reads as "that
-  element isn't on this level". `PlanPane` had **no instance-level tests at all**, so nothing would
-  have noticed. `apps/web/src/viewer/planPaneSelection.test.ts` is now the thing that fails first.
-
-  **Slice 6 scoped by measurement, 2026-08-09 — it is an INTEGRATION, not a build.** The markup and
-  takeoff layer is already complete and wired: all five client methods (`drawingMarkup`,
-  `addDrawingMarkup`, `saveDrawingMarkups`, `deleteDrawingMarkup`, `promoteDrawingMarkup`) have
-  callers, the read side has four, and every one of them is in `apps/web/src/drawings/drawings.ts`.
-  Nothing needs writing; it needs to be reachable from the Sheets canvas so a drawing is marked up
-  where it is being looked at, rather than in a different room.
-
-  **✅ SLICE 6 SHIPPED v0.3.1071 — and it was a build, as the re-check below predicted.**
-  `apps/web/src/drawings/markupLayer.ts` is the layer, mountable on any surface; the Drawings room and
-  the viewer's plan pane both mount it, and **both key it `plan:<storey>`** — the same key — so a pin
-  dropped in one appears in the other with no syncing and no second store. The identity does the work.
-  Three steps, not one: **characterise, extract, mount.** `apps/web/src/drawings/drawings.test.ts`
-  came first — 13 tests over a 493-line class nothing had ever mounted — because refactoring untested
-  code is how a room quietly loses a feature with every suite still green. Those same tests then
-  proved the extraction changed nothing.
-  **The import-cycle guard caught the design error**: putting the layer under `drawings/` and importing
-  it from `viewer/planPane` closed `markupLayer → ui/sheetGuid → viewer/planPane → markupLayer`. The
-  fix was not a re-route — the layer now takes an `onReveal` dependency, because **how you reveal an
-  element is a property of the surface, not of the markup**, and a layer that reached for one host's
-  hook could only ever be mounted where that hook was right.
-
-  **Re-checked 2026-08-23 — slice 6 was still open THEN, and "an INTEGRATION, not a build" understated
-  it.** *(Past tense as of 2026-08-26: it shipped in v0.3.1071, which the ✅ line above records. Left
-  in place because its prediction was right and that is the part worth keeping — but re-read it as
-  history, not as status. This entry has now had a stale present-tense paragraph twice.)*
-  The five client methods and their callers are all present, exactly as measured. But every caller
-  lives inside the `DrawingsRoom` class in `apps/web/src/drawings/drawings.ts`, and the markup layer
-  is *class state coupled to that room's DOM* — `markupOn`, the `markup[]` array, `buildToolbar()`,
-  `openPdfMarkup()` and a `.dwg-viewport` selector — not a mountable module. So "make it reachable
-  from the Sheets canvas" means **extracting the layer first**, which is a decomposition with the
-  usual seam questions, not a wiring change. The measurement that produced the original framing
-  counted *methods with callers*, which is the right check for "does this exist" and says nothing
-  about whether it can be mounted somewhere else. **Reachability and reusability are different
-  properties, and a caller census only measures the first.**
-
-  **The one real design question, and the non-negotiables answer it.** Markups key on a sheet id — a
-  persisted document record — and the viewer's Sheets mode renders `plan.svg?storey=…&scale=…`, a
-  live cut with no record and no id. So a generated plan needs an identity to attach markups to.
-  Keying on the storey NAME would look natural and is wrong: levels can be renamed here, and every
-  markup on that level would orphan silently. Per the non-negotiable — *reference by IFC GlobalId,
-  never transient ids* — the key is the **storey's GlobalId**. That is a rule the project already
-  holds, not a new decision, and it is the reason this is specified rather than open.
-
-  Cost that follows: `PlanPane` asks for a storey by name (`activeStorey()`), so slice 6 also has to
-  carry the storey's GUID down to the cut request. The existing `${sheet.id}#pdf` convention shows
-  the codebase already namespaces markup stores by suffix, so `plan:<storeyGuid>` fits the pattern
-  that is there.
-
-  **PREMISE-CHECK 2026-08-26, before starting the sprint row — and it found the row's own subject
-  half-wrong.** Slice 6 had shipped, so "and slice 6 as specified above" was stale here too. But it
-  shipped **keyed on the storey NAME**, which this entry had specified against three paragraphs
-  earlier (*"keying on the storey NAME would look natural and is wrong"*), which the project's first
-  non-negotiable forbids, and which `drawingStoreys` had never required — it has served `guid` beside
-  `name` since it shipped. `apps/web/src/api/authoring.ts` had even been widened to expose
-  `levels[].guid` **for this exact purpose**, with a comment warning against the `?? level.name`
-  fallback. The groundwork was laid and the consumer never used it. *A specification written in the
-  same entry as the work is not a check — only a test is.* Fixed in v0.3.1106: the key is
-  `plan:<storeyGuid>`, the pre-GUID key is read so nothing already stored disappears, and the
-  forbidden fallback is now a failing test in `apps/web/src/viewer/planPane.test.ts`.
-
-  **PREMISE-CHECK 2026-08-26 on the last remaining item, and it found the surface that item points at
-  was EMPTY.** "The spec surface now exists" was true and misleading: `project_manual` defaulted to
-  `system="MasterFormat"` and `routers/authoring_docs.spec_manual` passed nothing, while **57 of this
-  repository's 58 tracked IFC files declare Uniclass and none declare MasterFormat**. Every project's
-  manual returned zero sections and reported no error, because an empty manual is also what an
-  unclassified model returns. `services/api/test_specmanual.py` passed throughout — its fixture
-  classifies with MasterFormat, so the population was filtered by the thing under test. Fixed in
-  v0.3.1107, gated by `services/api/test_spec_system.py`, which measures the corpus rather than
-  quoting it.
-
-  ✅ **KEYNOTE → SPEC SECTION — landed in v0.3.1108**, and with it the entry's last named item.
-  *(lowercase "landed" deliberately, as in items 1, 2 and 3 and for the same reason.)* A keynote
-  prefixes the classification code governing the assembly it points at — `04 22 00  200mm MASONRY
-  WALL`. What made it reachable was an identity already present and being discarded:
-  `section_drawing_svg` cut with `cut_baked_classed`, which keeps the class and drops the GlobalId,
-  so the frame building keynotes had nothing to look a classification up by. `cut_baked_guided` has
-  carried `(guid, class, polyline)` since R38-PLAN-IDENTITY and the section path now uses it — which
-  also closes an accounting gap, since the guided cut logs meshes that fail to section where the
-  classed one dropped them silently. **A group cites only when every member agrees**, an unclassified
-  member counting as disagreement: the keynote partition (class + material + thickness) is not the
-  spec partition, and a citation covering only some of the elements a leader points at is a false
-  statement on a construction document. `services/api/test_keynote_spec.py`.
-
-  **Everything this entry named is now shipped**, and the one carried-over limitation with it: the
-  pre-GUID markup backfill landed in v0.3.1110 as
-  `POST /projects/{pid}/drawings/markups/rekey-storeys` — dry-run by default, idempotent, and
-  refusing to resolve a duplicated storey name rather than guessing which level a pin belonged to.
-  `services/api/test_markup_rekey.py`.
-
-  What remains is **the live DOM verification this entry has flagged as unverified since slice 4** —
-  `createViewerApp` needs a WebGL context and a Fragments worker, so the tab strip, the spec pane and
-  the keynote column have never been seen in a browser. Unit tests cover the behaviour and `tsc`
-  covers the wiring; that is not the same claim and the entry has never pretended otherwise.
-  *(The sentence that stood here — "one residual limitation … a markup created before v0.3.1106 is
-  still name-keyed and still orphans on rename … it is a backfill, not a code change" — was true
-  when written and false three lines below a paragraph saying the backfill shipped. **The fourth time
-  this entry's prose contradicted its own status**, and the third caught by review rather than by me.
-  A status sentence is not a footnote: it has to be re-read whenever the thing it describes moves.)*
-  **Print paper picker (v0.3.993):**
-  Issue / Sheet PDF / Place and the paper-space editor share `drawings.py` `PAGES` — ARCH-C/D/B/A and
-  ISO A0–A4. Default is **ARCH-C (24×18 in)**; that is not an ISO A size. ARCH-D is full-size US
-  CDs (36×24), ARCH-B is half of D, ARCH-A is the next ARCH step (often called quarter of D).
-  Unknown `page` is 422, never a silent A1/A3. Omitting `page` on `compose()` is still A3 so old
-  links do not change paper. 11×17 is omitted on purpose (not half of 24×36). Live PDF still
-  needs a source IFC — the demo's "no model" cannot exercise the box.
 
 ## 🧱 Decomposition & reliability carry-overs (interleave one per few releases)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1110",
+      "version": "0.3.1111",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
## What this is

The premise-check on the next roadmap sprint row (R36-VIEWER-SUBAPP) found the row's own subject already shipped except for one thing: **the live DOM verification this entry had flagged as unverified since slice 4.** Doing it found a broken non-negotiable.

## The finding

`createViewerApp` needs a WebGL context and a Fragments worker, which is why nobody had opened it. A headless Chromium has both:

```
WEBGL {"ok":true,"ver":"WebGL 2.0 (OpenGL ES 3.0 Chromium)"}
TABS  [model(selected) · sheets · specs]
REFUSAL "open a project first — a sheet is cut from its model"
AFTER_REFUSAL ["model:true","sheets:false","specs:false"]
```

Every behaviour the unit tests assert is correct. That is the boring half. The interesting half is what they could not see, in the same run:

```
pageerror: Failed to fetch dynamically imported module: .../viewer/app.ts
REQFAIL https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm :: ERR_CERT_AUTHORITY_INVALID
```

`three/examples/jsm/loaders/TTFLoader.js` opens with a **static import of a CDN URL**. Rolldown cannot bundle a URL specifier, so it emitted it verbatim — as **line 1 of `three-*.js`**, the chunk every 3D module depends on. It is reached through `@thatopen/components-front`, which imports `TTFLoader` for a `DrawingEditor` font loader this app never constructs; a static import is loaded whether or not it is used.

The consequence is not a missing font. With no route to jsdelivr the chunk never evaluates, the viewer's dynamic import rejects, and **nothing renders and nothing reports it** — the failure an air-gapped deployment has. Against the fourth non-negotiable in `CLAUDE.md`: *the viewer must run fully offline*.

## The fix

`apps/web/src/shims/TTFLoader.ts` keeps the module's shape and refuses at the point of use, aliased in `vite.config.ts`. A stub rather than a vendored font parser: `LengthMeasurement`, `AreaMeasurement` and `AngleMeasurement` are the only things this app imports from `components-front` and none of them loads a font, so vendoring opentype.js would add a dependency to make a path work that nothing enters.

## The gate

`apps/web/scripts/check-offline.mjs` greps the **built output**, not the config. `vite.config.ts` already carries the reason in as many words for the vendor split beside it: a config that stops taking effect still builds, still emits the right filenames, and is wrong. An alias is the same shape — bump the dependency, rename the upstream file, and it quietly matches nothing.

Measured both ways:

| | result |
|---|---|
| with the alias | `check-offline OK - 85 bundled JS files, no import reaches the network.` |
| alias removed, rebuilt | `assets/three-CgftFnju.js imports https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm` → exit 1 |
| remote import injected into `dist/` | caught, exit 1 |

It refuses to pass on a directory holding fewer than ten JS files, because "0 remote imports" reads identically whether the bundle is clean or absent. Runs in CI after the build; costs about a second. It flags URLs in *import positions* only — a URL in a string the app deliberately fetches (the update check in `ui/update.ts`, correctly guarded and documented as returning null offline) is not a module the runtime must reach before evaluating the file.

## Also in here

The comment introducing the canvas mode switch said `specs` **is deliberately NOT registered** — three lines above the registration of `specs`. True when written in v0.3.918, false from v0.3.920, and it stood for 190 versions because nothing reads a comment. The test beside it proves the tab is real and could not see the prose denying it. `canvasMode.test.ts` now fails on a comment that says a registered mode is not registered; verified by restoring the old comment and watching it fail.

## R36-VIEWER-SUBAPP is complete

Everything it named has shipped and the last open item is closed. Moved to `roadmap-completed.md` with the entry intact, removed from Lane E, and sprint row 3 struck with its prediction checked. Its lesson, kept in the archive: **an entry cannot check itself** — five of its slices were re-scoped or fixed by a premise-check that contradicted this entry's own prose, and every one of those was caught by running something rather than by re-reading the paragraph above it.

## Verification

- 2,017 vitest tests across 197 files — pass
- `tsc --noEmit`, `eslint` — clean
- `npm run build` + `npm run budget` (200.5 KB of 220 KB) + `npm run offline` — pass
- `test_file_sizes.py`, `test_claude_md_gates.py`, `test_doc_substance.py`, `roadmapLanes.test.ts` — pass
- Both gates mutation-checked: each fails on the change it exists to catch

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_