### PR TITLE
v0.3.1132 — eight routes frozen as callerless while the UI called them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ caller is expected"*, which is what made them look considered.
 ## Two mechanisms, because one shape is decidable and the other is not
 
 * **Templated stem** (`exports/${file}.xlsx`) is a **pattern**: the parent segment and the extension
-  must still match literally. Six routes, and dropping the parent anchor vouches for six more that
-  nothing calls.
+  must still match literally. Six routes are accepted. Dropping the parent anchor *would* vouch for
+  six more that nothing calls — measured as a mutation, not shipped behaviour.
 * **Templated extension** (`model/export.${fmt}`) is a **two-entry named list with its call site
   recorded**, because as a pattern it is wrong in both directions: it vouches for six `export.*`
   routes of which only two are called. The other four are frozen correctly, and each says the same
@@ -56,7 +56,7 @@ nothing. Five mutations, all failing, all restored.
 way — `/leaf` instead of substring, measured at 81 → 124 frozen, 43 newly unreachable. Opposite
 change to the same rule; the earlier decision does not speak to this one.
 
-Uncalled by the rule: **81 → 75**.
+Uncalled by the rule: **81 → 73** — the strict baseline is 81 and the two leniencies remove eight.
 
 ## v0.3.1131 (2026-08-31) — nine comments describing something else, and the reason nobody widened the gate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1132 (2026-08-31) — eight routes frozen as callerless while the UI called them
+
+`ROUTE-INTERP`. `test_route_reachability` flags a route when its **last static segment** appears
+nowhere in the web source. The file's header already knew literal matching is unsound against a
+client that builds URLs from template literals — that is *why* the rule is the last segment. **It
+assumes the last segment is written out.** Eight routes are built with that segment templated too, so
+their leaf appears nowhere, and every one was frozen in `KNOWN_UNCALLED` as deliberately callerless:
+
+| route | built at | value passed at |
+|---|---|---|
+| `/exports/{cobie,qto,schedule,spaces}.xlsx` | `viewer/tools/exportsSection.ts:57` | the four-entry list on line 54 |
+| `/schedule/{gantt,lob}.svg` | `api/schedule.ts:193-4` | `portal/panels/schedule.ts:731` |
+| `/model/export.{jsonld,parquet}` | `api/model.ts:185` | `portal/panels/standards.ts:488-489` |
+
+The list's own contract is that *"a frozen route that gains a caller must leave"*. These never lacked
+one — eight entries in the allowlist that records deliberate decisions were false, and four of them
+sat under a heading reading *"a user reaches these by clicking a link the server builds, so no client
+caller is expected"*, which is what made them look considered.
+
+## Two mechanisms, because one shape is decidable and the other is not
+
+* **Templated stem** (`exports/${file}.xlsx`) is a **pattern**: the parent segment and the extension
+  must still match literally. Six routes, and dropping the parent anchor vouches for six more that
+  nothing calls.
+* **Templated extension** (`model/export.${fmt}`) is a **two-entry named list with its call site
+  recorded**, because as a pattern it is wrong in both directions: it vouches for six `export.*`
+  routes of which only two are called. The other four are frozen correctly, and each says the same
+  thing — **a signature that accepts a value is not a call site that passes one**:
+
+  | route | why it stays frozen |
+  |---|---|
+  | `/model/export.ifcx` | `modelExportUrl` is typed `"csv" \| "jsonld" \| "parquet"` |
+  | `/drawings/sheet.dxf` | `sheetPath` accepts `"dxf"`; its only caller `openSheet` is `("svg" \| "pdf")` |
+  | `/energy/export.{gbxml,idf}` | **`energyExportUrl` has no caller at all** — an unwired client method |
+
+That last row is a new finding this release does not fix: both formats the energy exporter offers are
+unreachable, and the client method that would reach them is called by nothing.
+
+## The leniency is pinned, because it moves the number the *rewarded* way
+
+Every previous correction here made the gate stricter. This one makes it more permissive, and the
+file's own generated-types comment says that is the direction nobody investigates. So the change is
+not trusted to be small — it is measured against the pre-change rule and every route it vouches for
+is named, **attributed to its mechanism** (six by pattern, two by list; swapping them keeps the total
+right and fails the attribution), and the named list gets the mirror of `KNOWN_UNCALLED`'s rot check:
+an allowlist asserting *"this IS called"* outlives its caller exactly the way these eight outlived
+nothing. Five mutations, all failing, all restored.
+
+**This is not the matcher-sharpening this file has rejected twice.** That proposal went the other
+way — `/leaf` instead of substring, measured at 81 → 124 frozen, 43 newly unreachable. Opposite
+change to the same rule; the earlier decision does not speak to this one.
+
+Uncalled by the rule: **81 → 75**.
+
 ## v0.3.1131 (2026-08-31) — nine comments describing something else, and the reason nobody widened the gate
 
 `DOC-STRAND`. A doc comment immediately followed by another doc comment has lost its own

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1131",
+    "version": "0.3.1132",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1131",
+  "version": "0.3.1132",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,9 +236,13 @@ instances:
   `test_route_reachability` flags a route when its last static segment appears nowhere in the web
   source. Its header already knew literal matching is unsound against a client that builds URLs from
   template literals — that is why the rule is the *last* segment. **It assumes that segment is
