### PR TITLE
v0.3.1123 — a scheme the team refused could still win the comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ an unapproved scheme is a real thing to test, which is what a comparison is *for
 These three modules already separated LISTED from RANKED — for unmeasured carbon and unpriced
 economics, as their own notes say. Refusal simply was not one of the reasons.
 
+**And the same defect, a third time, caught by review.** Excluding a refused option from the
+*ranking* left the counts describing the *unfiltered* set: `option_economics` reported
+`unpriced_count: 1` while **zero** options lacked an IRR — the rejected one has 30% and was simply
+missing from `priced` — and `option_carbon`'s `measured` + `unavailable` no longer summed to
+`count`. This is the third appearance of one shape: v0.3.1122's `billed_to_date` excluded refused
+invoices while `invoice_count` did not; then this; then carbon's parts not summing. **Filter a
+computation, leave a count over the unfiltered set.** Both now take their counts against the ranked
+population and return `in_contention_count`, so `count` reconciles rather than leaving a reader to
+infer the difference. Asserted, not just fixed: the test pins `unpriced_count` to the number of
+options that actually lack a figure, and pins both responses to add up.
+
 **A vacuous test, caught by mutation-checking rather than by review.** The first `option_carbon`
 mutation **did not fire**: reverting the fix broke nothing, because the rejected option carried no
 carbon figure and so could never have won that ranking. Adding one exposed a *second* vacuity — with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1123 (2026-08-30) — a scheme the team refused could still win the comparison
+
+**Four `REFUSAL-READERS` instances, all of the form "a refused thing ranks first".** Unlike v0.3.1122
+these move no money directly; they move what the product *recommends*, which is worse in one respect:
+a wrong number gets questioned, a wrong recommendation gets built.
+
+| endpoint | measured before | after |
+|---|---|---|
+| `/design/options/compare` | a REJECTED option named **best-in-class on all four** of its populated metrics | the live scheme leads |
+| `/design/options/carbon` | the rejected option was `lowest_total` | `Scheme D — live` |
+| `/design/options/economics` | the rejected option was `best_irr`, at 30% against a live 12% | the live scheme |
+| `/feasibility/compare` | a SUPERSEDED zoning scheme ranked **#1** at 240,000 GFA vs a live 80,000 | excluded and named |
+
+**The design-option case is the sharpest.** The engine already knew: the same response reported
+`rejected: 1` in `by_state` while naming that option the leader. The state was not missing, not
+buried, not expensive to reach — it was one field away, counted, and ignored.
+
+**The feasibility case is the most consequential.** The top scheme is the baseline every other
+scheme's deltas are measured against, so a superseded FAR-12 envelope made a live FAR-4 scheme read
+as a 160,000 SF *shortfall* against something nobody can build. Its own sibling `feasibility()`,
+thirty lines below in the same file, already reads that state to prefer an approved record — one
+function in the file honoured it and the other did not, the same shape as the accounting and
+procurement defects. `compare` also **dropped `workflow_state` before returning**, so no caller could
+have filtered even if it wanted to; every row now carries it.
+
+**Nothing is hidden.** All four endpoints keep listing the refused item and name what left the
+ranking — `not_in_contention`, `superseded_excluded` — following `compute_appraisal`'s
+`excluded_comparables`. A ranking whose field silently shrank reads as a thinner set of options
+rather than as a decision somebody recorded. `draft` and `proposed` are deliberately still ranked:
+an unapproved scheme is a real thing to test, which is what a comparison is *for*.
+
+These three modules already separated LISTED from RANKED — for unmeasured carbon and unpriced
+economics, as their own notes say. Refusal simply was not one of the reasons.
+
+**A vacuous test, caught by mutation-checking rather than by review.** The first `option_carbon`
+mutation **did not fire**: reverting the fix broke nothing, because the rejected option carried no
+carbon figure and so could never have won that ranking. Adding one exposed a *second* vacuity — with
+the rejected option excluded, nothing was measured at all, `lowest_total` went `None`, and the
+assertion passed for a new wrong reason. It took a live carbon-bearing option to make the check real.
+Both guards are now in the test with the reasoning inline. Every assertion carries a **positive
+control** (the option leads while live) so no exclusion test can pass merely because its subject was
+uncompetitive.
+
 ## v0.3.1122 (2026-08-30) — the owner rejected the invoice; five money numbers went on counting it
 
 **A rejected owner invoice was booked as revenue.** `accounting.journal_entries` posted every

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1122",
+    "version": "0.3.1123",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1122",
+  "version": "0.3.1123",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -315,8 +315,8 @@ instances:
   needs reading, not just counting" — and this sweep proves the cost both ways: 9 real defects a count
   would have missed the reasons for, and 5 correct readers a count would have broken.
 
-  **A COROLLARY the class keeps producing, now seen three times: when you filter a computation,
-  every count derived from that set moves with it.** v0.3.1122 excluded refused invoices from
+  **When you filter a computation, every count derived from that set must move with it.** This class
+  has now produced that corollary three times. v0.3.1122 excluded refused invoices from
   `billed_to_date` and left `invoice_count` unfiltered, so one payload reported money from N
   invoices beside a count of N+1. v0.3.1123 excluded refused options from `priced` and left
   `unpriced_count` derived from all options, so an option WITH an IRR was reported as unpriced; and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -315,6 +315,16 @@ instances:
   needs reading, not just counting" — and this sweep proves the cost both ways: 9 real defects a count
   would have missed the reasons for, and 5 correct readers a count would have broken.
 
