### PR TITLE
v0.3.1131 — nine comments describing something else, and the reason nobody widened the gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1131 (2026-08-31) — nine comments describing something else, and the reason nobody widened the gate
+
+`DOC-STRAND`. A doc comment immediately followed by another doc comment has lost its own
+declaration. It does not disappear — it attaches itself to the *next* declaration down and is read as
+documenting that. `apps/web/src/api/docComments.test.ts` has caught this inside `apps/web/src/api`
+since v0.3.1075. **Everywhere else in `apps/web/src` it was unchecked, and the roadmap's standing
+"~25 orphaned comments, not yet fixed or gated" had been a candidate count for a month.**
+
+Measured: **ten**, not ~25 — the `api/` cleanup had been the bulk of it. **Nine were real.**
+
+**The gate stayed narrow for a reason that did not survive being checked.** Its own docstring
+argued widening "would need a rule that can tell a header and a narrative from a leftover, and that
+rule does not exist yet", naming two shapes:
+
+* **A module header written below the import block is real — and needs no exemption, because it is
+  structural.** Nothing but imports stands above it. That is computable, it exempts exactly one site
+  (`apps/web/src/portal/panels/budget.ts`), and it cannot exempt a block with a declaration above it.
+* **The "narrative above the thing it motivates" was not a shape at all.** `apps/web/src/main.ts`
+  had no stranded comment. And the `apps/web/src/viewer/app.ts` RAIL-SPLIT block that reads as
+  deliberate prose documents `distributeToolGroups` — declared **42 lines further down**, past
+  `railGroup` and past `railGroup`'s own comment. It was residue, classified as intentional by
+  reading it rather than by looking for its owner.
+
+*A gate's scope is part of its claim, and so is the reason given for not widening it.*
+
+**All nine were moves, not deletes** — the opposite of what the `api/` cleanup found, where most
+orphans described features with no method left in the file. Not chance: `client.ts` was the file the
+methods were moving *out of*, so its residue was abandoned; these are feature modules that only had
+things inserted into them, so the owner is still a few dozen lines away. In **every one of the nine
+cases that owner carried no comment of its own**, so nine silently undocumented functions
+(`auditRooms`, `showMarkupGrid`, two different `renderBudget`s, `RegisterFilter`, `composeExhibit`,
+`refreshDealMemory`, `installClickEcho`, `distributeToolGroups`) got their documentation back and
+nothing was deleted.
+
+Gated tree-wide by `apps/web/src/tooling/docStranded.test.ts` (336 files, 4 mutations). The *pairing*
+half — does this comment share a word with the method below it? — stays inside `api/` on its own
+merits: outside it, a comment legitimately describes a paragraph of behaviour rather than one method.
+**Two rules that shipped together do not have to keep the same scope**, and assuming they did is what
+kept this half narrow after its stated blocker had stopped being true.
+
 ## v0.3.1130 (2026-08-31) — a release you could sign and nobody could check
 
 `ASSET-VERIFY`. `asset_rights.py` shipped both halves of a signed release manifest and only sealing

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1130",
+    "version": "0.3.1131",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1130",
+  "version": "0.3.1131",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/dev/liveAudit.ts
+++ b/apps/web/src/dev/liveAudit.ts
@@ -197,16 +197,16 @@ export function judgeRoom(det: HTMLElement | null, id: string): RoomReport {
   return { id, verdict: "ok", destinations, open, detail: `${destinations} destinations` };
 }
 
+/** Selector for the nav container that HOLDS the rail. Its absence and a room's absence are
+ *  different facts, and conflating them is the bug this constant exists to prevent. */
+export const NAV_SEL = ".portal-nav, .pnav";
+
 /**
  * Audit the room rail — the surface the redesign actually introduced.
  *
  * `auditWorkspaces` walks workspace tabs and therefore says nothing about the rail itself. This is
  * the rail, which was entirely unmeasured before this ring.
  */