-  written out.** Eight routes template it too: `/exports/{cobie,qto,schedule,spaces}.xlsx`
-  (`apps/web/src/viewer/tools/exportsSection.ts`), `/schedule/{gantt,lob}.svg`
-  (`apps/web/src/api/schedule.ts`) and `/model/export.{jsonld,parquet}` (`apps/web/src/api/model.ts`).
+  written out.** Eight routes template it too. Each is listed as *URL built at → value passed at*,
+  because the second is the evidence that it is reached and the first alone is not:
+  `/exports/{cobie,qto,schedule,spaces}.xlsx` — built and enumerated in
+  `apps/web/src/viewer/tools/exportsSection.ts`; `/schedule/{gantt,lob}.svg` — built in
+  `apps/web/src/api/schedule.ts`, both kinds passed in `apps/web/src/portal/panels/schedule.ts`;
+  `/model/export.{jsonld,parquet}` — built in `apps/web/src/api/model.ts`, both passed in
+  `apps/web/src/portal/panels/standards.ts`.
   Every one had a caller; every one was frozen as deliberately callerless, four of them under a
   heading saying no client caller was expected — **which is what made them look considered**.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -230,6 +230,37 @@ Seven of eleven engines once shipped with no route. The R32 filing-spine entries
 band are all closed and recorded in [`roadmap-completed.md`](roadmap-completed.md). The current
 instances:
 
