### PR TITLE
v0.3.1122 — the owner rejected the invoice; five money numbers went on counting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,31 @@ its discipline"), now marked ⛔ to say so.
 Widening the item regex did not fix it. `laneRows()` held a **second hand-kept copy** of the same
 six-character rule, so the code was in the population, absent from every lane, and the suite failed
 naming it an orphan while the lane row plainly listed it — two copies of one rule inside the check
-that exists to catch two copies of one rule. Both now read a single `CODE_HEAD`.
+that exists to catch two copies of one rule.
+
+**And "both now read a single `CODE_HEAD`" was itself a claim narrower than it sounded.** Review
+found the copies do not stop at that file: there were **nine across three suites**, so
+`REFUSAL-READERS` stayed invisible to `roadmapStale` and `roadmapSelfConsistent`, both of which
+reported a pass on an item they could not see. All nine now carry the same rule (measured per
+regex shape: 31 → 33 codes and 27 → 29, nothing lost either way).
+
+The duplication is **gated rather than removed**: these suites are deliberately self-contained
+(node + vitest only), so a shared module would be the first import between them. A new check asserts
+every code-head rule across the three files is character-for-character identical, reading the file
+*text* rather than the compiled regex — because the failure being prevented is a copy that was never
+wired to anything, which a runtime check over imported values cannot see. A second check asserts the
+rule is wide enough for the longest code the roadmap actually contains, so the limit is measured
+against the file instead of being a number someone must remember to raise. Mutation-checked: one
+copy reverted fails the gate and names the file.
+
+**The population in the roadmap entry was also derived wrong, and that correction is the more
+useful one.** The table said 17 unfiltered sites while the classification below it summed to 19.
+The reason: the derivation matched `list_records(db, "<type>"` and nothing else, but
+`billed_to_date` and `wip.schedule` read the same records through `sum_field`, a SQL aggregate.
+Counting the other accessors gives `sum_field` 3 and `count_records` 2 — 49 reads, not 44. So **two
+of the five defects this release fixes were never in the population at all**; they were found by
+reading the module, not by the sweep meant to be exhaustive. A derived population is only as
+complete as its list of accessors.
 
 ## v0.3.1121 (2026-08-29) — a `.mass` you can prove is authentic, and the first tag in thirty releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,33 @@ rule is wide enough for the longest code the roadmap actually contains, so the l
 against the file instead of being a number someone must remember to raise. Mutation-checked: one
 copy reverted fails the gate and names the file.
 
+**A second review round found the fix had made one payload disagree with itself.**
+`/projects/{pid}/construction-draws` returns `actual_billed` from `billed_to_date` — which this
+release taught to exclude refused applications — beside an `invoice_count` from `count_records`,
+which was not taught anything. So the endpoint reported money from N invoices next to a count of
+N+1: measured, `actual_billed` $1,000,000 with `invoice_count` 3. **Excluding an amount without
+excluding its count is not half a fix, it is a new defect**, and `count_records` had the principle
+in its own docstring — *"a count that ignores a filter the list applied reports a total the page
+cannot account for, and a total is exactly the number a user trusts without checking"* — while
+lacking the parameter to honour it. It now takes `exclude_states`, matching `sum_field`. Pinned as
+a PAIRED assertion, because either half alone passes while the response contradicts itself.
+
+**And the widening was described wrong in three places.** `[A-Z][A-Z0-9]{1,11}-` admits a head of
+**twelve** characters, not eleven — the leading `[A-Z]` sits outside the quantifier. The regex is
+fine; the prose was off by one, and so was the new gate's own second assertion, which compared the
+quantifier bound against a full code length and would therefore have **rejected a 12-character code
+its own regex accepts**. That is the same claim-wider-than-the-property mistake this release is
+about, pointing the other way. The assertion now converts bound to admissible length explicitly;
+the rule stays at twelve rather than narrowing to make the sentence true, because narrowing a limit
+is what created this whole section.
+
+**Not fixed here, and recorded instead:** the same portal reader shows `data.status` from the
+free-text blob rather than `workflow_state`, so a certified application can read as a draft to the
+owner and the paid/outstanding split can be wrong independently of any refusal. That is which
+status the page *shows*, not which invoices it *counts* — pre-existing, client-facing, and it
+changes a contract the portal tests encode, so it is its own slice under `REFUSAL-READERS` rather
+than a rider on this one.
+
 **The population in the roadmap entry was also derived wrong, and that correction is the more
 useful one.** The table said 17 unfiltered sites while the classification below it summed to 19.
 The reason: the derivation matched `list_records(db, "<type>"` and nothing else, but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1122 (2026-08-30) — the owner rejected the invoice; five money numbers went on counting it