+  **A COROLLARY the class keeps producing, now seen three times: when you filter a computation,
+  every count derived from that set moves with it.** v0.3.1122 excluded refused invoices from
+  `billed_to_date` and left `invoice_count` unfiltered, so one payload reported money from N
+  invoices beside a count of N+1. v0.3.1123 excluded refused options from `priced` and left
+  `unpriced_count` derived from all options, so an option WITH an IRR was reported as unpriced; and
+  carbon's `measured` + `unavailable` stopped summing to `count`. Both fixed by taking the counts
+  against the ranked population and returning `in_contention_count` so the response reconciles.
+  *Check this explicitly on each of the remaining five — it is the second-order defect this whole
+  class generates, and it has now escaped local verification twice.*
+
   **A vacuity found by mutation-testing, worth more than the four fixes.** The first `option_carbon`
   mutation did not fire: reverting the fix broke nothing, because the rejected option carried no
   carbon figure and could never have won that ranking. Adding one exposed a SECOND vacuity — with the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -250,7 +250,7 @@ instances:
   | of those, with no state reference in scope | **17** |
   | ├ real, **fixed in v0.3.1122** | **3** (`owner_invoice`) |
   | ├ **correct as-is**, reasoned | **5** |
-  | └ **real and still open** | **9** |
+  | └ **real and still open** | **9** → **5** *(4 closed v0.3.1123)* |
   | *plus* aggregate reads the derivation never counted | **5** (`sum_field` 3 · `count_records` 2) |
   | of those, real and **fixed in v0.3.1122** | **2** (`billed_to_date`, `wip.schedule`) |
 
@@ -271,14 +271,17 @@ instances:
   **The nine open ones**, each verified to have no state filter anywhere in its path (the reader *and*
   its downstream helper were both read):
 
-  - `design_options.compare`, `option_carbon.compare_carbon`, `option_economics.compare_economics` —
-    a design option the team REJECTED still competes in the ranking and can win it, so the
-    recommended scheme can be one that was refused. Fix shape is the appraisal one: drop it from the
-    ranking, name it alongside rather than silently.
-  - `feasibility.compare_scenarios` — ranks every `zoning` scheme including SUPERSEDED ones, and the
-    top scheme sets the deltas. **Its own sibling `study`, thirty lines below, does read the state** —
-    one function in the file filters and the other does not, which is the exact shape of the
-    accounting and procurement bugs.
+  - ✅ **`design_options.compare`, `option_carbon.compare_carbon`, `option_economics.compare_economics`
+    — CLOSED v0.3.1123.** A REJECTED option was named best-in-class on all four populated metrics,
+    was `lowest_total` for carbon, and was `best_irr` at 30% against a live 12% — while the same
+    `compare` response reported `rejected: 1` in `by_state`. One rule,
+    `design_options.DESIGN_OPTION_NOT_IN_CONTENTION`, now shared by all three; each still LISTS the
+    option and names it in `not_in_contention`.
+  - ✅ **`feasibility.compare` — CLOSED v0.3.1123.** A SUPERSEDED scheme ranked #1 at 240,000 GFA
+    against a live 80,000, and the top scheme is the BASELINE every delta is measured against, so a
+    live scheme read as a 160,000 SF shortfall against an envelope nobody can build. It also dropped
+    `workflow_state` before returning, so no caller could filter even in principle; rows now carry
+    it, and `superseded_excluded` names what left. Drafts are still ranked on purpose.
   - `rfi.rfi_register` — a VOID RFI still counts in the open and overdue totals and in ball-in-court.
     RFI ageing is a contractual metric. `sync.py` filters; this does not.
   - `prequalification.score_project` — a rejected sub still carries a score and inflates `high_risk`.
@@ -311,6 +314,15 @@ instances:
   *A count is not a population.* The procurement fix said so in its own message — "the population
   needs reading, not just counting" — and this sweep proves the cost both ways: 9 real defects a count
   would have missed the reasons for, and 5 correct readers a count would have broken.
+
+  **A vacuity found by mutation-testing, worth more than the four fixes.** The first `option_carbon`
+  mutation did not fire: reverting the fix broke nothing, because the rejected option carried no
+  carbon figure and could never have won that ranking. Adding one exposed a SECOND vacuity — with the
+  rejected option excluded, nothing was measured at all, so `lowest_total` went `None` and the
+  assertion passed for a new wrong reason. Two vacuous checks stacked in one assertion, neither
+  visible from a green run. Every exclusion assertion here now carries a **positive control** (the
+  subject leads while live), so none can pass merely because its subject was uncompetitive. *Apply
+  the same to the remaining five: an exclusion test whose subject could not have won proves nothing.*
 
   **Not gated yet, and the obvious gate is the wrong one.** A check that every reader of a
   refusal-bearing type mentions the state produces false positives on all five correct readers, and a

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1122",
+      "version": "0.3.1123",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/src/aec_api/design_options.py
+++ b/services/api/src/aec_api/design_options.py
@@ -67,6 +67,24 @@ _METRICS = {
 }
 
 
