### PR TITLE
v0.3.1133 — the debug hook shipped the renderer, and energy export had no click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## v0.3.1133 (2026-09-01) — the debug hook shipped the renderer, and energy export had no click
+
+Two leftovers from looking at what a user can actually reach.
+
+**The preview-eval hook was a production API.** `window.__viewer` assigned the Fragments
+loader, THREE, `openFile` and the renderer on every session, including shipped builds. The
+Cost/Deal rooms and drawings only need `selectByGuid` / `selectByGuids`. Those two stay;
+everything else is DEV-only. `__takeoff` — a click driver with no product caller — no longer
+attaches in production at all. Gated in `apps/web/src/viewer/debugHook.ts` and asserted both
+ways (prod keys only; DEV keeps the live-verification surface).
+
+**`energyExportUrl` had no caller.** Both `/energy/export.{gbxml,idf}` writers were live, tested,
+and frozen as deliberately unreachable because a client method that accepts a format is not a
+click that passes one. Exports now has those two buttons; the routes moved from
+`KNOWN_UNCALLED` into `CALLED_VIA_TEMPLATED_EXT` with the call-site text as evidence. The
+simplified `/exports/model.gbxml` button is unchanged — different engine, still labelled as
+building-level.
+
+Uncalled by the leaf rule: **73 → 71**. `test_groups` now picks the array by its source
+GlobalId rather than "any array". The live-audit compare fixture dropped the deleted classic
+shell as a run label.
+
 ## v0.3.1132 (2026-08-31) — eight routes frozen as callerless while the UI called them
 
 `ROUTE-INTERP`. `test_route_reachability` flags a route when its **last static segment** appears

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aec/web",
-    "version": "0.3.1132",
+    "version": "0.3.1133",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Massing",
-  "version": "0.3.1132",
+  "version": "0.3.1133",
   "identifier": "com.ibuilder.aecbim",
   "build": {
     "frontendDist": "../dist",

--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -301,7 +301,7 @@ const UNCALLED: readonly string[] = [
   "createType", "decisionGate",
   "docGraph", "draftPost", "drawingSchedulesCalc", "drawingSetPlan",
   "drawingsSyncStatus", "ebcPathways", "editType", "elements5dMap",
-  "energyExportUrl", "energyModel", "equipmentSpecCheck",
+  "energyModel", "equipmentSpecCheck",
   "expandMacro", "feasibilityLotSupply", "feasibilitySellout", "holdSell",
   "importFamilyPack", "layoutVerify", "listMacros", "listingReso",
   "liveStream", "loanCovenants", "massingOptionRecipes", "mcpTools",

--- a/apps/web/src/dev/liveAudit.test.ts
+++ b/apps/web/src/dev/liveAudit.test.ts
@@ -257,31 +257,31 @@ describe("compareRuns — the gate on any change to the shell", () => {
   const rep = (_label: string, panes: Array<[string, "ok" | "empty" | "slow"]>) =>
     summarise(panes.map(([id, verdict]) => ({ id, verdict, chars: 0, controls: 0, detail: "" })));
 
-  it("a pane that renders in classic and not under the spine is a REGRESSION", () => {
-    const d = compareRuns(rep("classic", [["ws:Cost", "ok"]]), rep("spine", [["ws:Cost", "empty"]]));
+  it("a pane that rendered before and not after is a REGRESSION", () => {
+    const d = compareRuns(rep("before", [["ws:Cost", "ok"]]), rep("after", [["ws:Cost", "empty"]]));
     expect(d.regressions).toEqual(["ws:Cost"]);
     expect(d.gains).toEqual([]);
   });
   it("`slow` is a pass on both sides, so a slower-but-rendering pane is not a regression", () => {
-    const d = compareRuns(rep("classic", [["ws:Model", "ok"]]), rep("spine", [["ws:Model", "slow"]]));
+    const d = compareRuns(rep("before", [["ws:Model", "ok"]]), rep("after", [["ws:Model", "slow"]]));
     expect(d.regressions).toEqual([]);
     expect(d.same).toBe(1);
   });
-  it("a pane fixed by the new shell is a gain, not silence", () => {
-    const d = compareRuns(rep("classic", [["ws:Field", "empty"]]), rep("spine", [["ws:Field", "ok"]]));
+  it("a pane fixed by the later run is a gain, not silence", () => {
+    const d = compareRuns(rep("before", [["ws:Field", "empty"]]), rep("after", [["ws:Field", "ok"]]));
     expect(d.gains).toEqual(["ws:Field"]);
   });
   it("a pane present in only one run is INCOMPARABLE, never a regression", () => {
     // The two runs may have walked different tab sets; calling that a defect would block a release
     // on a measurement artifact rather than on a real one.
-    const d = compareRuns(rep("classic", [["ws:Only", "ok"]]), rep("spine", [["ws:Other", "ok"]]));
+    const d = compareRuns(rep("before", [["ws:Only", "ok"]]), rep("after", [["ws:Other", "ok"]]));
     expect(d.regressions).toEqual([]);
     expect(d.incomparable).toEqual(["ws:Only", "ws:Other"]);
     expect(d.same).toBe(0);
   });
   it("identical runs report no regressions and no gains", () => {
-    const d = compareRuns(rep("classic", [["a", "ok"], ["b", "ok"]]),
-                            rep("spine", [["a", "ok"], ["b", "ok"]]));
+    const d = compareRuns(rep("before", [["a", "ok"], ["b", "ok"]]),
+                            rep("after", [["a", "ok"], ["b", "ok"]]));
     expect(d).toMatchObject({ regressions: [], gains: [], incomparable: [], same: 2 });
   });
 });

--- a/apps/web/src/drawings/pdfTakeoff.ts
+++ b/apps/web/src/drawings/pdfTakeoff.ts
@@ -11,6 +11,7 @@ import workerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 import { toast } from "../ui/feedback";
 import { askText } from "../ui/prompt";
 import { countOnRgba } from "../ui/symbolCount";
+import { installTakeoffHook } from "../viewer/debugHook";
 import { documentWords, locatePassage, paintCiteBox } from "./citeLocate";
 
 // PDF-ADOPT slice 1 of 3: opening and page access now go through the vendored drawing-review engine
@@ -456,14 +457,14 @@ export async function openPdfTakeoff(source?: PdfSource, opts: TakeoffOpts = {})
   }
   // fit width on first open
   const avail = viewport.clientWidth - 40; if (canvas.width > avail) setScale(scale * (avail / canvas.width));
-  // test hook (mirrors __viewer): drive modes/clicks/commit from preview_eval
-  (window as unknown as Record<string, unknown>).__takeoff = {
+  // Preview-eval driver. Production builds do not attach it — see `installTakeoffHook`.
+  installTakeoffHook({
     setMode, click: async (xPdf: number, yPdf: number) => { draft.push({ x: xPdf, y: yPdf }); if (mode === "count") { await commit(); draft = []; } else if (mode === "calibrate" && draft.length === 2) await calibrate(); else if (mode === "rect" && draft.length === 2) await commit(); else if (mode === "symbol" && draft.length === 2) await matchSymbols(); drawOverlay(); },
     commit, measures, calibrated: () => calOk(), exportPdf, saveSet,
     placeText: (t: string, x: number, y: number) => { measures.push({ id: ++seq, kind: "text", pts: [{ x, y }], value: 0, unit: "", label: t, page: pageNum, text: t }); drawOverlay(); renderList(); },
     placeStamp: async (tpl: string, x: number, y: number) => { const t = await resolveStamp(tpl); measures.push({ id: ++seq, kind: "stamp", pts: [{ x, y }], value: 0, unit: "", label: t, page: pageNum, text: t }); drawOverlay(); renderList(); },
     close: () => ov.remove(),
-  };
+  });
 }
 
 function pickPdf(): Promise<File | null> {

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -17,6 +17,7 @@ import {
 import { canAcceptDraftDrag, dropCompletion, readDraftDragKey } from "./railDrag";
 import { parseDynConstraint } from "./dynInput";
 import { mountCadBar } from "./cadBar";
+import { installViewerHook } from "./debugHook";
 import { ModelLoader } from "./loader";
 import { loadProjectModel as loadProjectModelImpl } from "./loadProjectModel";
 import { buildAnnotationSection } from "./tools/annotationSection";
@@ -2501,8 +2502,9 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     }
   }
 
-  // debug hook for automated/preview testing
-  (window as unknown as Record<string, unknown>).__viewer = { viewer, loader, fitToModels, selectByGuid, selectByGuids, openFile, referenceModels, THREE };
+  // Selection hook for Cost/Deal/drawings. Extra preview-eval fields (THREE, loader, openFile)
+  // stay DEV-only — see `debugHook.ts`.
+  installViewerHook({ viewer, loader, fitToModels, selectByGuid, selectByGuids, openFile, referenceModels, THREE });
 
   // ---- self-initialise: load the project model + build panels --------------
   void (async () => {

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -17,8 +17,7 @@ import {
 import { canAcceptDraftDrag, dropCompletion, readDraftDragKey } from "./railDrag";
 import { parseDynConstraint } from "./dynInput";
 import { mountCadBar } from "./cadBar";
-import { installViewerHook } from "./debugHook";
-import { ModelLoader } from "./loader";
+import { installViewerHook } from "./debugHook"; import { ModelLoader } from "./loader";
 import { loadProjectModel as loadProjectModelImpl } from "./loadProjectModel";
 import { buildAnnotationSection } from "./tools/annotationSection";
 import { buildContentLibrarySection } from "./tools/contentLibrarySection";
@@ -2502,8 +2501,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     }
   }
 
-  // Selection hook for Cost/Deal/drawings. Extra preview-eval fields (THREE, loader, openFile)
-  // stay DEV-only — see `debugHook.ts`.
+  // Selection hook: prod is GlobalId only; DEV keeps preview-eval fields (debugHook.ts).
   installViewerHook({ viewer, loader, fitToModels, selectByGuid, selectByGuids, openFile, referenceModels, THREE });
 
   // ---- self-initialise: load the project model + build panels --------------

--- a/apps/web/src/viewer/debugHook.test.ts
+++ b/apps/web/src/viewer/debugHook.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  VIEWER_HOOK_DEV_KEYS,
+  VIEWER_HOOK_PROD_KEYS,
+  installTakeoffHook,
+  installViewerHook,
+} from "./debugHook";
+
+type Hooks = { __viewer?: Record<string, unknown>; __takeoff?: unknown };
+
+const win = () => window as unknown as Hooks;
+
+afterEach(() => {
+  delete win().__viewer;
+  delete win().__takeoff;
+});
+
+describe("viewer debug hook — production is selection only", () => {
+  it("exposes GlobalId selection and nothing else when not in DEV", () => {
+    const selectByGuid = vi.fn();
+    const selectByGuids = vi.fn();
+    installViewerHook({
+      selectByGuid,
+      selectByGuids,
+      viewer: { world: true },
+      loader: { load: true },
+      THREE: { WebGLRenderer: true },
+      openFile: vi.fn(),
+      fitToModels: vi.fn(),
+      referenceModels: [],
+    }, { dev: false });
+
+    const hook = win().__viewer!;
+    expect(Object.keys(hook).sort()).toEqual([...VIEWER_HOOK_PROD_KEYS].sort());
+    expect(hook.viewer).toBeUndefined();
+    expect(hook.loader).toBeUndefined();
+    expect(hook.THREE).toBeUndefined();
+    expect(hook.openFile).toBeUndefined();
+
+    (hook.selectByGuid as (g: string, fit?: boolean) => void)("1kP9xAbCdEf7Qa", true);
+    expect(selectByGuid).toHaveBeenCalledWith("1kP9xAbCdEf7Qa", true);
+  });
+
+  it("keeps the preview-eval surface in DEV so live verification still works", () => {
+    const selectByGuid = vi.fn();
+    const selectByGuids = vi.fn();
+    const THREE = { REVISION: "test" };
+    installViewerHook({
+      selectByGuid,
+      selectByGuids,
+      viewer: { id: "v" },
+      loader: { id: "l" },
+      THREE,
+      openFile: vi.fn(),
+      fitToModels: vi.fn(),
+      referenceModels: [{ id: "r" }],
+    }, { dev: true });
+
+    const hook = win().__viewer!;
+    expect(Object.keys(hook).sort()).toEqual([...VIEWER_HOOK_DEV_KEYS].sort());
+    expect(hook.THREE).toBe(THREE);
+    expect(hook.viewer).toEqual({ id: "v" });
+  });
+
+  it("does not invent DEV fields the caller never passed", () => {
+    installViewerHook({
+      selectByGuid: vi.fn(),
+      selectByGuids: vi.fn(),
+    }, { dev: true });
+    const hook = win().__viewer!;
+    expect(Object.keys(hook).sort()).toEqual([...VIEWER_HOOK_PROD_KEYS].sort());
+    expect("THREE" in hook).toBe(false);
+  });
+});
+
+describe("takeoff debug hook — production has no driver", () => {
+  it("does not attach __takeoff when not in DEV", () => {
+    installTakeoffHook({ click: vi.fn() }, { dev: false });
+    expect(win().__takeoff).toBeUndefined();
+  });
+
+  it("clears a leftover DEV hook when production install runs", () => {
+    win().__takeoff = { stale: true };
+    installTakeoffHook({ click: vi.fn() }, { dev: false });
+    expect(win().__takeoff).toBeUndefined();
+  });
+
+  it("attaches the driver in DEV", () => {
+    const click = vi.fn();
+    installTakeoffHook({ click }, { dev: true });
+    expect(win().__takeoff).toEqual({ click });
+  });
+});

--- a/apps/web/src/viewer/debugHook.ts
+++ b/apps/web/src/viewer/debugHook.ts
@@ -1,0 +1,70 @@
+/**
+ * The viewer used to dump the renderer, the Fragments loader, THREE, and `openFile` onto
+ * `window.__viewer` for automated preview tests. That assignment is unconditional, so a production
+ * build shipped the same surface a debugger uses.
+ *
+ * Production callers (`sheetGuid`, the Cost/Deal rooms) only need `selectByGuid` /
+ * `selectByGuids` — IFC GlobalId in, selection out. Everything else is a DEV affordance.
+ *
+ * `installTakeoffHook` is the same rule for `__takeoff`: a preview-eval driver, not a product API.
+ */
+
+export const VIEWER_HOOK_PROD_KEYS = ["selectByGuid", "selectByGuids"] as const;
+
+export const VIEWER_HOOK_DEV_KEYS = [
+  ...VIEWER_HOOK_PROD_KEYS,
+  "viewer",
+  "loader",
+  "fitToModels",
+  "openFile",
+  "referenceModels",
+  "THREE",
+] as const;
+
+export type ViewerHookProd = {
+  selectByGuid: (guid: string, fit?: boolean) => void;
+  selectByGuids: (guids: string[], fit?: boolean) => void | Promise<void>;
+};
+
+export type ViewerHookDev = ViewerHookProd & {
+  viewer?: unknown;
+  loader?: unknown;
+  fitToModels?: unknown;
+  openFile?: unknown;
+  referenceModels?: unknown;
+  THREE?: unknown;
+};
+
+type HookTarget = { __viewer?: unknown; __takeoff?: unknown };
+
+function isDev(explicit?: boolean): boolean {
+  return explicit ?? import.meta.env.DEV === true;
+}
+
+/** Attach the selection hook. Extra debug fields only land when `dev` is true. */
+export function installViewerHook(api: ViewerHookDev, opts: { dev?: boolean } = {}): void {
+  const hook: Record<string, unknown> = {
+    selectByGuid: api.selectByGuid,
+    selectByGuids: api.selectByGuids,
+  };
+  if (isDev(opts.dev)) {
+    for (const k of VIEWER_HOOK_DEV_KEYS) {
+      if (k === "selectByGuid" || k === "selectByGuids") continue;
+      if (k in api) hook[k] = api[k as keyof ViewerHookDev];
+    }
+  }
+  (window as unknown as HookTarget).__viewer = hook;
+}
+
+/** Preview-eval takeoff driver. Absent in production — there is no product caller. */
+export function installTakeoffHook(
+  api: Record<string, unknown>,
+  opts: { dev?: boolean } = {},
+): void {
+  const w = window as unknown as HookTarget;
+  if (!isDev(opts.dev)) {
+    delete w.__takeoff;
+    return;
+  }
+  w.__takeoff = api;
+}

--- a/apps/web/src/viewer/tools/exportsSection.test.ts
+++ b/apps/web/src/viewer/tools/exportsSection.test.ts
@@ -37,6 +37,8 @@ function harness(over: Partial<ExportsDeps> = {}) {
       structure: { element_volume_m3: 1450 },
     })),
     takeoff2d: vi.fn(async () => ({})),
+    energyExportUrl: (pid: string, fmt: "gbxml" | "idf") =>
+      `https://api.test/projects/${pid}/energy/export.${fmt}`,
   } as unknown as ApiClient;
 
   const deps: ExportsDeps = {
@@ -73,6 +75,7 @@ describe("R39-DECOMP-VIEWER ① — the Exports section, extracted", () => {
     const { host } = harness();
     const text = labels(host).join("\n");
     for (const expected of ["Quantity takeoff", "COBie", "Space schedule", "4D schedule", "gbXML",
+                            "Energy envelope", "EnergyPlus IDF",
                             "Discipline quantities", "Closeout package", "Export IFC",
                             ".glb", ".gltf", "2D takeoff"]) {
       expect(text, `missing "${expected}"`).toContain(expected);
@@ -125,16 +128,28 @@ describe("R39-DECOMP-VIEWER ① — the Exports section, extracted", () => {
   // section can be built while a project is open and clicked after it closes.
   it("refuses the project-dependent actions when there is no project, at click time", () => {
     const { host, notify } = harness({ projectId: null });
-    for (const needle of ["Discipline quantities", "2D takeoff"]) {
+    for (const needle of ["Discipline quantities", "2D takeoff", "Energy envelope", "EnergyPlus IDF"]) {
       [...host.querySelectorAll("button")].find((b) => b.textContent?.includes(needle))!.click();
     }
-    expect(notify).toHaveBeenCalledTimes(2);
+    expect(notify).toHaveBeenCalledTimes(4);
     expect(notify).toHaveBeenCalledWith("connect a project first", "error");
+  });
+
+  it("opens the energy envelope through energyExportUrl, not a hand-built path", () => {
+    const { host, opened } = harness();
+    for (const needle of ["Energy envelope", "EnergyPlus IDF"]) {
+      [...host.querySelectorAll("button")].find((b) => b.textContent?.includes(needle))!.click();
+    }
+    expect(opened).toEqual([
+      "https://api.test/projects/P-1/energy/export.gbxml",
+      "https://api.test/projects/P-1/energy/export.idf",
+    ]);
   });
 
   it("carries a tooltip on every export whose format is not self-evident", () => {
     const { host } = harness();
-    for (const needle of ["gbXML", "Closeout package", "Export IFC", ".glb", ".gltf", "2D takeoff"]) {
+    for (const needle of ["gbXML", "Energy envelope", "EnergyPlus IDF",
+                          "Closeout package", "Export IFC", ".glb", ".gltf", "2D takeoff"]) {
       const b = [...host.querySelectorAll("button")].find((x) => x.textContent?.includes(needle))!;
       expect(b.title, `"${needle}" has no tooltip`).toBeTruthy();
     }

--- a/apps/web/src/viewer/tools/exportsSection.ts
+++ b/apps/web/src/viewer/tools/exportsSection.ts
@@ -64,6 +64,25 @@ export function buildExportsSection(d: ExportsDeps): void {
     + "model (OpenStudio/EnergyPlus/IES). Simplified: building-level envelope, not per-space surfaces.";
   b.appendChild(gbx);
 
+  // ENERGY phase 1 — the thermal-model writers. Distinct from the simplified gbXML above:
+  // these serialize zones / surfaces / constructions from `energy_export`. The client method
+  // existed with no caller; both formats it offers were frozen as deliberately unreachable.
+  const envGbx = toolBtn2("↓ Energy envelope (gbXML)", () => {
+    if (!projectId) { notify("connect a project first", "error"); return; }
+    window.open(api.energyExportUrl(projectId, "gbxml"), "_blank");
+  });
+  envGbx.title = "Thermal envelope as gbXML — Campus / Building / Space / Surface + Construction "
+    + "from the IFC assemblies. Geometry and constructions only; no HVAC, schedules or loads.";
+  b.appendChild(envGbx);
+
+  const envIdf = toolBtn2("↓ EnergyPlus IDF", () => {
+    if (!projectId) { notify("connect a project first", "error"); return; }
+    window.open(api.energyExportUrl(projectId, "idf"), "_blank");
+  });
+  envIdf.title = "EnergyPlus IDF envelope — Building / Zone / Material / Construction / "
+    + "BuildingSurface:Detailed. Add HVAC, schedules and loads in the simulation setup.";
+  b.appendChild(envIdf);
+
   // discipline quantities — reinforcement tonnage, MEP linear runs, structural volume
   b.appendChild(toolBtn2("🔩 Discipline quantities", async () => {
     if (!projectId) { notify("connect a project first", "error"); return; }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -231,7 +231,7 @@ band are all closed and recorded in [`roadmap-completed.md`](roadmap-completed.m
 instances:
 
 - ✅ **ROUTE-INTERP — eight routes were frozen as callerless while the UI called them** *(S — Lane C;
-  **CLOSED v0.3.1132**)*
+  **CLOSED v0.3.1132**; energy half **SHIPPED v0.3.1133**)*
 
   `test_route_reachability` flags a route when its last static segment appears nowhere in the web
   source. Its header already knew literal matching is unsound against a client that builds URLs from
@@ -257,13 +257,14 @@ instances:
   the opposite direction. This one is pinned by a differential naming every route it vouches for,
   attributed per mechanism, plus the mirror of `KNOWN_UNCALLED`'s rot check on the named list.
 
-  **TWO THINGS IT LEAVES OPEN, both measured on the way through.** `energyExportUrl`
-  (`apps/web/src/api/client.ts`) **has no caller at all**, so both formats the energy exporter offers
-  are unreachable — an unwired client method of the R37-TESTED-UNWIRED kind. And this band names
-  three remaining items while the gate freezes **75** routes, 38 of them under no category at all and
-  7 explicitly labelled *"genuinely unreached capabilities … worth someone's attention"*. **The band
-  and the gate disagree about the size of the same class by an order of magnitude**, and nothing
-  makes them agree; deriving that population is a bigger item than this was.
+  **TWO THINGS IT LEAVES OPEN, both measured on the way through.** `energyExportUrl` was the
+  first: an unwired client method, both formats unreachable. **Wired v0.3.1133** — Exports now
+  passes `"gbxml"` and `"idf"`; the two routes moved from `KNOWN_UNCALLED` into
+  `CALLED_VIA_TEMPLATED_EXT`. The second remains: this band names three remaining items while the
+  gate freezes **71** routes, 38 of them under no category at all and 7 explicitly labelled
+  *"genuinely unreached capabilities … worth someone's attention"*. **The band and the gate
+  disagree about the size of the same class by an order of magnitude**, and nothing makes them
+  agree; deriving that population is a bigger item than this was.
 
 - ✅ ⭐ **REFUSAL-READERS — a record in a refused state still counts** *(M — Lane C; population
   DERIVED 2026-08-30, **CLOSED v0.3.1124** — 3 releases, 14 readers, one behavioural gate)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/web": {
       "name": "@aec/web",
-      "version": "0.3.1132",
+      "version": "0.3.1133",
       "dependencies": {
         "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/services/api/test_groups.py
+++ b/services/api/test_groups.py
@@ -56,7 +56,7 @@ assert len(m.by_type("IfcColumn")) == before + 5, (before, len(m.by_type("IfcCol
 # --- inspectors ----------------------------------------------------------------------------------
 lst = groups.list_groups(m)
 assert any(x["name"] == "West grid line" and x["members"] == 4 for x in lst["groups"]), lst["groups"]
-arr_g = next(x for x in lst["groups"] if x.get("array"))
+arr_g = next(x for x in lst["groups"] if x.get("array") and x["array"].get("source") == cols[3])
 assert arr_g["array"]["source"] == cols[3], arr_g
 assert arr_g["array"]["nx"] == 3 and arr_g["array"]["ny"] == 2, arr_g
 assert any(x["name"] == "Braced frame A" and x["parts"] == 2 for x in lst["assemblies"]), lst["assemblies"]

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -194,7 +194,8 @@ KNOWN_UNCALLED: set[str] = {
     # tool. Its entry is deleted rather than kept, which is this list's own contract working — the
     # freeze recorded "this was looked at", and a frozen route that gains a caller must leave.
     "/projects/{pid}/drawings/sheet.dxf",
-    "/projects/{pid}/energy/export.gbxml", "/projects/{pid}/energy/export.idf",
+    # `/energy/export.{gbxml,idf}` left here in v0.3.1133: `energyExportUrl` is now called from
+    # `exportsSection.ts` with both formats. They moved to `CALLED_VIA_TEMPLATED_EXT`.
     "/projects/{pid}/entitlements/condition-checks", "/projects/{pid}/ffe-bom",
     "/projects/{pid}/golden-thread", "/projects/{pid}/k1-pack",
     "/projects/{pid}/lod/handover-readiness", "/projects/{pid}/mep/pressure-loss",
@@ -285,12 +286,14 @@ def strip_comments(src: str) -> str:
 #:
 #:     model/export.ifcx    `modelExportUrl` is typed "csv" | "jsonld" | "parquet" — no caller passes it
 #:     drawings/sheet.dxf   `sheetPath` accepts "dxf"; its only caller `openSheet` is ("svg" | "pdf")
-#:     energy/export.gbxml  `energyExportUrl` HAS NO CALLER AT ALL — an unwired client method
-#:     energy/export.idf    (same method; both formats it offers are unreachable)
 #:
-#: So the extension case cannot be a pattern in either direction: matching it would call four
-#: unreachable routes reachable, and refusing it leaves two called routes frozen as callerless. A
-#: two-entry list whose evidence is asserted below is the honest instrument.
+#: `energy/export.{gbxml,idf}` LEFT this list in v0.3.1133 — `exportsSection.ts` now passes both
+#: formats through `energyExportUrl`. They sit in the named list below, same instrument as jsonld
+#: / parquet, because an extension pattern would still vouch for `model/export.ifcx`.
+#:
+#: So the extension case cannot be a pattern in either direction: matching it would call remaining
+#: unreachable `export.*` routes reachable, and refusing it leaves called routes frozen as
+#: callerless. A named list whose evidence is asserted below is the honest instrument.
 #:
 #: `model/export.csv` is absent because it is not flagged at all — it shares its leaf with
 #: `/projects/{pid}/modules/{key}/export.csv`, which IS called literally. That is the shared-leaf
@@ -299,6 +302,8 @@ CALLED_VIA_TEMPLATED_EXT: dict[str, str] = {
     #: route -> the call-site text that must still exist for this entry to be true
     "/projects/{pid}/model/export.jsonld": 'modelExportUrl(pid, "jsonld")',
     "/projects/{pid}/model/export.parquet": 'modelExportUrl(pid, "parquet")',
+    "/projects/{pid}/energy/export.gbxml": 'energyExportUrl(projectId, "gbxml")',
+    "/projects/{pid}/energy/export.idf": 'energyExportUrl(projectId, "idf")',
 }
 
 
@@ -455,10 +460,11 @@ _STEM_GAIN = [
     "/projects/{pid}/exports/schedule.xlsx", "/projects/{pid}/exports/spaces.xlsx",
     "/projects/{pid}/schedule/gantt.svg", "/projects/{pid}/schedule/lob.svg",
 ]
-check("the two leniencies together vouch for EXACTLY the eight routes whose callers were read",
+check("the two leniencies together vouch for EXACTLY the ten routes whose callers were read",
       _GAINED == sorted(_STEM_GAIN + list(CALLED_VIA_TEMPLATED_EXT)),
-      f"gained {_GAINED}, expected {sorted(_STEM_GAIN + list(CALLED_VIA_TEMPLATED_EXT))} — a NINTH "
-      f"route is not a smaller number, it is a route nobody has looked at being called reachable")
+      f"gained {_GAINED}, expected {sorted(_STEM_GAIN + list(CALLED_VIA_TEMPLATED_EXT))} — an "
+      f"ELEVENTH route is not a smaller number, it is a route nobody has looked at being called "
+      f"reachable")
 
 #: ATTRIBUTED, because two mechanisms summing to the right total is not the same as each being right.
 #: The pattern must account for the six and the named list for the two; swap them and the aggregate
@@ -466,7 +472,7 @@ check("the two leniencies together vouch for EXACTLY the eight routes whose call
 _BY_PATTERN = sorted(r for r in _GAINED
                      if r not in CALLED_VIA_TEMPLATED_EXT
                      and (_p := _templated_stem(r)) is not None and _p.search(_CODE))
-check("  ...six of them through the STEM pattern, and the other two only through the named list",
+check("  ...six of them through the STEM pattern, and the other four only through the named list",
       _BY_PATTERN == sorted(_STEM_GAIN),
       f"the pattern accounts for {_BY_PATTERN}, expected {sorted(_STEM_GAIN)}")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What & why

The preview-eval hook (`window.__viewer`) assigned the Fragments loader, THREE, `openFile` and the renderer on every session, including production builds. Cost/Deal/drawings only need IFC GlobalId selection. `__takeoff` is a click driver with no product caller.

Separately, `energyExportUrl` accepted `gbxml` | `idf` with no caller, so both live energy writers stayed frozen as deliberately unreachable.

## What changed

- Production `__viewer` is `selectByGuid` / `selectByGuids` only. Extra preview-eval fields stay DEV-only (`apps/web/src/viewer/debugHook.ts`).
- `__takeoff` no longer attaches in production.
- Exports adds Energy envelope (gbXML) and EnergyPlus IDF via `energyExportUrl`. The simplified `/exports/model.gbxml` button is unchanged.
- Those two routes moved from `KNOWN_UNCALLED` into `CALLED_VIA_TEMPLATED_EXT` (73 → 71 uncalled).
- `test_groups` selects the array by source GlobalId. Live-audit compare fixtures dropped the deleted classic-shell run label.
- `app.ts` stays on the 2,570-line extraction pin (the import must not grow it).

## Verified locally

- Web: typecheck, lint, vitest **2055/2055**, `npm run build` + `npm run build:desktop`
- Desktop shell: Rust 1.98 `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, `Cargo.lock --locked`
- API: full `run_tests.py` **657/659**. The two reds: `test_file_sizes` (fixed in 4959ff9e), `test_supply_chain_gate` (this VM’s user-site `pip install` pulled ansible/python-apt; not in CI’s hash-pinned tree)

## Checklist

- [x] Backend ruff + affected tests
- [x] Web typecheck / lint / full vitest / both production builds
- [x] Desktop Rust clippy + fmt + lock
- [x] CHANGELOG + version **0.3.1133**
- [x] No secrets / no competitor names

Not tagged until this is on `main` and CI is green. Tagging publishes a desktop Release (draft until published).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c51b94b1-7bc9-44e3-aaa6-af892b5692e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c51b94b1-7bc9-44e3-aaa6-af892b5692e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Energy envelope (gbXML) and EnergyPlus IDF download buttons to the Exports section.
  - Export buttons open generated download links and require an active project.

- **Security & Reliability**
  - Limited production diagnostic access to essential model-selection actions.
  - Removed takeoff debugging controls from production builds.

- **Documentation**
  - Updated release and roadmap information for the new energy export options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->