### PR TITLE
v0.3.1112–1113 — the firm's own closed projects beside the number being underwritten, and a dead-code gate that counted prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1113 (2026-08-27) — a dead-code gate that counted prose, and the gap it still cannot see
+
+**Two changes and one correction, and the correction is the useful part.**
+
+`test_dead_code_population.py` counted every non-docstring string literal as a reference, deliberately:
+registries dispatch on strings, and that rule is why `register_recipe` survived a sweep. But it makes
+no distinction between a dispatch key and an English sentence, so any function whose name is a common
+word is reached by prose. The gate had already recorded this once — `evm.quadrant`, *"a limitation,
+stated rather than hidden"* — and left it needing a human.
+
+It needed a rule: **a key is a token, a sentence has spaces.** A string literal now counts only when
+the whole literal is identifier-shaped — `add_wall`, `cost_per_sf`, `drawings.markups.rekey_storeys`
+match; a payload note reading *"…is shown beside it rather than folded into it"* does not.
+
+Measured before and after, because this file's own history is four corrections to a population rule:
+**0 unreferenced → 1**, and the one is `sync_property`, which R37-TRIAGE already documents as
+genuinely uncalled and masked by its own `NotImplementedError` string. It moves from invisible to
+**explicitly exempted, with the reason and a rot-check in both directions**. An exemption anybody can
+read beats a mask nobody can see; from the outside they are identical — a green run over a function
+nothing calls.
+
+**Writing that exemption list immediately broke the gate, which is the sharpest part.** Adding
+`"sync_property"` as a dict key made `sync_property` referenced — the key is identifier-shaped by
+construction, so it survives the very filter it was added because of. The ratchet went back to zero
+and the entry documenting it read as stale. **An exemption list that satisfies the check it exempts
+from is the gate measuring itself**, the same shape as the `specPane` string that made
+`canvasMode.test.ts` too weak in v0.3.1111. The gate no longer reads its own file: it names symbols to
+talk about them, and it is not a caller.
+
+### The correction: this is NOT why `beside` was missed
+
+Yesterday's find — `deal_memory.beside()`, built and wired to nothing — scored **60 references** here,
+and it would be neat to say the prose rule is why. It is not, and checking rather than asserting is
+the whole discipline: **under the tightened rule `beside` still has two references, one of them
+`test_deal_memory.py`, which has imported it since the engine shipped in PR #180.**
+
+The test tree counts as callers **by design** — that is the 35 → 13 correction in this gate's own
+header, and it is right for the question the gate asks. But it means *"tested, and wired to nothing"*
+is invisible to it by construction, and no string rule reaches that.
+
+So the gap was measured instead of narrated: **20 public functions in `aec_api` are referenced only by
+the test tree**, `beside` having been the 21st. That is the third instance of one shape after
+`read_p6xml_all` and the spec manual's MasterFormat default, and all three were found by hand. Three
+hand-finds is a population, not a coincidence.
+
+It is recorded as **R37-TESTED-UNWIRED** rather than ratcheted, because the number is not the
+deliverable: several of the 20 are legitimately test-only surface — `sbom`, `pdf_sanity` and
+`is_dual_licensed` exist for the supply-chain *gates*, which are tests by design. R37-TRIAGE's record
+is the warning: reading its 12 candidates found **eight live**, and the two deleted without reading
+had to be put back.
+
 ## v0.3.1112 (2026-08-27) — the firm's own closed projects, beside the number being underwritten
 
 **R35-DEAL-MEMORY's engine shipped with the item and the function it exists for had no caller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,35 @@ deliverable: several of the 20 are legitimately test-only surface — `sbom`, `p
 is the warning: reading its 12 candidates found **eight live**, and the two deleted without reading
 had to be put back.
 
+### Review round on the above, and the sharpest finding was already a test
+
+**`test_route_authz.py` failed on the new route, and it was right about something a correct hand-check
+would still have got wrong.** The first version authorised with
+`if pid not in (member_project_ids(db, user) or {pid})`. `member_project_ids` returns **None** for "no
+restriction" and an **empty set** for "a member of nothing" — and `or {pid}` collapses the second into
+the first, so a signed-in user belonging to no project was authorised for any project id they typed.
+
+The route now uses `Depends(require_role("viewer"))`, like every other `/projects/{pid}` route in that
+file. The gate walks those routes and requires the *tagged* dependency, so a bespoke membership check
+is invisible to it **whether or not the check is correct** — it is not looking for authorization, it
+is looking for the one authorization anybody audits. Running it before pushing would have taken four
+seconds; the full backend suite takes twenty-two minutes, and skipping the suite meant skipping this.
+
+Three more, all real:
+
+* **`hard_cost` accepted NaN and Infinity.** `not x` is False for NaN and every comparison with NaN is
+  False, so both halves of `not hard_cost or hard_cost <= 0` let it through; it then divided into the
+  response and left as `null` under orjson — *a comparison with a missing number in it, which reads as
+  "no history" rather than as bad input.* Now `math.isfinite`, with all five cases pinned.
+* **The $/SF strip was painted once by `renderBudget()`**, so editing "Hard cost $" left a comparison
+  for the PREVIOUS hard cost beside the new number. It rides the same debounce as the solve now, and
+  a late reply for a superseded cost is dropped rather than allowed to win by arriving last. Three
+  regression tests, one of which fails on the `cost_lines[1]` shortcut the sum replaced.
+* **The test inherited `DATABASE_URL`.** `setdefault` keeps `run_tests.py` in control of the per-test
+  database, which is right — but it also inherits whatever a developer exported, and this file calls
+  `create_all` and commits fixtures. It now refuses to start against anything that is not a local
+  sqlite path, rather than quietly creating test schema in a real database.
+
 ## v0.3.1112 (2026-08-27) — the firm's own closed projects, beside the number being underwritten
 
 **R35-DEAL-MEMORY's engine shipped with the item and the function it exists for had no caller
@@ -67,7 +96,7 @@ shape one ring over.
 
 `GET /projects/{pid}/deal-memory/beside` is the route, and the proforma's cost budget is the screen:
 