+#: Design-option states that are OUT OF CONTENTION — listed, but never named best-in-class.
+#:
+#: `reject` is the team's explicit decision that a scheme is not the answer. Letting it win a metric
+#: makes the comparison recommend a scheme somebody already refused, and the card gives no hint:
+#: measured before this, a rejected option was named leader on ALL FOUR of its populated metrics
+#: while the same response reported `rejected: 1` in `by_state`. The state was not missing or hard to
+#: reach — it was one field away, counted, and ignored.
+#:
+#: This does not hide anything. Every option stays in `options` and in `by_state`; `not_in_contention`
+#: names what was dropped from the ranking, exactly as `marketing.compute_appraisal` names its
+#: `excluded_comparables`. A ranking whose field silently shrank reads as a weaker field rather than
+#: as a decision somebody made.
+#:
+#: These modules already separate LISTED from RANKED — for unmeasured carbon and unpriced economics,
+#: as their own notes say. Refusal simply was not one of the reasons.
+DESIGN_OPTION_NOT_IN_CONTENTION = ("rejected",)
+
+
 def compare(db: Session, pid: str) -> dict[str, Any]:
     rows = me.list_records(db, "design_option", pid, limit=100000) if "design_option" in me.TABLES else []
     opts = [_option(r) for r in rows if _d(r).get("name")]
@@ -90,8 +108,10 @@ def compare(db: Session, pid: str) -> dict[str, Any]:
         o["derived_hard_cost"] = e["hard_cost"] if e and e["basis"] == "derived" else None
         o["irr_agrees_with_proforma"] = e["agrees_with_declared"] if e else None
 
+    contenders = [o for o in opts if o["state"] not in DESIGN_OPTION_NOT_IN_CONTENTION]
+
     def _leader(key: str, lower: bool) -> str | None:
-        vals = [(o[key], o["name"]) for o in opts if o.get(key) is not None]
+        vals = [(o[key], o["name"]) for o in contenders if o.get(key) is not None]
         if not vals:
             return None
         return (min if lower else max)(vals, key=lambda t: t[0])[1]
@@ -110,11 +130,14 @@ def compare(db: Session, pid: str) -> dict[str, Any]:
 
     return {
         "count": len(opts), "options": opts, "leaders": leaders,
+        "not_in_contention": [o["name"] for o in opts
+                              if o["state"] in DESIGN_OPTION_NOT_IN_CONTENTION],
         "selected": selected["name"] if selected else None,
         "by_state": {s: sum(1 for o in opts if o["state"] == s)
                      for s in ("proposed", "shortlisted", "selected", "rejected")},
         "note": "Options compared on program, economics and embodied carbon; best-in-class named per "
                 "metric. An option whose carbon_basis is 'unavailable' carries no figure and is never "
-                "named best-in-class. Promote one to 'selected' to set the project's design direction "
-                "(its drawing set becomes current).",
+                "named best-in-class, and a REJECTED option is listed but never named best-in-class "
+                "either — see `not_in_contention`. Promote one to 'selected' to set the project's "
+                "design direction (its drawing set becomes current).",
     }

--- a/services/api/src/aec_api/feasibility.py
+++ b/services/api/src/aec_api/feasibility.py
@@ -149,13 +149,31 @@ def compare(db, pid: str, actual_gfa_sf: float | None = None) -> dict[str, Any]:
     recs = me.list_records(db, "zoning", pid, limit=100000)
     if not recs:
         return {"scenarios": [], "count": 0, "warnings": ["Add Zoning & Site records (one per scheme) to compare."]}
+    # A SUPERSEDED scheme is not a candidate. `supersede` is the explicit act of replacing a zoning
+    # record (with `reopen` back to draft), so ranking one can make the winner — and therefore the
+    # BASELINE every other scheme's deltas are measured against — a scheme that no longer applies.
+    # Measured before this: a superseded FAR-12 scheme ranked first at 240,000 GFA against a live
+    # FAR-4 scheme's 80,000, so the live scheme was reported as a 160,000 SF shortfall against an
+    # envelope nobody can build.
+    #
+    # `draft` stays: an unapproved scheme is a real thing to test, which is what this comparison is
+    # FOR. Only the explicit replacement is excluded. The sibling `feasibility()` thirty lines below
+    # already reads this state to prefer an approved record — one function in the file honoured it
+    # and this one did not.
+    #
+    # `workflow_state` is now carried on every row. It was dropped before the caller could see it,
+    # so the UI had no way to mark a scheme as superseded even if it wanted to — the same shape as
+    # the appraisal defect, where the state was discarded before any filter could apply.
+    superseded = [r for r in recs if r.get("workflow_state") == "superseded"]
+    live = [r for r in recs if r.get("workflow_state") != "superseded"]
     scen = []
