### PR TITLE
v0.3.1127 — the roadmap described a defect that a release had already ended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1127 (2026-08-31) — the roadmap described a defect that a release had already ended
+
+Documentation only; no engine changed. Two roadmap entries said `eot.py` **"names four AACE methods
+and performs none of them. All four return an identical number on the same input."** Both are
+corrected, because the claim was false — and false on the day it was written.
+
+Measured through `eot.analyse`, one job, baseline finish 2026-01-31, two excusable events totalling
+20 days:
+
+| actual finish | `impacted_as_planned` | `as_planned_vs_as_built` | `time_impact` | `windows` |
+|---|---|---|---|---|
+| 2026-02-10 (slip 10) | **20.0** | **10.0** *(capped)* | *refuses* | *refuses* |
+| 2026-03-12 (slip 40) | 20.0 | 20.0 *(cap idle)* | *refuses* | *refuses* |
+
+Three distinct outcomes where the as-built cap binds, two where it does not, and the two series
+methods never return a number at all — they refuse with `method_needs_schedule_updates`. "All four
+return an identical number" is therefore untrue on every input, not merely on some.
+
+**The fix predated the claim by four days.** `v0.3.971` shipped 2026-08-16 under the title *"four
+delay methods, one number, and a label that said otherwise"*; the roadmap paragraph was dated
+*"measured 2026-08-20"*. A measurement date is what stops a reader re-checking a sentence, so an
+inherited date made this harder to catch, not easier.
+
+**The citation contradicted the claim it supported.** The paragraph cited
+`services/api/test_schedule_windows.py` as its pin. That test asserts `windows` and `time_impact`
+return `None` — *"which is now the REASON they refuse"*. The gate had been green on the **corrected**
+behaviour the entire time. *A citation is evidence that a file exists, not that it says what the
+sentence claims* — `test_claude_md_gates.py` checks the former and cannot check the latter.
+
+No new gate. The behaviour is already pinned twice (`test_schedule_windows.py`, `test_eot_methods.py`)
+and both were green throughout; what failed was prose that the existing gates already contradicted.
+A string-matching guard on one sentence would rot the same way the sentence did.
+
+**What survives is the genuine open decision, unchanged:** whether `/schedule/eot` should delegate to
+`schedule_windows` and `schedule_modelled` — which perform three of the four for real — or keep its
+own number and cite theirs. An EOT figure ends up in arbitration, so that remains a domain call.
+
 ## v0.3.1126 (2026-08-31) — the rejection flag fired on the sub who was still biddable
 
 The tail of `PORTAL-STATUS`. `prequalification.score_record` raised its "marked rejected" flag from

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1126",
+    "version": "0.3.1127",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1126",
+  "version": "0.3.1127",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -587,12 +587,34 @@ auditable one — its own docstring says a caller-typed baseline "is unauditable
 different EOTs from one project by typing different dates" — but putting an extension-of-time figure
 in front of a user is a decision about what the product asserts in an arbitration, not a wiring task.
 
-**⚠ FOUND WHILE WIRING THESE TWO: `eot.py` names four AACE methods and performs none of them.** All
-four return an identical number on the same input — the method is recorded as a label and the
-arithmetic never changes, because nothing in it re-schedules a network. Three of the four *are*
-network operations. Pinned in `services/api/test_schedule_windows.py`; `schedule_windows` and
-`schedule_modelled` now perform three of the four for real. **Whether `/schedule/eot` should delegate
-to them, or keep its own number and cite theirs, is a domain decision** — the EOT figure ends up in
+**⚠ CORRECTED 2026-08-31 — the paragraph that stood here was FALSE, and false on the day it was
+written.** It said `eot.py` "names four AACE methods and performs none of them. All four return an
+identical number on the same input." Measured through `eot.analyse` on one job (baseline finish
+2026-01-31, two excusable events totalling 20 days):
+
+| actual finish | `impacted_as_planned` | `as_planned_vs_as_built` | `time_impact` | `windows` |
+|---|---|---|---|---|
+| 2026-02-10 (slip 10) | **20.0** | **10.0** *(capped)* | *refuses* | *refuses* |
+| 2026-03-12 (slip 40) | 20.0 | 20.0 *(cap idle)* | *refuses* | *refuses* |
+
+Three distinct outcomes where the cap binds, two where it does not — and **the series pair never
+returns a number at all**, refusing with `method_needs_schedule_updates`. So "all four return an
+identical number" is untrue on *every* input, not merely on some.
+
+**The fix predates the claim.** `v0.3.971` shipped **2026-08-16** under the title *"four delay
+methods, one number, and a label that said otherwise"* — it is the release that ended this. The
+paragraph above was dated *"measured 2026-08-20"*, four days later. **A claim can be stale on the day
+it is written**, and this one carried a measurement date, which is exactly what stops a reader
+re-checking it.
+
+**Its own citation contradicted it.** It cited `services/api/test_schedule_windows.py` as the pin;
+that test asserts `windows` and `time_impact` return `None` — *"which is now the REASON they refuse"*.
+The gate had been green on the corrected behaviour the whole time. **A citation is not evidence of
+what it is cited for** — nobody re-read the test the sentence pointed at.
+
+**What survives is the real decision, and it is unchanged:** `schedule_windows` and
+`schedule_modelled` perform three of the four for real. **Whether `/schedule/eot` should delegate to
+them, or keep its own number and cite theirs, is a domain decision** — the EOT figure ends up in
 arbitration, and changing what it means is not a refactor. Both still ship.
 
 **R46 IS COMPLETE (v0.3.967): 29 of 29 reachable, allowlist empty.** Recorded in `services/api/test_vendor_reachable.py`, which fails the build until each is either wired