-```
+```text
 🏛 Your own history: this deal's hard cost is $250/SF ($500,000 ÷ 2,000 SF) — inside the range
    your 6 closed project(s) landed in ($225–$275, median $250). A comparison, not a verdict.
 ```
@@ -121,7 +150,7 @@ the Model tab selected.** The unit tests were right about every one of those.
 
 They could not have caught what the same run found in the first second:
 
-```
+```text
 pageerror: Failed to fetch dynamically imported module: .../viewer/app.ts
 REQFAIL https://cdn.jsdelivr.net/npm/opentype.js@1.3.4/+esm :: ERR_CERT_AUTHORITY_INVALID
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1112 (2026-08-27) — the firm's own closed projects, beside the number being underwritten
+
+**R35-DEAL-MEMORY's engine shipped with the item and the function it exists for had no caller
+anywhere.** `deal_memory.comps` has been routed since the start. `deal_memory.beside()` — the last
+function in that module, whose own docstring calls it *"the shape the underwriting screen wants"* —
+was never routed, never in the client, on no screen. Nothing failed, because `test_reachable` asks
+whether a MODULE is reachable and `deal_memory` is: the portfolio route imports it. *A module can be
+reachable and its whole reason for existing still be unreachable* — `read_p6xml_all` was the same
+shape one ring over.
+
+`GET /projects/{pid}/deal-memory/beside` is the route, and the proforma's cost budget is the screen:
+
+```
+🏛 Your own history: this deal's hard cost is $250/SF ($500,000 ÷ 2,000 SF) — inside the range
+   your 6 closed project(s) landed in ($225–$275, median $250). A comparison, not a verdict.
+```
+
+**It offers one of the engine's three metrics, and the other two are decisions rather than an
+unfinished job.** `cost_per_sf` is a unit conversion: a hard cost and a GFA turn into it.
+`cost_variance_pct` is not — the nearest thing a proforma enters is a contingency, and *"your
+contingency should cover this firm's historical overrun"* is a claim the product would be making in
+an underwriting, which is the same call `/schedule/eot` is still waiting on. `schedule_variance_days`
+beside an entered `construction_months` would be a category error in matching units, which is the
+dangerous kind: both are numbers of time and the screen would look right.
+
+`no_gfa` is its own status rather than folded into `insufficient_history` — load a model versus close
+more projects are different remedies, and answering the first with the second sends somebody hunting
+for history they already have. `services/api/test_deal_memory_beside.py` holds all of it, including
+the anti-vacuity check that the deal on screen is excluded from its own comp set.
+
+**The "by vintage" half was nearly left out, and two gates arguing is what caught it.**
+`clientCallers.test.ts` rejected `portfolioDealMemory` — no screen, so a typed method would exist
+only to satisfy a gate. Then `test_route_reachability` failed the other way: the new route put the
+substring `deal-memory` into the web source, and that rule matches a leaf against the whole blob, so
+its frozen entry for `/portfolio/deal-memory` read as *"quietly became called"* while nothing called
+it. **A substring test cannot tell which route a string belongs to.**
+
+Neither gate was wrong and neither could be satisfied by wording. Re-reading the item settled it — it
+asks for realised outcomes *"(… cost/SF by vintage)"*, and `comps` returns `vintage` per project. The
+comp list was in the item all along; wiring only the summary was the half-build. A "which projects?"
+disclosure now shows them, newest first, with the excluded count beside them so a partial comp set
+cannot read as a whole history. Sharpening the needle instead was measured and rejected: a
+two-segment needle is already rejected in that file with numbers, and **328 of 941 routes share a
+leaf**, so "a shared leaf decides nothing" would take a third of the surface out of the gate's reach.
+
+Also in this release, and the same shape one level up: **the roadmap and its own gate were blind in
+the same place, so they agreed.** The SCALE-SEAM bullet was headed `㉗` while its own next words said
+㉗ shipped in v0.3.1086, and the Lane I cell called ㉗ "the only open slice". `MARKS` in
+`apps/web/src/shell/roadmapLanes.test.ts` stopped at ㉗, and marks are an optional group on both
+sides of that check — so a numeral it cannot spell does not fail to parse, it drops, and item and
+lane row degrade to the same bare code. Measured both ways: a mismatch *inside* the vocabulary fails
+correctly; one *outside* it passed 13 of 13. `MARKS` now spells ㉘ (29 item codes before, 29 after —
+nothing moved, which is the point), and forgetting to widen it next time fails a test instead of
+quietly narrowing what is enforced.
+
 ## v0.3.1111 (2026-08-27) — the viewer could not run offline, and nothing on screen said so
 
 **A non-negotiable was being broken by a transitive import, and it was found by opening the app in a

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1112",
+    "version": "0.3.1113",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1111",
+    "version": "0.3.1112",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1112",
+  "version": "0.3.1113",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1111",
+  "version": "0.3.1112",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -12,7 +12,7 @@ import { withMep } from "./mep";
 import { withTopics } from "./topics";
 import { withAi } from "./ai";
 import { withEvm } from "./evm";
-import { withCodeCheck } from "./codecheck";
+import { withCodeCheck } from "./codecheck"; import { withDealMemory } from "./dealMemory";
 import { withPdfTools } from "./pdfTools";
 import { withIds } from "./ids";
 import { withSpecialty } from "./specialty";
@@ -61,7 +61,7 @@ import type {
 
 // Transport (baseUrl, token, json/_pdfPost/url/health) lives in HttpCore; ApiClient adds the typed
 // domain methods below. Every `api.method()` call site is unchanged by the split.
-export class ApiClient extends withPdfTools(withCodeCheck(withSpecialty(withIds(withEvm(withRisk(withEntitlements(withPrecon(withAi(withTopics(withMep(withDocuments(withModels(withElements(withDrawingSheets(withDrawingSet(withMarkup(withSync(withConnections(withDocQa(withFinance(withContracts(withAuth(withProforma(withDesignOptions(withRoutines(withCost(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore)))))))))))))))))))))))))))))))))) {
+export class ApiClient extends withDealMemory(withPdfTools(withCodeCheck(withSpecialty(withIds(withEvm(withRisk(withEntitlements(withPrecon(withAi(withTopics(withMep(withDocuments(withModels(withElements(withDrawingSheets(withDrawingSet(withMarkup(withSync(withConnections(withDocQa(withFinance(withContracts(withAuth(withProforma(withDesignOptions(withRoutines(withCost(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAuthoring(HttpCore))))))))))))))))))))))))))))))))))) {
   /** Admin: integration settings (AI / email / SSO). Secret values are never returned. */
   integrations() {
     return this.json<{ groups: IntegrationGroup[] }>("/settings/integrations");

--- a/apps/web/src/api/dealMemory.ts
+++ b/apps/web/src/api/dealMemory.ts
@@ -1,0 +1,100 @@
+/** R35-DEAL-MEMORY: this firm's own realised $/SF, beside the hard cost being underwritten.
+ *
+ *  A new file rather than methods in `client.ts`, per the extraction rule in `test_file_sizes.py`:
+ *  a *field* folds onto an existing line, a *feature* moves to a domain module. **Deliberately NOT
+ *  labelled SCALE-SEAM ㉘** — a seam slice EXTRACTS an existing group and shrinks `client.ts`, and
+ *  this adds a feature that was never in it. The ratchet said so before I did: the one import line
+ *  took the file 2,837 → 2,838 and failed, which is a slice claim failing its own definition.
+ *
+ *  **`deal_memory.beside()` — the function whose own docstring says it is "the shape the underwriting
+ *  screen wants" — had no caller anywhere**, server or client, while `deal_memory.comps` had been
+ *  routed since the engine shipped. So `test_reachable` passed: the MODULE is imported, by the
+ *  portfolio route. *A module can be reachable and its whole reason for existing still be
+ *  unreachable* — `read_p6xml_all` was the same shape one ring over.
+ *
+ *  **Both methods are here, and the second one is here because two gates argued about it.**
+ *  `portfolioDealMemory` was written, then removed when `clientCallers.test.ts` failed on it — no
+ *  screen, so a typed method for it would exist only to satisfy a gate. Then
+ *  `test_route_reachability` failed the other way: adding `/projects/{pid}/deal-memory/beside` put
+ *  the substring `deal-memory` into the web source, so its frozen entry for `/portfolio/deal-memory`
+ *  read as "quietly became called" when nothing had called it.
+ *
+ *  Neither gate was wrong and neither could be satisfied by wording. What settled it was re-reading
+ *  the roadmap item, which asks for realised outcomes *"(exit cap achieved vs assumed, actual
+ *  lease-up months, **cost/SF by vintage**)"* — and `comps` returns `vintage` per project. The comp
+ *  list was part of the item all along; wiring only the summary comparison was the half-build, and
+ *  the gate collision is what made that visible.
+ *
+ *  A mixin, so every call site resolves unchanged. `api/surface.test.ts` is what proves it.
+ */
+import { HttpCore } from "./httpCore";
+
+type Ctor<T> = new (...args: any[]) => T;
+
+/** `beside()`'s answer: where an entered number sits against the firm's own history. */
+export interface DealMemoryBeside {
+  metric: string;
+  /** `no_gfa` is the route's own, and is NOT a `beside()` status — see the method's comment. */
+  status: "ok" | "insufficient_history" | "no_recorded_source" | "unknown_metric" | "not_a_number"
+    | "no_gfa";
+  entered: number | null;
+  median?: number; p25?: number; p75?: number; count?: number;
+  position?: "below_p25" | "within_iqr" | "above_p75";
+  comparison?: null;
+  note?: string;
+  gfa_sf?: number;
+  hard_cost?: number;
+}
+
+/** One metric's realised distribution across the caller's own closed projects. */
+export interface DealMemoryMetric {
+  status: "ok" | "insufficient_history" | "no_recorded_source";
+  count?: number;
+  median?: number; p25?: number; p75?: number; min?: number; max?: number;
+  note?: string;
+}
+
+/** One closed project as it contributes to the comp set. */
+export interface DealMemoryProject {
+  id: string; name: string; vintage: number | null;
+  budget: number | null; actual: number | null; gfa_sf: number | null;
+  cost_variance_pct: number | null; cost_per_sf: number | null;
+  schedule_variance_days: number | null;
+}
+
+export function withDealMemory<TBase extends Ctor<HttpCore>>(Base: TBase) {
+  return class DealMemory extends Base {
+  /** The closed projects behind the comparison — the "by vintage" half of the roadmap item.
+   *
+   *  `exit_cap_achieved` and `lease_up_months` come back as `no_recorded_source` and are never
+   *  computed: nothing records a realised exit cap or a lease-up actual, and reading either off the
+   *  latest scenario would compare an assumption to itself and report perfect underwriting accuracy
+   *  forever. Render the refusal — it is the honest half of the payload.
+   *
+   *  `excluded` is not noise either: a project with no actual spend is excluded rather than counted
+   *  as zero variance, and showing the count is what stops a small comp set looking like a complete
+   *  one. */
+  portfolioDealMemory() {
+    return this.json<{
+      project_count: number;
+      metrics: Record<string, DealMemoryMetric>;
+      projects: DealMemoryProject[];
+      excluded: { id: string; name: string; reason: string; note: string }[];
+      excluded_count: number; min_samples: number; note: string;
+    }>("/portfolio/deal-memory");
+  }
+
+  /** This firm's own realised $/SF, beside the hard cost being underwritten.
+   *
+   *  `hard_cost` is dollars, not $/SF: the server divides by the project's GFA because
+   *  `energy.project_gfa_sf` is the one definition of GFA and deriving it here would make a second.
+   *  A project whose properties index is not loaded answers `no_gfa` — a real and common outcome,
+   *  and deliberately distinct from `insufficient_history`: one means "we cannot express your number
+   *  in this metric's units", the other means "we have no history to compare it against", and they
+   *  send a reader looking in different places. */
+  dealMemoryBeside(pid: string, hardCost: number) {
+    return this.json<DealMemoryBeside>(
+      `/projects/${pid}/deal-memory/beside?hard_cost=${encodeURIComponent(String(hardCost))}`);
+  }
+  };
+}

--- a/apps/web/src/proforma/proforma.render.test.ts
+++ b/apps/web/src/proforma/proforma.render.test.ts
@@ -228,3 +228,64 @@ describe("reserve study — an unverified suggestion says so", () => {
     expect(host.textContent).toContain("unreliable");
   });
 });
+
+/**
+ * R35-DEAL-MEMORY — the $/SF strip must describe the hard cost that is on screen NOW.
+ *
+ * Review finding, 2026-08-27: the strip was painted once by `renderBudget()`, so editing
+ * "Hard cost $" left a comparison for the PREVIOUS hard cost sitting beside the new number. That is
+ * the defect class this whole release is about — a report that misdescribes what it reports on —
+ * and it is worse on an underwriting screen than most places, because the two numbers are adjacent
+ * and the stale one looks like it was computed from the fresh one.
+ *
+ * Driven through `refreshDealMemory`, the seam the fix created, rather than through a keystroke:
+ * the debounce is `window.setTimeout` and pinning a timer would test the scheduler, not the sum.
+ */
+describe("the deal-memory strip follows the hard cost", () => {
+  function mountBudget(pid: string | null = "P1") {
+    const api = {
+      dealMemoryBeside: vi.fn().mockResolvedValue({
+        metric: "cost_per_sf", status: "insufficient_history", entered: null,
+      }),
+    };
+    const root = document.createElement("div");
+    document.body.replaceChildren(root);
+    const ui = new ProformaUI(root, api as unknown as ApiClient, vi.fn(), () => pid);
+    const priv = ui as unknown as {
+      a: { cost_lines: { category: string; amount: number }[] };
+      memoryEl?: HTMLElement;
+      refreshDealMemory(): void;
+    };
+    // mount a connected element for the strip — `refreshDealMemory` refuses to paint a detached one
+    const el = document.createElement("div"); root.appendChild(el); priv.memoryEl = el;
+    return { api, priv };
+  }
+
+  it("sends the CURRENT hard-cost total, not the one from first render", () => {
+    const { api, priv } = mountBudget();
+    priv.refreshDealMemory();
+    expect(api.dealMemoryBeside).toHaveBeenLastCalledWith("P1", 20_000_000);
+
+    // the edit the reviewer described: change the hard line, refresh, expect the NEW total
+    const hard = priv.a.cost_lines.find((c) => c.category === "hard")!;
+    hard.amount = 26_500_000;
+    priv.refreshDealMemory();
+    expect(api.dealMemoryBeside).toHaveBeenLastCalledWith("P1", 26_500_000);
+  });
+
+  it("sums every hard line rather than reading cost_lines[1]", () => {
+    // The default deal happens to put hard cost second. A budget synced from the GC's does not, and
+    // an index would have compared the wrong line against the firm's own history — silently, since
+    // any number looks plausible in a $/SF strip.
+    const { api, priv } = mountBudget();
+    priv.a.cost_lines.push({ category: "hard", amount: 1_000_000 } as never);
+    priv.refreshDealMemory();
+    expect(api.dealMemoryBeside).toHaveBeenLastCalledWith("P1", 21_000_000);
+  });
+
+  it("asks nothing when there is no project", () => {
+    const { api, priv } = mountBudget(null);
+    priv.refreshDealMemory();
+    expect(api.dealMemoryBeside).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -1050,6 +1050,79 @@ export class ProformaUI {
     };
     refreshRecon();
 
+    // R35-DEAL-MEMORY — the firm's OWN realised $/SF, beside the hard cost being entered.
+    //
+    // The engine and `/portfolio/deal-memory` shipped with the item; `deal_memory.beside()` — the
+    // function whose docstring says it is "the shape the underwriting screen wants" — had no caller
+    // anywhere. This is that caller.
+    //
+    // Only $/SF is asked for, and the omissions are decisions rather than a partial job. A realised
+    // cost VARIANCE has no counterpart among these fields (the nearest is contingency, and "your
+    // contingency should cover our historical overrun" is a claim this product would be making, not
+    // a unit conversion); a realised schedule VARIANCE is not a duration, so putting it beside
+    // `construction_months` would be a category error in matching units.
+    const memory = document.createElement("div"); memory.className = "meta";
+    memory.style.cssText = "margin:0 0 8px;font-size:11px";
+    host.insertBefore(memory, body);
+    const hardCost = (this.a.cost_lines as { category: string; amount: number }[])
+      // Summed by CATEGORY, not read from `cost_lines[1]`. The default deal happens to put hard cost
+      // second; a budget synced from the GC's does not, and an index would have quietly compared the
+      // wrong line against the firm's history.
+      .filter((c) => c.category === "hard").reduce((t, c) => t + (Number(c.amount) || 0), 0);
+    if (!hardCost) { memory.style.display = "none"; } else {
+      memory.textContent = "checking your own closed projects…";
+      void this.api.dealMemoryBeside(pid, hardCost).then((m) => {
+        // Every non-ok status is SHOWN, not hidden. They are different answers with different
+        // remedies — load a model, close more projects, capture a disposition — and a blank strip
+        // reads as "we checked and there is nothing to say", which is true of none of them.
+        if (m.status === "ok") {
+          const at = m.position === "within_iqr" ? "inside" : m.position === "below_p25" ? "below" : "above";
+          const col = m.position === "within_iqr" ? "var(--status-good)" : "var(--status-warn)";
+          memory.innerHTML = `🏛 Your own history: this deal's hard cost is <b>$${m.entered}/SF</b> `
+            + `(${money(m.hard_cost ?? 0)} ÷ ${Math.round(m.gfa_sf ?? 0).toLocaleString()} SF) — `
+            + `<span style="color:${col}">${at}</span> the range your <b>${m.count}</b> closed `
+            + `project(s) landed in ($${m.p25}–$${m.p75}, median $${m.median}). `
+            + `A comparison, not a verdict. <button class="tool-btn" id="pf-dm-more" `
+            + `style="font-size:10px;padding:1px 6px">which projects?</button>`;
+          // "cost/SF BY VINTAGE" is in the roadmap item's own words, and a range with no projects
+          // behind it cannot be argued with — the reader cannot tell whether it is six comparable
+          // buildings or six unrelated ones. On demand rather than always, because the range is the
+          // answer and the list is the evidence for it.
+          const more = memory.querySelector<HTMLButtonElement>("#pf-dm-more");
+          if (more) more.onclick = () => {
+            more.disabled = true; more.textContent = "loading…";
+            void this.api.portfolioDealMemory().then((mem) => {
+              const withSf = mem.projects.filter((p) => p.cost_per_sf != null)
+                .sort((a, b) => (b.vintage ?? 0) - (a.vintage ?? 0));
+              const rows = withSf.map((p) =>
+                `<tr><td>${escapeHtml(p.name)}</td><td class="num">${p.vintage ?? "—"}</td>`
+                + `<td class="num">$${p.cost_per_sf}</td></tr>`).join("");
+              const box = document.createElement("div"); box.style.marginTop = "4px";
+              // The excluded count travels with the list. Showing six projects out of eight without
+              // saying so makes a partial comp set read as the whole history — the same shape as a
+              // report that misdescribes itself, one screen over.
+              box.innerHTML = `<table class="fin-table"><tr><th>Project</th><th class="num">Vintage`
+                + `</th><th class="num">$/SF</th></tr>${rows}</table>`
+                + (mem.excluded_count
+                  ? `<div class="meta" style="font-size:10px">${mem.excluded_count} project(s) `
+                    + `excluded — no actual spend recorded, so counting them as zero variance would `
+                    + `drag the range toward "we were exactly right".</div>`
+                  : "");
+              more.replaceWith(box);
+            }).catch(() => { more.disabled = false; more.textContent = "which projects?"; });
+          };
+        } else if (m.status === "no_gfa") {
+          memory.textContent = "🏛 Your own history: load this project's model to compare its hard "
+            + "cost per square foot against your closed projects.";
+        } else if (m.status === "insufficient_history") {
+          memory.textContent = "🏛 Your own history: not enough closed projects yet to show a $/SF "
+            + "range — it fills in as they close, and a range from too few is noise wearing a dollar sign.";
+        } else {
+          memory.textContent = `🏛 Your own history: ${m.note ?? m.status}`;
+        }
+      }).catch(() => { memory.style.display = "none"; });   // endpoint absent → hide, say nothing false
+    }
+
     // construction draw schedule — sourced from the GC's cost-loaded schedule (relational tie)
     const draws = document.createElement("div"); draws.className = "meta"; draws.style.cssText = "margin:0 0 8px;font-size:11px";
     host.insertBefore(draws, body);

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -64,6 +64,7 @@ export class ProformaUI {
   private timer = 0;
   private lastResult?: ProformaResult;   // latest solve, for the Overview command center
   private overviewEl?: HTMLElement;       // the Overview tab's container (re-rendered on each solve)
+  private memoryEl?: HTMLElement;         // R35 deal-memory strip — repainted on every hard-cost edit
 
   constructor(private root: HTMLElement, private api: ApiClient,
               private setStatus: (m: string) => void,
@@ -88,7 +89,11 @@ export class ProformaUI {
         set(this.a, path, kind === "pct" ? v / 100 : v);
         if (path === "equity.lp_pct") set(this.a, "equity.gp_pct", 1 - v / 100);
         clearTimeout(this.timer);
-        this.timer = window.setTimeout(() => this.solve(), 350);  // debounced live solve
+        // The deal-memory strip rides the SAME debounce as the solve, because it describes the same
+        // numbers. It used to be painted once by `renderBudget()`, so editing "Hard cost $" left a
+        // $/SF comparison on screen for the PREVIOUS hard cost — a number describing an input that is
+        // no longer there, next to the one that replaced it.
+        this.timer = window.setTimeout(() => { void this.solve(); this.refreshDealMemory(); }, 350);
       };
       wrap.appendChild(inp); form.appendChild(wrap);
     }
@@ -103,7 +108,7 @@ export class ProformaUI {
         const v = parseFloat(inp.value);
         set(this.a, path, inp.value.trim() === "" || isNaN(v) ? null : v / scale);
         clearTimeout(this.timer);
-        this.timer = window.setTimeout(() => this.solve(), 350);
+        this.timer = window.setTimeout(() => { void this.solve(); this.refreshDealMemory(); }, 350);
       };
       wrap.appendChild(inp); form.appendChild(wrap);
     };