-    for rec in recs:
+    for rec in live:
         f = compute(rec, actual_gfa_sf=actual_gfa_sf)
         if f.get("error"):
             continue
         scen.append({
             "ref": rec.get("ref"), "zoning_id": rec.get("id"),
+            "workflow_state": rec.get("workflow_state"),
             "site": f.get("site"), "use_type": f.get("use_type"),
             "far": (f.get("inputs") or {}).get("far"),
             "max_floors": f.get("max_floors"),
@@ -169,7 +187,16 @@ def compare(db, pid: str, actual_gfa_sf: float | None = None) -> dict[str, Any]:
         if best:
             s["delta_units"] = (s["unit_yield"] or 0) - (best["unit_yield"] or 0)
             s["delta_gfa_sf"] = round((s["allowed_gfa_sf"] or 0) - (best["allowed_gfa_sf"] or 0), 1)
-    return {"scenarios": scen, "count": len(scen), "best_ref": best["ref"] if best else None}
+    return {"scenarios": scen, "count": len(scen), "best_ref": best["ref"] if best else None,
+            # Named rather than silently dropped: a comparison whose field shrank without saying so
+            # reads as a thinner set of options rather than as a decision somebody recorded.
+            "superseded_excluded": [{"ref": r.get("ref"), "zoning_id": r.get("id")}
+                                    for r in superseded],
+            "note": ("Schemes ranked by unit yield, then allowed GFA; deltas are vs. the top scheme. "
+                     "SUPERSEDED records are excluded from the ranking and named in "
+                     "`superseded_excluded` — a replaced scheme cannot be the baseline the live ones "
+                     "are measured against. Drafts ARE ranked: an unapproved scheme is a real option "
+                     "to test.")}
 
 
 def feasibility(db, pid: str, actual_gfa_sf: float | None = None, zoning_id: str | None = None) -> dict[str, Any]:

--- a/services/api/src/aec_api/option_carbon.py
+++ b/services/api/src/aec_api/option_carbon.py
@@ -150,7 +150,12 @@ def compare_carbon(db: Session, pid: str) -> dict[str, Any]:
                 o["embodied_kgco2e"] - selected["embodied_kgco2e"], 1)
 
     return {
+        # `measured` and `unavailable` describe the RANKED population, so they sum to
+        # `in_contention_count`, not to `count`. Returning that explicitly is the difference between
+        # a reader who can account for every option and one who sees 1 + 0 against a count of 2 and
+        # has to guess. See the note in `option_economics` — same shape, found the same way.
         "count": len(opts),
+        "in_contention_count": len(contenders),
         "measured_count": len(measured),
         "unavailable_count": len(unavailable),
         "options": opts,

--- a/services/api/src/aec_api/option_carbon.py
+++ b/services/api/src/aec_api/option_carbon.py
@@ -127,8 +127,14 @@ def compare_carbon(db: Session, pid: str) -> dict[str, Any]:
         if "design_option" in me.TABLES else []
     opts = [option_carbon(r) for r in rows if (r.get("data") or r).get("name")]
 
-    measured = [o for o in opts if o["embodied_kgco2e"] is not None]
-    unavailable = [o for o in opts if o["embodied_kgco2e"] is None]
+    # A REJECTED scheme is listed but not ranked — the same separation this module already makes for
+    # an unmeasured one, for a second reason. Without it the lowest-carbon headline can name a scheme
+    # the team refused, which is worse here than elsewhere: carbon is the number an option gets
+    # promoted on.
+    from .design_options import DESIGN_OPTION_NOT_IN_CONTENTION
+    contenders = [o for o in opts if o["state"] not in DESIGN_OPTION_NOT_IN_CONTENTION]
+    measured = [o for o in contenders if o["embodied_kgco2e"] is not None]
+    unavailable = [o for o in contenders if o["embodied_kgco2e"] is None]
     ranked = sorted(measured, key=lambda o: o["embodied_kgco2e"])
     by_intensity = [o for o in measured if o["kgco2e_per_m2"] is not None]
     by_intensity.sort(key=lambda o: o["kgco2e_per_m2"])
@@ -156,8 +162,11 @@ def compare_carbon(db: Session, pid: str) -> dict[str, Any]:
         # difference between a reader who knows to check and one who does not.
         "mixed_basis": len([b for b in mix if b != BASIS_UNAVAILABLE]) > 1,
         "basis_meanings": _WHY,
+        "not_in_contention": [o["name"] for o in opts
+                              if o["state"] in DESIGN_OPTION_NOT_IN_CONTENTION],
         "note": ("Options with no basis are listed and NOT ranked — an option that could not be "
-                 "measured is not an option with zero carbon."),
+                 "measured is not an option with zero carbon. A REJECTED option is listed and not "
+                 "ranked for the other reason: it is not in contention. See `not_in_contention`."),
         "message": (None if measured else
                     "No option can be given an embodied-carbon figure yet. Record `embodied_kgco2e` "
                     "on an option, or give it a gross area and a known building type."),

--- a/services/api/src/aec_api/option_economics.py
+++ b/services/api/src/aec_api/option_economics.py
@@ -183,8 +183,20 @@ def compare_economics(db: Session, pid: str) -> dict[str, Any]:
     disagree = [o for o in derived if o["agrees_with_declared"] is False]
 
     return {
-        "count": len(opts), "priced_count": len(priced), "derived_count": len(derived),
-        "unpriced_count": len(opts) - len(priced),
+        # `count` is everything LISTED; the pricing counts describe the RANKED population, so they
+        # are taken against `contenders`. Deriving `unpriced_count` from `opts` instead reported a
+        # rejected option that HAS an IRR as unpriced — measured: unpriced_count 1 while zero
+        # options lacked a figure. The exclusion and the count that describes it must run over the
+        # same population, or the response contradicts itself; `in_contention_count` is returned so
+        # a reader can reconcile `count` rather than having to infer the difference.
+        #
+        # THIRD TIME THIS SHAPE HAS APPEARED (v0.3.1122 `billed_to_date` vs `invoice_count`, then
+        # `priced` vs `unpriced_count`, then carbon's `measured`+`unavailable` not summing): filter a
+        # computation, leave a count over the unfiltered set. Whenever a filter is added here, every
+        # count derived from that set moves with it.
+        "count": len(opts), "in_contention_count": len(contenders),
+        "priced_count": len(priced), "derived_count": len(derived),
+        "unpriced_count": len(contenders) - len(priced),
         "options": opts,
         "best_irr": ranked[0]["name"] if ranked else None,
         "scenarios": [{"id": i, "name": n} for i, n in candidates],

--- a/services/api/src/aec_api/option_economics.py
+++ b/services/api/src/aec_api/option_economics.py
@@ -171,7 +171,13 @@ def compare_economics(db: Session, pid: str) -> dict[str, Any]:
         sc = by_id.get(ref) or by_name.get(ref.lower()) if ref else None
         opts.append(option_economics(r, sc, candidates))
 
-    priced = [o for o in opts if o["irr_pct"] is not None]
+    # Same separation this module already makes between listed and ranked, for a second reason:
+    # `best_irr` must not name a scheme the team rejected. `derived` / `disagree` deliberately keep
+    # reading EVERY option, rejected included — "your declared IRR disagrees with your proforma" is
+    # a data-quality finding about a record, and it stays true whether or not the scheme is in play.
+    from .design_options import DESIGN_OPTION_NOT_IN_CONTENTION
+    contenders = [o for o in opts if o["state"] not in DESIGN_OPTION_NOT_IN_CONTENTION]
+    priced = [o for o in contenders if o["irr_pct"] is not None]
     ranked = sorted(priced, key=lambda o: -o["irr_pct"])
     derived = [o for o in opts if o["basis"] == BASIS_DERIVED]
     disagree = [o for o in derived if o["agrees_with_declared"] is False]
@@ -188,9 +194,12 @@ def compare_economics(db: Session, pid: str) -> dict[str, Any]:
              "derived_irr_pct": o["irr_pct"],
              "delta_pct": o["declared_vs_derived_irr_pct"]} for o in disagree],
         "basis_meanings": _WHY,
