### PR TITLE
The templated-extension comment carried a count that had inverted

### DIFF
--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -505,10 +505,11 @@ check("  ...six of them through the STEM pattern, and the other four only throug
 #: sentence should have been. It is a ratchet with a stated direction: the list may grow as more
 #: templated-extension routes gain callers, and each addition must bring its own evidence string,
 #: which the staleness check below then holds to.
-check("the templated-extension list is the size its own documentation claims",
+check("the templated-extension list is exactly the four routes measured at their call sites",
       len(CALLED_VIA_TEMPLATED_EXT) == 4,
-      f"{len(CALLED_VIA_TEMPLATED_EXT)} entries — if a route gained a caller, update the block "
-      f"comment above the dict in the same commit rather than leaving it to be discovered")
+      f"{len(CALLED_VIA_TEMPLATED_EXT)} entries — THIS LINE is where the count lives, so change the "
+      f"4 here as part of adding or removing a route, and check the block comment above the dict "
+      f"still reads true. Editing only the comment cannot satisfy this assertion")
 
 _stale = sorted(r for r, ev in CALLED_VIA_TEMPLATED_EXT.items() if ev not in _CODE)
 check("  ...and every named entry's CALL SITE is still there — this list can rot too",

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -293,9 +293,16 @@ def strip_comments(src: str) -> str:
 #: the call site that passes it. **Named, not matched, and that is the whole point.**
 #:
 #: `api/model.ts:185` builds `/projects/${pid}/model/export.${fmt}`, so a pattern that allowed a
-#: templated extension would vouch for every `model/export.*` route at once. Measured: it vouches for
-#: six, and only two of them are called. The other four are frozen below and each is frozen
-#: CORRECTLY, because **a signature that accepts a value is not a call site that passes one**:
+#: templated extension would vouch for every `model/export.*` route at once — which is why this is a
+#: list and not a pattern.
+#:
+#: **THE COUNTS HERE ARE NOT WRITTEN DOWN, THEY ARE ASSERTED.** This sentence used to read "it
+#: vouches for six, and only two of them are called. The other four are frozen below" — and by
+#: v0.3.1143 that had inverted: four are called (the dict below) and two are frozen (the table
+#: below). Nothing caught it, because a count in a comment is not checked by anything. The route
+#: lists are pinned by the differential further down, so the numbers live there; the two entries
+#: below are named because they are the ones a reader needs, and each is frozen CORRECTLY, because
+#: **a signature that accepts a value is not a call site that passes one**:
 #:
 #:     model/export.ifcx    `modelExportUrl` is typed "csv" | "jsonld" | "parquet" — no caller passes it
 #:     drawings/sheet.dxf   `sheetPath` accepts "dxf"; its only caller `openSheet` is ("svg" | "pdf")
@@ -493,6 +500,16 @@ check("  ...six of them through the STEM pattern, and the other four only throug
 #: an allowlist asserting the OPPOSITE polarity — "this IS called" — needs the mirror of it, or it
 #: outlives its caller exactly the way the six frozen entries outlived theirs. Each entry names the
 #: call-site text that makes it true, and that text must still be in the source.
+#: The named list is a POPULATION, so its size is asserted rather than described. The comment above
+#: it carried a count for one release after that count stopped being true; this is the check that
+#: sentence should have been. It is a ratchet with a stated direction: the list may grow as more
+#: templated-extension routes gain callers, and each addition must bring its own evidence string,
+#: which the staleness check below then holds to.
+check("the templated-extension list is the size its own documentation claims",
+      len(CALLED_VIA_TEMPLATED_EXT) == 4,
+      f"{len(CALLED_VIA_TEMPLATED_EXT)} entries — if a route gained a caller, update the block "
+      f"comment above the dict in the same commit rather than leaving it to be discovered")
+
 _stale = sorted(r for r, ev in CALLED_VIA_TEMPLATED_EXT.items() if ev not in _CODE)
 check("  ...and every named entry's CALL SITE is still there — this list can rot too",
       not _stale,


### PR DESCRIPTION
# What & why

`CALLED_VIA_TEMPLATED_EXT`'s block comment in `test_route_reachability.py` said:

> Measured: it vouches for six, and only **two** of them are called. The other **four** are frozen below

By v0.3.1143 that had **inverted**. The dict holds **four** called routes — `model/export.jsonld`, `model/export.parquet`, and the two energy formats wired in v0.3.1133 — and the table beneath lists **two** frozen ones, `model/export.ifcx` and `drawings/sheet.dxf`.

Nothing caught it, and nothing could have: **a count in a comment is not checked by anything.** This file's entire thesis is that unverified prose drifts, and the prose describing its newest mechanism drifted within one release of that mechanism shipping.

## Two changes, and the second is the point

- **The sentence no longer carries the counts.** The route lists are already pinned by the differential further down, so that is where the numbers live. The two frozen entries stay named, because they are what a reader actually needs.
- **`len(CALLED_VIA_TEMPLATED_EXT) == 4` is now asserted**, with a failure message telling whoever grows the list to update the comment in the same commit. A ratchet with a stated direction: the list may grow as more templated-extension routes gain callers, and each addition must bring its own evidence string, which the existing staleness check then holds to.

## Credit where it's due

The v0.3.1133 edit that moved the energy pair was careful and correct — it added real call-site evidence strings (`energyExportUrl(projectId, "gbxml")` / `("idf")`) and updated the counterexample table so the two remaining frozen routes are right. It just left one sentence behind. That is exactly the shape this file keeps finding one level down, met one level up.

## Verification

- **Mutation:** adding a fifth entry fails **three** checks — the new size pin, the differential, and the staleness check (the invented evidence string isn't in the source).
- `ruff` clean. Full backend suite running; this will not be merged until it is green.

## ⚠️ No version bump, deliberately — and you should know why

`main` is at **v0.3.1143** with **v0.3.1133** the newest tag: **10 ahead of a bound of 10**, sitting exactly at the limit.

```
shipped v0.3.1143 · newest tag v0.3.1133 · 10 ahead (bound 10)
```

Bumping to 1144 would make it 11 and re-break `test_release_current`, so this comment-and-assertion fix ships without one. **The next release of any size will fail that gate until v0.3.1143 is tagged.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated route reachability assertion messaging to clearly identify the expected templated-route count as the source of truth.
  - Improved failure guidance to indicate that both the count and related documentation must be updated when the route list changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->