### PR TITLE
v0.3.1128 — the sweep that found nothing, recorded so nobody runs it again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1128 (2026-08-31) — the sweep that found nothing, recorded so nobody runs it again
+
+Documentation only; no engine changed. v0.3.1127 corrected a roadmap claim that a release had
+already ended, and the obvious next inference was *"if one was stale, sweep them all"*. That was
+checked rather than assumed. **It is not a class.**
+
+**Population:** the 21 `⚠` markers in `docs/roadmap.md`, of which exactly **five** assert
+present-tense runtime behaviour that can be executed and falsified. The rest are SHIPPED rows,
+sweep-run headers, prior corrections and the 18-findings table; one more (`takt.py`'s name) is a
+semantics decision with nothing to falsify.
+
+**Four of five accurate.** The EOT surface is dark as described; `/schedule/risk` really does serve
+the same engine as `/schedule/montecarlo` (`schedule_risk_mc.for_project`); the three PPC
+implementations really were unified in v0.3.974 and are held by `services/api/test_ppc_divergence.py`;
+`/schedule/compare` really does return `finish_move_working_days` and `calendar_vs_working_gap_days`.
+The one false claim was the one already fixed.
+
+**Why the negative result is worth a release.** Every defect class this repository has found by
+sweeping — the refusal-state readers, `PORTAL-STATUS`, the status/workflow drift — showed *several*
+instances on the first probe. This one showed one and four counter-examples. *A sample of one is a
+finding, not a pattern.* Recording it stops the next reader inferring a class from the v0.3.1127
+entry and spending days confirming that well-maintained entries are well maintained.
+
+**The gap is stated rather than papered over.** Only the falsifiable five were swept. A roadmap
+sentence that misdescribes something unexecutable — an intent, a plan, a reason — cannot be caught
+this way, and no gate proposed here would catch it. The 103 test-file citations in the roadmap were
+considered as a population and rejected: filtering mechanically cannot separate a citation
+*describing what a test asserts* from one offered as *corroboration of a live defect*. That needs
+reading, not grep.
+
 ## v0.3.1127 (2026-08-31) — the roadmap described a defect that a release had already ended
 
 Documentation only; no engine changed. Two roadmap entries said `eot.py` **"names four AACE methods

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1127",
+    "version": "0.3.1128",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1127",
+  "version": "0.3.1128",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -612,6 +612,35 @@ that test asserts `windows` and `time_impact` return `None` — *"which is now t
 The gate had been green on the corrected behaviour the whole time. **A citation is not evidence of
 what it is cited for** — nobody re-read the test the sentence pointed at.
 
+**AND IT IS NOT A CLASS — swept 2026-08-31, four of five accurate.** The obvious next inference from
+the correction above is *"if one roadmap claim was stale, sweep them all"*. That was checked instead
+of assumed, and the answer is no. **Population:** the 21 `⚠` markers in this file, of which exactly
+**five** assert present-tense runtime behaviour that can be executed and falsified; the rest are
+SHIPPED rows, sweep-run headers, prior corrections and the 18-findings table, and one more
+(`takt.py`'s name) is a semantics decision with nothing to falsify.
+
+| claim | verdict |
+|---|---|
+| the EOT surface is dark, no client references it | **accurate** — re-verified the same day |
+| `eot.py` performs none of the four methods | **FALSE** — the correction above |
+| `/schedule/risk` and `/schedule/montecarlo` disagree by 38 days | **accurate, and resolved** — the alias calls `schedule_risk_mc.for_project`, the same engine |
+| three PPC implementations disagree | **accurate, and resolved** — one rule since v0.3.974, held by `services/api/test_ppc_divergence.py` |
+| `/schedule/compare` returns `finish_move_working_days` and `calendar_vs_working_gap_days` | **accurate** — both fields present, gate green |
+
+**The negative result is the point, and it is recorded so nobody runs this sweep again.** Every
+defect class this repository has found by sweeping — the refusal-state readers, `PORTAL-STATUS`,
+the status/workflow drift — showed **several** instances on the first probe. This one showed one, and
+four counter-examples. *A sample of one is a finding, not a pattern*, and the cost of the mistake runs
+the other way from the usual: generalising from it would have spent days confirming that
+well-maintained entries are well maintained.
+
+**What was NOT swept, stated so the gap is not mistaken for coverage.** Only the falsifiable five.
+A roadmap sentence that misdescribes something unexecutable — an intent, a plan, a reason — cannot be
+caught this way, and no gate proposed here would catch it either. The 103 test-file citations in this
+file were considered as a population and rejected: filtering them mechanically cannot separate a
+citation *describing what a test asserts* (self-consistent, the overwhelming majority) from one
+offered as *corroboration of a live defect* (the failing shape). That separation needs reading.
+
 **What survives is the real decision, and it is unchanged:** `schedule_windows` and
 `schedule_modelled` perform three of the four for real. **Whether `/schedule/eot` should delegate to
 them, or keep its own number and cite theirs, is a domain decision** — the EOT figure ends up in

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1127",
+      "version": "0.3.1128",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
# What & why

`v0.3.1127` corrected a roadmap claim that a release had already ended. The obvious next inference is *"if one roadmap claim was stale, sweep them all."* That was **checked rather than assumed**, and the answer is no — **it is not a class**. This records the negative result.

## Population, and how it was drawn

The **21 `⚠` markers** in `docs/roadmap.md` — the file's own defect flag. Of those, exactly **five** assert present-tense runtime behaviour that can be executed and falsified. The rest are SHIPPED rows, sweep-run headers, prior corrections and the 18-findings table; one more (`takt.py`'s name) is a semantics decision with nothing to falsify.

| claim | verdict |
|---|---|
| the EOT surface is dark, no client references it | **accurate** — re-verified the same day |
| `eot.py` performs none of the four methods | **FALSE** — fixed in v0.3.1127 |
| `/schedule/risk` and `/schedule/montecarlo` disagree by 38 days | **accurate, and resolved** — the alias calls `schedule_risk_mc.for_project`, the same engine |
| three PPC implementations disagree | **accurate, and resolved** — one rule since v0.3.974, held by `services/api/test_ppc_divergence.py` |
| `/schedule/compare` returns `finish_move_working_days` and `calendar_vs_working_gap_days` | **accurate** — both fields present, gate green |

Each verdict was reached by running something, not by reading the entry.

## Why a negative result is worth a release

Every defect class this repository has found by sweeping — the refusal-state readers, `PORTAL-STATUS`, the status/workflow drift — showed **several** instances on the first probe. This one showed **one, and four counter-examples**.

*A sample of one is a finding, not a pattern.* The cost of the mistake runs the opposite way from the usual: generalising from it would have spent days confirming that well-maintained entries are well maintained. Recording it stops the next reader inferring a class from the v0.3.1127 entry and doing exactly that.

## The gap is stated, not papered over

Only the falsifiable five were swept. A roadmap sentence that misdescribes something **unexecutable** — an intent, a plan, a reason — cannot be caught this way, and no gate proposed here would catch it either.

The **103 test-file citations** in the roadmap were considered as a population and rejected. Filtering them mechanically cannot separate a citation *describing what a test asserts* (self-consistent, the overwhelming majority) from one offered as *corroboration of a live defect* (the failing shape). That separation needs reading, not grep — so claiming a clean sweep over them would have been a coverage claim I could not back.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check src/ ../data/src/` clean
- [x] Backend: doc gates pass — `test_claude_md_gates`, `test_roadmap_status`, `test_doc_substance`, `test_file_sizes`. No new test files, so the `run_tests.py` TESTS manifest is unchanged
- [x] Web: typecheck clean; full suite **2045 tests / 200 files**, including the roadmap parsers sensitive to bullet shape (`roadmapStale`, `roadmapSelfConsistent`, `roadmapLanes`, `versionConsistency` — 37 tests)
- [x] No import cycles introduced (docs-only; no source file touched)
- [x] `CHANGELOG.md` entry added (newest at top); roadmap addendum placed beside the v0.3.1127 correction, where a reader following that correction will meet it
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` **and** `package-lock.json` → 0.3.1128
- [x] No secrets, no competitor names in shipped docs

**Docs only — no engine changed.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.3.1128.
  * Updated the roadmap with findings from a review of documented runtime behavior claims.
  * Recorded verification results, including one previously corrected inaccurate claim and four confirmed claims.

* **Chores**
  * Updated the application version to 0.3.1128.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->