-        "note": ("An option is ranked only on a figure that exists. A `declared` figure is shown and "
-                 "labelled, never promoted to `derived`; an `unlinked` option is never priced from "
-                 "another scheme's deal."),
+        "not_in_contention": [o["name"] for o in opts
+                              if o["state"] in DESIGN_OPTION_NOT_IN_CONTENTION],
+        "note": ("An option is ranked only on a figure that exists, and only if it is still in "
+                 "contention — a REJECTED option is listed but never named `best_irr`. A `declared` "
+                 "figure is shown and labelled, never promoted to `derived`; an `unlinked` option is "
+                 "never priced from another scheme's deal."),
         "message": (None if priced else
                     "No option can be priced yet. Link a proforma scenario to an option (set its "
                     "`scenario` field), or record hard_cost / irr_pct directly."),

--- a/services/api/src/aec_api/option_economics.py
+++ b/services/api/src/aec_api/option_economics.py
@@ -194,6 +194,15 @@ def compare_economics(db: Session, pid: str) -> dict[str, Any]:
         # `priced` vs `unpriced_count`, then carbon's `measured`+`unavailable` not summing): filter a
         # computation, leave a count over the unfiltered set. Whenever a filter is added here, every
         # count derived from that set moves with it.
+        # `unpriced_count` counts among CONTENDERS, not among all options, so that
+        # `priced_count + unpriced_count == in_contention_count` and the response reconciles. The
+        # alternative — counting missing IRRs across every option — answers a different question and
+        # reconciles with nothing; a rejected option with no figure is not a gap in the ranking,
+        # because it was never going to be ranked.
+        #
+        # The distinction is invisible unless a REFUSED option also lacks a figure, which is exactly
+        # the case the test now covers: with both semantics agreeing on the original data, the
+        # assertion was passing without discriminating between them.
         "count": len(opts), "in_contention_count": len(contenders),
         "priced_count": len(priced), "derived_count": len(derived),
         "unpriced_count": len(contenders) - len(priced),
@@ -212,7 +221,11 @@ def compare_economics(db: Session, pid: str) -> dict[str, Any]:
                  "contention — a REJECTED option is listed but never named `best_irr`. A `declared` "
                  "figure is shown and labelled, never promoted to `derived`; an `unlinked` option is "
                  "never priced from another scheme's deal."),
+        # "in contention" because `priced` is now contenders-only: a project whose ONLY priced
+        # option was rejected would otherwise be told no option can be priced, which is not what
+        # happened — one was, and then refused.
         "message": (None if priced else
-                    "No option can be priced yet. Link a proforma scenario to an option (set its "
+                    "No option in contention can be priced yet. Link a proforma scenario to an "
+                    "option (set its "
                     "`scenario` field), or record hard_cost / irr_pct directly."),
     }

--- a/services/api/test_design_engine.py
+++ b/services/api/test_design_engine.py
@@ -102,11 +102,31 @@ with TestClient(app) as c:
     # zero options actually lacking a figure. This is the third appearance of one shape (v0.3.1122's
     # billed-vs-invoice_count, then this, then carbon's parts not summing): filter a computation,
     # leave a count over the unfiltered set.
