### PR TITLE
v0.3.1126 — the rejection flag fired on the sub who was still biddable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ Both changes mutation-checked: reverting the flag to the blob, and collapsing th
 a plain rejection, each fail a specific assertion. A positive control asserts a clean record raises
 neither, so the pair cannot pass by flagging everything.
 
+### The first cut fixed the field and left the normalisation — found in review
+
+`score_record` canonicalised `workflow_state`; `score_project` compared the raw stored value. The two
+then agreed on **which field** to read and disagreed on **how to read it**, which reproduced the same
+defect one line away. Measured through `/prequal/scores` with `workflow_state` stored as `"Rejected"`:
+the flag read `rejected` while `in_pool` stayed **true** and the sub kept its place in `pool_count`
+and `high_risk`. Transitions write canonical states, but a bundle import preserves whatever it is
+given, so the non-canonical case is reachable rather than theoretical.
+
+Both now go through one `state_key()` helper — *a rule split across two call sites is a rule with two
+places to drift, and this one drifted inside the release that exists to stop exactly that.* Asserted
+over `rejected` / `Rejected` / `"  REJECTED  "`, with a positive control that a non-refusal state
+survives canonicalisation without becoming one, so the loop cannot pass on a helper that always
+returns `"rejected"`.
+
 ## v0.3.1125 (2026-08-31) — the owner's page said nothing had been paid, and it never could
 
 **`PORTAL-STATUS`.** The client-facing payment schedule showed `data["status"]` — a select a person

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1126 (2026-08-31) — the rejection flag fired on the sub who was still biddable
+
+The tail of `PORTAL-STATUS`. `prequalification.score_record` raised its "marked rejected" flag from
+`data["status"]`, the typed field, while v0.3.1124 had moved `in_pool` to `workflow_state`, the field
+the reject transition sets. The two then answered to different fields, and came out **inverted**.
+
+Measured through `/prequal/scores`, on two subs driven through the real transitions:
+
+| sub | workflow | `in_pool` | flag before | flag after |
+|---|---|---|---|---|
+| rejected by the **transition** | `rejected` | `false` | **none** | `rejected` |
+| merely submitted, `"Rejected"` **typed in the blob** | `submitted` | `true` | **"marked rejected"** | `status field says rejected, but the workflow says submitted` |
+
+So the flag fired on the sub who was **still in the bidding pool** and stayed silent on the one the
+team had actually refused — the worst of both readings, and worse than either field alone.
+
+**The typed value is neither believed nor dropped.** `modules.transition()` never writes `data`, so
+the two fields drift on their own with nothing to reconcile them; a person typing "Rejected" while
+the workflow says otherwise is a real disagreement, and naming it is more use than picking a side.
+`PREQUAL_NOT_IN_POOL` moves above `score_record`, which is now its first reader — *the flag and the
+pool must not answer to different fields.*
+
+Both changes mutation-checked: reverting the flag to the blob, and collapsing the disagreement into
+a plain rejection, each fail a specific assertion. A positive control asserts a clean record raises
+neither, so the pair cannot pass by flagging everything.
+
 ## v0.3.1125 (2026-08-31) — the owner's page said nothing had been paid, and it never could
 
 **`PORTAL-STATUS`.** The client-facing payment schedule showed `data["status"]` — a select a person

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ given, so the non-canonical case is reachable rather than theoretical.
 Both now go through one `state_key()` helper — *a rule split across two call sites is a rule with two
 places to drift, and this one drifted inside the release that exists to stop exactly that.* Asserted
 over `rejected` / `Rejected` / `"  REJECTED  "`, with a positive control that a non-refusal state
-survives canonicalisation without becoming one, so the loop cannot pass on a helper that always
+survives canonicalisation without becoming one, so the test cannot pass if the helper always
 returns `"rejected"`.
 
 ## v0.3.1125 (2026-08-31) — the owner's page said nothing had been paid, and it never could

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1125",
+    "version": "0.3.1126",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1125",
+  "version": "0.3.1126",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -420,9 +420,13 @@ instances:
   *REFUSAL-READERS' population was derived too NARROW and missed five real reads; this one is too
   WIDE and flags twenty-three non-defects. Neither a match nor a miss is evidence — only reading is.*
 