@@ -1012,6 +1017,79 @@ export class ProformaUI {
   /** Developer cost budget: line-item hard/soft/acquisition costs (description × $/unit × qty) with
    *  per-category contingency, that roll into the proforma's cost_lines. The institutional gap the
    *  flat cost drivers don't cover. */
+  /** Repaint the deal-memory strip from the CURRENT assumptions. Safe to call when it is not mounted.
+   *
+   *  Only $/SF is asked for. A realised cost VARIANCE has no counterpart among these fields — the
+   *  nearest is a contingency, and "your contingency should cover our historical overrun" is a claim
+   *  this product would be making, not a unit conversion — and a realised schedule VARIANCE is not a
+   *  duration, so putting it beside `construction_months` would be a category error in matching units.
+   */
+  private refreshDealMemory() {
+    const memory = this.memoryEl;
+    const pid = this.projectId();
+    if (!memory || !pid || !memory.isConnected) return;
+    // Summed by CATEGORY, not read from `cost_lines[1]`. The default deal happens to put hard cost
+    // second; a budget synced from the GC's does not, and an index would have quietly compared the
+    // wrong line against the firm's history.
+    const hardCost = (this.a.cost_lines as { category: string; amount: number }[])
+      .filter((c) => c.category === "hard").reduce((t, c) => t + (Number(c.amount) || 0), 0);
+    if (!hardCost) { memory.style.display = "none"; return; }
+    memory.style.display = "";
+    memory.textContent = "checking your own closed projects…";
+    void this.api.dealMemoryBeside(pid, hardCost).then((m) => {
+      // A late reply for a hard cost the user has already changed must not overwrite the current
+      // one. Same defect as the stale strip, one layer down: two in-flight requests, and the SLOWER
+      // one wins by arriving last.
+      if (m.hard_cost != null && m.hard_cost !== hardCost) return;
+      // Every non-ok status is SHOWN, not hidden. They are different answers with different remedies
+      // — load a model, close more projects, capture a disposition — and a blank strip reads as "we
+      // checked and there is nothing to say", which is true of none of them.
+      if (m.status === "ok") {
+        const at = m.position === "within_iqr" ? "inside" : m.position === "below_p25" ? "below" : "above";
+        const col = m.position === "within_iqr" ? "var(--status-good)" : "var(--status-warn)";
+        memory.innerHTML = `🏛 Your own history: this deal's hard cost is <b>$${m.entered}/SF</b> `
+          + `(${money(m.hard_cost ?? 0)} ÷ ${Math.round(m.gfa_sf ?? 0).toLocaleString()} SF) — `
+          + `<span style="color:${col}">${at}</span> the range your <b>${m.count}</b> closed `
+          + `project(s) landed in ($${m.p25}–$${m.p75}, median $${m.median}). `
+          + `A comparison, not a verdict. <button class="tool-btn" id="pf-dm-more" `
+          + `style="font-size:10px;padding:1px 6px">which projects?</button>`;
+        // "cost/SF BY VINTAGE" is in the roadmap item's own words, and a range with no projects
+        // behind it cannot be argued with — the reader cannot tell whether it is six comparable
+        // buildings or six unrelated ones. On demand: the range is the answer, the list is evidence.
+        const more = memory.querySelector<HTMLButtonElement>("#pf-dm-more");
+        if (more) more.onclick = () => {
+          more.disabled = true; more.textContent = "loading…";
+          void this.api.portfolioDealMemory().then((mem) => {
+            const withSf = mem.projects.filter((p) => p.cost_per_sf != null)
+              .sort((a, b) => (b.vintage ?? 0) - (a.vintage ?? 0));
+            const rows = withSf.map((p) =>
+              `<tr><td>${escapeHtml(p.name)}</td><td class="num">${p.vintage ?? "—"}</td>`
+              + `<td class="num">$${p.cost_per_sf}</td></tr>`).join("");
+            const box = document.createElement("div"); box.style.marginTop = "4px";
+            // The excluded count travels with the list. Showing six projects out of eight without
+            // saying so makes a partial comp set read as the whole history.
+            box.innerHTML = `<table class="fin-table"><tr><th>Project</th><th class="num">Vintage`
+              + `</th><th class="num">$/SF</th></tr>${rows}</table>`
+              + (mem.excluded_count
+                ? `<div class="meta" style="font-size:10px">${mem.excluded_count} project(s) `
+                  + `excluded — no actual spend recorded, so counting them as zero variance would `
+                  + `drag the range toward "we were exactly right".</div>`
+                : "");
+            more.replaceWith(box);
+          }).catch(() => { more.disabled = false; more.textContent = "which projects?"; });
+        };
+      } else if (m.status === "no_gfa") {
+        memory.textContent = "🏛 Your own history: load this project's model to compare its hard "
+          + "cost per square foot against your closed projects.";
+      } else if (m.status === "insufficient_history") {
+        memory.textContent = "🏛 Your own history: not enough closed projects yet to show a $/SF "
+          + "range — it fills in as they close, and a range from too few is noise wearing a dollar sign.";
+      } else {
+        memory.textContent = `🏛 Your own history: ${m.note ?? m.status}`;
+      }
+    }).catch(() => { memory.style.display = "none"; });   // endpoint absent → say nothing false
+  }
+
   private renderBudget() {
     this.root.querySelector("#pf-budget")?.remove();   // idempotent — re-render replaces, never duplicates
     const host = document.createElement("div"); host.id = "pf-budget";
@@ -1054,74 +1132,14 @@ export class ProformaUI {
     //
     // The engine and `/portfolio/deal-memory` shipped with the item; `deal_memory.beside()` — the
     // function whose docstring says it is "the shape the underwriting screen wants" — had no caller
-    // anywhere. This is that caller.
-    //
-    // Only $/SF is asked for, and the omissions are decisions rather than a partial job. A realised
-    // cost VARIANCE has no counterpart among these fields (the nearest is contingency, and "your
-    // contingency should cover our historical overrun" is a claim this product would be making, not
-    // a unit conversion); a realised schedule VARIANCE is not a duration, so putting it beside
-    // `construction_months` would be a category error in matching units.
+    // anywhere. This is that caller. Painting lives in `refreshDealMemory()` so the same code runs
+    // on first render AND on every debounced hard-cost edit; it was inline here until review pointed
+    // out that a strip painted once describes whatever the hard cost USED to be.
     const memory = document.createElement("div"); memory.className = "meta";
     memory.style.cssText = "margin:0 0 8px;font-size:11px";
     host.insertBefore(memory, body);
-    const hardCost = (this.a.cost_lines as { category: string; amount: number }[])
-      // Summed by CATEGORY, not read from `cost_lines[1]`. The default deal happens to put hard cost
-      // second; a budget synced from the GC's does not, and an index would have quietly compared the
-      // wrong line against the firm's history.
-      .filter((c) => c.category === "hard").reduce((t, c) => t + (Number(c.amount) || 0), 0);
-    if (!hardCost) { memory.style.display = "none"; } else {
-      memory.textContent = "checking your own closed projects…";
-      void this.api.dealMemoryBeside(pid, hardCost).then((m) => {
-        // Every non-ok status is SHOWN, not hidden. They are different answers with different
-        // remedies — load a model, close more projects, capture a disposition — and a blank strip
-        // reads as "we checked and there is nothing to say", which is true of none of them.
-        if (m.status === "ok") {
-          const at = m.position === "within_iqr" ? "inside" : m.position === "below_p25" ? "below" : "above";
-          const col = m.position === "within_iqr" ? "var(--status-good)" : "var(--status-warn)";
-          memory.innerHTML = `🏛 Your own history: this deal's hard cost is <b>$${m.entered}/SF</b> `
-            + `(${money(m.hard_cost ?? 0)} ÷ ${Math.round(m.gfa_sf ?? 0).toLocaleString()} SF) — `
-            + `<span style="color:${col}">${at}</span> the range your <b>${m.count}</b> closed `
-            + `project(s) landed in ($${m.p25}–$${m.p75}, median $${m.median}). `
-            + `A comparison, not a verdict. <button class="tool-btn" id="pf-dm-more" `
-            + `style="font-size:10px;padding:1px 6px">which projects?</button>`;
-          // "cost/SF BY VINTAGE" is in the roadmap item's own words, and a range with no projects
-          // behind it cannot be argued with — the reader cannot tell whether it is six comparable
-          // buildings or six unrelated ones. On demand rather than always, because the range is the
-          // answer and the list is the evidence for it.
-          const more = memory.querySelector<HTMLButtonElement>("#pf-dm-more");
-          if (more) more.onclick = () => {
-            more.disabled = true; more.textContent = "loading…";
-            void this.api.portfolioDealMemory().then((mem) => {
-              const withSf = mem.projects.filter((p) => p.cost_per_sf != null)
-                .sort((a, b) => (b.vintage ?? 0) - (a.vintage ?? 0));
-              const rows = withSf.map((p) =>
-                `<tr><td>${escapeHtml(p.name)}</td><td class="num">${p.vintage ?? "—"}</td>`
-                + `<td class="num">$${p.cost_per_sf}</td></tr>`).join("");
-              const box = document.createElement("div"); box.style.marginTop = "4px";
-              // The excluded count travels with the list. Showing six projects out of eight without
-              // saying so makes a partial comp set read as the whole history — the same shape as a
-              // report that misdescribes itself, one screen over.
-              box.innerHTML = `<table class="fin-table"><tr><th>Project</th><th class="num">Vintage`
-                + `</th><th class="num">$/SF</th></tr>${rows}</table>`
-                + (mem.excluded_count
-                  ? `<div class="meta" style="font-size:10px">${mem.excluded_count} project(s) `
-                    + `excluded — no actual spend recorded, so counting them as zero variance would `
-                    + `drag the range toward "we were exactly right".</div>`
-                  : "");
-              more.replaceWith(box);
-            }).catch(() => { more.disabled = false; more.textContent = "which projects?"; });
-          };
-        } else if (m.status === "no_gfa") {
-          memory.textContent = "🏛 Your own history: load this project's model to compare its hard "
-            + "cost per square foot against your closed projects.";
-        } else if (m.status === "insufficient_history") {
-          memory.textContent = "🏛 Your own history: not enough closed projects yet to show a $/SF "
-            + "range — it fills in as they close, and a range from too few is noise wearing a dollar sign.";
-        } else {
-          memory.textContent = `🏛 Your own history: ${m.note ?? m.status}`;
-        }
-      }).catch(() => { memory.style.display = "none"; });   // endpoint absent → hide, say nothing false
-    }
+    this.memoryEl = memory;
+    this.refreshDealMemory();
 
     // construction draw schedule — sourced from the GC's cost-loaded schedule (relational tie)
     const draws = document.createElement("div"); draws.className = "meta"; draws.style.cssText = "margin:0 0 8px;font-size:11px";

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -56,7 +56,16 @@ const OPEN = LINES.slice(0, GATED_AT === -1 ? LINES.length : GATED_AT);
  * ㉕ is not a considered limit either, just a further-off one. **A vocabulary this check defines is
  * part of its population, so widening it is a real change and not housekeeping.**
  */
-const MARKS = "①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳㉑㉒㉓㉔㉕㉖㉗";
+//
+// Widened to ㉘ on 2026-08-27, and MEASURED because this file says an unmeasured widening is a new
+// number with no idea what moved: **29 item codes before, 29 after — nothing gained, nothing lost.**
+// That is the expected result and it is the point. Widening the vocabulary changes nothing on its
+// own; it only makes ㉘ *writable*. What the narrow vocabulary had been doing was worse than hiding
+// an item — the SCALE-SEAM bullet was HEADED `㉗` while its own next words said ㉗ shipped in
+// v0.3.1086, and the Lane I cell called ㉗ "the only open slice". Both wrong, and this gate agreed
+// with both, because a code it cannot spell is a code it cannot contradict. *A check and the text it
+// checks, blind in the same place, agree — and the agreement reads as verification.*
+const MARKS = "①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳㉑㉒㉓㉔㉕㉖㉗㉘";
 
 /**
  * One source for the marker vocabulary, because there were **two** and they had already drifted.
@@ -419,6 +428,53 @@ describe("the roadmap lane table", () => {
     const orphans = [...CODES].filter((c) => !assigned.has(c) && !parked.has(base(c)));
     expect(orphans, `unassigned roadmap items — add each to a lane row or to Parked: ${orphans.join(", ")}`)
       .toEqual([]);
+  });
+
+  it("spells every slice numeral actually in use — an unspellable mark is an unenforceable one", () => {
+    /**
+     * ADDED 2026-08-27, after a mutation showed the gate above could not catch the drift it exists
+     * for. Marks were handled as an OPTIONAL group on both sides — the item regex and the lane-cell
+     * regex — so a numeral outside `MARKS` does not fail to parse: it silently drops, and BOTH sides
+     * degrade to the bare code. They then agree.
+     *
+     * Measured, both directions, rather than argued:
+     *
+     *   lane cell ㉕ vs item ㉘, both in MARKS   → FAILS, naming `SCALE-SEAM ㉘`   ✅
+     *   MARKS ends at ㉗, item and cell say ㉘  → 13 passed                        ❌
+     *
+     * That second line is the whole finding. **A check and the text it checks, blind in the same
+     * place, agree — and the agreement reads as verification.** It is not hypothetical: the
+     * SCALE-SEAM bullet was headed `㉗` while its own next words said ㉗ shipped in v0.3.1086, and
+     * the Lane I cell called ㉗ "the only open slice". Two contradictions, in the two places this
+     * file checks, and it reported green over both.
+     *
+     * The docstring on `MARKS` says widening the vocabulary is a real change and not housekeeping.
+     * It is right, and that is the reason this exists rather than a reason to leave it to memory:
+     * FIVE consecutive slices recorded "㉖/㉗/㉘ needs MARKS widened" in the roadmap entry as a note
+     * to a future reader, which is a reminder rather than a check. Now the widening is still a
+     * deliberate act — but forgetting it fails here instead of quietly narrowing what is enforced.
+     *
+     * Scanned across the whole file, not just the open half: a numeral in the gated section is just
+     * as unspellable, and the ⛔ exclusion is applied AFTER parsing.
+     */
+    const ENCLOSED = /[\u2460-\u2473\u3251-\u325F\u32B1-\u32BF]/gu;
+    const unspellable = new Map<string, string>();
+    // Indexed, not `for…of` with `indexOf`: `LANE_ROW_LINES` holds line NUMBERS, and `indexOf`
+    // answers with the FIRST line equal to this text. Two identical lines — a repeated separator,
+    // say — would have made this ask about the wrong one. Written the slow way first, here.
+    for (const [i, ln] of LINES.entries()) {
+      // Only lines this file actually parses: an item bullet or a lane-table row. A numeral in prose
+      // — and this file's own docstrings are full of them — is not a code and must not fail here.
+      const isItem = /^\s*[-*] (?:(?:✅|◧|🟡|⭐|⛔)️? )*\*\*[A-Z][A-Z0-9]{1,5}-/.test(ln);
+      if (!isItem && !LANE_ROW_LINES.has(i)) continue;
+      for (const m of ln.matchAll(ENCLOSED)) {
+        if (!MARKS.includes(m[0])) unspellable.set(m[0], ln.trim().slice(0, 90));
+      }
+    }
+    expect([...unspellable.keys()],
+      "these slice numerals appear on an item bullet or a lane row but are NOT in MARKS, so both "
+      + "the item regex and the lane-cell regex drop them and agree on the bare code — widen MARKS:\n"
+      + [...unspellable].map(([k, ln]) => `  ${k}  ${ln}`).join("\n")).toEqual([]);
   });
 
   it("gives each item code exactly one bullet", () => {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -717,7 +717,7 @@ two rows share a path, so two agents in different rows cannot collide.
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE |
-| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R35-DEAL-MEMORY · R37-TRIAGE · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
+| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R37-TRIAGE · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · UX-3 *(library depth — `apps/web/src/viewer/tools/authoringSection.ts`)* · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
@@ -2182,13 +2182,36 @@ Shipped 2026-08-01:
 
 Shipped 2026-08-21:
 
-- ◧ **R35-DEAL-MEMORY** *(M — `deal_memory.py` shipped)* — the platform's own closed deals as a comp database: when underwriting
+- ✅ **R35-DEAL-MEMORY** *(M — SHIPPED v0.3.1112)* — the platform's own closed deals as a comp database: when underwriting
   a new deal, surface this portfolio's realised outcomes (exit cap achieved vs assumed, actual
   lease-up months, cost/SF by vintage) beside the assumption being entered. External research
   (2026-08) puts this "institutional knowledge" layer as the least-commoditised part of the
   AI-underwriting stack — and it is the one layer that cannot be bought, because it is made of the
   operator's own history. Builds on `benchmarking.py`'s cross-project aggregation and the
   provenance spine; no new dependency.
+
+  **PREMISE-CHECK 2026-08-27, and the entry was half-right in the way that reads as done.**
+  `deal_memory.py` had shipped, was tested, and was routed — `GET /portfolio/deal-memory`. But
+  `beside()`, the last function in it and the only one that answers the sentence above, **had no
+  caller anywhere**: not a route, not the client, not a screen. `test_reachable` passes because the
+  MODULE is imported, by the portfolio route. *A module can be reachable and its whole reason for
+  existing still be unreachable* — the same finding R46 recorded about `read_p6xml_all`, and the
+  second time this shape has been found by opening the file rather than by a gate.
+
+  Shipped as `GET /projects/{pid}/deal-memory/beside`, on the proforma's cost budget, held by
+  `services/api/test_deal_memory_beside.py`. **One of the engine's three metrics is offered and the
+  other two are refused on the record**: `cost_per_sf` is a unit conversion from an entered hard cost
+  and a GFA; `cost_variance_pct` beside a contingency would be the product asserting *"your
+  contingency should cover our historical overrun"*, the same domain call `/schedule/eot` is waiting
+  on; and a schedule VARIANCE beside an entered DURATION is a category error in matching units.
+
+  **The "by vintage" half was nearly left out, and two gates disagreeing is what caught it.**
+  `clientCallers.test.ts` refused a `portfolioDealMemory` with no screen; `test_route_reachability`
+  then read its own frozen entry as called, because the new route put the substring `deal-memory`
+  into the web source and that rule matches a leaf against the whole blob. Neither was wrong.
+  Re-reading this entry settled it — it asks for cost/SF **by vintage**, `comps` returns `vintage`
+  per project, and only the summary had been wired. **A gate collision is worth reading as evidence
+  about the work, not as an obstacle to it.**
 
 Also settled, no code change: **the Fragments converter stays Node, by constraint** — the Fragments
 serializer exists only in the JS kernel libraries, so `services/converter/` is the one deliberate

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -671,7 +671,7 @@ exact failure `roadmapLanes.test.ts` documents in its `MARKS` note. The gates ca
   is the specific error row 2 made.
 * **Not the next SCALE-SEAM slice.** ㉘ is genuinely next in a series that has shipped twenty-six
   increments, but the series is now cutting into `client.ts` at 2,837 lines from a 3,600-odd start. The marginal slice
-  is worth less than it was, and ㉘ additionally needs `MARKS` widened in
+  is worth less than it was. *(㉘ also needed `MARKS` widened; that shipped in v0.3.1112.)* The vocabulary lives in
   `apps/web/src/shell/roadmapLanes.test.ts` — a vocabulary change to a population check, which that
   file's own docstring calls a real change and not housekeeping.
 * **Not R22-ENTITLEMENT.** It led the last cut and two of its three parts shipped. What is left is the part
@@ -2493,7 +2493,7 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
   it "licences" while the code, the type and the route all say `licenses`, so the comment shared no
   word with its method. Fixed by matching the code rather than by widening the exemption set, which is
   frozen and may only shrink.*
-  **㉘ needs `MARKS` widened again** in `apps/web/src/shell/roadmapLanes.test.ts`.
+  **㉘ required `MARKS` widened, and that landed in v0.3.1112** — measured as that file demands (29 item codes before, 29 after), and with a new assertion so the NEXT slice fails a test rather than relying on this sentence. *Which it had to, because this sentence still read "㉘ needs `MARKS` widened again" in the very release that widened it — the fifth stale status line in this ring, caught by review. A note asking a future reader to remember something is the thing a gate replaces, and leaving it up after building the gate is the same defect one level out.*
 
   **㉖ took the code-compliance group out** (8 methods; `client.ts` 2,961 → 2,883) as
   `apps/web/src/api/codecheck.ts`. **It is the first slice grouped by what the methods ANSWER rather

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -723,7 +723,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | — |
-| **I · API client** | `apps/web/src/api/` | SCALE-SEAM ㉗ *(the only open slice; ②–㉖ have shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
+| **I · API client** | `apps/web/src/api/` | SCALE-SEAM ㉘ *(the only open slice; ②–㉗ have shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
 | **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `apps/web/src/tooling/`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | R39-TSC-CACHE *(local typecheck once diverged from CI; cause unknown, prior explanation retracted — an OBSERVATION, not a defect with a known fix. Read the entry before "fixing" it: the proposed fix is named there and rejected)* |
 
 **Parked — not available to pick up.** These are decisions or multi-release commitments, listed so
@@ -2422,7 +2422,7 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
 
 ## 🧱 Decomposition & reliability carry-overs (interleave one per few releases)
 
-- ◧ ⭐ **SCALE-SEAM ㉗ — `client.ts` is no longer a god-file, but the split is not finished.** *(㉗ PDF tools SHIPPED v0.3.1086; ②–㉖ already shipped)*
+- ◧ ⭐ **SCALE-SEAM ㉘ — `client.ts` is no longer a god-file, but the split is not finished.** *(②–㉗ have shipped, ㉗ PDF tools in v0.3.1086. **This heading read `㉗` until 2026-08-27** — naming a slice its own next words called shipped, because `MARKS` in `apps/web/src/shell/roadmapLanes.test.ts` stopped at ㉗ and nothing could spell the open one)*
   **㉗ took the PDF tools and A/E/C seals out** (9 methods, one contiguous run; `client.ts` 2,883 →
   2,837) as `apps/web/src/api/pdfTools.ts`. Grouped by what they DO, following ㉖: the run spans
   `/pdf/*`, `/stamps/library` and `/licenses/mine`, and a prefix split would separate `stampLibrary`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -717,7 +717,7 @@ two rows share a path, so two agents in different rows cannot collide.
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE |
-| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R37-TRIAGE · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
+| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R37-TRIAGE · R37-TESTED-UNWIRED · QTO-TRADE *(blocks the four procurement methods; a trade classification for QTO lines, not UI)* · R43-MASSINGBILL-CORE |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · UX-3 *(library depth — `apps/web/src/viewer/tools/authoringSection.ts`)* · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
@@ -2240,6 +2240,41 @@ claim must be premise-checked against TODAY's tree before acting; several are al
 * Its hotspot list (§3) is corroborated independently: `main.ts`, `portal.ts`, `client.ts` are the
   repo's own known god-files, and SCALE-SEAM already split `client.ts` by domain after this index
   was taken. Credit what shipped; keep the rest.
+
+- ◧ **R37-TESTED-UNWIRED** *(M — Lane C; measured 2026-08-27, NOT yet read)*
+  — **20 public functions in `aec_api` are referenced only by the test tree.**
+
+  Found by looking for the general case of a specific defect: `deal_memory.beside()` was built,
+  tested and reachable by nothing in production, and `test_dead_code_population.py` scored it **60
+  references** — its own test among them. That gate counts the test tree as callers **on purpose**;
+  it is the 35 → 13 correction its header describes, and it is right for the question it asks. But it
+  means *"tested, and wired to nothing"* is invisible to it by construction, and no refinement of the
+  string rule reaches that — tightening it was tried the same day and `beside` still came back
+  referenced, by its own test.
+
+  This is the third instance of one shape, and the first two were each found by hand: `read_p6xml_all`
+  (R46 — *"a module can be reachable and its whole reason for existing still be unreachable"*),
+  `project_manual`'s MasterFormat default (a test whose fixture supplied the very system under test),
+  and now `beside`. **Three hand-finds is a population, not a coincidence.**
+
+  The 20, by defining module: `mep.block_cooling_load` · `ids_authoring.build_from_use_case` ·
+  `cited_answer.cite_record` · `pid_lock.cross_process_status` · `test_fit.depth_range` ·
+  `photo_cv.duplicate_of` · `ids_authoring.eir_for_use_case` · `parcels_bridge.fetch_parcels` ·
+  `supply_chain.is_dual_licensed` · `folder_template.owner_of` · `supply_chain.pdf_sanity` ·
+  `soft_clash.rule_for` · `supply_chain.sbom` · `takeoff_scope.scope_annotations` ·
+  `payments_bridge.send_payment` · `energy_star_bridge.sync_property` · `licensing.tier_at_least` ·
+  `agent_packs.tools_for` · `rooms.unmapped_sections` · `module_schema.validate_dir`.
+
+  **The number is not the deliverable and must not be ratcheted before it is read.** Several are
+  plainly legitimate test-only surface — `sbom`, `pdf_sanity` and `is_dual_licensed` exist for the
+  supply-chain *gates*, which are tests by design, and `sync_property` is the documented refusal stub
+  already exempted in `services/api/test_dead_code_population.py`. Others may be the same defect
+  `beside` was. R37-TRIAGE's own record is the warning: reading its 12 candidates found **eight
+  live**, and the two it deleted without reading had to be put back. *A population rule that looks
+  reasonable is wrong until you read what it selected* — and this one has not been read.
+
+  Output: each of the 20 marked wire / keep-as-test-surface / delete with the evidence, then a
+  ratchet at whatever survives.
 
 - ◧ **R37-TRIAGE** *(M — Lane C; do FIRST, before any deletion or split)*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1111",
+      "version": "0.3.1112",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1112",
+      "version": "0.3.1113",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -68,7 +68,7 @@ TESTS = ["test_provenance_report", "test_provenance_estimate_leg", "test_answers
          "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approval_conditions", "test_agent_packs", "test_mcp_attribution", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
          "test_ids_authoring", "test_procurement", "test_conceptual", "test_parcels", "test_net",
          "test_design_phase", "test_family_library", "test_change_instruments", "test_turnover",
-         "test_prod_hardening", "test_diligence", "test_deal_funnel", "test_deal_memory", "test_operations", "test_reserves_cam", "test_esg",
+         "test_prod_hardening", "test_diligence", "test_deal_funnel", "test_deal_memory", "test_deal_memory_beside", "test_operations", "test_reserves_cam", "test_esg",
          "test_cde", "test_openbim_quality", "test_bim_kpi", "test_mcp_standards", "test_twin",
          "test_procurement_gate", "test_sheet_extract", "test_program", "test_pull_plan",
          "test_approval_cycles",

--- a/services/api/src/aec_api/routers/operations.py
+++ b/services/api/src/aec_api/routers/operations.py
@@ -2,6 +2,8 @@
 reserve study / capital plan, and CAM reconciliation."""
 from __future__ import annotations
 
+import math
+
 from fastapi import APIRouter, Body, Depends, HTTPException, Response
 from sqlalchemy.orm import Session
 
@@ -129,7 +131,7 @@ def portfolio_deal_memory(db: Session = Depends(get_db), user: str = Depends(cur
 
 @router.get("/projects/{pid}/deal-memory/beside")
 def project_deal_memory_beside(pid: str, hard_cost: float, db: Session = Depends(get_db),
-                               user: str = Depends(current_user)):
+                               user: str = Depends(require_role("viewer"))):
     """R35-DEAL-MEMORY: this firm's own realised $/SF, beside the hard cost being underwritten.
 
     `deal_memory.comps` has been routed since the engine shipped and `beside()` — the function whose
@@ -153,11 +155,23 @@ def project_deal_memory_beside(pid: str, hard_cost: float, db: Session = Depends
     would put a second one in the tree. It needs a loaded properties index, so `no_gfa` is a real and
     common answer and is reported as itself rather than as "no history".
     """
+    # `require_role("viewer")` above, NOT a membership test written here. The first version of this
+    # route hand-rolled one — `if pid not in (member_project_ids(db, user) or {pid})` — and it was
+    # wrong in the way a hand-rolled gate usually is: `member_project_ids` returns **None** for "no
+    # restriction" and an **empty set** for "a member of nothing", and `or {pid}` collapsed the second
+    # into the first, authorising any project id for a user with no memberships.
+    #
+    # `services/api/test_route_authz.py` caught it before review did, and by the right mechanism: it
+    # walks every `/projects/{pid}` route and requires the tagged `require_role` dependency, so a
+    # bespoke check is invisible to it *whether or not the check is correct*. **The gate is not
+    # looking for authorization, it is looking for the one authorization anybody audits** — which is
+    # why matching the pattern matters more here than the logic being locally right.
     _project(db, pid)
-    if pid not in (member_project_ids(db, user) or {pid}):
-        raise HTTPException(403, "not a member of this project")
-    if not hard_cost or hard_cost <= 0:
-        raise HTTPException(422, "hard_cost must be a positive number of dollars")
+    # `isfinite`, not just `> 0`: NaN passes both `not x` and `x <= 0`, then divides into the
+    # response and reaches the client as `null` under orjson — a comparison with a missing number in
+    # it, which reads as "no history" rather than as bad input.
+    if not hard_cost or not math.isfinite(hard_cost) or hard_cost <= 0:
+        raise HTTPException(422, "hard_cost must be a positive, finite number of dollars")
     gfa = energy.project_gfa_sf(db, pid)
     if not gfa:
         # NOT folded into the `beside()` refusals: "we have no history" and "we cannot express your

--- a/services/api/src/aec_api/routers/operations.py
+++ b/services/api/src/aec_api/routers/operations.py
@@ -127,6 +127,56 @@ def portfolio_deal_memory(db: Session = Depends(get_db), user: str = Depends(cur
     return deal_memory.comps(db, project_ids=member_project_ids(db, user))
 
 
+@router.get("/projects/{pid}/deal-memory/beside")
+def project_deal_memory_beside(pid: str, hard_cost: float, db: Session = Depends(get_db),
+                               user: str = Depends(current_user)):
+    """R35-DEAL-MEMORY: this firm's own realised $/SF, beside the hard cost being underwritten.
+
+    `deal_memory.comps` has been routed since the engine shipped and `beside()` — the function whose
+    docstring says it is *"the shape the underwriting screen wants"* — had **no caller anywhere**,
+    server or client. A module can be reachable and its whole reason for existing still be
+    unreachable; `read_p6xml_all` was the same shape one ring over.
+
+    **Only `cost_per_sf` is offered, and that is a refusal about the other two rather than an
+    oversight.** Of the three metrics `comps` reports:
+
+    * `cost_per_sf` — the proforma enters a hard cost and this project has a GFA, so the entered
+      value can be put in the metric's own units. Offered.
+    * `cost_variance_pct` — a realised over/under against a budget. The nearest thing a proforma
+      enters is a contingency, and "your contingency should cover our historical overrun" is a claim
+      about what the product asserts in an underwriting, not a unit conversion. **Not offered here;
+      it needs the same domain call `/schedule/eot` is waiting on.**
+    * `schedule_variance_days` — a variance, not a duration. Comparing it to an entered
+      `construction_months` is a category error wearing matching units.
+
+    GFA comes from `energy.project_gfa_sf`, the one definition, because deriving $/SF client-side
+    would put a second one in the tree. It needs a loaded properties index, so `no_gfa` is a real and
+    common answer and is reported as itself rather than as "no history".
+    """
+    _project(db, pid)
+    if pid not in (member_project_ids(db, user) or {pid}):
+        raise HTTPException(403, "not a member of this project")
+    if not hard_cost or hard_cost <= 0:
+        raise HTTPException(422, "hard_cost must be a positive number of dollars")
+    gfa = energy.project_gfa_sf(db, pid)
+    if not gfa:
+        # NOT folded into the `beside()` refusals: "we have no history" and "we cannot express your
+        # number in the metric's units" are different problems with different remedies, and reporting
+        # the second as the first would send someone looking for closed projects they already have.
+        return {"metric": "cost_per_sf", "status": "no_gfa", "entered": None, "comparison": None,
+                "note": ("this project has no gross floor area — load the model's properties index, "
+                         "or the entered hard cost cannot be expressed per square foot")}
+    memory = deal_memory.comps(db, project_ids=member_project_ids(db, user))
+    out = deal_memory.beside("cost_per_sf", round(hard_cost / gfa, 2), memory)
+    # The project being underwritten is in its own comp set by construction — `comps` scopes to the
+    # caller's projects and does not know which one is on screen. It is excluded anyway, because a
+    # project with no ACTUAL spend is excluded rather than counted as zero variance, and a deal being
+    # underwritten has none. Said out loud because relying on it silently is how it stops being true.
+    out["gfa_sf"] = gfa
+    out["hard_cost"] = hard_cost
+    return out
+
+
 @router.get("/pipeline/funnel")
 def pipeline_funnel(db: Session = Depends(get_db), user: str = Depends(current_user)):
     """R22-PIPELINE: the acquisition funnel across the caller's projects — stage counts and value,

--- a/services/api/test_dead_code_population.py
+++ b/services/api/test_dead_code_population.py
@@ -128,6 +128,38 @@ _STRIP_TS = [
 _STRIP_HASH = re.compile(r"^\s*#.*$", re.M)   # yaml / toml / cfg
 
 
+#: A string literal counts as a reference only when it is shaped like a **dispatch key** -- one
+#: identifier, or a dotted/colon/slash/dash path of them. `"add_wall"`, `"cost_per_sf"` and
+#: `"drawings.markups.rekey_storeys"` match; an English sentence does not.
+#:
+#: **ADDED 2026-08-27, after finding by hand a function this gate scored SIXTY references for.**
+#: `deal_memory.beside()` -- the function R35-DEAL-MEMORY exists to put on a screen -- had no route,
+#: no client method and no screen, and most of those sixty were the English word *beside* in prose,
+#: including plain string literals held as payload text (`deal_funnel.py` returns a note reading
+#: "…is shown beside it rather than folded into it").
+#:
+#: **That is `quadrant` a second time, and the fix belongs here — but it is NOT why `beside` was
+#: missed, and saying so would be this gate making the same kind of claim it exists to catch.**
+#: Measured: under the tightened rule `beside` still has two references, and one of them is
+#: `test_deal_memory.py`, which has imported it since the engine shipped in PR #180. **The test tree
+#: counts as callers by design** — that is the 35 → 13 correction this file's header describes — so
+#: "tested but wired to nothing" is invisible to this gate on purpose, and no string rule reaches it.
+#: The gap is real and measured: **20 public functions in `aec_api` are referenced only by tests**
+#: (2026-08-27), `beside` having been the 21st. Recorded as its own roadmap item rather than
+#: smuggled in here, because each of the 20 needs reading — several are legitimately test-only
+#: surface, and R37-TRIAGE's whole lesson is that the reading is the value, not the number.
+#:
+#: What this rule DOES fix is the prose mask, and it is worth fixing on its own: counting every
+#: string literal was right about registries and wrong about prose, and the two are distinguishable
+#: by shape. A key is a token; a sentence has spaces.
+#:
+#: Measured before and after, because this file's own history is four corrections to a population
+#: rule: **0 unreferenced → 1**, and the one is `sync_property`, which the roadmap already documents
+#: as genuinely uncalled and masked by its own `NotImplementedError` string. It moves from invisible
+#: to explicitly exempted below, which is the direction that matters.
+_KEY_SHAPED = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:[.:/-][A-Za-z0-9_]+)*$")
+
+
 def _py_names(text: str) -> str:
     """Every identifier a Python file actually *uses*, via the parser rather than a regex.
 
@@ -160,8 +192,8 @@ def _py_names(text: str) -> str:
         elif isinstance(node, ast.keyword) and node.arg:
             out.append(node.arg)
         elif isinstance(node, ast.Constant) and isinstance(node.value, str) \
-                and id(node) not in docstrings:
-            out.append(node.value)          # string dispatch is a real reference
+                and id(node) not in docstrings and _KEY_SHAPED.match(node.value.strip()):
+            out.append(node.value)          # string dispatch is a real reference -- a SENTENCE is not
     return " ".join(out)
 
 
@@ -189,6 +221,19 @@ def _sources() -> list[tuple[str, str]]:
                 if not fn.endswith(SEARCH_EXTS):
                     continue
                 p = os.path.join(dirpath, fn)
+                # THIS FILE IS NOT A CALLER. It names symbols to talk about them -- the blind-spot
+                # table, the deleted-for-cause list, and (since 2026-08-27) the deliberately-uncalled
+                # exemptions, whose keys are identifier-shaped by construction and therefore survive
+                # the key-shape filter that every other prose mention now fails.
+                #
+                # Found the moment the exemption list was written: adding `"sync_property"` as a dict
+                # key made `sync_property` referenced, the ratchet went back to zero, and the entry
+                # documenting it read as stale. **An exemption list that satisfies the check it is
+                # exempting from is the gate measuring itself** -- the same shape as the `specPane`
+                # string that made `canvasMode.test.ts` too weak, and as an allowlist entry that
+                # vouches for its own route.
+                if os.path.abspath(p) == os.path.abspath(__file__):
+                    continue
                 try:
                     ext = os.path.splitext(fn)[1]
                     out.append((p, _code_only(open(p, encoding="utf-8", errors="replace").read(), ext)))
@@ -316,11 +361,43 @@ check(
 #                          by calling the two functions it wraps
 #   classification.discipline_names -- an option list nothing offered
 # Each was deleted for saying something false about itself, not merely for being uncalled.
+#: Uncalled ON PURPOSE, each with the reason. **Not a convenience list** -- an entry here is a claim
+#: that deleting the function would remove something the codebase needs, and it is checked in both
+#: directions below, so it cannot rot into a fiction.
+#:
+#: `sync_property` arrived here on 2026-08-27 and was NOT newly dead. It has been uncalled the whole
+#: time; the roadmap entry for R37-TRIAGE says so in as many words, and adds the part that matters:
+#: *"the gate counts it as referenced because that error string names it -- a limitation, stated
+#: rather than hidden"*. Tightening the string rule above removed the mask. **An exemption anybody
+#: can read beats a mask nobody can see**, and the two look identical from the outside: both are a
+#: green run over a function nothing calls.
+DELIBERATELY_UNCALLED: dict[str, str] = {
+    "sync_property": (
+        "a refusal stub. It raises NotImplementedError and names ITSELF as the place to implement "
+        "the credentialed ENERGY STAR exchange. Deleting it would remove the documented extension "
+        "point from a module whose whole contract is 'never fabricate a score' — the docstring is "
+        "the deliverable, not the body."),
+}
+
+surprises = sorted(set(unreferenced) - set(DELIBERATELY_UNCALLED))
 check(
     "no public function in aec_api is unreachable under the corrected rule",
-    not unreferenced,
-    ", ".join(unreferenced) if unreferenced
-    else "0 unreferenced — add one and this fails at the commit that adds it, which is the point",
+    not surprises,
+    ", ".join(surprises) if surprises
+    else f"0 unreferenced beyond the {len(DELIBERATELY_UNCALLED)} kept on purpose — add one and this "
+         "fails at the commit that adds it, which is the point",
+)
+
+# The other direction, because an exemption list that only ever grows is the failure this file was
+# written about one level up: `test_route_reachability` learned the same thing, and its comment
+# ("an allowlist entry that outlives its reason reads as a deliberate exemption forever") is the
+# reason this is a check rather than a note.
+stale = sorted(n for n in DELIBERATELY_UNCALLED if n not in unreferenced)
+check(
+    "every deliberately-uncalled entry is still uncalled — the list cannot rot",
+    not stale,
+    f"{stale} — now referenced, or renamed/deleted. Either way remove the entry: a kept name that "
+    "no longer means anything pre-authorises whatever reuses it.",
 )
 
 # The three blind spots, asserted individually. Without these the ratchet above could pass because

--- a/services/api/test_deal_memory_beside.py
+++ b/services/api/test_deal_memory_beside.py
@@ -39,6 +39,17 @@ import sys
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///./_dm_beside.db")
 os.environ.setdefault("STORAGE_DIR", "./_storage_dm_beside")
+
+# `setdefault`, so `run_tests.py` keeps control of the per-test database it already assigns -- but
+# then CHECKED, because setdefault also inherits whatever a developer happens to have exported. This
+# file calls `Base.metadata.create_all` and commits fixture projects; against an inherited Postgres
+# that is test schema and test rows in a real database, and the cleanup below only unlinks a local
+# `.db` file. Refuse rather than proceed: a destructive test that silently retargets is worse than
+# one that will not start.
+_DB = os.environ["DATABASE_URL"]
+if not _DB.startswith("sqlite:///"):
+    raise SystemExit(f"refusing to run: DATABASE_URL is {_DB!r}, not a local sqlite file. This test "
+                     "creates tables and commits fixtures; point it at a scratch sqlite path.")
 os.environ.pop("AEC_RBAC", None)
 for _f in ("./_dm_beside.db",):
     if os.path.exists(_f):
@@ -146,7 +157,10 @@ try:
     cost_engine.summary = lambda db, pid: BUILT.get(pid, {})        # noqa: E731
 
     # ---- refusals -----------------------------------------------------------------------------------
-    for bad in (0.0, -5.0):
+    # NaN and inf pass BOTH halves of a `not x or x <= 0` guard -- `not nan` is False and every
+    # comparison with nan is False -- so they reached the division and left as `null` under orjson: a
+    # comparison with a missing number in it, which reads as "no history" rather than as bad input.
+    for bad in (0.0, -5.0, float("nan"), float("inf"), float("-inf")):
         try:
             call(LIVE, bad)
             check(f"a hard cost of {bad} is refused", False, "no HTTPException raised")

--- a/services/api/test_deal_memory_beside.py
+++ b/services/api/test_deal_memory_beside.py
@@ -1,0 +1,185 @@
+"""R35-DEAL-MEMORY reaches the underwriting screen — and refuses two of its three metrics.
+
+## What was actually wrong
+
+`deal_memory.comps` has been routed since the engine shipped. `deal_memory.beside()` — the last
+function in that module, whose own docstring says it is *"the shape the underwriting screen wants"* —
+had **no caller anywhere in the tree**: not a route, not the client, not a screen.
+
+Nothing failed. `test_reachable.py` asks whether a MODULE is reachable, and `deal_memory` is: the
+portfolio route imports it. So the item read as shipped while the half it exists for was dark. That
+is `read_p6xml_all` again one ring over, and the lesson recorded there holds here: **a module can be
+reachable and its whole reason for existing still be unreachable.**
+
+## The refusals, which are the load-bearing part
+
+`comps` reports three real metrics. The route offers exactly ONE of them, and the other two are
+decisions rather than an unfinished job:
+
+* **`cost_per_sf` — offered.** The proforma enters a hard cost and the project has a GFA, so the
+  entered number can be put in the metric's own units. A unit conversion, not a claim.
+* **`cost_variance_pct` — NOT offered.** The nearest thing a proforma enters is a contingency, and
+  *"your contingency should cover this firm's historical overrun"* is an assertion the product would
+  be making in an underwriting. Same shape as `/schedule/eot`, which is built and deliberately unwired
+  for exactly this reason.
+* **`schedule_variance_days` — NOT offered.** A variance is not a duration. Beside an entered
+  `construction_months` it would be a category error wearing matching units, which is the most
+  dangerous kind: both are numbers of time and the screen would look right.
+
+And `no_gfa` is its own status rather than folded into `insufficient_history`. They are different
+problems with different remedies — load a model vs close more projects — and answering the first with
+the second sends somebody hunting for history they already have.
+
+Run: cd services/api && PYTHONPATH=src:../data/src ./.venv/bin/python test_deal_memory_beside.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./_dm_beside.db")
+os.environ.setdefault("STORAGE_DIR", "./_storage_dm_beside")
+os.environ.pop("AEC_RBAC", None)
+for _f in ("./_dm_beside.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+_DATA_SRC = os.path.join(os.path.dirname(__file__), "..", "data", "src")
+if _DATA_SRC not in sys.path:
+    sys.path.insert(0, _DATA_SRC)
+
+from fastapi import HTTPException  # noqa: E402
+
+from aec_api import cost as cost_engine  # noqa: E402
+from aec_api import deal_memory as dm  # noqa: E402
+from aec_api import energy  # noqa: E402
+from aec_api.db import Base, SessionLocal, engine  # noqa: E402
+from aec_api.models import Project  # noqa: E402
+from aec_api.routers.operations import project_deal_memory_beside  # noqa: E402
+
+Base.metadata.create_all(engine)
+
+FAILED: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    print(("PASS  " if ok else "FAIL  ") + name + ("   " + detail if detail else ""))
+    if not ok:
+        FAILED.append(name)
+
+
+#: Six closed projects, all built, all with a GFA — one above `MIN_SAMPLES` so a distribution exists
+#: at all. Costs chosen so the quartiles are easy to read: $/SF of 200,220,240,260,280,300.
+BUILT = {f"built{i}": {"budget": 100.0, "actual": (200.0 + i * 20) * 1000.0} for i in range(6)}
+GFA = {f"built{i}": 1000.0 for i in range(6)}
+#: The deal being underwritten. No actual spend, so `comps` excludes it from its own comp set — the
+#: property the route's comment relies on, asserted here rather than assumed.
+LIVE = "underwriting"
+GFA[LIVE] = 2000.0
+
+with SessionLocal() as db:
+    for pid in [*BUILT, LIVE]:
+        db.add(Project(id=pid, name=pid))
+    db.commit()
+
+_real_summary, _real_gfa = cost_engine.summary, energy.project_gfa_sf
+cost_engine.summary = lambda db, pid: BUILT.get(pid, {})            # noqa: E731 — focused seam
+energy.project_gfa_sf = lambda db, pid: GFA.get(pid)                # noqa: E731
+
+
+def call(pid: str, hard_cost: float):
+    with SessionLocal() as db:
+        return project_deal_memory_beside(pid, hard_cost, db=db, user="tester")
+
+
+try:
+    # ---- the comp set really is six, and excludes the deal on screen --------------------------------
+    # Anti-vacuity, and the route's own stated assumption. If the live project counted, its $/SF would
+    # be in the distribution it is being compared against — a number compared to itself, which is the
+    # exact failure this whole module was written to avoid.
+    with SessionLocal() as db:
+        memory = dm.comps(db)
+    m = memory["metrics"]["cost_per_sf"]
+    check("the comp set is the six BUILT projects", m["status"] == "ok" and m["count"] == 6, str(m))
+    check("...and the deal being underwritten is excluded from its own comps",
+          LIVE in {e["id"] for e in memory["excluded"]}, str(memory["excluded_count"]))
+
+    # ---- inside the range ---------------------------------------------------------------------------
+    # 2000 SF at $250/SF = $500,000. The six landed 200…300, so p25–p75 straddles 250.
+    out = call(LIVE, 500_000.0)
+    check("a hard cost inside the firm's own range says so", out["status"] == "ok"
+          and out["position"] == "within_iqr", f"{out.get('status')} {out.get('position')}")
+    check("...reporting the ENTERED value in the metric's units, not the dollars",
+          out["entered"] == 250.0, str(out.get("entered")))
+    check("...and showing the division it did, so the number can be checked",
+          out["gfa_sf"] == 2000.0 and out["hard_cost"] == 500_000.0,
+          f"{out.get('gfa_sf')} / {out.get('hard_cost')}")
+    check("...as a comparison rather than a verdict", "not a verdict" in (out.get("note") or ""),
+          (out.get("note") or "")[:60])
+
+    # ---- above the range ----------------------------------------------------------------------------
+    high = call(LIVE, 2000.0 * 400.0)
+    check("a hard cost above the firm's own history is reported as above",
+          high["position"] == "above_p75", str(high.get("position")))
+    low = call(LIVE, 2000.0 * 100.0)
+    check("...and below as below", low["position"] == "below_p25", str(low.get("position")))
+
+    # ---- no GFA is its OWN answer -------------------------------------------------------------------
+    energy.project_gfa_sf = lambda db, pid: None                    # noqa: E731
+    nogfa = call(LIVE, 500_000.0)
+    check("a project with no GFA answers no_gfa", nogfa["status"] == "no_gfa", str(nogfa["status"]))
+    check("...NOT insufficient_history — different problem, different remedy",
+          nogfa["status"] != "insufficient_history" and "model" in (nogfa["note"] or ""),
+          (nogfa.get("note") or "")[:70])
+    energy.project_gfa_sf = lambda db, pid: GFA.get(pid)            # noqa: E731
+
+    # ---- too little history is NOT a range ----------------------------------------------------------
+    # Under the sample floor the engine emits no distribution, and the route must pass that through
+    # rather than inventing quartiles from two projects. A range from too few is noise wearing a
+    # dollar sign, and it would be on a screen next to somebody's underwriting.
+    thin = dict(list(BUILT.items())[:2])
+    cost_engine.summary = lambda db, pid: thin.get(pid, {})         # noqa: E731
+    few = call(LIVE, 500_000.0)
+    check("under the sample floor no range is offered", few["status"] == "insufficient_history",
+          str(few["status"]))
+    check("...and no median leaks out with it", few.get("median") is None, str(few.get("median")))
+    cost_engine.summary = lambda db, pid: BUILT.get(pid, {})        # noqa: E731
+
+    # ---- refusals -----------------------------------------------------------------------------------
+    for bad in (0.0, -5.0):
+        try:
+            call(LIVE, bad)
+            check(f"a hard cost of {bad} is refused", False, "no HTTPException raised")
+        except HTTPException as e:
+            check(f"a hard cost of {bad} is refused", e.status_code == 422, str(e.status_code))
+    try:
+        call("nosuchproject", 500_000.0)
+        check("an unknown project is 404, not an empty comparison", False, "no HTTPException")
+    except HTTPException as e:
+        check("an unknown project is 404, not an empty comparison", e.status_code == 404,
+              str(e.status_code))
+
+    # ---- the two metrics NOT offered, asserted as a decision -----------------------------------------
+    # The route answers about cost_per_sf and nothing else. Pinned so that wiring either of the other
+    # two later is a deliberate act with this file failing first, rather than a quiet addition: both
+    # would put a NEW claim in front of an underwriter.
+    check("the route answers about cost_per_sf and only that", out["metric"] == "cost_per_sf",
+          out["metric"])
+    check("...and the two it refuses are still in the engine, available to a later decision",
+          {"cost_variance_pct", "schedule_variance_days"} <= set(memory["metrics"]),
+          str(sorted(memory["metrics"])))
+finally:
+    cost_engine.summary, energy.project_gfa_sf = _real_summary, _real_gfa
+    engine.dispose()
+    for _f in ("./_dm_beside.db",):
+        if os.path.exists(_f):
+            os.remove(_f)
+
+if FAILED:
+    print("FAILED:", ", ".join(FAILED))
+    sys.exit(1)
+print("DEAL MEMORY BESIDE OK - the underwriting screen can now reach `beside()`, which had no caller "
+      "anywhere while the module it lives in counted as reachable. $/SF is offered because a hard "
+      "cost and a GFA convert into it; a realised cost variance and a realised schedule variance are "
+      "refused, because putting either beside a contingency or a duration would be the product "
+      "asserting something rather than converting units.")

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -109,7 +109,21 @@ KNOWN_UNCALLED: set[str] = {
     #: is a UI gap, not an unfinished endpoint.
     "/projects/{pid}/model/load-timings",
     "/bcf/3.0/projects/{pid}/topics/{guid}/document_references",
-    "/benchmarks/unit-rates", "/cost/datasets/import-custom", "/portfolio/deal-memory",
+    "/benchmarks/unit-rates", "/cost/datasets/import-custom",
+    # "/portfolio/deal-memory" REMOVED v0.3.1112 — it gained a real caller, `portfolioDealMemory` in
+    # apps/web/src/api/dealMemory.ts, behind the "which projects?" disclosure on the proforma's cost
+    # budget. Recorded because the route it should have been removed for is NOT the route that flagged
+    # it: adding `/projects/{pid}/deal-memory/beside` put the substring `deal-memory` into the web
+    # source, and this rule matches a leaf against the whole blob, so the frozen entry read as called
+    # while nothing called it. **A substring test cannot tell which route a string belongs to** — the
+    # same coarseness `MIN_SEGMENT` documents from the other end, met from this one.
+    #
+    # It was tempting to answer that by sharpening the needle or by shadowing the entry. Both were
+    # measured and rejected: a two-segment needle is already rejected above with numbers, and 328 of
+    # 941 routes share a leaf with another route, so "a shared leaf decides nothing" would take a
+    # third of the surface out of this gate's reach. The real fix was to stop half-wiring the item —
+    # R35-DEAL-MEMORY asks for realised outcomes *by vintage*, and only the summary comparison had
+    # been built. The gate collision is what made the missing half visible.
     "/proforma/entitlement-risk", "/proforma/provenance/admissibility",
     # "/projects/preview-bundle" REMOVED v0.3.1061 — it gained a real caller in
     # apps/web/src/api/library.ts (the `.mass` preview from PR #336), so freezing it as


### PR DESCRIPTION
Three findings, all one kind: **a check and the thing it checks, blind in the same place, agree — and the agreement reads as verification.**

---

# v0.3.1112 — R35-DEAL-MEMORY reaches the underwriting screen

`deal_memory.comps` has been routed since the item shipped. `deal_memory.beside()` — the last function in the module, whose own docstring calls it *"the shape the underwriting screen wants"* — was never routed, never in the client, on no screen.

Nothing failed. `test_reachable` asks whether a **module** is reachable, and `deal_memory` is: the portfolio route imports it. *A module can be reachable and its whole reason for existing still be unreachable.*

`GET /projects/{pid}/deal-memory/beside`, on the proforma's cost budget:

```
🏛 Your own history: this deal's hard cost is $250/SF ($500,000 ÷ 2,000 SF) — inside the range
   your 6 closed project(s) landed in ($225–$275, median $250). A comparison, not a verdict.
   [which projects?]
```

### One metric offered, two refused on the record

| metric | offered? | why |
|---|---|---|
| `cost_per_sf` | ✅ | a hard cost and a GFA **convert** into it — a unit conversion, not a claim |
| `cost_variance_pct` | ❌ | the nearest entered field is a contingency, and *"your contingency should cover this firm's historical overrun"* is a claim the **product** would be making in an underwriting — the same domain call `/schedule/eot` is still waiting on |
| `schedule_variance_days` | ❌ | a variance is not a duration. Beside an entered `construction_months` it is a category error **in matching units** — the dangerous kind, because both are numbers of time and the screen would look right |

`no_gfa` is its own status rather than folded into `insufficient_history`: *load a model* and *close more projects* are different remedies. Both mutations checked — folding the status, and dropping the positive-cost guard.

### Two gates disagreed, and that caught the half-build

`clientCallers.test.ts` refused a `portfolioDealMemory` with no screen. Then `test_route_reachability` failed the *other* way: the new route put the substring `deal-memory` into the web source, and that rule matches a leaf against the whole blob, so its frozen entry for `/portfolio/deal-memory` read as *"quietly became called"* while nothing called it. **A substring test cannot tell which route a string belongs to.**

Neither gate was wrong. Re-reading the item settled it — it asks for realised outcomes *"(… cost/SF **by vintage**)"*, and `comps` returns `vintage` per project. Wiring only the summary was the half-build. Sharpening the needle was **measured and rejected**: a two-segment needle is already rejected in that file with numbers, and **328 of 941 routes share a leaf**.

### The roadmap and its own gate were blind in the same place

The SCALE-SEAM bullet was **headed `㉗`** while its own next words said ㉗ shipped in v0.3.1086, and the Lane I cell called ㉗ *"the only open slice"*. `MARKS` stopped at ㉗, and marks are an **optional** group on both sides of that check — so a numeral it cannot spell drops, and item and lane row degrade to the same bare code.

| mutation | result |
|---|---|
| lane cell ㉕ vs item ㉘, both in `MARKS` | FAILS, naming `SCALE-SEAM ㉘` ✅ |
| `MARKS` ends at ㉗, item and cell say ㉘ | 13 passed ❌ |

`MARKS` now spells ㉘ — **29 item codes before, 29 after.** Nothing moved, which is the point: widening changes nothing on its own, it only makes ㉘ *writable*. Forgetting to widen it next time now fails a test.

**Not labelled SCALE-SEAM ㉘**: a seam slice extracts an existing group and shrinks `client.ts`; this adds a feature that was never in it. The ratchet said so before I did — the one import line took the file 2,837 → 2,838 and failed.

---

# v0.3.1113 — the dead-code gate counted prose, and its own exemption list

`test_dead_code_population.py` counted every non-docstring string literal as a reference, deliberately: registries dispatch on strings. But it drew no line between a dispatch key and an English sentence, so any function whose name is a common word is reached by prose. The gate had recorded this once already — `evm.quadrant`, *"a limitation, stated rather than hidden"* — and left it needing a human.

It needed a rule: **a key is a token, a sentence has spaces.** Measured, because this file's history is four corrections to a population rule: **0 unreferenced → 1**, and the one is `sync_property`, which R37-TRIAGE documents as genuinely uncalled and masked by its own `NotImplementedError` string. It moves from invisible to **explicitly exempted, with the reason and a rot-check in both directions.**

**Writing that exemption list immediately broke the gate.** Adding `"sync_property"` as a dict key made it referenced — the key is identifier-shaped by construction, so it survives the very filter it exists because of. **An exemption list that satisfies the check it exempts from is the gate measuring itself.** The gate no longer reads its own file.

## The correction — this is NOT why `beside` was missed

It would be neat to say the prose rule explains yesterday's find. It does not, and checking rather than asserting is the discipline: **under the tightened rule `beside` still has two references, one of them `test_deal_memory.py`, which has imported it since the engine shipped in PR #180.**

The test tree counts as callers **by design** — the 35 → 13 correction in this gate's own header. So *"tested, and wired to nothing"* is invisible to it by construction, and no string rule reaches it.

The gap was measured instead: **20 public functions in `aec_api` are referenced only by the test tree**, `beside` having been the 21st. Third instance of one shape after `read_p6xml_all` and the spec manual's MasterFormat default — all three found by hand. Recorded as **R37-TESTED-UNWIRED**, *not* ratcheted: several are legitimately test-only surface (`sbom`, `pdf_sanity`, `is_dual_licensed` serve the supply-chain gates, which are tests by design), and R37-TRIAGE's record is the warning — reading its 12 candidates found eight live, and the two deleted without reading had to be put back.

---

## Verification

- 2,018 vitest tests / 197 files — pass
- `tsc --noEmit`, `eslint`, `ruff check src/ ../data/src/` — clean
- `npm run build`, `budget` (200.5 KB / 220 KB), `offline` (85 files, 0 network imports) — pass
- `test_deal_memory`, `test_deal_memory_beside`, `test_dead_code_population`, `test_reachable`, `test_route_reachability`, `test_file_sizes`, `test_claude_md_gates`, `test_doc_substance`, `roadmapLanes.test.ts` — pass
- Every new assertion mutation-checked against the change it exists to catch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deal-memory comparisons to the proforma budget screen, showing how hard costs compare with closed-project history.
  - Added “which projects?” details, including included projects and excluded-count information.
  - Added clearer messages for missing building area and insufficient history.

- **Bug Fixes**
  - Connected deal-memory comparisons to the underwriting workflow.
  - Prevented unsupported metrics and invalid cost inputs from producing misleading results.

- **Documentation**
  - Updated roadmap and release version information to reflect the shipped functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->