-    _no_irr = sum(1 for o in _eco["options"] if o["irr_pct"] is None)
-    assert _eco["unpriced_count"] == _no_irr, \
-        ("unpriced_count disagrees with how many options lack an IRR",
-         _eco["unpriced_count"], _no_irr)
+    # `unpriced_count` counts among CONTENDERS so the response reconciles:
+    # priced + unpriced == in_contention. Counting missing IRRs across ALL options instead answers a
+    # different question and reconciles with nothing — a refused option with no figure is not a gap
+    # in the ranking, because it was never going to be ranked.
+    #
+    # A REFUSED option with NO IRR is added below precisely because it is the only case where those
+    # two readings differ. Without it both give the same number and this assertion passes while
+    # discriminating between nothing — the same vacuity as the carbon check above, one level up.
+    _mute = c.post(f"/projects/{pid}/modules/design_option",
+                   json={"data": {"name": "Scheme E — refused, unpriced",
+                                  "gross_area_sf": 8000}}).json()
+    _act(c, pid, "design_option", _mute["id"], "reject")
+    _eco = c.get(f"/projects/{pid}/design/options/economics").json()
+    _contender_no_irr = sum(1 for o in _eco["options"]
+                            if o["irr_pct"] is None and o["name"] not in _eco["not_in_contention"])
+    _all_no_irr = sum(1 for o in _eco["options"] if o["irr_pct"] is None)
+    assert _all_no_irr != _contender_no_irr, \
+        ("the two readings must DIFFER here or this assertion discriminates nothing",
+         _all_no_irr, _contender_no_irr)
+    assert _eco["unpriced_count"] == _contender_no_irr, \
+        ("unpriced_count must count among contenders, not across every option",
+         _eco["unpriced_count"], _contender_no_irr, _all_no_irr)
     assert _eco["in_contention_count"] + len(_eco["not_in_contention"]) == _eco["count"], _eco
+    assert _eco["priced_count"] + _eco["unpriced_count"] == _eco["in_contention_count"], _eco
+    _car = c.get(f"/projects/{pid}/design/options/carbon").json()
     assert _car["measured_count"] + _car["unavailable_count"] == _car["in_contention_count"], _car
     assert _car["in_contention_count"] + len(_car["not_in_contention"]) == _car["count"], _car
 

--- a/services/api/test_design_engine.py
+++ b/services/api/test_design_engine.py
@@ -49,6 +49,53 @@ with TestClient(app) as c:
     assert cmp["leaders"]["irr_pct"]["option"].startswith("Scheme B"), cmp["leaders"]
     assert a["delta_vs_selected"]["irr_pct"] == 0, a         # A is the selected -> zero delta vs itself
 
+    # --- a REJECTED option is LISTED but never named best-in-class --------------------------------
+    # Measured before this: a rejected scheme with the best figure on every metric was named leader
+    # on ALL FOUR populated metrics, while the SAME response reported `rejected: 1` in `by_state`.
+    # The state was one field away, counted, and ignored. It is not hidden now — it stays in
+    # `options` and in `by_state`, and `not_in_contention` names it, the way the appraisal fix names
+    # its excluded comparables.
+    # `embodied_kgco2e` is deliberately present and LOWEST. Without it this scheme is
+    # carbon-`unavailable`, never enters `measured`, and the carbon assertion below passes whatever
+    # the engine does — a check that cannot fail. Caught by mutation-testing this exact block: the
+    # carbon revert broke nothing until the option actually had a figure that could win.
+    _rej = _mk(c, pid, "design_option", {"name": "Scheme C — refused", "gross_area_sf": 99000,
+                                         "unit_count": 400, "efficiency_pct": 99,
+                                         "hard_cost": 100, "energy_eui": 1, "irr_pct": 99,
+                                         "embodied_kgco2e": 1000, "building_type": "Residential"})
+    # A LIVE option carrying carbon too, so that after the exclusion something is still measured.
+    # Without it `measured_count` falls to 0, `lowest_total` becomes None, and "not Scheme C" passes
+    # for a second wrong reason — the guard below fired on exactly that.
+    _mk(c, pid, "design_option", {"name": "Scheme D — live", "gross_area_sf": 11000,
+                                  "unit_count": 40, "efficiency_pct": 78, "hard_cost": 2_500_000,
+                                  "energy_eui": 50, "irr_pct": 9,
+                                  "embodied_kgco2e": 5000, "building_type": "Residential"})
+    _cmp_open = c.get(f"/projects/{pid}/design/options/compare").json()
+    assert _cmp_open["leaders"]["irr_pct"]["option"].startswith("Scheme C"), \
+        ("a proposed option SHOULD be able to lead — otherwise this test proves nothing",
+         _cmp_open["leaders"])
+    assert c.get(f"/projects/{pid}/design/options/carbon").json()["lowest_total"] \
+        .startswith("Scheme C"), "and it should lead on carbon while live, for the same reason"
+    _act(c, pid, "design_option", _rej["id"], "reject")
+    cmp2 = c.get(f"/projects/{pid}/design/options/compare").json()
+    for _k in ("irr_pct", "gross_area_sf", "efficiency_pct", "cost_per_sf", "energy_eui"):
+        assert not (cmp2["leaders"][_k]["option"] or "").startswith("Scheme C"), \
+            (f"a rejected option was named best-in-class on {_k}", cmp2["leaders"])
+    assert cmp2["count"] == 4 and cmp2["by_state"]["rejected"] == 1, cmp2   # listed, not hidden
+    assert cmp2["not_in_contention"] == ["Scheme C — refused"], cmp2["not_in_contention"]
+
+    # the two sibling rankings draw the same line, and `options` still lists everything
+    _car = c.get(f"/projects/{pid}/design/options/carbon").json()
+    assert _car["measured_count"] >= 1, ("nothing is measured, so the carbon assertion below would "
+                                         "pass vacuously", _car)
+    assert _car["lowest_total"] == "Scheme D — live", _car["lowest_total"]
+    assert not (_car["lowest_total"] or "").startswith("Scheme C"), _car["lowest_total"]
+    assert _car["not_in_contention"] == ["Scheme C — refused"], _car
+    _eco = c.get(f"/projects/{pid}/design/options/economics").json()
+    assert not (_eco["best_irr"] or "").startswith("Scheme C"), _eco["best_irr"]
+    assert _eco["not_in_contention"] == ["Scheme C — refused"], _eco
+    assert len(_eco["options"]) == 4, "a rejected option is dropped from the RANKING, not the list"
+
     # --- B3: design standards ruleset + model check ----------------------------------------------
     _mk(c, pid, "design_standard", {"name": "PVC potable pipe (banned)", "category": "Material",
                                     "status": "prohibited", "match_keyword": "pvc"})