-  **Follow-on, small:** `prequalification.py:129` raises its "marked rejected" flag from the blob
-  while `in_pool` now comes from `workflow_state`, so a sub rejected through the real transition gets
-  no flag. Harmless (the flag is informational and case-folded) but the two should share a source.
+  **Follow-on — CLOSED v0.3.1126, and it was not harmless.** This entry guessed that the flag merely
+  went missing on a workflow-rejected sub. Measured: the flag and the pool were **inverted** — it
+  fired on the sub still IN the pool (blob typed "Rejected", workflow `submitted`) and was silent on
+  the one the team had refused. The flag now reads `workflow_state`, the same authority as `in_pool`,
+  and a typed value the workflow contradicts is reported as a **disagreement** rather than believed
+  or dropped. *Predicting which way a defect points is not the same as measuring it — this one was
+  worse than the guess, as `/rfi/register` was in v0.3.1124.*
 
   `client_portal._payment_schedule` renders `str(d.get("status") or "draft")` — the free-text `data`
   blob — instead of `workflow_state`, the field the transitions actually set. A certified pay

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1125",
+      "version": "0.3.1126",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/src/aec_api/prequalification.py
+++ b/services/api/src/aec_api/prequalification.py
@@ -106,6 +106,19 @@ def _rating_score(rating) -> tuple[float, str]:
     return max(0.0, min(15.0, scaled)), f"rating {rating}"
 
 
+#: Prequalification states where the sub is NOT in the bidding pool. A rejected prequalification is
+#: a decision the team already made; its risk is not risk the project is carrying.
+#:
+#: `score_record` has always noticed rejection — but through `data["status"]`, a free-text field a
+#: person types, while ignoring `workflow_state`, the field the reject TRANSITION actually sets. It
+#: raised a "marked rejected" flag and then scored and counted the record anyway. The state was not
+#: missing; it was read from the wrong field and acted on in no way that changed a number.
+#:
+#: Defined ABOVE `score_record` as of v0.3.1126, because that function is now its first reader:
+#: the flag and the pool must not answer to different fields.
+PREQUAL_NOT_IN_POOL = ("rejected",)
+
+
 def score_record(rec: dict, project_size: float | None = None, today: date | None = None) -> dict:
     """Compute a 0-100 Q-score + risk band + factor breakdown + flags for one prequalification record."""
     today = today or datetime.now(timezone.utc).date()
