### PR TITLE
fix(ci): the container gate watched the Dockerfiles and not what they install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,8 +245,19 @@ jobs:
             exit 0
           fi
           # Kept in sync with the build matrix by test_container_pr_gate.py, which runs this very
-          # pattern against each matrix `dockerfile` path.
-          if printf '%s\n' "$files" | grep -qE '(^|/)Dockerfile$|(^|/)\.dockerignore$|^\.github/workflows/ci\.yml$'; then
+          # pattern against each matrix `dockerfile` path AND against every dependency manifest
+          # those Dockerfiles install from.
+          #
+          # The manifests are here because a Dockerfile is not the only build input it has. The API
+          # image does `COPY services/api/requirements.lock` then `pip install --require-hashes` from
+          # it, and the web image copies `package.json` / `package-lock.json` before `npm ci` — so a
+          # dependency change alters the image without touching a single line matched above. Until
+          # 2026-08-28 none of those four paths was in this pattern, which meant every pip and npm
+          # bump reported `Container build (PR, no push)  skipping` and merged without any job ever
+          # building the image whose contents it had just changed. That is the same "a skipped job is
+          # not a passed job" hole this whole item exists to close, arriving through the input the
+          # filter was not watching rather than the one it was.
+          if printf '%s\n' "$files" | grep -qE '(^|/)Dockerfile$|(^|/)\.dockerignore$|^\.github/workflows/ci\.yml$|(^|/)package(-lock)?\.json$|(^|/)requirements\.lock$'; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
           else
             echo "touched=false" >> "$GITHUB_OUTPUT"

--- a/services/api/test_container_pr_gate.py
+++ b/services/api/test_container_pr_gate.py
@@ -168,6 +168,44 @@ if pat:
     check("...while NOT matching an unrelated file -- the filter can still say no",
           not wrong, ", ".join(wrong) or "none of the four decoys matched")
 
+    # ------------------------------------------------------------------------------------------ 5
+    # A Dockerfile is not the only build input a Dockerfile has.
+    #
+    # Rules 1 and 3 both reason about Dockerfile PATHS. Neither can see that the API image is built
+    # from `services/api/requirements.lock` (`COPY`, then `pip install --require-hashes` from it) and
+    # the web image from `package.json` / `package-lock.json` (`COPY`, then `npm ci`). Until
+    # 2026-08-28 the filter matched none of those four paths, so every pip and npm bump -- the five
+    # web toolchain bumps of #358-#364 and the anthropic 1.x lock recompile among them -- reported
+    # `Container build (PR, no push)  skipping` and merged without any job building the image whose
+    # dependency set it had just replaced.
+    #
+    # Same shape as the converter gap above, and worth naming as such: **a gate's population is part
+    # of its claim.** That one was a Dockerfile outside the matrix. This one is a build input that is
+    # not a Dockerfile at all -- outside the population by KIND rather than by omission, which is why
+    # rule 3's converse could not reach it either.
+    #
+    # Derived by reading each matrix Dockerfile's own COPY lines, never listed here: the day an image
+    # starts copying a new lock file, that path is covered without editing this test.
+    manifest = re.compile(r"^(package\.json|package-lock\.json|requirements[^/]*\.(lock|txt))$")
+    inputs: dict[str, str] = {}
+    for image, df in sorted(pub_images.items()):
+        for line in (ROOT / df).read_text(encoding="utf-8").splitlines():
+            m = re.match(r"\s*COPY\s+(.*)$", line)
+            if not m or "--from=" in m.group(1):
+                continue          # `--from=` copies out of an earlier STAGE, not the build context
+            srcs = [t for t in m.group(1).split() if not t.startswith("--")][:-1]   # last is dest
+            for src in srcs:
+                if manifest.match(src.rsplit("/", 1)[-1]):
+                    inputs.setdefault(src, image)
+    check("the matrix Dockerfiles declare dependency manifests to check at all",
+          bool(inputs), ", ".join(sorted(inputs)) or "none found -- rule 5 would be vacuous")
+    missed = sorted(q for q in inputs if not rx.search(q))
+    check("...and the filter matches every manifest an image is actually built from",
+          not missed,
+          ", ".join(f"{q} (builds {inputs[q]})" for q in missed) + " -- a dependency bump there "
+          "reports `skipping` and never builds the image it changed" if missed
+          else f"all {len(inputs)} matched")
+
 # The error branch, read as text: the body between a failed enumeration and its closing `fi` must
 # set touched=true. Gating the build off because an API call failed is the same silence this item
 # exists to remove.


### PR DESCRIPTION
`docker-scope` decides whether a PR builds the container images, from a regex over the changed
files. It matched `Dockerfile`, `.dockerignore` and `ci.yml` — and nothing else. But a Dockerfile is
not the only build input a Dockerfile has:

```
services/api/Dockerfile   COPY services/api/requirements.lock …
                          RUN  pip install --require-hashes -r /tmp/req/requirements.lock
apps/web/Dockerfile       COPY package.json package-lock.json ./
                          COPY apps/web/package.json …
```

A dependency change replaces what the image *contains* without touching a line the filter watches,
so `Container build (PR, no push)` reports **skipping** — which renders green.

**Every pip and npm bump has merged that way**, including the five web toolchain bumps of #358–#364,
the python floors of #368, and the anthropic 1.x lock recompile of #369 an hour ago. None of those
greens had built the image whose dependency set it had just replaced.

This is the hole `test_container_pr_gate.py` exists to close, arriving through the input the filter
was *not* watching rather than the one it was — a skipped job is not a passed job, and it reads
identically either way.

It is also the converter gap from that same file, one level out. That was a Dockerfile outside the
matrix; this is a build input that is not a Dockerfile at all, so it sat outside the population by
**kind** rather than by omission — which is why rule 3's converse, added specifically to catch "a
file nobody listed", could not reach it either.

## The fix

Rule 5 derives the check rather than listing it: read each matrix Dockerfile's own `COPY` lines,
keep the sources whose basename is a dependency manifest, and assert the extracted filter matches
every one. `--from=` copies are skipped — those come out of an earlier build stage, not the build
context, so they are not PR-visible paths.

It finds four today, and the day an image starts copying a new lock file that path is covered
without editing the test:

```
PASS  the matrix Dockerfiles declare dependency manifests to check at all
      apps/web/package.json, package-lock.json, package.json, services/api/requirements.lock
PASS  ...and the filter matches every manifest an image is actually built from   all 4 matched
```

Mutation-checked by reverting the filter to its previous value — it fails and *names* them:

```
FAIL  ...and the filter matches every manifest an image is actually built from
      apps/web/package.json (builds web), package-lock.json (builds web), package.json (builds web),
      services/api/requirements.lock (builds api) -- a dependency bump there reports `skipping` and
      never builds the image it changed
```

The decoy assertion still passes, so the widened filter has not become one that matches everything
and quietly makes the `touched=false` branch dead code.

## Self-verifying

This PR edits `ci.yml`, which the filter already matched, so the container jobs run here — you
should see `Container build (PR, no push)` actually build all three images rather than skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