--- a/services/api/test_design_engine.py
+++ b/services/api/test_design_engine.py
@@ -96,6 +96,20 @@ with TestClient(app) as c:
     assert _eco["not_in_contention"] == ["Scheme C — refused"], _eco
     assert len(_eco["options"]) == 4, "a rejected option is dropped from the RANKING, not the list"
 
+    # Every count must describe the population it names, and the response must RECONCILE.
+    # `unpriced_count` was derived from all options while `priced` came from contenders only, so a
+    # rejected option that HAS an IRR was reported as unpriced — measured: unpriced_count 1 against
+    # zero options actually lacking a figure. This is the third appearance of one shape (v0.3.1122's
+    # billed-vs-invoice_count, then this, then carbon's parts not summing): filter a computation,
+    # leave a count over the unfiltered set.
+    _no_irr = sum(1 for o in _eco["options"] if o["irr_pct"] is None)
+    assert _eco["unpriced_count"] == _no_irr, \
+        ("unpriced_count disagrees with how many options lack an IRR",
+         _eco["unpriced_count"], _no_irr)
+    assert _eco["in_contention_count"] + len(_eco["not_in_contention"]) == _eco["count"], _eco
+    assert _car["measured_count"] + _car["unavailable_count"] == _car["in_contention_count"], _car
+    assert _car["in_contention_count"] + len(_car["not_in_contention"]) == _car["count"], _car
+
     # --- B3: design standards ruleset + model check ----------------------------------------------
     _mk(c, pid, "design_standard", {"name": "PVC potable pipe (banned)", "category": "Material",
                                     "status": "prohibited", "match_keyword": "pvc"})

--- a/services/api/test_feasibility.py
+++ b/services/api/test_feasibility.py
@@ -76,6 +76,44 @@ with TestClient(app) as c:
     assert top["unit_yield"] >= cmp["scenarios"][1]["unit_yield"], cmp                 # sorted desc
     assert cmp["scenarios"][1]["delta_units"] < 0, cmp["scenarios"][1]                 # the lesser scheme
 
+    # --- a SUPERSEDED scheme is not a candidate, and must not become the BASELINE -----------------
+    # `supersede` is the explicit act of replacing a zoning record. Ranking one makes the winner —
+    # and therefore the scheme every other delta is measured against — an envelope that no longer
+    # applies. Measured before this: a superseded FAR-12 scheme ranked first at 240,000 GFA, so the
+    # live scheme was reported as a 160,000 SF shortfall against something nobody can build.
+    #
+    # The sibling `feasibility()` in the same file already reads this state to prefer an approved
+    # record. One function honoured it and this one did not.
+    _sup = c.post(f"/projects/{pid}/modules/zoning", json={"data": {
+        "site": "Airspace parcel — WITHDRAWN", "use_type": "Mixed-Use",
+        "site_area_sf": 20_000, "far": 20.0, "height_limit_ft": 600, "floor_to_floor_ft": 12,
+        "lot_coverage_pct": 90, "efficiency_pct": 90, "avg_unit_sf": 850,
+        "parking_ratio": 1.0}}).json()["id"]
+    # positive control: while it is live it DOES rank first, so the assertion below cannot pass
+    # merely because the scheme is uncompetitive.
+    _open = c.get(f"/projects/{pid}/feasibility/compare").json()
+    assert _open["scenarios"][0]["site"].startswith("Airspace"), \
+        ("a live scheme must be rankable — otherwise the exclusion below proves nothing",
+         [x["site"] for x in _open["scenarios"]])
+    for _act2 in ("approve", "supersede"):
+        assert c.post(f"/projects/{pid}/modules/zoning/{_sup}/transition",
+                      json={"action": _act2}).status_code == 200
+
+    cmp2 = c.get(f"/projects/{pid}/feasibility/compare").json()
+    assert cmp2["count"] == 2, ("a superseded scheme was still ranked", cmp2["count"])
+    assert not cmp2["scenarios"][0]["site"].startswith("Airspace"), cmp2["scenarios"][0]
+    assert cmp2["best_ref"] == cmp["best_ref"], "the live baseline must be unchanged by the exclusion"
+    # named, not silently dropped
+    assert [x["zoning_id"] for x in cmp2["superseded_excluded"]] == [_sup], cmp2["superseded_excluded"]
+    # every row now carries the state — it used to be dropped before any caller could see it
+    assert all("workflow_state" in x for x in cmp2["scenarios"]), cmp2["scenarios"][0]
+    # ...and the converse: `reopen` puts it back in contention
+    assert c.post(f"/projects/{pid}/modules/zoning/{_sup}/transition",
+                  json={"action": "reopen"}).status_code == 200
+    cmp3 = c.get(f"/projects/{pid}/feasibility/compare").json()
+    assert cmp3["count"] == 3 and cmp3["scenarios"][0]["site"].startswith("Airspace"), \
+        ("reopen must restore a superseded scheme", cmp3["count"])
+
     # report renders
     assert "site_feasibility" in {x["id"] for x in c.get("/reports").json()["reports"]}
     pdf = c.get(f"/projects/{pid}/reports/site_feasibility.pdf")