+
+**A rejected owner invoice was booked as revenue.** `accounting.journal_entries` posted every
+`owner_invoice` as debit 1200 / credit 4000 — Accounts Receivable and Contract Revenue — with no
+regard for its workflow state. Measured through the routes with a rejected $250,000 application
+beside a certified $100,000 one, the trial balance reported **accounts receivable of $350,000
+against $100,000 actually owed**.
+
+Rejecting an owner invoice is the *owner* refusing to pay it — `reject` is their transition, and
+`revise` (rejected -> draft) is the GC's way back. Every consumer of the record ignored that:
+
+| reader | what it got wrong |
+|---|---|
+| `accounting.journal_entries` | posted AR + Contract Revenue for a refused application |
+| `/accounting/trial-balance` | AR $350,000 instead of $100,000 |
+| `project_budget.billed_to_date` | "THE single 'billed' number" the loan-draws, draw-composition and investment memo all quote |
+| `wip.schedule` | `billed` drives over/under-billing, which posts BACK as the WIP-ADJ revenue line — one refused invoice moving the ledger by two routes |
+| `client_portal` payment schedule | billed the owner for the invoice **they** rejected — and displayed `data.status` (default "draft") rather than the workflow state, so it showed as a draft that nonetheless counted |
+| `/loan-draws` | drew $350,000 and accrued interest on the balance it invented ($2,085.62 -> $595.89) |
+
+**This is the AP fix from v0.3.1121 met in a mirror.** That release fixed `journal()` for
+`sub_invoice`; this defect sat twenty lines below it, in a different function, reading a different
+record type, and was untouched. *Adjacency in a file is not a relationship* — the fix and the bug
+were as close as two pieces of code can be.
+
+The rule is a **named constant**, `project_budget.OWNER_INVOICE_NOT_BILLED`, not five inline checks:
+a record type with five readers is a rule with four places to rot. `sum_field` has carried an
+`exclude_states` parameter — and named *"billed-to-date"* as its example — since it was written; the
+call site simply never passed it.
+
+`submitted`, `approved` and `paid` stay: the first two are live receivables, the third is history
+that belongs in the books. `draft` also stays, deliberately — whether an unsent draft counts as
+billed is a separate question from whether a *refused* one does, and only the second has an answer
+the workflow states. Only the explicit refusal is refused.
+
+Pinned in `test_accounting.py`, `test_portal_txn.py` and `test_wip.py`, each asserting the converse
+too — a submitted application still bills, and `revise` restores a refused one, so the fix cannot
+degrade into "only certified counts". All five engine changes mutation-checked independently.
+
+**The roadmap lane gate was measuring 31 of 33 items, and it took adding an item to notice.** The
+new roadmap entry for this class is called `REFUSAL-READERS`; `roadmapLanes.test.ts` passed with it
+in place, and the pass was vacuous — the item regex capped a code head at six characters and
+`REFUSAL-` is seven, so the bullet was never in the population. Widened to eleven and measured as
+that file requires: **31 codes before, 33 after, none lost.** The second code gained is
+`QUALITY-ROOM`, an entry that had been invisible to the gate for its whole life and so was never
+required to be in a lane; it is a question answered and declined in place ("the register stays with
+its discipline"), now marked ⛔ to say so.
+
+Widening the item regex did not fix it. `laneRows()` held a **second hand-kept copy** of the same
+six-character rule, so the code was in the population, absent from every lane, and the suite failed
+naming it an orphan while the lane row plainly listed it — two copies of one rule inside the check
+that exists to catch two copies of one rule. Both now read a single `CODE_HEAD`.
+
 ## v0.3.1121 (2026-08-29) — a `.mass` you can prove is authentic, and the first tag in thirty releases
 
 **Sealing a container is now possible, and opt-in.** A `.mass` can carry `asset_rights.json`, a signed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1121",
+    "version": "0.3.1122",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1121",
+  "version": "0.3.1122",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -126,8 +126,29 @@ const CLOSED = "⛔";
 // Both widenings were MEASURED first — one bullet gained by the marker fix, four by the length
 // fix. A regex change to a population check is a population change, and an unmeasured one is a
 // new number with no idea what moved.
+//
+// THIRD widening 2026-08-30, `{1,5}` -> `{1,11}` on the code HEAD (the part before the dash), and
+// it was found the way the docstring above predicts rather than by reading this line: a new item
+// `REFUSAL-READERS` was added, this suite passed, and the pass was VACUOUS — `REFUSAL` is seven
+// characters and the head could match at most six, so the bullet was never in the population at
+// all. A population check that silently omits the thing you just added reports success for the
+// same reason the omission happened.
+//
+// Measured, as the note above requires: 31 codes before, 33 after, none lost. The two gained are
+// `REFUSAL-READERS` and — independently — `QUALITY-ROOM`, an entry that had been invisible to this
+// gate for its whole life and was therefore never required to be in a lane. That second one is the
+// argument for widening rather than renaming the new item to fit: a limit that quietly drops
+// anything over six characters had already dropped something.
+//
+// ONE definition, used by both readers. Widening the item regex above did NOT fix the gate, because
+// the lane-CELL parser in `laneRows()` carried its own hand-kept copy of the same `{1,5}` head and
+// still could not see the code — so the item was in the population, absent from every lane, and the
+// suite failed with the new code named as an orphan while the lane row plainly listed it. Two copies
+// of one rule inside the check that exists to catch two copies of one rule.
+const CODE_HEAD = String.raw`[A-Z][A-Z0-9]{1,11}-`;
+
 const ITEM = new RegExp(
-  String.raw`^\s*[-*] (?:(?:✅|◧|🟡|⭐|${CLOSED})️? )*\*\*([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{1,}?)(?:\s*([${MARKS}]))?(?:\s|\*\*|—)`,
+  String.raw`^\s*[-*] (?:(?:✅|◧|🟡|⭐|${CLOSED})️? )*\*\*(${CODE_HEAD}[A-Z0-9-]{1,}?)(?:\s*([${MARKS}]))?(?:\s|\*\*|—)`,
 );
 
 function itemCodes(lines: string[]): Set<string> {
@@ -194,7 +215,7 @@ function laneRows(): Lane[] {
       // Only things shaped like a code; prose cells ("no standalone items…") contribute none.
       .map((text) => ({
         text,
-        code: new RegExp(String.raw`^([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]+(?: [${MARKS}])?)`).exec(text)?.[1],
+        code: new RegExp(String.raw`^(${CODE_HEAD}[A-Z0-9-]+(?: [${MARKS}])?)`).exec(text)?.[1],
       }))
       .filter((e): e is LaneItem => Boolean(e.code));
     const items = entries.map((e) => e.code);

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -127,7 +127,8 @@ const CLOSED = "⛔";
 // fix. A regex change to a population check is a population change, and an unmeasured one is a
 // new number with no idea what moved.
 //
-// THIRD widening 2026-08-30, `{1,5}` -> `{1,11}` on the code HEAD (the part before the dash), and
+// THIRD widening 2026-08-30, `{1,5}` -> `{1,11}` on the code HEAD (the part before the dash — so
+// heads of up to TWELVE characters, since the leading `[A-Z]` is outside the quantifier), and
 // it was found the way the docstring above predicts rather than by reading this line: a new item
 // `REFUSAL-READERS` was added, this suite passed, and the pass was VACUOUS — `REFUSAL` is seven
 // characters and the head could match at most six, so the bullet was never in the population at
@@ -139,6 +140,10 @@ const CLOSED = "⛔";
 // gate for its whole life and was therefore never required to be in a lane. That second one is the
 // argument for widening rather than renaming the new item to fit: a limit that quietly drops
 // anything over six characters had already dropped something.
+//
+// ("Widened to eleven" is how this was first written up, in three places. The quantifier is 11; the
+// admissible head is 12. Kept as 12 rather than narrowed to make the prose true, because narrowing
+// a limit is the move that created this whole section.)
 //
 // ONE definition, used by both readers. Widening the item regex above did NOT fix the gate, because
 // the lane-CELL parser in `laneRows()` carried its own hand-kept copy of the same `{1,5}` head and
@@ -760,6 +765,14 @@ describe("the roadmap readers agree on what an item code looks like", () => {
     // The population check that the rule above is FOR. A head limit below the longest real code
     // is the defect this whole section exists for, so it is measured against the file rather
     // than asserted as a number someone has to remember to raise.
+    //
+    // The `+ 1` is not a fudge and was not here first. `[A-Z][A-Z0-9]{1,11}-` admits a head of
+    // TWELVE characters, because the leading `[A-Z]` sits OUTSIDE the quantifier — so the bound in
+    // the source and the length of a code are two different measurements, and comparing them
+    // directly made this assertion fail one character early. Review caught it; a 12-character code
+    // would have been rejected by a gate whose own regex accepts it, which is the same
+    // claim-wider-than-the-property mistake the section above is about, pointing the other way.
+    const effectiveMax = (bound: number) => bound + 1;     // the leading [A-Z], outside {n,m}
     const longest = [...LINES.join("\n").matchAll(/\*\*([A-Z][A-Z0-9-]{2,})[\s—*]/g)]
       .map((m) => m[1])
       .filter((c): c is string => Boolean(c) && c!.includes("-"))
@@ -767,7 +780,8 @@ describe("the roadmap readers agree on what an item code looks like", () => {
       .reduce((a, b) => Math.max(a, b), 0);
     const rule = /\[A-Z\]\[A-Z0-9\]\{\d+,(\d+)\}-/.exec(
       readFileSync(resolve(REPO, "apps/web/src/shell/roadmapLanes.test.ts"), "utf8"));
-    expect(Number(rule?.[1]), `the longest code head in the roadmap is ${longest} characters`)
+    expect(effectiveMax(Number(rule?.[1])),
+      `the longest code head in the roadmap is ${longest} characters`)
       .toBeGreaterThanOrEqual(longest);
   });
 });

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -238,7 +238,7 @@ function parkedCodes(): Set<string> {
   // `{1,}` for the same reason as the item regex above: `REL-7` was listed here as parked and this
   // pattern could not see it, so the item check reported it unassigned while the Parked paragraph
   // said otherwise. Two regexes over one vocabulary, and both were wrong the same way.
-  return new Set([...text.matchAll(/\b([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{1,})\b/g)]
+  return new Set([...text.matchAll(/\b([A-Z][A-Z0-9]{1,11}-[A-Z0-9-]{1,})\b/g)]
     .map((m) => m[1]).filter((c): c is string => Boolean(c)));
 }
 
@@ -492,7 +492,7 @@ describe("the roadmap lane table", () => {
     for (const [i, ln] of LINES.entries()) {
       // Only lines this file actually parses: an item bullet or a lane-table row. A numeral in prose
       // — and this file's own docstrings are full of them — is not a code and must not fail here.
-      const isItem = /^\s*[-*] (?:(?:✅|◧|🟡|⭐|⛔)️? )*\*\*[A-Z][A-Z0-9]{1,5}-/.test(ln);
+      const isItem = /^\s*[-*] (?:(?:✅|◧|🟡|⭐|⛔)️? )*\*\*[A-Z][A-Z0-9]{1,11}-/.test(ln);
       if (!isItem && !LANE_ROW_LINES.has(i)) continue;
       for (const m of ln.matchAll(ENCLOSED)) {
         if (!MARKS.includes(m[0])) unspellable.set(m[0], ln.trim().slice(0, 90));
@@ -715,5 +715,59 @@ describe("the lane table covers the tree it governs", () => {
     expect(unowned.some((f) => f.startsWith("apps/web/src/proforma/")),
       "proforma/ is unclaimed today — if this fails, either a row was added (update this test) " +
       "or the matcher stopped working").toBe(true);
+  });
+});
+
+/**
+ * Every roadmap reader must agree on how long an item CODE can be.
+ *
+ * `CODE_HEAD` above was introduced because two copies of that rule lived in THIS file and the
+ * widened one did not fix the gate. A review then found the copies do not stop at this file:
+ * there were NINE across three suites, and `REFUSAL-READERS` was invisible to
+ * `roadmapStale` and `roadmapSelfConsistent` — both of which reported a pass on an item they
+ * could not see. Widening two of nine and writing "both now read a single CODE_HEAD" was itself
+ * a claim narrower than it sounded.
+ *
+ * These files are deliberately self-contained (node + vitest only), so a shared module would be
+ * the first import between them. The duplication is gated instead of removed: this asserts every
+ * head rule across the roadmap suites is character-for-character the same, so a tenth copy, or a
+ * widening that lands in one file and not its siblings, fails here rather than going quiet.
+ *
+ * It reads the file TEXT, not the compiled regex, because the failure being prevented is a copy
+ * that was never wired to anything — exactly what a runtime check over imported values misses.
+ */
+describe("the roadmap readers agree on what an item code looks like", () => {
+  const SUITES = ["roadmapLanes.test.ts", "roadmapSelfConsistent.test.ts", "roadmapStale.test.ts"];
+  const HEAD = /\[A-Z\]\[A-Z0-9\]\{(\d+),(\d+)\}-/g;
+
+  it("uses ONE code-head rule across every roadmap suite", () => {
+    const found = new Map<string, string[]>();
+    for (const f of SUITES) {
+      const text = readFileSync(resolve(REPO, "apps/web/src/shell", f), "utf8");
+      for (const m of text.matchAll(HEAD)) {
+        const rule = `{${m[1]},${m[2]}}`;
+        found.set(rule, [...(found.get(rule) ?? []), f]);
+      }
+    }
+    expect(found.size, `roadmap suites disagree on the code-head rule: ` +
+      [...found].map(([r, fs]) => `${r} in ${[...new Set(fs)].join(", ")}`).join("  |  ") +
+      ". Widen every copy together or an item longer than the narrowest rule is silently " +
+      "dropped from that reader's population, and it passes because it cannot see the item.")
+      .toBe(1);
+  });
+
+  it("that rule is wide enough for every code the roadmap actually uses", () => {
+    // The population check that the rule above is FOR. A head limit below the longest real code
+    // is the defect this whole section exists for, so it is measured against the file rather
+    // than asserted as a number someone has to remember to raise.
+    const longest = [...LINES.join("\n").matchAll(/\*\*([A-Z][A-Z0-9-]{2,})[\s—*]/g)]
+      .map((m) => m[1])
+      .filter((c): c is string => Boolean(c) && c!.includes("-"))
+      .map((c) => c.split("-")[0]?.length ?? 0)
+      .reduce((a, b) => Math.max(a, b), 0);
+    const rule = /\[A-Z\]\[A-Z0-9\]\{\d+,(\d+)\}-/.exec(
+      readFileSync(resolve(REPO, "apps/web/src/shell/roadmapLanes.test.ts"), "utf8"));
+    expect(Number(rule?.[1]), `the longest code head in the roadmap is ${longest} characters`)
+      .toBeGreaterThanOrEqual(longest);
   });
 });

--- a/apps/web/src/shell/roadmapSelfConsistent.test.ts
+++ b/apps/web/src/shell/roadmapSelfConsistent.test.ts
@@ -84,7 +84,7 @@ const MARKS = "①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳㉑�
 const GLYPHS = "(?:✅ |◧ |🟡 |⭐ |⛔️ |⛔ )?";
 
 const ITEM = new RegExp(
-  String.raw`^\s*[-*] ${GLYPHS}\*\*([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,}?)(?:\s*([${MARKS}]))?(?:\s|\*\*|—)`,
+  String.raw`^\s*[-*] ${GLYPHS}\*\*([A-Z][A-Z0-9]{1,11}-[A-Z0-9-]{2,}?)(?:\s*([${MARKS}]))?(?:\s|\*\*|—)`,
 );
 
 interface Bullet { line: number; done: boolean; partial: boolean; bodyShipped: boolean }
@@ -130,7 +130,7 @@ function bullets(): Map<string, Bullet> {
 function laneClaims(lines: readonly string[] = OPEN): Map<string, string> {
   const out = new Map<string, string>();
   const CLAIM = new RegExp(
-    String.raw`^([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]+(?: [${MARKS}])?)\s*\*\(([^)]*)\)\*`,
+    String.raw`^([A-Z][A-Z0-9]{1,11}-[A-Z0-9-]+(?: [${MARKS}])?)\s*\*\(([^)]*)\)\*`,
   );
   for (const l of lines) {
     if (!/^\|\s*\*\*[A-Z] · /.test(l)) continue;
@@ -189,7 +189,7 @@ describe("the roadmap is self-consistent about what has shipped", () => {
     // be missed by both readers identically, so the comparison could not see the one drift most
     // likely to actually happen. A second reader that inherits the first one's blind spot is not a
     // second reader.
-    const LOOSE = /^\s*[-*] (?:[^*\s]{1,3} )?\*\*([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,})/;
+    const LOOSE = /^\s*[-*] (?:[^*\s]{1,3} )?\*\*([A-Z][A-Z0-9]{1,11}-[A-Z0-9-]{2,})/;
     const missed: string[] = [];
     for (let i = 0; i < OPEN.length; i++) {
       const l = OPEN[i] ?? "";

--- a/apps/web/src/shell/roadmapStale.test.ts
+++ b/apps/web/src/shell/roadmapStale.test.ts
@@ -46,7 +46,7 @@ const REPO = resolve(__dirname, "../../../..");
 
 /** Bullet form the roadmap uses for an item, with its optional status marker. */
 const ITEM =
-  /^\s*[-*] (?:(✅|◧|🟡|⭐) )?\*\*([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,}?)(?:\s*([①②③④⑤⑥]))?(?:\s|\*\*|—)/;
+  /^\s*[-*] (?:(✅|◧|🟡|⭐) )?\*\*([A-Z][A-Z0-9]{1,11}-[A-Z0-9-]{2,}?)(?:\s*([①②③④⑤⑥]))?(?:\s|\*\*|—)/;
 
 /** Markers that mean "something exists" — ⭐ is a PRIORITY flag, not a status, and does not count. */
 const DONE_MARKERS = new Set(["✅", "◧", "🟡"]);
@@ -156,7 +156,7 @@ function scanDeclaringModules(): Declared {
       const t = head.trimStart();
       if (!t.startsWith('"""') && !t.startsWith("'''")) continue;   // no module docstring
       const first = t.split("\n")[0] ?? "";
-      for (const m of first.matchAll(/\b([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,})\b/g)) {
+      for (const m of first.matchAll(/\b([A-Z][A-Z0-9]{1,11}-[A-Z0-9-]{2,})\b/g)) {
         const id = m[1]!;
         ids.set(id, [...(ids.get(id) ?? []), f.slice(REPO.length + 1).replace(/\\/g, "/")]);
       }
@@ -377,7 +377,7 @@ function webModulesDeclaring(): { ids: Map<string, string[]>; scanned: number; w
     const first = firstDocLine(readFileSync(f, "utf8").slice(0, 800));
     if (first === null) continue;
     withDoc++;
-    for (const m of first.matchAll(/\b([A-Z][A-Z0-9]{1,5}-[A-Z0-9-]{2,})\b/g)) {
+    for (const m of first.matchAll(/\b([A-Z][A-Z0-9]{1,11}-[A-Z0-9-]{2,})\b/g)) {
       const id = m[1]!;
       ids.set(id, [...(ids.get(id) ?? []), f.slice(REPO.length + 1).split(sep).join("/")]);
     }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -230,6 +230,68 @@ Seven of eleven engines once shipped with no route. The R32 filing-spine entries
 band are all closed and recorded in [`roadmap-completed.md`](roadmap-completed.md). The current
 instances:
 
+- ◧ ⭐ **REFUSAL-READERS — a record in a refused state still counts** *(M — Lane C; population
+  DERIVED 2026-08-30, five readers fixed in v0.3.1122, **nine still open**)*
+
+  **This is a defect CLASS, not a bug.** Between 2026-08-29 and 2026-08-30 five separate fixes landed
+  that are all the same mistake: an engine reads records of a type whose workflow carries a refusal
+  state and computes as though the refusal never happened — a rejected sub invoice posted to the
+  ledger and exported to QuickBooks, a rejected invoice holding a PO in permanent review, an excluded
+  comparable still valuing a property, a compliance gate reading the oldest prequalification, and (in
+  v0.3.1122) a rejected OWNER invoice booked as Accounts Receivable and Contract Revenue.
+
+  Each was found one at a time, by a proxy the procurement fix itself described as unreliable. So the
+  population was derived instead:
+
+  | | |
+  |---|---|
+  | record types carrying a refusal state | **27** of 139 modules |
+  | read sites against those types | **44** |
+  | sites with no state reference in scope | **17** |
+  | of those: real, **fixed in v0.3.1122** | **5** (all `owner_invoice`) |
+  | of those: **correct as-is**, reasoned | **5** |
+  | of those: **real and still open** | **9** |
+
+  **The nine open ones**, each verified to have no state filter anywhere in its path (the reader *and*
+  its downstream helper were both read):
+
+  - `design_options.compare`, `option_carbon.compare_carbon`, `option_economics.compare_economics` —
+    a design option the team REJECTED still competes in the ranking and can win it, so the
+    recommended scheme can be one that was refused. Fix shape is the appraisal one: drop it from the
+    ranking, name it alongside rather than silently.
+  - `feasibility.compare_scenarios` — ranks every `zoning` scheme including SUPERSEDED ones, and the
+    top scheme sets the deltas. **Its own sibling `study`, thirty lines below, does read the state** —
+    one function in the file filters and the other does not, which is the exact shape of the
+    accounting and procurement bugs.
+  - `rfi.rfi_register` — a VOID RFI still counts in the open and overdue totals and in ball-in-court.
+    RFI ageing is a contractual metric. `sync.py` filters; this does not.
+  - `prequalification.score_project` — a rejected sub still carries a score and inflates `high_risk`.
+  - `approval_conditions.for_project` — tracks outstanding conditions on a DENIED entitlement.
+  - `specs.submittal_log` and `spine.traceability` — a VOID spec section still demands submittals and
+    still reads as a traceability gap.
+
+  **The five that are CORRECT as-is are the point of the entry, not a footnote.** A pattern-matching
+  gate would have "fixed" all five and broken two of them:
+
+  - `rentroll.rent_roll`, `leasemgmt.lease_management`, `proforma` rollover — all three load leases
+    unfiltered and filter in the *summarizer* (`rentroll.ACTIVE_STATES`), one call away and outside
+    any window a grep would use. `renewal_pipeline` includes expired leases **on purpose** — they are
+    its subject.
+  - `opendata.py` — one reader builds the DEDUPLICATION set for permit import, so it must see expired
+    permits or it re-imports them; the other is a historical permit-timeline benchmark, where expired
+    permits are the data.
+
+  *A count is not a population.* The procurement fix said so in its own message — "the population
+  needs reading, not just counting" — and this sweep proves the cost both ways: 9 real defects a count
+  would have missed the reasons for, and 5 correct readers a count would have broken.
+
+  **Not gated yet, and the obvious gate is the wrong one.** A check that every reader of a
+  refusal-bearing type mentions the state produces false positives on all five correct readers, and a
+  gate that cries wolf trains people to append to its allowlist without thinking — worse than none.
+  The honest gate is BEHAVIOURAL: per record type, drive the real route, move the record into its
+  refusal state, and assert the consuming number does not move. That is a property rather than a
+  pattern, and it cannot be satisfied by a filter in the wrong place. Scoped as the next slice.
+
 - ◧ **CITE-RECORD — three of four citation builders are wired, the record one is not** *(XS —
   Lane C; measured 2026-08-29)*
 
@@ -781,7 +843,7 @@ two rows share a path, so two agents in different rows cannot collide.
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE |
-| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R43-MASSINGBILL-CORE · ASSET-VERIFY *(the verification half of asset-rights has no product caller; see Band 2)* · SOFT-CLASH-RULES *(six of seven sourced clearances never evaluated; see Band 2)* · CITE-RECORD *(XS — the record citation builder has no producer; see Band 2)* |
+| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | REFUSAL-READERS · R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R43-MASSINGBILL-CORE · ASSET-VERIFY *(the verification half of asset-rights has no product caller; see Band 2)* · SOFT-CLASH-RULES *(six of seven sourced clearances never evaluated; see Band 2)* · CITE-RECORD *(XS — the record citation builder has no producer; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · UX-3 *(library depth — `apps/web/src/viewer/tools/authoringSection.ts`)* · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
@@ -1053,7 +1115,7 @@ that rotted were all sentences no test read. Note for whoever extends it — the
   two-shell period bought is kept: `parity.test` still asserts the room rail reaches every
   destination the lifecycle-stage catalog lists, so *nothing became unreachable* outlives the shell
   that motivated it.
-- **QUALITY-ROOM** — inspections/ITP sit in Design because an inspection checks the built thing
+- ⛔ **QUALITY-ROOM** — inspections/ITP sit in Design because an inspection checks the built thing
   against the design. Answered 2026-07-28: the *task* already reaches Work via the queue
   (`INS-001`, `DEF-001`, `NCR-001` are in it now), so the *register* stays with its discipline.
   Revisit only if that stops feeling right in use.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -246,11 +246,27 @@ instances:
   | | |
   |---|---|
   | record types carrying a refusal state | **27** of 139 modules |
-  | read sites against those types | **44** |
-  | sites with no state reference in scope | **17** |
-  | of those: real, **fixed in v0.3.1122** | **5** (all `owner_invoice`) |
-  | of those: **correct as-is**, reasoned | **5** |
-  | of those: **real and still open** | **9** |
+  | `list_records` sites against those types | **44** |
+  | of those, with no state reference in scope | **17** |
+  | ├ real, **fixed in v0.3.1122** | **3** (`owner_invoice`) |
+  | ├ **correct as-is**, reasoned | **5** |
+  | └ **real and still open** | **9** |
+  | *plus* aggregate reads the derivation never counted | **5** (`sum_field` 3 · `count_records` 2) |
+  | of those, real and **fixed in v0.3.1122** | **2** (`billed_to_date`, `wip.schedule`) |
+
+  **THE POPULATION WAS DERIVED WRONG THE FIRST TIME, and the error is the most useful thing here.**
+  The 17 unfiltered sites break down as 3 + 5 + 9, but v0.3.1122 fixed **five** `owner_invoice`
+  readers. The two extra are `project_budget.billed_to_date` and `wip.schedule`, and they were
+  **never in the population at all**: the derivation matched `list_records(db, "<type>"` and nothing
+  else, while those two read the same records through `sum_field` — a SQL aggregate. Counting the
+  other accessors afterwards: `sum_field` 3, `count_records` 2, so 49 reads rather than 44.
+
+  So **two of the five defects that release fixed lived in the 5 sites the derivation could not
+  see** — they were found by reading the module, not by the sweep that was supposed to be
+  exhaustive. A derived population is only as complete as its list of accessors, and a completeness
+  claim computed over one accessor is confident and wrong in exactly the way this entry warns about
+  everywhere else. *(Found by review, not by us: the counts did not add up, and the reason they did
+  not add up was the finding.)*
 
   **The nine open ones**, each verified to have no state filter anywhere in its path (the reader *and*
   its downstream helper were both read):

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -286,6 +286,17 @@ instances:
   - `specs.submittal_log` and `spine.traceability` — a VOID spec section still demands submittals and
     still reads as a traceability gap.
 
+  **A tenth, adjacent and NOT a refusal-reader — `client_portal._payment_schedule` displays
+  `data.status`, not `workflow_state`.** Raised in review of v0.3.1122 and deliberately left out of
+  it: that release fixed which invoices the schedule *counts*, and this is which status it *shows*.
+  The row renders `str(d.get("status") or "draft")` from the free-text data blob, so a certified
+  application whose blob was never written reads as a draft to the owner — and `paid` is totalled
+  from that same string, so the client-facing paid/outstanding split can be wrong independently of
+  any refusal. Pre-existing, client-facing, and it changes a contract the portal tests encode
+  (`test_portal_txn.py` seeds `status` in the blob), so it needs its own slice rather than a rider
+  on a fix for a different defect. Shape: prefer `workflow_state`, fall back to the blob only when
+  the state is absent, and drive the real transitions in the test.
+
   **The five that are CORRECT as-is are the point of the entry, not a footnote.** A pattern-matching
   gate would have "fixed" all five and broken two of them:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1121",
+      "version": "0.3.1122",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/src/aec_api/accounting.py
+++ b/services/api/src/aec_api/accounting.py
@@ -128,7 +128,14 @@ def journal_entries(db: Session, project_id: str) -> dict:
 
     for e in journal(db, project_id):                         # costs + sub bills → cost / AP
         je(e["date"], e["ref"] or "", e["memo"], [("5000", e["amount"], 0), ("2000", 0, e["amount"])])
+    from .project_budget import OWNER_INVOICE_NOT_BILLED
     for r in (me.list_records(db, "owner_invoice", project_id, limit=100_000) if "owner_invoice" in me.TABLES else []):
+        # The AR side of the same defect the AP loop above was fixed for — and it survived that fix
+        # because it sits in a DIFFERENT function twenty lines below, reading a different record type.
+        # Measured before this: a rejected $250,000 application posted debit 1200 / credit 4000 and
+        # the trial balance reported ACCOUNTS RECEIVABLE OF $350,000 against $100,000 actually owed.
+        if r.get("workflow_state") in OWNER_INVOICE_NOT_BILLED:
+            continue
         d = r.get("data", {})
         amt = _num(d.get("amount"))
         if amt:

--- a/services/api/src/aec_api/client_portal.py
+++ b/services/api/src/aec_api/client_portal.py
@@ -51,7 +51,13 @@ def _payment_schedule(db: Session, pid: str) -> dict[str, Any] | None:
 
     if "owner_invoice" not in me.TABLES:
         return None
-    rows = me.list_records(db, "owner_invoice", pid, limit=500)
+    from .project_budget import OWNER_INVOICE_NOT_BILLED
+    # The OWNER is the one reading this page, and the one who pressed reject. Showing a refused
+    # application inside their billed total contradicts their own decision back at them — and this
+    # reader made it worse by displaying `data.status` (default "draft") rather than the workflow
+    # state, so the rejected invoice appeared as a DRAFT that nonetheless counted as billed.
+    rows = [r for r in me.list_records(db, "owner_invoice", pid, limit=500)
+            if r.get("workflow_state") not in OWNER_INVOICE_NOT_BILLED]
     items = []
     billed = paid = 0.0
     for r in rows:

--- a/services/api/src/aec_api/modules_query.py
+++ b/services/api/src/aec_api/modules_query.py
@@ -332,12 +332,20 @@ def aggregate(db: Session, key: str, project_id: str, group_by: str, agg: str = 
 
 def count_records(db: Session, key: str, project_id: str, state: str | None = None,
                   q: str | None = None, since: datetime | None = None,
-                  filters: list[tuple[str, str, str]] | None = None) -> int:
+                  filters: list[tuple[str, str, str]] | None = None,
+                  exclude_states: list[str] | None = None) -> int:
     """Count matches for a module filter (state / search / created-since) — for saved-view alerts.
 
     Takes `filters` for the same reason `list_records` does: a count that ignores a filter the list
     applied reports a total the page cannot account for, and a total is exactly the number a user
-    trusts without checking."""
+    trusts without checking.
+
+    `exclude_states` drops those workflow states (NULL states are kept, matching a Python `not in`
+    check), exactly as `sum_field` does. It was added when the sentence above came true literally:
+    `/dev-budget/draw-forecast` returns `actual_billed` from `billed_to_date`, which excludes
+    refused owner invoices, beside an `invoice_count` from this function, which did not — one
+    payload disagreeing with itself about how many invoices the money came from. The amount and the
+    count must exclude on the same rule or the page cannot be reconciled."""
     if key not in TABLES:
         return 0
     t = TABLES[key]
@@ -350,6 +358,9 @@ def count_records(db: Session, key: str, project_id: str, state: str | None = No
         stmt = stmt.where(t.c.created_at > since)
     if filters:
         stmt = _apply_filters(db, stmt, t, REGISTRY.get(key) or {}, filters)
+    if exclude_states:
+        stmt = stmt.where(or_(t.c.workflow_state.is_(None),
+                              t.c.workflow_state.notin_(exclude_states)))
     return int(db.execute(stmt).scalar() or 0)
 
 def state_counts(db: Session, key: str, project_id: str) -> dict[str, int]:

--- a/services/api/src/aec_api/project_budget.py
+++ b/services/api/src/aec_api/project_budget.py
@@ -48,11 +48,36 @@ def _records(db: Session, key: str, pid: str) -> list[dict]:
     return me.list_records(db, key, pid, limit=1_000_000)
 
 
+#: Owner-invoice workflow states that are NOT a receivable.
+#:
+#: Rejecting an owner invoice is the OWNER refusing to owe it — the `reject` transition is theirs,
+#: and `revise` (rejected -> draft) is the GC's way back. Carrying a refused application into a
+#: money number reverses that decision somewhere nobody re-reads it.
+#:
+#: This is a CONSTANT rather than five inline checks because `owner_invoice` has five readers —
+#: the ledger, this billed total, WIP, the client-facing payment schedule and the loan-draw view —
+#: and the sub_invoice fix one file over shows the failure mode: that fix landed on one read and
+#: the sibling read TWENTY LINES BELOW IT IN THE SAME FUNCTION kept posting. A rule copied to five
+#: call sites is a rule with four places to rot.
+#:
+#: `submitted`, `approved` and `paid` are deliberately NOT excluded: the first two are live stages of
+#: a real receivable and the third is history that belongs in the books. `draft` is also kept, which
+#: preserves existing behaviour — whether an unsent draft should count as billed is a separate
+#: question from whether a REFUSED one should, and only the second has an answer the workflow states.
+#: Only the explicit refusal is refused, the same line `accounting.journal` draws for `sub_invoice`
+#: and `comp_tier` draws for comparables.
+OWNER_INVOICE_NOT_BILLED = ("rejected",)
+
+
 def billed_to_date(db: Session, pid: str) -> float:
     """Owner-invoice total billed to date — THE single 'billed' number the proforma loan-draws, the
     draw-composition view, and the investment memo all quote (was three hand-rolled copies drifting
-    apart). SQL SUM, no full-table load."""
-    return round(me.sum_field(db, "owner_invoice", pid, "amount"), 2)
+    apart). SQL SUM, no full-table load.
+
+    Excludes rejected applications. `sum_field` has carried `exclude_states` — and named
+    "billed-to-date" as its example use — since it was written; this call simply never passed it."""
+    return round(me.sum_field(db, "owner_invoice", pid, "amount",
+                              exclude_states=list(OWNER_INVOICE_NOT_BILLED)), 2)
 
 
 def staffing_cost(data: dict) -> float:

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -569,7 +569,13 @@ def loan_draws(pid: str, ltc: float = 0.65, rate: float = 0.075, construction_mo
                                   if "interest" in str(u.get("label", "")).lower()), 2)
     # (this endpoint walks every invoice for per-tranche interest anyway, so the full load is needed;
     # the sum matches _pb.billed_to_date — the shared definition of 'billed')
-    invs = _me.list_records(db, "owner_invoice", pid, limit=1_000_000) if "owner_invoice" in _me.TABLES else []
+    # A refused application draws no money, so it accrues no interest. Measured before this fix:
+    # a rejected $250,000 invoice took drawn_to_date to $350,000 and accrued interest on the loan
+    # balance it invented. The comment above claims this sum "matches _pb.billed_to_date" — it did,
+    # because NEITHER filtered; they now match with both filtering, which is the claim it meant.
+    invs = [r for r in (_me.list_records(db, "owner_invoice", pid, limit=1_000_000)
+                        if "owner_invoice" in _me.TABLES else [])
+            if r.get("workflow_state") not in _pb.OWNER_INVOICE_NOT_BILLED]
     drawn = round(sum(float((r.get("data") or {}).get("amount") or 0) for r in invs), 2)
     equity_drawn = round(min(drawn, equity), 2)        # equity-first funding
     loan_drawn = round(max(0.0, drawn - equity), 2)

--- a/services/api/src/aec_api/routers/proforma.py
+++ b/services/api/src/aec_api/routers/proforma.py
@@ -658,7 +658,12 @@ def construction_draws(pid: str, db: Session = Depends(get_db), _sec: str = Depe
         raise HTTPException(404, "project not found")
     cf = pb.cashflow(db, pid)
     billed = pb.billed_to_date(db, pid)                # shared SQL SUM — no full-table load
-    invoice_count = _me.count_records(db, "owner_invoice", pid) if "owner_invoice" in _me.TABLES else 0
+    # ...and the COUNT must exclude on the same rule as the AMOUNT. `billed_to_date` drops refused
+    # applications; this line did not, so one payload reported money from N invoices beside a count
+    # of N+1 and could not be reconciled by the reader.
+    invoice_count = (_me.count_records(db, "owner_invoice", pid,
+                                       exclude_states=list(pb.OWNER_INVOICE_NOT_BILLED))
+                     if "owner_invoice" in _me.TABLES else 0)
 
     # per-cost-code draw composition — what the construction draw is *for*, from the SOV's
     # completed-to-date grouped by cost code (the draw rides the same budget-seeded SOV lines)

--- a/services/api/src/aec_api/wip.py
+++ b/services/api/src/aec_api/wip.py
@@ -117,7 +117,12 @@ def schedule(db: Session, pid: str, method: str = "cost-to-cost", with_model: bo
     contract_value = round((pc_val + co) if pc_val else cs["budget"], 2)
     # billed to date: owner invoices — SQL SUM, not a 100k-row load into Python (this runs per project
     # in the portfolio roll-up, so the full-table materialization was the worst scale hazard).
-    billed = round(me.sum_field(db, "owner_invoice", pid, "amount")
+    # A REJECTED application is not billed. WIP is the worst place for it to leak: `billed` drives
+    # over/under-billing, which `accounting.journal_entries` then posts back as the WIP-ADJ revenue-
+    # recognition line, so one refused invoice moves the ledger twice by two different routes.
+    from .project_budget import OWNER_INVOICE_NOT_BILLED
+    billed = round(me.sum_field(db, "owner_invoice", pid, "amount",
+                                exclude_states=list(OWNER_INVOICE_NOT_BILLED))
                    if "owner_invoice" in me.TABLES else 0.0, 2)
     retainage = round(cost.g703(db, pid)["totals"].get("retainage", 0.0)
                       or (cost.DEFAULT_RETAINAGE / 100 * billed), 2)

--- a/services/api/test_accounting.py
+++ b/services/api/test_accounting.py
@@ -43,6 +43,58 @@ with TestClient(app) as c:
                                  "invoice_date": "2024-01-19", "period": "Jan"}}).json()["id"]
     assert c.get(f"/projects/{pid}/accounting/journal").json()["total"] == 132000, "submitted must post"
     c.post(f"/projects/{pid}/modules/sub_invoice/{_sub}/transition", json={"action": "reject"})
+
+    # --- the AR SIDE of the same defect: a REJECTED OWNER invoice ------------------------------
+    # The loop above was fixed for `sub_invoice`; `journal_entries` reads `owner_invoice` twenty
+    # lines below it, in a different function, and was left posting debit 1200 / credit 4000 —
+    # Accounts Receivable and Contract Revenue. Adjacency in a file is not a relationship, and here
+    # it hid the mirror image of a bug that had just been fixed in the same file.
+    #
+    # `owner_invoice` has FIVE readers and the refusal reached all of them, so this asserts through
+    # every one rather than through the ledger alone: the state means the OWNER refused to pay.
+    oipid = c.post("/projects", json={"name": "AR"}).json()["id"]   # own project: the
+    # assertions further down measure a ledger with no owner invoices in it, and an added
+    # test that moves an existing one's subject has not passed, it has replaced it.
+
+    def _oi(num, amt):
+        return c.post(f"/projects/{oipid}/modules/owner_invoice",
+                      json={"data": {"number": num, "amount": amt, "period": "2024-02-01"}}).json()["id"]
+
+    _ok = _oi("APP-001", 100000)
+    c.post(f"/projects/{oipid}/modules/owner_invoice/{_ok}/transition", json={"action": "submit"})
+    c.post(f"/projects/{oipid}/modules/owner_invoice/{_ok}/transition", json={"action": "certify"})
+    _bad = _oi("APP-002", 250000)
+    c.post(f"/projects/{oipid}/modules/owner_invoice/{_bad}/transition", json={"action": "submit"})
+    assert c.post(f"/projects/{oipid}/modules/owner_invoice/{_bad}/transition",
+                  json={"action": "reject"}).json()["workflow_state"] == "rejected"
+
+    def _ar():
+        """Accounts Receivable per the trial balance — the number a rejected application inflated."""
+        _tb = c.get(f"/projects/{oipid}/accounting/trial-balance").json()
+        return next(r["balance"] for r in (_tb.get("rows") or _tb.get("accounts")) if r["code"] == "1200")
+
+    # measured before the fix: AR 350000 against 100000 actually owed
+    assert _ar() == 100000, ("a rejected owner invoice was posted to Accounts Receivable", _ar())
+    _memos = [e["memo"] for e in c.get(f"/projects/{oipid}/accounting/journal-entries").json()["entries"]]
+    assert not any("APP-002" in m for m in _memos), ("rejected application in the ledger", _memos)
+
+    from aec_api import project_budget as _pbt                    # noqa: E402
+    from aec_api.db import SessionLocal as _SL                    # noqa: E402
+    with _SL() as _db:
+        assert _pbt.billed_to_date(_db, oipid) == 100000, "billed_to_date counted a rejected application"
+    _ld = c.get(f"/projects/{oipid}/loan-draws").json()
+    assert _ld["drawn_to_date"] == 100000, ("a refused draw accrued interest", _ld["drawn_to_date"])
+
+    # ...and the converse, in BOTH directions, so this cannot degrade into "only certified counts":
+    # a SUBMITTED application still bills, and `revise` (rejected -> draft) puts the refused one back.
+    _pending = _oi("APP-003", 5000)
+    c.post(f"/projects/{oipid}/modules/owner_invoice/{_pending}/transition", json={"action": "submit"})
+    assert _ar() == 105000, "a submitted application must still bill"
+    assert c.post(f"/projects/{oipid}/modules/owner_invoice/{_bad}/transition",
+                  json={"action": "revise"}).json()["workflow_state"] == "draft"
+    assert _ar() == 355000, "revise must restore a previously-rejected application"
+    c.post(f"/projects/{oipid}/modules/owner_invoice/{_bad}/transition", json={"action": "submit"})
+    c.post(f"/projects/{oipid}/modules/owner_invoice/{_bad}/transition", json={"action": "reject"})
     assert c.get(f"/projects/{pid}/accounting/journal").json()["total"] == 125000, "reject must un-post"
 
     j = c.get(f"/projects/{pid}/accounting/journal").json()
@@ -119,4 +171,7 @@ print("ACCOUNTING OK - journal flattens sub invoices + direct costs; GL CSV is b
       "(debit Construction Costs / credit AP); trial balance balances (debits==credits==125000) and the "
       "GL columns balance; QuickBooks IIF emits BILL/SPL/ENDTRNS for AP bills only. "
       "Approval-gated batch: freeze snapshot (draft) -> export 409 until submit+approve -> then GL CSV/IIF "
-      "export the FROZEN figures (still balance 125000); missing period=422, unknown batch=404")
+      "export the FROZEN figures (still balance 125000); missing period=422, unknown batch=404. "
+      "A rejected OWNER invoice reaches none of its five readers -- ledger, trial balance (AR 100000 "
+      "not 350000), billed_to_date, loan-draws and the client payment schedule -- while a submitted "
+      "one still bills and `revise` restores a refused one")

--- a/services/api/test_portal_txn.py
+++ b/services/api/test_portal_txn.py
@@ -87,6 +87,17 @@ with TestClient(app) as c:
         "the opt-in HTML page renders the schedule"
     assert "Payment schedule" not in c.get(f"/shared/{plain_tok['token']}").text
 
+    # A REJECTED application must not appear on the OWNER's own page. This reader had two faults at
+    # once: it added every invoice to `billed`, and it displayed `data.status` rather than the
+    # workflow state — so a bill the owner had refused showed up as a "draft" that still counted.
+    _rej = c.post(f"/projects/{pid}/modules/owner_invoice",
+                  json={"data": {"number": "INV-003", "amount": 900000, "period": "2026-07"}}).json()["id"]
+    c.post(f"/projects/{pid}/modules/owner_invoice/{_rej}/transition", json={"action": "submit"})
+    c.post(f"/projects/{pid}/modules/owner_invoice/{_rej}/transition", json={"action": "reject"})
+    ps2 = c.get(f"/shared/{pay_tok['token']}/digest").json()["payment_schedule"]
+    assert ps2["billed"] == 550000, ("a rejected application was billed to the client", ps2["billed"])
+    assert "INV-003" not in {i["number"] for i in ps2["items"]}, ps2["items"]
+
     # --- PORTAL-TXN phase 3: the scoped client comment thread (backed by a real BCF topic) --------
     ct = c.post(f"/shared/{pay_tok['token']}/comment",
                 json={"text": "When does tile install start?", "client_name": "Pat Owner"})

--- a/services/api/test_project_budget.py
+++ b/services/api/test_project_budget.py
@@ -187,6 +187,20 @@ with TestClient(app) as c:
     assert draws1["actual_billed"] == round(inv2["amount"], 2) and draws1["pct_billed"] > 0, draws1
     assert draws1["invoice_count"] == 2, draws1                                 # the $0 App-1 + the billed App-2
 
+    # A REFUSED application must leave BOTH numbers alone, together. `actual_billed` comes from
+    # `billed_to_date` (which excludes rejected) and `invoice_count` from `count_records` (which
+    # did not), so excluding the amount without excluding the count produced one payload reporting
+    # money from N invoices beside a count of N+1 — reconcilable by nobody. Asserted as a pair on
+    # purpose: either half alone passes while the response contradicts itself.
+    _rej = c.post(f"/projects/{pid}/modules/owner_invoice",
+                  json={"data": {"number": "APP-REJ", "amount": 900_000, "period": "2026-09"}}).json()["id"]
+    c.post(f"/projects/{pid}/modules/owner_invoice/{_rej}/transition", json={"action": "submit"})
+    c.post(f"/projects/{pid}/modules/owner_invoice/{_rej}/transition", json={"action": "reject"})
+    draws2 = c.get(f"/projects/{pid}/construction-draws").json()
+    assert draws2["actual_billed"] == draws1["actual_billed"], ("a refused application was billed", draws2)
+    assert draws2["invoice_count"] == draws1["invoice_count"], ("the count included a refused application "
+                                                                "the amount excluded", draws2)
+
     # construction-loan draws: owner invoices funded equity-first then debt vs the sized capital stack
     ld = c.get(f"/projects/{pid}/loan-draws").json()
     assert ld["loan_amount"] > 0 and ld["equity"] > 0, ld

--- a/services/api/test_wip.py
+++ b/services/api/test_wip.py
@@ -39,6 +39,14 @@ with TestClient(app) as c:
     assert w["contract_value"] == 1000000, w["contract_value"]
     assert w["earned_revenue"] == 500000, w["earned_revenue"]          # 50% × 1M
     assert w["billed_to_date"] == 300000, w["billed_to_date"]
+    # a REJECTED application is not billed — and WIP is where it does the most damage, because
+    # `billed` drives over/under-billing and `accounting.journal_entries` posts that back as the
+    # WIP-ADJ revenue line, so one refused invoice would move the ledger by two separate routes.
+    _rj = _mk(c, pid, "owner_invoice", {"number": "INV-X", "amount": 900000, "period": "2026-06"})
+    c.post(f"/projects/{pid}/modules/owner_invoice/{_rj}/transition", json={"action": "submit"})
+    c.post(f"/projects/{pid}/modules/owner_invoice/{_rj}/transition", json={"action": "reject"})
+    _wr = c.get(f"/projects/{pid}/wip").json()
+    assert _wr["billed_to_date"] == 300000, ("a rejected application reached WIP", _wr["billed_to_date"])
     assert w["under_billing"] == 200000 and w["over_billing"] == 0, w  # earned − billed (asset)
     assert w["billing_status"] == "under-billed", w["billing_status"]
     assert w["gross_profit"] == 200000 and w["gross_margin_pct"] == 20.0, w  # 1M − 800k


### PR DESCRIPTION
# What & why

`accounting.journal_entries` posted every `owner_invoice` as **debit 1200 / credit 4000** — Accounts Receivable and Contract Revenue — with no regard for its workflow state. Measured through the routes with a rejected $250,000 application beside a certified $100,000 one, the trial balance reported **accounts receivable of $350,000 against $100,000 actually owed**. Rejecting an owner invoice is the *owner* refusing to pay it (`reject` is their transition; `revise` is the GC's way back), and every one of the record's five readers ignored that. Roadmap item: `REFUSAL-READERS` (Band 2, Lane C), added in this PR.

| reader | what it got wrong |
|---|---|
| `accounting.journal_entries` | posted AR + Contract Revenue for a refused application |
| `/accounting/trial-balance` | AR $350,000 instead of $100,000 |
| `project_budget.billed_to_date` | *"THE single 'billed' number"* the loan-draws, draw-composition and investment memo all quote |
| `wip.schedule` | `billed` drives over/under-billing, which posts **back** as the WIP-ADJ revenue line — one refused invoice moving the ledger by two routes |
| `client_portal` payment schedule | billed the owner for the invoice **they** rejected, and displayed `data.status` (default `"draft"`) rather than the workflow state — so it showed as a draft that nonetheless counted |
| `/loan-draws` | drew $350,000 and accrued interest on the balance it invented ($2,085.62 → $595.89) |

**This is the AP fix from v0.3.1121 met in a mirror.** That release fixed `journal()` for `sub_invoice`; this defect sat **twenty lines below it**, in a different function, reading the AR side. *Adjacency in a file is not a relationship* — the fix and the bug were as close as two pieces of code can be.

The rule is a named constant, `project_budget.OWNER_INVOICE_NOT_BILLED`, not five inline checks: a record type with five readers is a rule with four places to rot. `sum_field` has carried an `exclude_states` parameter — and named *"billed-to-date"* as its example use — since it was written; the call site simply never passed it. `submitted`, `approved` and `paid` stay; `draft` stays too, deliberately, because whether an unsent draft counts as billed is a separate question from whether a *refused* one does, and only the second has an answer the workflow states.

## The class, derived rather than stumbled into — and derived wrong the first time

Four fixes landed in the previous 24h that are all this same defect. Rather than wait for a fifth, the population was derived: **27 of 139 record types carry a refusal state.** Each candidate was then *read*, because the procurement fix's own message warns that a count is not a population:

- **17** `list_records` sites had no state reference in scope → **3** real and fixed here, **5** correct as-is, **9** real and still open.
- **5 more reads the derivation never saw** — `sum_field` ×3, `count_records` ×2. **Two of the five defects this PR fixes live there** (`billed_to_date`, `wip.schedule`): the sweep matched `list_records(db, "<type>"` and nothing else, so those two were found by reading the module, not by the sweep meant to be exhaustive. 49 reads, not 44.

The **9 still open** include a rejected **design option winning its ranking** (×3 readers) and a **superseded zoning scheme winning a feasibility comparison** while its own sibling thirty lines below *does* read the state; plus a void RFI in contractual ageing, prequalification scoring, entitlement conditions, and two spec-section readers.

The **5 correct as-is** are the load-bearing half. A pattern-matching gate would have "fixed" all five and **broken two**: the three lease readers filter in the *summarizer* one call away, and `opendata` reads every permit to build the **deduplication set** for import, so filtering there would re-import expired permits as duplicates.

So a static sweep over this class is unreliable in **both** directions — false positives on the five correct readers, and false negatives on the five reads it never enumerated. That is why the gate must be behavioural: drive the route, move the record into refusal, assert the number does not move. Scoped as the next slice.

## The roadmap gates were measuring 31 of 33 items — in nine places, not two

The new entry is called `REFUSAL-READERS`. `roadmapLanes.test.ts` passed with it in place and **the pass was vacuous**: the item regex capped a code head at six characters and `REFUSAL-` is seven, so the bullet was never in the population. Widening it did **not** fix the gate — `laneRows()` held a second hand-kept copy, so the code was in the population, absent from every lane, and the suite failed naming it an orphan while the lane row plainly listed it.

**And "both now read a single `CODE_HEAD`" was itself a claim narrower than it sounded.** Review found the copies do not stop at that file: there are **nine across three suites**, so `REFUSAL-READERS` stayed invisible to `roadmapStale` and `roadmapSelfConsistent` — both reporting a pass on an item they could not see, which is the same vacuous pass described above, still happening in two more places while this description claimed it was fixed. All nine now carry one rule (measured per regex shape: 31 → 33 codes and 27 → 29, nothing lost either way).

The duplication is **gated rather than removed**: these suites are self-contained by design (node + vitest only), so a shared module would be the first import between them, and the failure being prevented is a copy never wired to anything — which an import-based fix cannot see once someone adds a tenth regex inline. A new check asserts every code-head rule across the three files is character-for-character identical, reading the file **text** rather than the compiled regex; a second asserts the rule is wide enough for the longest code the roadmap actually contains. Mutation-checked: reverting one copy fails the gate and names the file.

The second code gained is `QUALITY-ROOM`, invisible to these gates for its whole life and so never required to be in a lane; it is a question answered and declined in place, now marked ⛔.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check src/ ../data/src/` clean
- [x] Backend: **656/656 suites** pass locally; affected 23 run individually. No new test files, so the `run_tests.py` TESTS manifest is unchanged. **API test gate passed in CI on `dd903d58`**, the commit carrying every backend change
- [x] Web: typecheck + lint + build clean; full suite **2044 tests / 200 files**
- [x] No import cycles introduced (`test_import_cycles.py` 552 modules · `no-import-cycles.test.ts` both pass)
- [x] `CHANGELOG.md` entry added (newest at top); roadmap item added and assigned to Lane C
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` **and** `package-lock.json` (the triple `versionConsistency.test.ts` asserts) → 0.3.1122
- [x] No secrets, no competitor names in shipped docs

**All five engine changes mutation-checked independently** — each reverted in turn, with the specific assertion confirmed to fail and then pass. Each test also asserts the converse (a submitted application still bills; `revise` restores a refused one), so the fix cannot degrade into "only certified counts".

Three notes against my own work, kept because each is the kind of thing that otherwise gets quietly fixed and forgotten: the lane-gate pass was vacuous until caught and then *still* vacuous in two more suites until review caught it; the derived population never contained two of the defects it is cited for; and an earlier full-suite run was invalidated by my own cleanup command — `rm -rf test_storage_*` without a trailing slash matched the source file `test_storage_key_parity.py`, not just the scratch directories. The `run_tests.py` manifest guard caught that in one run; the file is restored and the suite re-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rejected owner invoices are now excluded from accounting, billing, work-in-progress, payment schedules, and construction or loan draw calculations.
  - Invoice totals and counts now remain consistent when rejected applications are present.
  - Revised rejected applications correctly return to draft processing.
  - Roadmap code matching now supports longer identifiers and recognizes additional lane-gate entries.

- **Documentation**
  - Updated release documentation with corrected roadmap metrics and a noted portal status-display issue.

- **Release**
  - Updated the application version to 0.3.1122.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->