@@ -126,8 +139,21 @@ def score_record(rec: dict, project_size: float | None = None, today: date | Non
         flags.append("no bonding capacity")
     if expires and expires < today:
         flags.append("prequalification expired")
-    if d.get("status") and str(d.get("status")).lower() == "rejected":
-        flags.append("marked rejected")
+    # The flag reads the SAME authority as `in_pool` — `workflow_state`, which the reject transition
+    # sets — because until v0.3.1126 it did not, and the two came out inverted. Measured through
+    # /prequal/scores: a sub rejected through the real transition was out of the pool and carried NO
+    # flag, while one merely SUBMITTED with "Rejected" typed into the status field carried the flag
+    # and stayed in. The flag fired on the sub who was still biddable and stayed silent on the one
+    # the team had actually refused.
+    state = str(rec.get("workflow_state") or "").strip().lower()
+    typed = str(d.get("status") or "").strip().lower()
+    if state in PREQUAL_NOT_IN_POOL:
+        flags.append("rejected")
+    elif typed in PREQUAL_NOT_IN_POOL:
+        # Not silently dropped: somebody typed this, and it disagreeing with the workflow is itself
+        # worth seeing. `modules.transition()` never writes `data`, so the two drift on their own and
+        # nothing reconciles them — naming the disagreement is more use than believing either side.
+        flags.append(f"status field says rejected, but the workflow says {state or 'nothing'}")
     return {
         "company": d.get("company"), "trade": d.get("trade"), "ref": rec.get("ref"),
         "score": score, "risk_band": band,
@@ -137,16 +163,6 @@ def score_record(rec: dict, project_size: float | None = None, today: date | Non
                     {"factor": "Rating", "points": rat_p, "of": 15, "note": rat_n},
                     {"factor": "Currency", "points": cur_p, "of": 10, "note": cur_n}],
         "flags": flags}
-
-
-#: Prequalification states where the sub is NOT in the bidding pool. A rejected prequalification is
-#: a decision the team already made; its risk is not risk the project is carrying.
-#:
-#: `score_record` has always noticed rejection — but through `data["status"]`, a free-text field a
-#: person types, while ignoring `workflow_state`, the field the reject TRANSITION actually sets. It
-#: raised a "marked rejected" flag and then scored and counted the record anyway. The state was not
-#: missing; it was read from the wrong field and acted on in no way that changed a number.
-PREQUAL_NOT_IN_POOL = ("rejected",)
 
 
 def score_project(db: Session, project_id: str, project_size: float | None = None) -> dict:

--- a/services/api/src/aec_api/prequalification.py
+++ b/services/api/src/aec_api/prequalification.py
@@ -119,6 +119,20 @@ def _rating_score(rating) -> tuple[float, str]:
 PREQUAL_NOT_IN_POOL = ("rejected",)
 
 
+def state_key(rec: dict) -> str:
+    """The record's workflow state, canonicalised — the ONE way this module reads that field.
+
+    A helper rather than two call sites, because v0.3.1126's first cut fixed the flag to read
+    `workflow_state` and left `score_project` comparing the raw stored value. The two then agreed on
+    the FIELD and disagreed on its NORMALISATION, which reproduced the same defect one line away:
+    with `workflow_state` stored as `"Rejected"`, measured through /prequal/scores, the flag read
+    `rejected` while `in_pool` stayed true and the sub kept its place in `pool_count` and
+    `high_risk`. Transitions write canonical states, but a bundle import preserves whatever it is
+    given, so the non-canonical case is reachable rather than theoretical.
+    """
+    return str(rec.get("workflow_state") or "").strip().lower()
+
+
 def score_record(rec: dict, project_size: float | None = None, today: date | None = None) -> dict:
     """Compute a 0-100 Q-score + risk band + factor breakdown + flags for one prequalification record."""
     today = today or datetime.now(timezone.utc).date()
@@ -145,7 +159,7 @@ def score_record(rec: dict, project_size: float | None = None, today: date | Non
     # flag, while one merely SUBMITTED with "Rejected" typed into the status field carried the flag
     # and stayed in. The flag fired on the sub who was still biddable and stayed silent on the one
     # the team had actually refused.
-    state = str(rec.get("workflow_state") or "").strip().lower()
+    state = state_key(rec)
     typed = str(d.get("status") or "").strip().lower()
     if state in PREQUAL_NOT_IN_POOL:
         flags.append("rejected")
@@ -180,7 +194,9 @@ def score_project(db: Session, project_id: str, project_size: float | None = Non
     scored = [score_record(r, project_size) for r in recs]
     for s, r in zip(scored, recs):
         s["workflow_state"] = r.get("workflow_state")
-        s["in_pool"] = r.get("workflow_state") not in PREQUAL_NOT_IN_POOL
+        # `state_key`, not the raw field — the flag and the pool must agree on the normalisation as
+        # well as on which field to read. See that helper for what happened when they did not.
+        s["in_pool"] = state_key(r) not in PREQUAL_NOT_IN_POOL
     scored.sort(key=lambda s: s["score"])
     pool = [s for s in scored if s["in_pool"]]
     # Every count that describes the POOL is taken over `pool`, so the response reconciles:

--- a/services/api/test_prequal.py
+++ b/services/api/test_prequal.py
@@ -52,6 +52,20 @@ assert not [f for f in pq.score_record({"workflow_state": "approved",
                                         "data": {"company": "Clean"}})["flags"]
             if "reject" in f.lower()]
 
+# --- and the FLAG and the POOL must agree on the NORMALISATION, not just on the field -------------
+# The first cut of v0.3.1126 fixed which field to read and left score_project comparing the raw
+# stored value, which reproduced the same defect one line away: with workflow_state "Rejected",
+# measured through /prequal/scores, the flag read `rejected` while in_pool stayed true and the sub
+# kept its place in pool_count and high_risk. Transitions write canonical states, but a bundle
+# import preserves what it is given, so this is reachable rather than theoretical.
+for _raw in ("rejected", "Rejected", "  REJECTED  "):
+    assert pq.state_key({"workflow_state": _raw}) == "rejected", _raw
+    assert "rejected" in pq.score_record({"workflow_state": _raw, "data": {}})["flags"], _raw
+# POSITIVE CONTROL for the loop above: a state that is NOT a refusal must survive canonicalisation
+# without becoming one, or the assertions could pass on a helper that returns "rejected" always.
+assert pq.state_key({"workflow_state": "  Approved "}) == "approved"
+assert "rejected" not in pq.score_record({"workflow_state": " Approved ", "data": {}})["flags"]
+
 # --- endpoints ---
 with TestClient(app) as c:
     pid = c.post("/projects", json={"name": "P"}).json()["id"]

--- a/services/api/test_prequal.py
+++ b/services/api/test_prequal.py
@@ -29,6 +29,29 @@ assert "EMR above 1.0" in w["flags"] and "no bonding capacity" in w["flags"] and
 assert sum(f["of"] for f in s["factors"]) == 100                 # weights sum to 100
 assert s["score"] > w["score"]
 
+# --- the rejection FLAG answers to the same field as `in_pool` (v0.3.1126) ------------------------
+# It did not until then, and the two came out INVERTED: measured through /prequal/scores, a sub
+# rejected by the real transition was out of the pool carrying no flag, while one merely submitted
+# with "Rejected" typed into the status field carried the flag and stayed in. The flag fired on the
+# sub who was still biddable and was silent on the one the team had refused.
+_refused = pq.score_record({"workflow_state": "rejected", "data": {"company": "Refused"}})
+assert "rejected" in _refused["flags"], ("the workflow's own refusal must raise the flag",
+                                         _refused["flags"])
+# The blob is not silently believed OR silently dropped — a disagreement is named, because
+# modules.transition() never writes `data`, so the two drift with nothing to reconcile them.
+_typed = pq.score_record({"workflow_state": "submitted", "data": {"company": "Typed",
+                                                                  "status": "Rejected"}})
+_dis = [f for f in _typed["flags"] if "status field says rejected" in f]
+assert _dis and "submitted" in _dis[0], ("a typed rejection that the workflow contradicts must be "
+                                         "reported as a DISAGREEMENT, not as a rejection", _typed["flags"])
+assert "rejected" not in _typed["flags"], ("...and must not be reported as a plain rejection",
+                                           _typed["flags"])
+# POSITIVE CONTROL: a record with neither raises neither, so the two assertions above cannot pass
+# merely because this function flags everything.
+assert not [f for f in pq.score_record({"workflow_state": "approved",
+                                        "data": {"company": "Clean"}})["flags"]
+            if "reject" in f.lower()]
+
 # --- endpoints ---
 with TestClient(app) as c:
     pid = c.post("/projects", json={"name": "P"}).json()["id"]


### PR DESCRIPTION
# What & why

The tail of `PORTAL-STATUS`. `prequalification.score_record` raised its `"marked rejected"` flag from `data["status"]` — the typed field — while v0.3.1124 had moved `in_pool` to `workflow_state`, the field the reject **transition** sets. The two then answered to different fields, and came out **inverted**.

Measured through `/prequal/scores`, on two subs driven through the real transitions:

| sub | workflow | `in_pool` | flag **before** | flag **after** |
|---|---|---|---|---|
| rejected by the **transition** | `rejected` | `false` | **none** | `rejected` |
| merely submitted, `"Rejected"` **typed in the blob** | `submitted` | `true` | **`marked rejected`** | `status field says rejected, but the workflow says submitted` |

So the flag fired on the sub who was **still in the bidding pool**, and stayed silent on the one the team had actually refused. That is worse than either field alone would have been — a reader trusting the flag would have drawn exactly the wrong conclusion about both subs.

## The typed value is neither believed nor dropped

`modules.transition()` writes `workflow_state`, `modified_at` and `party_owner` and **never touches `data`**, so the two fields drift on their own with nothing to reconcile them. Somebody typing `"Rejected"` while the workflow says otherwise is a **real disagreement**, and naming it is more use than picking a side:

```python
if state in PREQUAL_NOT_IN_POOL:
    flags.append("rejected")
elif typed in PREQUAL_NOT_IN_POOL:
    flags.append(f"status field says rejected, but the workflow says {state or 'nothing'}")
```

`PREQUAL_NOT_IN_POOL` moves above `score_record`, which is now its first reader — *the flag and the pool must not answer to different fields.*

## The roadmap entry was wrong about which way it pointed

It called this "harmless" and guessed the flag merely went **missing** on a workflow-rejected sub. Measured, it was **inverted**. That is the same correction `/rfi/register` needed in v0.3.1124, where three sub-numbers the entry named were already correct and two it never mentioned were the actual defects. *Predicting which way a defect points is not the same as measuring it* — recorded in the roadmap entry rather than quietly fixed.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check src/ ../data/src/` clean
- [x] Backend: 5 affected suites pass (`test_prequal`, `test_refusal_readers`, `test_reports`, `test_dashboard`, `test_construction_depth`); no new test files, so the `run_tests.py` TESTS manifest is unchanged
- [x] Web: typecheck + lint clean; full suite **2045 tests / 200 files**
- [x] `test_claude_md_gates` and `test_file_sizes` green (no ratchet moved)
- [x] `CHANGELOG.md` entry added (newest at top); roadmap follow-on marked closed **with the correction recorded**
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` **and** `package-lock.json` → 0.3.1126
- [x] No secrets, no competitor names in shipped docs

**Both changes mutation-checked**: reverting the flag to read the blob, and collapsing the disagreement into a plain rejection, each fail a specific assertion. A **positive control** asserts a clean record raises neither flag, so the pair cannot pass merely because the function flags everything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected prequalification rejection indicators to reflect the actual workflow state.
  * Normalized mixed-case and whitespace-padded statuses for consistent reporting.
  * Conflicting status information now shows a disagreement instead of an incorrect rejection flag.
  * Improved accuracy of pool membership and rejection reporting.

* **Documentation**
  * Updated the roadmap and changelog with details of the resolved issue.

* **Chores**
  * Updated the application version to 0.3.1126.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->