### PR DESCRIPTION
# What & why

Four more `REFUSAL-READERS` instances, all one shape: **a refused thing ranks first.** Unlike v0.3.1122 these move no money directly — they move what the product *recommends*, which is worse in one respect: a wrong number gets questioned, a wrong recommendation gets built.

| endpoint | measured before | after |
|---|---|---|
| `/design/options/compare` | a REJECTED option named **best-in-class on all four** populated metrics | the live scheme leads |
| `/design/options/carbon` | the rejected option was `lowest_total` | `Scheme D — live` |
| `/design/options/economics` | the rejected option was `best_irr`, **30% against a live 12%** | the live scheme |
| `/feasibility/compare` | a SUPERSEDED zoning scheme ranked **#1**, 240,000 GFA vs a live 80,000 | excluded and named |

All four measured through their routes before and after, not reasoned about.

**The design-option case is the sharpest: the engine already knew.** The same `compare` response reported `rejected: 1` in `by_state` while naming that option the leader. The state was not missing, not buried, not expensive to reach — one field away, counted, ignored.

**The feasibility case is the most consequential.** The top scheme is the *baseline* every other scheme's deltas are measured against, so a superseded FAR-12 envelope made a live FAR-4 scheme read as a **160,000 SF shortfall against something nobody can build**. Its own sibling `feasibility()`, thirty lines below in the same file, already reads that state to prefer an approved record — one function in the file honoured it and the other did not, the same shape as the accounting and procurement defects. `compare` also **dropped `workflow_state` before returning**, so no caller could have filtered even in principle; every row now carries it.

**Nothing is hidden.** All four keep *listing* the refused item and name what left the ranking (`not_in_contention`, `superseded_excluded`), following `compute_appraisal`'s `excluded_comparables` — a ranking whose field silently shrank reads as a thinner set of options rather than as a decision somebody recorded. `draft` and `proposed` stay ranked deliberately: an unapproved scheme is a real thing to test, which is what a comparison is *for*. Only the explicit refusal is refused.

One rule, `design_options.DESIGN_OPTION_NOT_IN_CONTENTION`, shared by the three option readers — the v0.3.1122 precedent, because a record type with three readers is a rule with two places to rot. These modules already separated LISTED from RANKED, for unmeasured carbon and unpriced economics, as their own notes say; refusal simply was not one of the reasons.

## A vacuous test, caught by mutation-testing rather than by review

The first `option_carbon` mutation **did not fire** — reverting the fix broke nothing, because the rejected option carried no carbon figure and so could never have won that ranking. Adding one exposed a **second** vacuity: with the rejected option excluded, nothing was measured at all, `lowest_total` went `None`, and the assertion passed for a new wrong reason. **Two dead assertions stacked inside one check, neither visible from a green run.**

Both guards are now in the test with the reasoning inline, and every exclusion assertion carries a **positive control** — the subject leads *while live* — so none can pass merely because its subject was uncompetitive. Written forward in the roadmap for the remaining five instances: *an exclusion test whose subject could not have won proves nothing.*

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check src/ ../data/src/` clean
- [x] Backend: **19 suites** touching the changed engines pass; no new test files, so the `run_tests.py` TESTS manifest is unchanged
- [x] Web: typecheck + lint clean; full suite **2044 tests / 200 files**; 388 shell gates
- [x] No import cycles introduced (the two new cross-module references are function-local, matching the house pattern)
- [x] `CHANGELOG.md` entry added (newest at top); roadmap item updated — `REFUSAL-READERS` open count **9 → 5**
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` **and** `package-lock.json` (the triple `versionConsistency.test.ts` asserts) → 0.3.1123
- [x] No secrets, no competitor names in shipped docs

**All four engine changes mutation-checked independently** — each reverted in turn, the specific assertion confirmed to fail, then pass. Each test also asserts the converse: `reopen` restores a superseded zoning scheme to contention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected design options are now excluded from comparison, carbon, and economics rankings while remaining visible in results.
  * Superseded feasibility scenarios no longer influence rankings or baseline comparisons.
  * Results identify excluded options and include workflow status for every returned scenario.
  * Ranking-related counts now reconcile with the eligible options being evaluated.

* **Documentation**
  * Updated the changelog and roadmap to reflect these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->