@@ -1235,10 +1257,16 @@ that rotted were all sentences no test read. Note for whoever extends it — the
   what the product asserts, not a UI choice. Surfaced here by the 2026-08-29 sweep because it was
   recorded inside a ring entry that now reads ✅, where a reader looking for open decisions would not
   find it.
-- **`eot.py` names four AACE methods and performs none of them.** All four return an identical number
-  on the same input; three of the four *are* network operations. `schedule_windows` and
-  `schedule_modelled` now perform three for real. **Whether `/schedule/eot` should delegate to them or
-  keep its own number and cite theirs is the same arbitration question**, and both still ship today.
+- **Whether `/schedule/eot` should delegate its analysis to `schedule_windows` and
+  `schedule_modelled`, or keep its own number and cite theirs.** *(This bullet used to open by
+  claiming `eot.py` "names four AACE methods and performs none of them. All four return an identical
+  number on the same input." **That was false, and false when written** — `v0.3.971` had ended it four
+  days earlier, on 2026-08-16. Measured 2026-08-31: three distinct outcomes where the as-built cap
+  binds, and the two series methods refuse outright rather than returning any number. The full
+  measurement and the reason the error survived a cited test are in the R46 entry above.)* The
+  decision itself is untouched by that correction: `schedule_windows` and `schedule_modelled` perform
+  three of the four for real, **an EOT figure ends up in arbitration**, and changing what one means is
+  a domain call rather than a refactor. Both still ship today.
 - **The three renames and the `/edit` body shape in R43-VIEWER-CONFORMANCE.** *(Again not opening
   with the code — `roadmapStale.test.ts` reads an unmarked bullet headed by an item id as a second,
   contradicting copy of that item, which is exactly what this would have been.)* Every one is *which side

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1126",
+      "version": "0.3.1127",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
# What & why

Two `docs/roadmap.md` entries — one in the R46 block, one in the open-decisions list — claimed that `eot.py` **"names four AACE methods and performs none of them. All four return an identical number on the same input."** Both are corrected. The claim is false, and it was false on the day it was written.

Measured through `eot.analyse` on one job (baseline finish 2026-01-31, two excusable events totalling 20 days):

| actual finish | `impacted_as_planned` | `as_planned_vs_as_built` | `time_impact` | `windows` |
|---|---|---|---|---|
| 2026-02-10 (slip 10) | **20.0** | **10.0** *(capped)* | *refuses* | *refuses* |
| 2026-03-12 (slip 40) | 20.0 | 20.0 *(cap idle)* | *refuses* | *refuses* |

Three distinct outcomes where the as-built cap binds, two where it does not — and **the two series methods never return a number at all**, refusing with `method_needs_schedule_updates`. So "all four return an identical number" is untrue on *every* input, not merely on some.

## The fix predated the claim by four days

`v0.3.971` shipped **2026-08-16** under the title *"four delay methods, one number, and a label that said otherwise"* — it is the release that ended exactly this. The roadmap paragraph was dated *"measured 2026-08-20"*.

That date is the reason it survived. **A measurement date is what stops a reader re-checking a sentence**, so inheriting one made this harder to catch, not easier.

## Its own citation contradicted it

The paragraph cited `services/api/test_schedule_windows.py` as its pin. That test asserts `windows` and `time_impact` return `None` — *"which is now the REASON they refuse"*. The gate had been green on the **corrected** behaviour the entire time.

*A citation is evidence that a file exists, not that it says what the sentence claims.* `test_claude_md_gates.py` checks the former by design and structurally cannot check the latter.

## No new gate, deliberately

The behaviour is already pinned twice — `test_schedule_windows.py` and `test_eot_methods.py` — and both were green throughout. What failed was prose that the existing gates already contradicted, not a missing check. A string-matching guard on one sentence would rot the same way the sentence did.

## What survives

The genuine open decision is preserved and unchanged: **whether `/schedule/eot` should delegate to `schedule_windows` and `schedule_modelled` — which perform three of the four for real — or keep its own number and cite theirs.** An EOT figure ends up in arbitration, so that stays a domain call, not a refactor.

The separate "EOT surface is dark" item was also re-verified and is **accurate as written**: both routes are live (`main.py:559`), `grep "schedule/eot" apps/web/src` returns 0, `/schedule/eot/sourced` is recorded in `KNOWN_UNCALLED`, and `/schedule/eot` escapes that gate only because its leaf `eot` is 3 characters against `MIN_SEGMENT = 5`. Left untouched — it is a scope decision, not a defect.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check src/ ../data/src/` clean
- [x] Backend: affected `test_*.py` pass — `test_eot`, `test_eot_methods`, `test_eot_sourced`, `test_claude_md_gates`, `test_roadmap_status`, `test_doc_substance`, `test_file_sizes`. No new test files, so the `run_tests.py` TESTS manifest is unchanged
- [x] Web: typecheck clean; full suite **2045 tests / 200 files**, including the three roadmap parsers (`roadmapStale`, `roadmapSelfConsistent`, `roadmapLanes` — 33 tests) that are sensitive to bullet shape
- [x] No import cycles introduced (docs-only change; no source file touched)
- [x] `CHANGELOG.md` entry added (newest at top); both roadmap entries corrected
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` **and** `package-lock.json` → 0.3.1127
- [x] No secrets, no competitor names in shipped docs

**Docs only — no engine changed.** The two surviving occurrences of the false wording are inside the quoted-and-corrected record, which is intentional: deleting the wrong sentence would destroy the evidence of what was wrong.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_