+- ✅ **ROUTE-INTERP — eight routes were frozen as callerless while the UI called them** *(S — Lane C;
+  **CLOSED v0.3.1132**)*
+
+  `test_route_reachability` flags a route when its last static segment appears nowhere in the web
+  source. Its header already knew literal matching is unsound against a client that builds URLs from
+  template literals — that is why the rule is the *last* segment. **It assumes that segment is
+  written out.** Eight routes template it too: `/exports/{cobie,qto,schedule,spaces}.xlsx`
+  (`apps/web/src/viewer/tools/exportsSection.ts`), `/schedule/{gantt,lob}.svg`
+  (`apps/web/src/api/schedule.ts`) and `/model/export.{jsonld,parquet}` (`apps/web/src/api/model.ts`).
+  Every one had a caller; every one was frozen as deliberately callerless, four of them under a
+  heading saying no client caller was expected — **which is what made them look considered**.
+
+  Two mechanisms, because one shape decides and the other cannot: a templated **stem** is a pattern
+  (anchored on the parent segment; dropping that anchor vouches for six more routes nothing calls),
+  while a templated **extension** is a two-entry named list carrying its call site, because as a
+  pattern it vouches for six `export.*` routes of which only two are called. The four that stay
+  frozen each say the same thing — **a signature that ACCEPTS a value is not a call site that PASSES
+  one**: `sheetPath` accepts `"dxf"` and its only caller is typed `("svg" | "pdf")`.
+
+  **This is not the matcher-sharpening rejected twice** (`/leaf`, measured 81 → 124 frozen). That was
+  the opposite direction. This one is pinned by a differential naming every route it vouches for,
+  attributed per mechanism, plus the mirror of `KNOWN_UNCALLED`'s rot check on the named list.
+
+  **TWO THINGS IT LEAVES OPEN, both measured on the way through.** `energyExportUrl`
+  (`apps/web/src/api/client.ts`) **has no caller at all**, so both formats the energy exporter offers
+  are unreachable — an unwired client method of the R37-TESTED-UNWIRED kind. And this band names
+  three remaining items while the gate freezes **75** routes, 38 of them under no category at all and
+  7 explicitly labelled *"genuinely unreached capabilities … worth someone's attention"*. **The band
+  and the gate disagree about the size of the same class by an order of magnitude**, and nothing
+  makes them agree; deriving that population is a bigger item than this was.
+
 - ✅ ⭐ **REFUSAL-READERS — a record in a refused state still counts** *(M — Lane C; population
   DERIVED 2026-08-30, **CLOSED v0.3.1124** — 3 releases, 14 readers, one behavioural gate)*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1131",