-/** Selector for the nav container that HOLDS the rail. Its absence and a room's absence are
- *  different facts, and conflating them is the bug this constant exists to prevent. */
-export const NAV_SEL = ".portal-nav, .pnav";
-
 export function auditRooms(expected: readonly string[] = ROOM_IDS): RoomAuditReport {
   // WAS THE RAIL BUILT AT ALL? The first version of this function skipped this and reported every
   // room `missing` whenever the nav had not been constructed — which is what happens on the landing

--- a/apps/web/src/drawings/drawings.ts
+++ b/apps/web/src/drawings/drawings.ts
@@ -403,9 +403,6 @@ export class DrawingsUI {
     inp.click();
   }
 
-  /** MARKUP-2b: the cross-sheet markups grid — every markup in the project in one sortable list with
-   *  Σ totals per kind, revision/carried status, and RFI links. DOM built with textContent throughout
-   *  (XSS-safe by construction — markup notes/authors are user text). */
   /**
    * R36 backfill — dry-run, show what would move, then apply only on confirm.
    *
@@ -495,6 +492,9 @@ export class DrawingsUI {
     }
   }
 
+  /** MARKUP-2b: the cross-sheet markups grid — every markup in the project in one sortable list with
+   *  Σ totals per kind, revision/carried status, and RFI links. DOM built with textContent throughout
+   *  (XSS-safe by construction — markup notes/authors are user text). */
   private async showMarkupGrid() {
     const pid = this.host_.projectId();
     if (!pid) return;

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -1183,14 +1183,14 @@ export class PortalUI {
   // the pin, which is why the star could be deleted from here rather than merely moved.
 
 
+  /** Cross-project executive portfolio — every job's on-schedule + on-budget status at a glance.
+   *  Rows are clickable to switch projects. The 'how's the whole book doing?' destination. */
+  private async renderPortfolio() { return (await import("./panels/portfolio")).renderPortfolio(this.panelCtx()); }
   /** First-class Budget destination — the GC's GMP project budget. Direct trade work (by CSI
    *  division + bid package) + General Conditions / Requirements (incl. staffing) + Overhead + Fee
    *  + Contingency = GMP, each line budget vs committed (buyout) vs variance, reconciled to the
    *  prime contract value and the developer proforma's construction hard cost. The on-budget half of
    *  what a project executive lives in, next to the Schedule destination. */
-  /** Cross-project executive portfolio — every job's on-schedule + on-budget status at a glance.
-   *  Rows are clickable to switch projects. The 'how's the whole book doing?' destination. */
-  private async renderPortfolio() { return (await import("./panels/portfolio")).renderPortfolio(this.panelCtx()); }
   private async renderBudget() { return (await import("./panels/budget")).renderBudget(this.panelCtx()); }
 
   private async renderScheduleViews(m: ModuleDef) { return (await import("./panels/schedule")).renderScheduleViews(this.panelCtx(), m); }

--- a/apps/web/src/portal/register/register.ts
+++ b/apps/web/src/portal/register/register.ts
@@ -27,14 +27,6 @@ const REF_RESOLVE_LIMIT = 500;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * MOD-FILTER — everything currently narrowing a register view.
- *
- * `q` and `state` were the whole vocabulary; `fields` is the per-field half. It is threaded through
- * `openModule` rather than held on the instance so that every re-render — a saved view, a page step,
- * an inline edit — either passes the filters on deliberately or drops them visibly. A filter
- * surviving in hidden state while the controls show something else is the worst of both.
- */
-/**
  * MOD-PERCENT — the field types that hold a MAGNITUDE, named once.
  *
  * The form layer asked `f.type === "number" || f.type === "currency"` in three separate places, and
@@ -90,6 +82,14 @@ export const READ_ONLY_FIELD_TYPES = [
   "table",
 ] as const;
 
+/**
+ * MOD-FILTER — everything currently narrowing a register view.
+ *
+ * `q` and `state` were the whole vocabulary; `fields` is the per-field half. It is threaded through
+ * `openModule` rather than held on the instance so that every re-render — a saved view, a page step,
+ * an inline edit — either passes the filters on deliberately or drops them visibly. A filter
+ * surviving in hidden state while the controls show something else is the worst of both.
+ */
 export interface RegisterFilter {
   q?: string;
   state?: string;
@@ -1670,32 +1670,6 @@ export class RegisterUI {
   }
 
   /**
-   * Compose Exhibit A — pick clauses, preview the assembled exhibit, then generate the PDF.
-   *
-   * NARROW BY TRADE, BECAUSE THE CATALOG OUTGREW THE PICKER
-   *     The library is 249 clauses across 21 MasterFormat divisions. This used to load all of them
-   *     into one flat 300px-tall checkbox list, which asks somebody to assemble a plumbing
-   *     subcontract from a list where the overwhelming majority of entries belong to other trades.
-   *     Passing the record's trade narrows it server-side — 249 -> 85 for plumbing — and the header
-   *     says which division it narrowed to, so a wrong trade on the record is visible rather than
-   *     silently producing a short exhibit.
-   *
-   * THE INITIAL SELECTION COMES FROM THE SERVER, WHICH IS THE BUG THIS REPLACES
-   *     The previous default was computed here:
-   *         `cb.checked = cl.category !== "Scope" || !trade || (cl.trade ?? "").toLowerCase() === trade`
-   *     The imported clauses carry no `trade` key at all — only body/category/default/division/id/
-   *     position/title — so that comparison was false for every one of the 242 imported clauses. The
-   *     dialog therefore opened with **every exclusion and every conditions clause ticked and almost
-   *     no scope clauses**, which is close to the opposite of a sensible subcontract exhibit. It was
-   *     a second selection rule that disagreed with the server's `default_ids`. Now there is one
-   *     rule: `scopeExhibit({trade})` returns the default selection and the boxes start there.
-   *
-   * EXCLUSIONS ARE AS PROMINENT AS INCLUSIONS
-   *     The point of the library gaining exclusions (69 of them) is that a subcontract can state what
-   *     is NOT included — that is where scope gaps come from. So the picker groups by category rather
-   *     than running them together, and the preview leads with the counts.
-   */
-  /**
    * `estimate.basis` -> the phase key `est_confidence._PHASE_CONF` scores against.
    *
    * **Explicit, because lowercasing is wrong for two of the five and wrong in the flattering
@@ -1901,6 +1875,32 @@ export class RegisterUI {
   }
 
 
+  /**
+   * Compose Exhibit A — pick clauses, preview the assembled exhibit, then generate the PDF.
+   *
+   * NARROW BY TRADE, BECAUSE THE CATALOG OUTGREW THE PICKER
+   *     The library is 249 clauses across 21 MasterFormat divisions. This used to load all of them
+   *     into one flat 300px-tall checkbox list, which asks somebody to assemble a plumbing
+   *     subcontract from a list where the overwhelming majority of entries belong to other trades.
+   *     Passing the record's trade narrows it server-side — 249 -> 85 for plumbing — and the header
+   *     says which division it narrowed to, so a wrong trade on the record is visible rather than
+   *     silently producing a short exhibit.
+   *
+   * THE INITIAL SELECTION COMES FROM THE SERVER, WHICH IS THE BUG THIS REPLACES
+   *     The previous default was computed here:
+   *         `cb.checked = cl.category !== "Scope" || !trade || (cl.trade ?? "").toLowerCase() === trade`
+   *     The imported clauses carry no `trade` key at all — only body/category/default/division/id/
+   *     position/title — so that comparison was false for every one of the 242 imported clauses. The
+   *     dialog therefore opened with **every exclusion and every conditions clause ticked and almost
+   *     no scope clauses**, which is close to the opposite of a sensible subcontract exhibit. It was
+   *     a second selection rule that disagreed with the server's `default_ids`. Now there is one
+   *     rule: `scopeExhibit({trade})` returns the default selection and the boxes start there.
+   *
+   * EXCLUSIONS ARE AS PROMINENT AS INCLUSIONS
+   *     The point of the library gaining exclusions (69 of them) is that a subcontract can state what
+   *     is NOT included — that is where scope gaps come from. So the picker groups by category rather
+   *     than running them together, and the preview leads with the counts.
+   */
   private async composeExhibit(m: ModuleDef, r: ModuleRecord, rid: string) {
     const pid = this.ctx.host.projectId()!;
     const api = this.ctx.host.api;

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -1015,16 +1015,6 @@ export class ProformaUI {
     }).catch(() => { bodyEl.innerHTML = `<div class="meta">specialty assets unavailable (API offline)</div>`; });
   }
 
-  /** Developer cost budget: line-item hard/soft/acquisition costs (description × $/unit × qty) with
-   *  per-category contingency, that roll into the proforma's cost_lines. The institutional gap the
-   *  flat cost drivers don't cover. */
-  /** Repaint the deal-memory strip from the CURRENT assumptions. Safe to call when it is not mounted.
-   *
-   *  Only $/SF is asked for. A realised cost VARIANCE has no counterpart among these fields — the
-   *  nearest is a contingency, and "your contingency should cover our historical overrun" is a claim
-   *  this product would be making, not a unit conversion — and a realised schedule VARIANCE is not a
-   *  duration, so putting it beside `construction_months` would be a category error in matching units.
-   */
   /**
    * Repaint the income-provenance strip. Same shape as `refreshDealMemory` and for the same reason:
    * it describes a number the user can edit, so painting it once would leave a claim about the rent
@@ -1052,6 +1042,13 @@ export class ProformaUI {
     }).catch(() => { el.style.display = "none"; });
   }
 
+  /** Repaint the deal-memory strip from the CURRENT assumptions. Safe to call when it is not mounted.
+   *
+   *  Only $/SF is asked for. A realised cost VARIANCE has no counterpart among these fields — the
+   *  nearest is a contingency, and "your contingency should cover our historical overrun" is a claim
+   *  this product would be making, not a unit conversion — and a realised schedule VARIANCE is not a
+   *  duration, so putting it beside `construction_months` would be a category error in matching units.
+   */
   private refreshDealMemory() {
     const memory = this.memoryEl;
     const pid = this.projectId();
@@ -1118,6 +1115,9 @@ export class ProformaUI {
     }).catch(() => { memory.style.display = "none"; });   // endpoint absent → say nothing false
   }
 
+  /** Developer cost budget: line-item hard/soft/acquisition costs (description × $/unit × qty) with
+   *  per-category contingency, that roll into the proforma's cost_lines. The institutional gap the
+   *  flat cost drivers don't cover. */
   private renderBudget() {
     this.root.querySelector("#pf-budget")?.remove();   // idempotent — re-render replaces, never duplicates
     const host = document.createElement("div"); host.id = "pf-budget";

--- a/apps/web/src/tooling/docStranded.test.ts
+++ b/apps/web/src/tooling/docStranded.test.ts
@@ -1,0 +1,161 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * DOC-STRAND — no doc comment in `apps/web/src` has lost the declaration it describes.
+ *
+ * ## The shape
+ *
+ * A `/** … *\/` block immediately followed by another one has no declaration of its own: whatever it
+ * documented moved, was renamed, or had something inserted between them. The comment does not
+ * disappear — it attaches itself visually to the *next* declaration down and is then read as
+ * documenting that. **A comment about a declaration that is not there is not documentation; it is a
+ * false statement positioned where the next reader will trust it.**
+ *
+ * `api/docComments.test.ts` has enforced exactly this since v0.3.1075, over `apps/web/src/api` only.
+ * That scoping was deliberate and argued in writing: widening it "would need a rule that can tell a
+ * header and a narrative from a leftover, and that rule does not exist yet". This is that widening,
+ * and it is possible because **one of the two shapes the scoping rested on did not survive being
+ * checked.**
+ *
+ * ## The two shapes, re-measured
+ *
+ * **A module header written below the import block is real — and it needs no exemption, because it
+ * is structural.** `portal/panels/budget.ts` opens with five imports and then the file's own header,
+ * followed by the first declaration's comment. Nothing but imports stands above it, and that is a
+ * property this gate can compute (`isFileHeader`). It is the only site in the tree with that shape.
+ *
+ * **The "context block above the thing it motivates" did NOT survive.** That claim named
+ * `viewer/app.ts` and `main.ts`. `main.ts` has no stranded comment at all. And the `viewer/app.ts`
+ * block reads as deliberate narrative but is not: it documented `distributeToolGroups`, declared
+ * **42 lines further down**, past `railGroup` and past `railGroup`'s own comment. It was residue of
+ * exactly the kind this gate catches, classified as intentional prose by reading it rather than by
+ * looking for its owner.
+ *
+ * *A gate's scope is part of its claim — and so is the reason given for not widening it.* That
+ * reason was two examples: one stale, one a misreading. Neither was wrong when written in the sense
+ * of careless; both were **assertions about the tree that nothing re-ran**, which is the same defect
+ * one level out from the one this file gates.
+ *
+ * ## What the nine were, and why every one was a MOVE
+ *
+ * Nine sites, each with a verifiable owner, and not one a delete:
+ *
+ *     dev/liveAudit.ts        -> auditRooms            (NAV_SEL was inserted between them)
+ *     drawings/drawings.ts    -> showMarkupGrid        (86 lines down)
+ *     portal/portal.ts        -> renderBudget          (renderPortfolio sat between)
+ *     portal/register/…       -> RegisterFilter        (53 lines down)
+ *     portal/register/…       -> composeExhibit        (232 lines down)
+ *     proforma/proforma.ts    -> renderBudget          (97 lines down)
+ *     proforma/proforma.ts    -> refreshDealMemory     (refreshIncomeBasis sat between)
+ *     ui/perfBeacon.ts        -> installClickEcho      (cappedSender sat between)
+ *     viewer/app.ts           -> distributeToolGroups  (railGroup sat between)
+ *
+ * **That is the opposite of what the `api/` cleanup found**, where most stranded comments described
+ * features with no method left in the file to own them and were deleted. The difference is not
+ * chance: `api/client.ts` was the file the methods were moving *out of*, so its residue was
+ * abandoned. These are feature modules that only ever had things inserted into them, so their
+ * residue is *separated* — the owner is still a few dozen lines away, undocumented.
+ *
+ * Every one of the nine owners had **no doc comment of its own**, so nothing was a duplicate to
+ * reconcile and nothing was lost. Nine functions that were silently undocumented got their
+ * documentation back, and nine declarations stopped carrying a description of something else.
+ *
+ * ## Why this is the whole tree while `docComments.test.ts` stays inside `api/`
+ *
+ * The *stranded* rule needs no understanding of prose — it is a shape, and its one false-positive
+ * shape is structural. The *pairing* rule next door (does this comment share a word with the method
+ * below it?) is the half that cannot be widened, because outside `api/` a comment legitimately
+ * describes a paragraph of behaviour rather than one method. **Two rules that shipped together do
+ * not have to keep the same scope**, and assuming they did is what kept this half narrow for a
+ * month after its blocker stopped being true.
+ */
+
+const ROOT = resolve(process.cwd(), "..", "..");
+
+const FILES = execFileSync("git", ["ls-files", "apps/web/src/**/*.ts", "apps/web/src/**/*.tsx"],
+  { cwd: ROOT, encoding: "utf8" })
+  .split("\n").map((s) => s.trim()).filter(Boolean)
+  .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".d.ts"));
+
+/**
+ * Is this stranded block the FILE'S OWN header, written below the import block?
+ *
+ * True when nothing but imports and comments stands above it. Structural, so it costs no frozen
+ * entry — an exemption list has to be maintained by hand and would admit a real residue the day
+ * someone added one near the top of a file. By construction it cannot exempt a block that has a
+ * declaration above it: `portal/register/register.ts` opens with fourteen imports and then two
+ * documented constants, so its block stays flagged despite also sitting near line 30.
+ */
+function isFileHeader(lines: string[], start: number): boolean {
+  for (let k = 0; k < start; k++) {
+    const t = (lines[k] ?? "").trim();
+    if (!t || t.startsWith("//") || t.startsWith("/*") || t.startsWith("*") || t.endsWith("*/")) continue;
+    if (t.startsWith("import ") || t.startsWith("export type {") || t.startsWith("export {")) continue;
+    return false;
+  }
+  return true;
+}
+
+/** Every `/** … *\/` block immediately followed by another, split by whether it is a file header. */
+function scan(): { stranded: string[]; headers: string[] } {
+  const stranded: string[] = [], headers: string[] = [];
+  for (const f of FILES) {
+    const lines = readFileSync(resolve(ROOT, f), "utf8").split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const l = lines[i] ?? "";
+      const closes = l.trimEnd().endsWith("*/") && (l.trim().startsWith("/**") || l.trim().startsWith("*"));
+      if (!closes || !(lines[i + 1] ?? "").trim().startsWith("/**")) continue;
+      let j = i;
+      while (j > 0 && !(lines[j] ?? "").trim().startsWith("/**")) j--;
+      const where = `${f}:${j + 1}  ${(lines[j] ?? "").trim().slice(0, 72)}`;
+      (isFileHeader(lines, j) ? headers : stranded).push(where);
+    }
+  }
+  return { stranded, headers };
+}
+
+const RESULT = scan();
+
+describe("DOC-STRAND — no doc comment has lost its declaration", () => {
+  it("scanned a plausible number of files — else every assertion below is vacuous", () => {
+    expect(FILES.length, `only ${FILES.length} source files matched`).toBeGreaterThan(250);
+  });
+
+  it("no doc comment is stranded above another doc comment", () => {
+    expect(RESULT.stranded,
+      "a comment directly above another comment has lost its declaration, and it WILL be read as "
+      + "documenting the next thing down. Find what it describes and move it there — all nine of the "
+      + "originals had an owner a few dozen lines away with no comment of its own. Delete it only "
+      + "once you have established the thing it describes has genuinely left the file.")
+      .toEqual([]);
+  });
+
+  /**
+   * The header exemption is a rule, so this is its positive control.
+   *
+   * `isFileHeader` returning true for everything would satisfy the assertion above while gating
+   * nothing — the same failure as an allowlist quietly grown to cover the tree, and indistinguishable
+   * from a correct rule if you only look at whether the suite is green. So it is pinned in both
+   * directions: it must still match the one header shape that exists, and it must refuse a block
+   * with a declaration above it.
+   */
+  it("the header rule matches file headers and nothing else", () => {
+    expect(RESULT.headers.length,
+      "0 means the rule matches nothing and is dead code; >1 means it has become over-broad and is "
+      + "now hiding residue. Either way it has stopped being the thing asserted above.")
+      .toBe(1);
+    expect(RESULT.headers[0]).toContain("apps/web/src/portal/panels/budget.ts");
+
+    const reg = readFileSync(resolve(ROOT, "apps/web/src/portal/register/register.ts"), "utf8").split("\n");
+    const modFilter = reg.findIndex((l) => l.includes("MOD-FILTER — everything currently narrowing"));
+    expect(modFilter, "MOD-FILTER's block is the fixture for this control").toBeGreaterThan(0);
+    expect(isFileHeader(reg, modFilter - 1),
+      "MOD-FILTER has two documented consts above it — a declaration, so never a file header")
+      .toBe(false);
+    expect(isFileHeader(reg, 0), "line 1 of any file trivially has nothing above it").toBe(true);
+  });
+});