+      "version": "0.3.1132",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -442,8 +442,13 @@ print(f"  routes {len(PATHS)} · web source {len(BLOB):,} chars · uncalled by t
 #
 # `_STRICT` is what the rule said before `_templated_stem` existed. The difference must be exactly
 # the six whose call sites were read, one line at a time, in `_templated_stem`'s docstring.
+#: Stripped ONCE. The first draft called `strip_comments(BLOB)` inside the comprehension below, so a
+#: 3.9 MB blob was re-stripped per candidate route — 943 times — and this gate became the slowest in
+#: the suite at 72 s. One variable also guarantees all four checks below compare against the same
+#: text as `uncalled_routes` did, which a repeated call only happens to do.
+_CODE = strip_comments(BLOB)
 _STRICT = {r for r in PATHS
-           if len(_leaf(r)) >= MIN_SEGMENT and _leaf(r) not in strip_comments(BLOB)}
+           if len(_leaf(r)) >= MIN_SEGMENT and _leaf(r) not in _CODE}
 _GAINED = sorted(_STRICT - FOUND)
 _STEM_GAIN = [
     "/projects/{pid}/exports/cobie.xlsx", "/projects/{pid}/exports/qto.xlsx",
@@ -460,7 +465,7 @@ check("the two leniencies together vouch for EXACTLY the eight routes whose call
 #: above still passes while both instruments are wrong.
 _BY_PATTERN = sorted(r for r in _GAINED
                      if r not in CALLED_VIA_TEMPLATED_EXT
-                     and (_p := _templated_stem(r)) is not None and _p.search(strip_comments(BLOB)))
+                     and (_p := _templated_stem(r)) is not None and _p.search(_CODE))
 check("  ...six of them through the STEM pattern, and the other two only through the named list",
       _BY_PATTERN == sorted(_STEM_GAIN),
       f"the pattern accounts for {_BY_PATTERN}, expected {sorted(_STEM_GAIN)}")
@@ -469,7 +474,7 @@ check("  ...six of them through the STEM pattern, and the other two only through
 #: an allowlist asserting the OPPOSITE polarity — "this IS called" — needs the mirror of it, or it
 #: outlives its caller exactly the way the six frozen entries outlived theirs. Each entry names the
 #: call-site text that makes it true, and that text must still be in the source.
-_stale = sorted(r for r, ev in CALLED_VIA_TEMPLATED_EXT.items() if ev not in strip_comments(BLOB))
+_stale = sorted(r for r, ev in CALLED_VIA_TEMPLATED_EXT.items() if ev not in _CODE)
 check("  ...and every named entry's CALL SITE is still there — this list can rot too",
       not _stale,
       f"no longer called: {_stale} — the evidence string is gone, so either the caller moved (update "

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -154,12 +154,21 @@ KNOWN_UNCALLED: set[str] = {
     #   EXPORT / DOWNLOAD ENDPOINTS — a user reaches these by clicking a link the server builds, so
     #   "no client caller" is expected. Listed rather than excluded by pattern: a download nobody
     #   links to is still unreachable, and only a person can tell the two apart.
-    "/projects/{pid}/exports/cobie.xlsx", "/projects/{pid}/exports/qto.xlsx",
-    "/projects/{pid}/exports/schedule.xlsx", "/projects/{pid}/exports/spaces.xlsx",
-    "/projects/{pid}/estimate/gaeb.x83", "/projects/{pid}/model/export.jsonld",
-    "/projects/{pid}/model/export.parquet", "/projects/{pid}/modules/{key}/log.pdf",
+    # `/exports/{cobie,qto,schedule,spaces}.xlsx` were frozen HERE and are now seen as called
+    # (v0.3.1132). They never lacked a caller: `viewer/tools/exportsSection.ts:57` opens
+    # `/projects/${projectId}/exports/${file}.xlsx` over a literal four-entry list. The leaf rule
+    # could not see it because the STEM is templated, which is the one shape the header's
+    # template-literal argument did not cover. Recorded rather than silently deleted: four entries
+    # under a heading that says "no client caller is expected" were four false claims, and the
+    # heading is what made them look considered.
+    # `/model/export.{jsonld,parquet}` left this list in v0.3.1132 — `standards.ts:488-489` links
+    # both. They moved to `CALLED_VIA_TEMPLATED_EXT`, which carries their call-site evidence and
+    # asserts it still exists.
+    "/projects/{pid}/estimate/gaeb.x83", "/projects/{pid}/modules/{key}/log.pdf",
     "/projects/{pid}/cost/lien-waiver.pdf", "/projects/{pid}/opendata/permits.geojson",
-    "/projects/{pid}/schedule/gantt.svg", "/projects/{pid}/schedule/lob.svg",
+    # `/schedule/{gantt,lob}.svg` left here in v0.3.1132 for the same reason: `api/schedule.ts:193-4`
+    # builds `/projects/${pid}/schedule/${kind}.svg`, and `portal/panels/schedule.ts:731` enumerates
+    # both kinds. Two call sites, one blind spot.
     #
     #   GENUINELY UNREACHED CAPABILITIES — these are the ones worth someone's attention, and the
     #   reason this exclusion was worth making. Each is a working engine behind a route the product
@@ -266,14 +275,91 @@ def strip_comments(src: str) -> str:
                       if not (line.lstrip().startswith("//") or line.lstrip().startswith("*")))
 
 
+#: Routes reached through a TEMPLATED EXTENSION — `<dir>/<stem>.${fmt}` — with the value verified at
+#: the call site that passes it. **Named, not matched, and that is the whole point.**
+#:
+#: `api/model.ts:185` builds `/projects/${pid}/model/export.${fmt}`, so a pattern that allowed a
+#: templated extension would vouch for every `model/export.*` route at once. Measured: it vouches for
+#: six, and only two of them are called. The other four are frozen below and each is frozen
+#: CORRECTLY, because **a signature that accepts a value is not a call site that passes one**:
+#:
+#:     model/export.ifcx    `modelExportUrl` is typed "csv" | "jsonld" | "parquet" — no caller passes it
+#:     drawings/sheet.dxf   `sheetPath` accepts "dxf"; its only caller `openSheet` is ("svg" | "pdf")
+#:     energy/export.gbxml  `energyExportUrl` HAS NO CALLER AT ALL — an unwired client method
+#:     energy/export.idf    (same method; both formats it offers are unreachable)
+#:
+#: So the extension case cannot be a pattern in either direction: matching it would call four
+#: unreachable routes reachable, and refusing it leaves two called routes frozen as callerless. A
+#: two-entry list whose evidence is asserted below is the honest instrument.
+#:
+#: `model/export.csv` is absent because it is not flagged at all — it shares its leaf with
+#: `/projects/{pid}/modules/{key}/export.csv`, which IS called literally. That is the shared-leaf
+#: coarseness `MIN_SEGMENT` documents, working in the forgiving direction for once.
+CALLED_VIA_TEMPLATED_EXT: dict[str, str] = {
+    #: route -> the call-site text that must still exist for this entry to be true
+    "/projects/{pid}/model/export.jsonld": 'modelExportUrl(pid, "jsonld")',
+    "/projects/{pid}/model/export.parquet": 'modelExportUrl(pid, "parquet")',
+}
+
+
+def _templated_stem(route: str) -> "re.Pattern[str] | None":
+    """`<parent>/${…}.<ext>` for a route whose leaf is a FILENAME — or None when that shape cannot apply.
+
+    The docstring at the top of this file already knew literal matching is unsound against a client
+    that builds URLs from template literals, and answered it with the last-static-segment rule. That
+    rule assumes the LAST segment is written out. Six routes are built with the last segment templated
+    too, so their leaf appears nowhere and they were frozen as callerless while the UI calls them:
+
+        exportsSection.ts:57   `/projects/${projectId}/exports/${file}.xlsx`   qto · cobie · spaces · schedule
+        api/schedule.ts:193-4  `/projects/${pid}/schedule/${kind}.svg`         gantt · lob
+
+    Both call sites enumerate their values as literals in the line above, so all six are genuinely
+    reachable. Checked by reading the enumeration, not by matching harder.
+
+    **DELIBERATELY THE STEM ONLY, NEVER THE EXTENSION — and there is a live counterexample.**
+    `sheetSpecs.ts:149` builds `/projects/${pid}/drawings/sheet.${fmt}` with `fmt: "svg" | "pdf" |
+    "dxf"`, so an extension-templating rule would vouch for `/projects/{pid}/drawings/sheet.dxf`.
+    Its only caller is `openSheet`, typed `(fmt: "svg" | "pdf")` — **nothing ever passes "dxf"**.
+    That route is correctly frozen, and it is the reason this leniency stops where it does: a
+    signature that ACCEPTS a value is not a call site that PASSES one.
+
+    The parent segment must still match literally, so this cannot drift toward the 40% noise the
+    header rejects: it widens only for a filename leaf, and only inside the route's own directory.
+    Measured: dropping that anchor vouches for **six** further routes, none of which is called.
+
+    **THIS IS NOT THE MATCHER-SHARPENING THIS FILE HAS REJECTED TWICE.** That proposal went the other
+    way — replace the substring test with `/leaf`, which was measured at 81 -> 124 frozen, 43 newly
+    unreachable, and turned down again during ASSET-VERIFY. This is a narrow *widening* on one shape,
+    bounded by a differential below that names every route it vouches for. The two are opposite
+    changes to the same rule and the earlier decision does not speak to this one.
+    """
+    segs = [s for s in route.strip("/").split("/") if not s.startswith("{")]
+    if len(segs) < 2 or "." not in segs[-1]:
+        return None
+    stem, _, ext = segs[-1].rpartition(".")
+    if not stem or not ext:
+        return None
+    return re.compile(rf"{re.escape(segs[-2])}/\$\{{[^}}]*\}}\.{re.escape(ext)}")
+
+
 def uncalled_routes(paths, blob: str) -> set[str]:
-    """Routes whose distinctive last static segment appears nowhere in the web source's CODE."""
+    """Routes whose distinctive last static segment appears nowhere in the web source's CODE.
+
+    A filename leaf may also be reached through a templated stem — see `_templated_stem`, which
+    carries the evidence and the counterexample that bounds it.
+    """
     code = strip_comments(blob)
     out = set()
     for r in paths:
         leaf = _leaf(r)
-        if len(leaf) >= MIN_SEGMENT and leaf not in code:
-            out.add(r)
+        if len(leaf) < MIN_SEGMENT or leaf in code:
+            continue
+        if r in CALLED_VIA_TEMPLATED_EXT:
+            continue
+        pat = _templated_stem(r)
+        if pat is not None and pat.search(code):
+            continue
+        out.add(r)
     return out
 
 
@@ -346,6 +432,62 @@ check("  and the exclusion is LOAD-BEARING: including them would vouch for route
 print(f"  generated-types exclusion worth {len(FOUND) - len(_with_generated)} routes "
       f"({len(FOUND)} uncalled, {len(_with_generated)} if the generated types were counted)")
 print(f"  routes {len(PATHS)} · web source {len(BLOB):,} chars · uncalled by this rule {len(FOUND)}")
+
+# --- the templated-stem leniency is PINNED, because it moves the number the wrong way ------------
+#
+# Every other correction in this file made the gate stricter. This one makes it more permissive, and
+# the block above says why that is the dangerous direction: a change that lowers the uncalled count
+# is rewarded by the ratchet and therefore not investigated. So the leniency is not trusted to be
+# small — it is measured, and the routes it vouches for are named.
+#
+# `_STRICT` is what the rule said before `_templated_stem` existed. The difference must be exactly
+# the six whose call sites were read, one line at a time, in `_templated_stem`'s docstring.
+_STRICT = {r for r in PATHS
+           if len(_leaf(r)) >= MIN_SEGMENT and _leaf(r) not in strip_comments(BLOB)}
+_GAINED = sorted(_STRICT - FOUND)
+_STEM_GAIN = [
+    "/projects/{pid}/exports/cobie.xlsx", "/projects/{pid}/exports/qto.xlsx",
+    "/projects/{pid}/exports/schedule.xlsx", "/projects/{pid}/exports/spaces.xlsx",
+    "/projects/{pid}/schedule/gantt.svg", "/projects/{pid}/schedule/lob.svg",
+]
+check("the two leniencies together vouch for EXACTLY the eight routes whose callers were read",
+      _GAINED == sorted(_STEM_GAIN + list(CALLED_VIA_TEMPLATED_EXT)),
+      f"gained {_GAINED}, expected {sorted(_STEM_GAIN + list(CALLED_VIA_TEMPLATED_EXT))} — a NINTH "
+      f"route is not a smaller number, it is a route nobody has looked at being called reachable")
+
+#: ATTRIBUTED, because two mechanisms summing to the right total is not the same as each being right.
+#: The pattern must account for the six and the named list for the two; swap them and the aggregate
+#: above still passes while both instruments are wrong.
+_BY_PATTERN = sorted(r for r in _GAINED
+                     if r not in CALLED_VIA_TEMPLATED_EXT
+                     and (_p := _templated_stem(r)) is not None and _p.search(strip_comments(BLOB)))
+check("  ...six of them through the STEM pattern, and the other two only through the named list",
+      _BY_PATTERN == sorted(_STEM_GAIN),
+      f"the pattern accounts for {_BY_PATTERN}, expected {sorted(_STEM_GAIN)}")
+
+#: THE NAMED LIST'S OWN ROT CHECK. `KNOWN_UNCALLED` has one (a frozen route must still exist);
+#: an allowlist asserting the OPPOSITE polarity — "this IS called" — needs the mirror of it, or it
+#: outlives its caller exactly the way the six frozen entries outlived theirs. Each entry names the
+#: call-site text that makes it true, and that text must still be in the source.
+_stale = sorted(r for r, ev in CALLED_VIA_TEMPLATED_EXT.items() if ev not in strip_comments(BLOB))
+check("  ...and every named entry's CALL SITE is still there — this list can rot too",
+      not _stale,
+      f"no longer called: {_stale} — the evidence string is gone, so either the caller moved (update "
+      f"the evidence) or the route is genuinely uncalled now (move it to KNOWN_UNCALLED)")
+
+#: THE COUNTEREXAMPLE, AS AN ASSERTION RATHER THAN A SENTENCE.
+#: `sheetSpecs.ts:149` builds `/projects/${pid}/drawings/sheet.${fmt}` and its type admits "dxf", so
+#: a leniency that also allowed a templated EXTENSION would call this route reachable. Its only
+#: caller `openSheet` is typed `(fmt: "svg" | "pdf")` and never passes "dxf". **A signature that
+#: accepts a value is not a call site that passes one** — which is exactly the confusion the six
+#: above were the other half of, and the reason this rule stops at the stem.
+check("  ...and NOT for sheet.dxf, whose EXTENSION is templated but whose caller never passes 'dxf'",
+      "/projects/{pid}/drawings/sheet.dxf" in FOUND,
+      "sheet.dxf is being read as called — the leniency has reached the extension, and the route it "
+      "now vouches for has no caller. Narrow it back to the stem.")
+print(f"  templated-URL leniencies worth {len(_STRICT) - len(FOUND)} routes "
+      f"({len(_BY_PATTERN)} by the stem pattern, {len(CALLED_VIA_TEMPLATED_EXT)} named; "
+      f"{len(_STRICT)} uncalled under the literal-leaf rule alone)")
 
 new = sorted(FOUND - KNOWN_UNCALLED)
 check("NO NEW UNREACHABLE ROUTE — a route the product cannot call is a feature nobody can use",


### PR DESCRIPTION
# What & why

`ROUTE-INTERP`. `test_route_reachability` flags a route when its **last static segment** appears nowhere in the web source. The file's header already knew literal matching is unsound against a client that builds URLs from template literals — that is *why* the rule is the last segment. **It assumes the last segment is written out.**

Eight routes template it too, so their leaf appears nowhere, and every one was frozen in `KNOWN_UNCALLED` as deliberately callerless. Each is listed as *URL built at → value passed at*, because the second is the evidence of reachability and the first alone is not:

| route | URL built at | value passed at |
|---|---|---|
| `/exports/{cobie,qto,schedule,spaces}.xlsx` | `viewer/tools/exportsSection.ts:57` | the four-entry list on line 54 |
| `/schedule/{gantt,lob}.svg` | `api/schedule.ts:193-4` | `portal/panels/schedule.ts:731` |
| `/model/export.{jsonld,parquet}` | `api/model.ts:185` | `portal/panels/standards.ts:488-489` |

The list's own contract is that *"a frozen route that gains a caller must leave"*. These never lacked one. Four sat under a heading reading *"a user reaches these by clicking a link the server builds, so no client caller is expected"* — **which is what made them look considered.**

## Two mechanisms, because one shape decides and the other cannot

**Templated stem** (`` `exports/${file}.xlsx` ``) is a **pattern**: parent segment and extension must still match literally. Dropping the parent anchor *would* vouch for six further routes nothing calls — measured as a mutation, not shipped behaviour.

**Templated extension** (`` `model/export.${fmt}` ``) is a **two-entry named list with its call site recorded**, because as a pattern it is wrong in *both* directions — it vouches for six `export.*` routes of which only two are called. The four that stay frozen each say the same thing, and it is the finding worth keeping: **a signature that ACCEPTS a value is not a call site that PASSES one.**

| route | why it stays frozen |
|---|---|
| `/model/export.ifcx` | `modelExportUrl` is typed `"csv" \| "jsonld" \| "parquet"` |
| `/drawings/sheet.dxf` | `sheetPath` accepts `"dxf"`; its only caller `openSheet` is `("svg" \| "pdf")` |
| `/energy/export.{gbxml,idf}` | **`energyExportUrl` has no caller at all** — an unwired client method |

That last row is a **new finding this release does not fix**. Recorded in the roadmap rather than bundled in here.

## The leniency is pinned, because it moves the number the *rewarded* way

Every previous correction to this file made the gate stricter. This one makes it more permissive, and the file's own generated-types comment says that is the direction nobody investigates. So it is not trusted to be small:

- measured against the pre-change rule, with **every route it vouches for named**;
- **attributed per mechanism** — six by pattern, two by list. Swapping them keeps the total right and fails the attribution;
- the named list gets the mirror of `KNOWN_UNCALLED`'s rot check. An allowlist asserting *"this IS called"* outlives its caller exactly the way these eight outlived nothing.

**Five mutations, all failing, all restored:** leniency off (the six resurface) · extension-templating allowed (`sheet.dxf` + 3 more vouched for) · parent anchor dropped (six more) · an evidence string broken (rot check fires) · a stem route moved into the named list (attribution fires).

**This is not the matcher-sharpening this file has rejected twice.** That proposal went the other way — `/leaf` instead of substring, measured at 81 → 124 frozen, 43 newly unreachable. Opposite change to the same rule.

Uncalled by the rule: **81 → 73** — the strict baseline is 81 and the two leniencies remove eight.

## Three wrong turns, all in the same direction

None was caught by refining the pattern:

1. a leaf-grep of the **web source alone** — but the category's claim is a link the *server* builds, so that was the wrong corpus;
2. adding the server, a bare-leaf grep read `Content-Disposition` filenames and zip member names as links;
3. a full-path grep said 18/21 unlinked — wrong, because the URL is templated.

Reading `exportsSection.ts` and `standards.ts` is what corrected each one. *A completeness verdict computed over a pattern is confident and unfounded; the call site decides.*

## From review

All three CodeRabbit findings addressed in `94813662`, one of them a real factual error (the count was `81 → 75`; it is `73` — 75 was the six-route number, carried forward when the release grew to eight and never re-measured).

Its **nitpick was the most valuable comment on the PR**: `strip_comments(BLOB)` sat inside the `_STRICT` set comprehension, re-stripping a 3.9 MB blob once per candidate route — 943 times — making this the slowest gate in the 659-suite run. Fixed in `1110b70f`, **70.4s → 8.9s**, behaviour unchanged and the new pins still fail under mutation. The correctness half matters more than the speed: all four checks now compare against the same stripped text, which repeated calls only happened to do.

## ⛔ Blocked on a release tag, not on this diff

`API test gate` is red, **658/659**, and the one failure is `test_release_current`: *"v0.3.1132 is bumped but v0.3.1121 is the newest TAG — 11 versions have been merged and never released… Tag the release rather than raising this bound"*. Reproduced identically locally, so not a flake.

Not fixed here on purpose: the remedy is a `v*` tag, which triggers `desktop.yml` to cut a GitHub Release and upload the binaries the auto-updater serves to users. That is a publish and the owner's call; raising the bound would be switching off the check that noticed. Raised with them — see the comment thread.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `python -m ruff check src/ ../data/src/` clean
- [x] Backend: full suite **658/659** locally and in CI, the single failure being the release-tag gate above
- [x] Web: typecheck clean; `eslint --max-warnings=0` clean; full suite **2048 tests / 201 files**
- [x] No import cycles introduced — the change is one test file plus docs
- [x] `CHANGELOG.md` entry added (newest at top); roadmap entry closed ✅ under Band 2
- [x] Version bumped in `apps/web/package.json`, `apps/web/src-tauri/tauri.conf.json` **and** `package-lock.json` → 0.3.1132
- [x] No secrets, no competitor names in shipped docs

**Deliberately not in this PR:** wiring `energyExportUrl`; and the larger disagreement it exposed — Band 2 names three remaining "built but unreachable" items while the gate freezes **73** routes, 38 under no category at all and 7 explicitly labelled *"worth someone's attention"*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved route reachability detection for templated URLs and extensions.
  * Eight previously flagged routes are now correctly recognized as reachable.
* **Bug Fixes**
  * Preserved accurate detection for routes without verified client call sites.
  * Reduced false or stale route evidence.
* **Documentation**
  * Updated the changelog and roadmap with route analysis details and clarified hypothetical behavior.
* **Release**
  * Updated the application version to 0.3.1132.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->