--- a/apps/web/src/ui/perfBeacon.ts
+++ b/apps/web/src/ui/perfBeacon.ts
@@ -61,12 +61,6 @@ export const CLICK_ECHO = "click_echo";
 const DEFAULT_MAX_PER_MINUTE = 120;
 
 /**
- * Attach the click-echo tracker. Returns a disposer.
- *
- * The interval is reported for every trusted click, including the ones that turn out to be fast:
- * a percentile computed only over clicks somebody suspected were slow is not a percentile.
- */
-/**
  * The send path both budgets share: a rolling per-minute cap, an implausible-interval drop, and a
  * reporter that cannot throw outward.
  *
@@ -93,6 +87,12 @@ function cappedSender(deps: { send: (b: string, ms: number) => void; now: () => 
   };
 }
 
+/**
+ * Attach the click-echo tracker. Returns a disposer.
+ *
+ * The interval is reported for every trusted click, including the ones that turn out to be fast:
+ * a percentile computed only over clicks somebody suspected were slow is not a percentile.
+ */
 export function installClickEcho(target: EventTarget, deps: ClickEchoDeps): () => void {
   const isUser = deps.isUserEvent ?? ((e: Event) => e.isTrusted);
   const report = cappedSender(deps, deps.maxPerMinute ?? DEFAULT_MAX_PER_MINUTE);

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -2292,19 +2292,6 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   }
 
   /**
-   * RAIL-SPLIT — move each `tool-group` to the rail panel that owns its job.
-   *
-   * Measured live: this one panel held **182 buttons and 11 inputs under 7 headings**, doing about
-   * ten unrelated jobs. "Tools" was not a category — it was where a control went when nobody
-   * decided. Each `section()` already declares what it is via `data-tool`, so the split is a
-   * re-parenting pass keyed off that, not a rewrite of 154 call sites. **A pass that only moves
-   * nodes cannot lose one**, which is the same property that made RAIL-TOOLBOX safe.
-   *
-   * A group with no destination stays in `panel-tools` on purpose. Unrouted must mean *visible in
-   * the old place*, never *gone*: a control that silently disappears looks exactly like one that was
-   * deliberately removed, and the next person to notice is a user who needed it.
-   */
-  /**
    * RAIL-SPLIT ② — put a named group of already-built controls into a rail panel.
    *
    * The controls are created by the code that owns their behaviour, exactly as before; this only
@@ -2353,6 +2340,19 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     }
   }
 
+  /**
+   * RAIL-SPLIT — move each `tool-group` to the rail panel that owns its job.
+   *
+   * Measured live: this one panel held **182 buttons and 11 inputs under 7 headings**, doing about
+   * ten unrelated jobs. "Tools" was not a category — it was where a control went when nobody
+   * decided. Each `section()` already declares what it is via `data-tool`, so the split is a
+   * re-parenting pass keyed off that, not a rewrite of 154 call sites. **A pass that only moves
+   * nodes cannot lose one**, which is the same property that made RAIL-TOOLBOX safe.
+   *
+   * A group with no destination stays in `panel-tools` on purpose. Unrouted must mean *visible in
+   * the old place*, never *gone*: a control that silently disappears looks exactly like one that was
+   * deliberately removed, and the next person to notice is a user who needed it.
+   */
   function distributeToolGroups(panel: HTMLElement) {
     // `authoring` is deliberately NOT split here. It genuinely mixes annotation, the content
     // library and fabrication detail under one heading, and splitting a section by guessing which

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3058,18 +3058,40 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
   the next at five, but its three types are interleaved with unrelated ones, so it is a more
   careful extraction than a late-session slice should be.
 
-  ⚠️ **THIS EXTRACTION HAS BEEN LEAVING DOC COMMENTS BEHIND, and it has done it twice.** When a
-  method moves, its comment stays with the file and attaches itself to whatever follows. Two
-  distinct shapes, both measured:
+  ✅ **THIS EXTRACTION WAS LEAVING DOC COMMENTS BEHIND, in two distinct shapes — BOTH NOW CLOSED
+  AND GATED** (the second in v0.3.1131, which is also when the count below stopped being a guess).
+  When a method moves, its comment stays with the file and attaches itself to whatever follows:
   * **Eleven methods documented as a NEIGHBOUR's job** — fixed v0.3.1075, gated by
     `apps/web/src/api/docComments.test.ts`. `evm()` was described as `resourceLoading()`.
-  * **~25 ORPHANED comments** — a doc comment immediately followed by another doc comment, its own
-    declaration gone. Three sampled, all genuine and all traceable to this split:
-    `httpCore.ts` still documents `setToken`, which moved to `api/auth.ts`; `model.ts` still
-    documents TOPIC-BOARD, which moved to `api/topics.ts` in ⑳; `authoring.ts` still documents an
-    IFCPATCH-LIB dry-run scan. **Not yet fixed or gated** — the count is a candidate count, not a
-    verified one, and a gate that fails on 25 sites belongs with the cleanup rather than before
-    it. *A wrong docstring is worse than none; an orphaned one is how a wrong one is made.*
+  * **ORPHANED comments — a doc comment immediately followed by another, its own declaration gone.
+    CLOSED v0.3.1131, tree-wide, and the "~25" was never a real number.** It was a candidate count
+    and said so, but it then sat here for a month reading like a measurement. The 23 inside `api/`
+    were fixed and gated with `apps/web/src/api/docComments.test.ts`; re-measured over the whole of
+    `apps/web/src` afterwards, what was left was **ten**, of which **one was legitimate**.
+    *A wrong docstring is worse than none; an orphaned one is how a wrong one is made.*
+
+    **Why it stayed at `api/`, and why that reason did not hold.** `docComments.test.ts` argued the
+    widening "would need a rule that can tell a header and a narrative from a leftover, and that rule
+    does not exist yet", naming two shapes. Checked: **a module header written below the imports is
+    real and needs no exemption — it is structural** (nothing but imports above it), and it occurs
+    exactly once, in `apps/web/src/portal/panels/budget.ts`. **The "narrative above the thing it
+    motivates" did not survive at all**: `apps/web/src/main.ts` had no stranded comment, and the
+    `apps/web/src/viewer/app.ts` RAIL-SPLIT block that reads as deliberate prose documents
+    `distributeToolGroups`, declared 42 lines below it past `railGroup` and past `railGroup`'s own
+    comment. *It was classified as intentional by reading it rather than by looking for its owner* —
+    the same defect the gate exists to catch, one level out. **A gate's scope is part of its claim,
+    and so is the reason given for not widening it.**
+
+    **All nine were MOVES, which is the opposite of what `api/` found** — there, most orphans
+    described features with no method left in the file and were deleted. Not chance:
+    `apps/web/src/api/client.ts` was the file methods were moving *out of*, so its residue was
+    abandoned; these are feature modules that only had things inserted into them, so their residue is
+    *separated* — the owner a few dozen lines away, and in **every one of the nine cases carrying no
+    comment of its own**. Nine silently undocumented functions got their documentation back and
+    nothing was deleted. Gated tree-wide by `apps/web/src/tooling/docStranded.test.ts`; the pairing
+    half stays inside `api/` on its own merits, because outside it a comment legitimately describes a
+    paragraph of behaviour rather than one method. *Two rules that shipped together do not have to
+    keep the same scope, and assuming they did is what kept this half narrow.*
 
   **㉓ took `/projects/{pid}/evm` out** (6 methods, one contiguous run — the tightest group left;
   `client.ts` 3,120 → 3,066) as `apps/web/src/api/evm.ts`, with `EvmEarnedSchedule`, whose only

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1130",
+      "version": "0.3.1131",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
# What & why

`DOC-STRAND`. A doc comment immediately followed by another doc comment has lost its own declaration. It does not disappear — it attaches itself to the **next** declaration down and is then read as documenting that.

`apps/web/src/api/docComments.test.ts` has caught this inside `apps/web/src/api` since v0.3.1075. Everywhere else in `apps/web/src` it was unchecked, and the roadmap's standing *"~25 orphaned comments … **not yet fixed or gated**"* had been sitting there for a month reading like a measurement. It was a candidate count, and it said so.

Measured tree-wide: **ten, not ~25** — the `api/` cleanup had been the bulk of it. **Nine were real.**

## The gate stayed narrow for a reason that did not survive being checked

Its docstring argued that widening *"would need a rule that can tell a header and a narrative from a leftover, and that rule does not exist yet"*, naming two shapes. Both were re-derived:

| claimed shape | holds? |
|---|---|
| a **module header written below the import block** | **yes — and it needs no exemption, because it is structural.** Nothing but imports stands above it. Computable, exempts exactly one site (`apps/web/src/portal/panels/budget.ts`), and cannot exempt a block that has a declaration above it |
| a **narrative above the thing it motivates** (`viewer/app.ts`, `main.ts`) | **no.** `main.ts` has no stranded comment at all. And the `viewer/app.ts` RAIL-SPLIT block that reads as deliberate prose documents `distributeToolGroups` — declared **42 lines further down**, past `railGroup` and past `railGroup`'s own comment |

That second one was residue, classified as intentional **by reading it rather than by looking for its owner**. *A gate's scope is part of its claim, and so is the reason given for not widening it.* Neither claim was careless when written; both were assertions about the tree that nothing re-ran — the same defect the gate catches, one level out.

## All nine were moves, not deletes

| stranded comment | its actual owner |
|---|---|
| `dev/liveAudit.ts` | `auditRooms` — `NAV_SEL` was inserted between them |
| `drawings/drawings.ts` | `showMarkupGrid`, 86 lines down |
| `portal/portal.ts` | `renderBudget` — `renderPortfolio` sat between |
| `portal/register/register.ts` | `RegisterFilter`, 53 lines down |
| `portal/register/register.ts` | `composeExhibit`, 232 lines down |
| `proforma/proforma.ts` | `renderBudget`, 97 lines down |
| `proforma/proforma.ts` | `refreshDealMemory` — `refreshIncomeBasis` sat between |
| `ui/perfBeacon.ts` | `installClickEcho` — `cappedSender` sat between |
| `viewer/app.ts` | `distributeToolGroups` — `railGroup` sat between |

**This is the opposite of what the `api/` cleanup found**, where most orphans described features with no method left in the file and were deleted. Not chance: `api/client.ts` was the file the methods were moving *out of*, so its residue was abandoned. These are feature modules that only ever had things inserted into them, so their residue is *separated* — the owner still a few dozen lines away.

In **every one of the nine cases that owner carried no doc comment of its own**. So nothing was a duplicate to reconcile, nothing was deleted, and nine silently undocumented functions got their documentation back.

## Scope of the new gate

`apps/web/src/tooling/docStranded.test.ts`, 336 files. The **pairing** rule next door — does this comment share a word with the method below it? — deliberately stays inside `api/`: outside it, a comment legitimately describes a paragraph of behaviour rather than one method. **Two rules that shipped together do not have to keep the same scope**, and assuming they did is what kept this half narrow after its stated blocker had stopped being true.

Four mutations, all of which fail and are restored: re-strand one comment; `isFileHeader` always-true (headers → 10, and the register control flips); always-false (headers → 0, `budget.ts` surfaces as residue); empty file population (the vacuity check fires).

`test_file_sizes` caught the one blank line this added to `portal.ts`, which is under an extraction ratchet. Removed rather than pinned — it was cosmetic. All five ratchets at +0.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Web: `tsc --noEmit` clean; `eslint src --max-warnings=0` clean
- [x] Web: full suite **2048 tests / 201 files** (was 2045 / 200)
- [x] Backend doc gates green: `test_claude_md_gates`, `test_roadmap_status`, `test_doc_substance`, `test_file_sizes`. **Full backend suite running; this will not be merged until it is green.**
- [x] No import cycles introduced — the change is comments plus one new test file
- [x] `CHANGELOG.md` entry added (newest at top); the roadmap's stale ⚠️ block corrected and closed ✅
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` **and** `package-lock.json` → 0.3.1131
- [x] No secrets, no competitor names in shipped docs

**Not in this PR, deliberately:** the pairing rule's scope, and `apps/web/src/portal/panels/budget.ts`'s header, which is correct where it is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_