### PR TITLE
The dependency scan's blocking gates could not block a merge, and a stale comment is why

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,19 @@
 name: Dependency scan
 
-# Report-only supply-chain scan (pip-audit + npm audit). Non-blocking by design — it surfaces
-# known CVEs in the job summary without failing the merge gate (ci.yml stays the hard gate).
-# Runs weekly and on dependency-manifest changes.
+# Supply-chain scan (pip-audit + npm audit + bandit + gitleaks). Each tool appears TWICE: a
+# report-only step that surfaces everything into the job summary, and a BLOCKING gate over the
+# subset that is unambiguously actionable. `scripts/audit_lock_gate.py` and
+# `scripts/audit_npm_gate.py` fail the build on an advisory that HAS a published fix.
+#
+# THIS HEADER USED TO SAY "Non-blocking by design ... ci.yml stays the hard gate", and it was
+# false from the moment those gates were added — which is very likely WHY this workflow had no
+# `pull_request:` trigger for as long as it didn't. A reader who believed the header had no reason
+# to wire an advisory-only scan into PRs. On 2026-09-03 that gap let FOUR merges (#393-#396) land
+# over a red scan carrying three pypdf CVEs and two HIGH browserslist advisories, every one of them
+# already fixed upstream. A stale comment is not a documentation problem when it is the reason a
+# gate was left unable to fire.
+#
+# Runs on dependency-manifest changes (push AND pull_request — see below), plus weekly.
 
 on:
   schedule:
@@ -22,6 +33,30 @@ on:
       - "**/package.json"
       - "**/package-lock.json"
       - ".github/workflows/security.yml"
+
+  # THE BLOCKING GATES ABOVE COULD NOT BLOCK A MERGE UNTIL THIS EXISTED. With only `push:`, they
+  # fire AFTER a PR lands — they report a merge that already happened. Same shape as
+  # R39-CONTAINER-PR ("a skipped job is not a passed job"), one level up: there a JOB could not run
+  # on the event that would let a human see the break first; here the whole WORKFLOW could not.
+  #
+  # Deliberately scoped to the SAME globs as `push:`, not left open:
+  #   * a PR that touches a manifest is the one that can introduce an advisory, and it gets audited;
+  #   * a PR that touches no manifest cannot, and is not slowed by ~2 minutes of scanning.
+  # An advisory published upstream against an UNCHANGED manifest is still caught by the weekly
+  # schedule and by `push:` — this trigger narrows nothing that was previously covered.
+  #
+  # The two glob lists must stay identical, and GitHub Actions does not honour YAML anchors, so the
+  # duplication is real and `test_lock_advisories.py` asserts the two lists are equal rather than
+  # trusting either to remember the other.
+  pull_request:
+    paths:
+      - "**/requirements*.txt"
+      - "**/requirements*.lock"
+      - "**/requirements*.in"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - ".github/workflows/security.yml"
+
   workflow_dispatch:
 
 permissions:

--- a/services/api/test_lock_advisories.py
+++ b/services/api/test_lock_advisories.py
@@ -25,7 +25,8 @@ import sys
 from datetime import date
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
-_GATE = os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "audit_lock_gate.py")
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+_GATE = os.path.join(ROOT, "scripts", "audit_lock_gate.py")
 
 
 def _load():
@@ -210,6 +211,60 @@ def test_the_push_and_pull_request_globs_stay_identical() -> None:
     print(f"PASS  push and pull_request audit the same manifests   {len(push)} glob(s), identical")
 
 
+def _matches_a_glob(path: str, globs: list[str]) -> bool:
+    """Does `path` match any of the workflow's `paths:` globs?
+
+    Shared by both coverage checks below so they cannot drift into disagreeing about what
+    "covered" means — two matchers for one question is the same defect this file keeps finding.
+    """
+    import fnmatch
+    return any(fnmatch.fnmatch(path, g)
+               or fnmatch.fnmatch(path, g.replace("**/", "*"))
+               or fnmatch.fnmatch(os.path.basename(path), g.removeprefix("**/"))
+               for g in globs)
+
+
+def test_the_npm_manifests_can_trigger_the_workflow_too() -> None:
+    """The npm half of the same question, which the Python half could not see.
+
+    RAISED IN REVIEW ON #398 and it was right. The check below iterates `audit_lock_gate.LOCKS`,
+    which contains ONLY `services/api/requirements.lock`. So deleting `**/package.json` and
+    `**/package-lock.json` from BOTH trigger lists left every assertion in this file green: the two
+    lists still matched each other, and the one audited path they knew about still matched. The
+    blocking npm gate would simply stop firing on manifest changes, silently.
+
+    That is mutation 4's failure mode -- both lists identical and both wrong -- on the ecosystem the
+    population did not cover. A coverage check is only as wide as the population it derives, and
+    this one had derived half the subject.
+
+    `audit_npm_gate.py` declares no path list to compare against (it shells out to `npm audit`,
+    whose subject is implicit), so the population comes from `git ls-files` rather than from a
+    constant: every TRACKED npm manifest must be able to start the workflow that audits it. Adding a
+    workspace tomorrow puts it in scope automatically; listing them here would not.
+    """
+    out = subprocess.run(["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True)
+    manifests = [p for p in out.stdout.split("\n")
+                 if os.path.basename(p) in ("package.json", "package-lock.json")]
+
+    # Vacuity guard: an empty population passes every assertion below while measuring nothing, and
+    # `git ls-files` returns empty from a non-repo. The lockfile is what `npm audit` actually reads,
+    # so its absence means the population is wrong rather than that the repo has no npm.
+    assert manifests, "no tracked npm manifests found — this check would pass by measuring nothing"
+    assert any(os.path.basename(p) == "package-lock.json" for p in manifests), (
+        "no package-lock.json in the derived population, but that is the file `npm audit` reads")
+
+    on = _triggers()
+    for event in ("push", "pull_request"):
+        globs = list((on.get(event) or {}).get("paths") or [])
+        assert globs, f"no `{event}: paths:` globs parsed"
+        missing = [m for m in manifests if not _matches_a_glob(m, globs)]
+        assert not missing, (
+            f"these tracked npm manifests match none of security.yml's `{event}` globs {globs}: "
+            f"{missing} — changing one would not run the blocking npm gate that audits it")
+    print(f"PASS  every tracked npm manifest can trigger the workflow on both events   "
+          f"{len(manifests)} manifest(s)")
+
+
 def test_every_audited_path_can_actually_trigger_the_workflow() -> None:
     """A gate that its own subject cannot trigger is not a smaller gate — it is no gate.
 
@@ -227,18 +282,13 @@ def test_every_audited_path_can_actually_trigger_the_workflow() -> None:
     between them, quietly measuring a merged list of twelve. It would still have passed. This file
     already carries the lesson one function up: a gate that greps prose measures the wrong text.
     """
-    import fnmatch
-
     gate = _load()
     on = _triggers()
     for event in ("push", "pull_request"):
         globs = list((on.get(event) or {}).get("paths") or [])
         assert globs, f"no `{event}: paths:` globs parsed"
         for lock in gate.LOCKS:
-            matched = [g for g in globs
-                       if fnmatch.fnmatch(lock, g) or fnmatch.fnmatch(lock, g.replace("**/", "*"))
-                       or fnmatch.fnmatch(os.path.basename(lock), g.removeprefix("**/"))]
-            assert matched, (
+            assert _matches_a_glob(lock, globs), (
                 f"{lock} is audited by the gate but matches none of security.yml's `{event}` "
                 f"globs {globs} — a change to it would not run the workflow that audits it")
     print(f"PASS  every audited lock can trigger the workflow on push AND pull_request   "
@@ -253,5 +303,6 @@ if __name__ == "__main__":
     test_the_workflow_actually_calls_the_gate_and_can_fail()
     test_the_blocking_gates_can_actually_block_a_merge()
     test_the_push_and_pull_request_globs_stay_identical()
+    test_the_npm_manifests_can_trigger_the_workflow_too()
     test_every_audited_path_can_actually_trigger_the_workflow()
     print("test_lock_advisories OK")

--- a/services/api/test_lock_advisories.py
+++ b/services/api/test_lock_advisories.py
@@ -141,38 +141,108 @@ def test_the_workflow_actually_calls_the_gate_and_can_fail() -> None:
     print("PASS  security.yml invokes the gate, with no continue-on-error and no `|| true`")
 
 
+def _triggers() -> dict:
+    """security.yml's `on:` block, parsed.
+
+    `yaml.safe_load` reads the bare key `on` as the BOOLEAN True under YAML 1.1, so the block can
+    arrive under either key depending on quoting. Checking only one is how a test like this reads
+    an empty dict and passes over a workflow it never examined.
+    """
+    import yaml
+    wf = os.path.join(os.path.dirname(__file__), "..", "..", ".github", "workflows", "security.yml")
+    with open(wf, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh.read()) or {}
+    on = doc.get("on", doc.get(True))
+    assert isinstance(on, dict) and on, (
+        "security.yml's `on:` block did not parse — this check would otherwise pass by measuring "
+        "nothing, which is the failure it exists to catch")
+    return on
+
+
+def test_the_blocking_gates_can_actually_block_a_merge() -> None:
+    """A gate that only runs AFTER the merge does not gate the merge.
+
+    THE DEFECT, 2026-09-03. This workflow hosts two BLOCKING gates -- `audit_lock_gate.py` and
+    `audit_npm_gate.py` -- and triggered on `push:` to main, a weekly schedule and manifest paths.
+    Never on `pull_request`. So neither gate could refuse a merge; each could only report one that
+    had already happened. Four PRs (#393-#396) landed over a red scan carrying three pypdf CVEs and
+    two HIGH browserslist advisories, every one already fixed upstream.
+
+    Same shape as `test_container_pr_gate.py` ("a skipped job is not a passed job"), one level up:
+    there a JOB could not run on the event that would show a human the break first; here the whole
+    WORKFLOW could not. A check that cannot run before the thing it guards is not a weaker check.
+
+    The file's own header had said "Non-blocking by design ... ci.yml stays the hard gate" for as
+    long as the gates existed, which is very likely WHY nobody wired the trigger: a reader who
+    believed the header had no reason to. That sentence is corrected, and this asserts the trigger
+    rather than the sentence -- prose cannot fail.
+    """
+    on = _triggers()
+    assert "pull_request" in on, (
+        "security.yml has no `pull_request:` trigger, so its two BLOCKING gates cannot refuse a "
+        "merge -- they can only report one that already happened. Add the trigger; do not weaken "
+        "the gates.")
+    print("PASS  the blocking gates run on pull_request, so they can actually block")
+
+
+def test_the_push_and_pull_request_globs_stay_identical() -> None:
+    """The ratchet on the duplication, because GitHub Actions does not honour YAML anchors.
+
+    Two lists of the same thing drift, and the drift is silent and asymmetric: a glob added to
+    `push:` but not `pull_request:` restores the original hole FOR THAT FILE ALONE -- the scan still
+    runs after the merge, so nothing looks broken, and every other assertion in this file still
+    passes. Derived from both blocks and compared; neither is listed here.
+
+    Division of labour with the check below, established by mutation rather than assumed: this one
+    catches DIVERGENCE and runs first, so it shadows the per-event check for that case. The
+    per-event check earns its place on the other failure -- both lists identical and both wrong,
+    where equality is satisfied and an audited lock still matches nothing.
+    """
+    on = _triggers()
+    push = list((on.get("push") or {}).get("paths") or [])
+    pr = list((on.get("pull_request") or {}).get("paths") or [])
+    assert push, "no `push: paths:` globs parsed"
+    assert pr, "no `pull_request: paths:` globs parsed"
+    assert push == pr, (
+        "security.yml's push and pull_request path globs have diverged. Any manifest reachable by "
+        f"only one of them is audited on only one event.\n  push only:         {sorted(set(push) - set(pr))}"
+        f"\n  pull_request only: {sorted(set(pr) - set(push))}")
+    print(f"PASS  push and pull_request audit the same manifests   {len(push)} glob(s), identical")
+
+
 def test_every_audited_path_can_actually_trigger_the_workflow() -> None:
     """A gate that its own subject cannot trigger is not a smaller gate — it is no gate.
 
     Found 2026-08-09, immediately after shipping the gate above. `security.yml` triggered on
-    `**/requirements*.txt`; the file it audits is `services/api/requirements.lock`, which matches
+    `**/requirements*.txt`; the file it audits is `services/api/requirements.lock`, which matched
     none of the globs. A lock-only change — the exact change that introduces or removes an advisory
     — could not start the workflow that checks the lock. The CVE-bump commit ran it only because it
     happened to touch `security.yml` in the same push.
 
     So this asserts the two halves against each other: every path in `audit_lock_gate.LOCKS` must
-    match one of the workflow's `paths:` globs. Neither list is trusted to remember the other.
+    match a trigger glob, on BOTH events. Neither list is trusted to remember the other.
+
+    Parsed as YAML now, not sliced out of the text. The original took the first `paths:` and cut to
+    `workflow_dispatch:` — which spanned BOTH glob lists the moment the `pull_request:` block landed
+    between them, quietly measuring a merged list of twelve. It would still have passed. This file
+    already carries the lesson one function up: a gate that greps prose measures the wrong text.
     """
     import fnmatch
 
     gate = _load()
-    wf = os.path.join(os.path.dirname(__file__), "..", "..", ".github", "workflows", "security.yml")
-    with open(wf, encoding="utf-8") as fh:
-        src = fh.read()
-    block = src[src.index("    paths:"):src.index("  workflow_dispatch:")]
-    globs = [ln.strip().lstrip("- ").strip('"')
-             for ln in block.splitlines() if ln.strip().startswith("- ")]
-    assert globs, "no paths: globs parsed — this check is reading the wrong part of the workflow"
-
-    for lock in gate.LOCKS:
-        matched = [g for g in globs
-                   if fnmatch.fnmatch(lock, g) or fnmatch.fnmatch(lock, g.replace("**/", "*"))
-                   or fnmatch.fnmatch(os.path.basename(lock), g.lstrip("**/"))]
-        assert matched, (
-            f"{lock} is audited by the gate but matches none of security.yml's trigger globs "
-            f"{globs} — a change to it would not run the workflow that audits it")
-    print(f"PASS  every audited lock can trigger the workflow   {len(gate.LOCKS)} path(s) vs "
-          f"{len(globs)} glob(s)")
+    on = _triggers()
+    for event in ("push", "pull_request"):
+        globs = list((on.get(event) or {}).get("paths") or [])
+        assert globs, f"no `{event}: paths:` globs parsed"
+        for lock in gate.LOCKS:
+            matched = [g for g in globs
+                       if fnmatch.fnmatch(lock, g) or fnmatch.fnmatch(lock, g.replace("**/", "*"))
+                       or fnmatch.fnmatch(os.path.basename(lock), g.removeprefix("**/"))]
+            assert matched, (
+                f"{lock} is audited by the gate but matches none of security.yml's `{event}` "
+                f"globs {globs} — a change to it would not run the workflow that audits it")
+    print(f"PASS  every audited lock can trigger the workflow on push AND pull_request   "
+          f"{len(gate.LOCKS)} path(s)")
 
 
 if __name__ == "__main__":
@@ -181,5 +251,7 @@ if __name__ == "__main__":
     test_a_fixable_advisory_blocks_and_an_unfixable_one_does_not()
     test_a_broken_audit_run_is_a_failure_not_a_pass()
     test_the_workflow_actually_calls_the_gate_and_can_fail()
+    test_the_blocking_gates_can_actually_block_a_merge()
+    test_the_push_and_pull_request_globs_stay_identical()
     test_every_audited_path_can_actually_trigger_the_workflow()
     print("test_lock_advisories OK")


### PR DESCRIPTION
# What & why

`security.yml` hosts two **blocking** gates — `scripts/audit_lock_gate.py` and `scripts/audit_npm_gate.py`, each failing the build on an advisory that *has* a published fix — and triggered on push-to-`main`, a weekly schedule, and manifest paths. **Never on `pull_request`.** So neither gate could refuse a merge; each could only report one that had already happened.

On 2026-09-03 that let **four merges (#393–#396) land over a red scan** carrying three pypdf CVEs and two HIGH browserslist advisories, every one already fixed upstream. #397 fixed the advisories. **This fixes the reason they got in.**

Same shape as R39-CONTAINER-PR, whose test file states it as *"a skipped job is not a passed job"* — one level up. There a **job** couldn't run on the event that would show a human the break first; here the whole **workflow** couldn't.

## The stale comment is the finding, not a tidy-up alongside it

The header read:

> Report-only supply-chain scan (pip-audit + npm audit). **Non-blocking by design** — it surfaces known CVEs in the job summary without failing the merge gate (ci.yml stays the hard gate).

True when written, and **false from the moment the blocking gates were added** — and very likely *why* nobody wired the trigger. A reader who believed the header had no reason to run an advisory-only scan on PRs.

This repo already knows that unverified prose drifts. What it hadn't recorded is prose drifting into **the reason a gate was left unable to fire**. Corrected, keeping the old sentence so the record survives.

## Scope of the trigger

Deliberately the **same globs as `push:`**, not left open:

- a PR touching a manifest is the one that can introduce an advisory → audited;
- a PR touching none cannot → not slowed.

Cost **measured** from run 1206 rather than guessed: python 99s, node 21s, sbom 12s, parallel, **~100s wall**. An advisory published upstream against an unchanged manifest is still covered by the schedule and by `push:` — this narrows nothing.

## Three new assertions, each proven by mutation

| mutation | result |
|---|---|
| delete the `pull_request` trigger | fails, naming the consequence |
| diverge one glob between the two lists | fails, printing the asymmetric difference |
| drop a glob from **both** lists | fails on the per-event check alone |

**The third earned its place the hard way.** The first two mutations both tripped the *equality* assertion, which runs first and shadows the per-event one — so the per-event check was not demonstrated by either, and I had no evidence it did anything at all. It needed the case equality cannot catch: both lists identical and both wrong. That division of labour is now in the docstring, marked as established by mutation rather than by design, because it was.

GitHub Actions does not honour YAML anchors, so the duplicated glob list is unavoidable; the equality assertion is the ratchet on it. Neither list is written in the test — both are derived.

## Two pre-existing defects in the same function

- **The paths check was sliced out of the text** as `src[index("    paths:") : index("  workflow_dispatch:")]`. The new `pull_request:` block sits between those bounds, so it would have silently measured a **merged list of twelve globs** and still passed. Parsed as YAML now, per this file's own lesson one function up: *a gate that greps prose measures the wrong text.* The `on:` key is read as both `"on"` and boolean `True`, since YAML 1.1 gives the bare key the latter.
- **`g.lstrip("**/")` strips a character *set*, not a prefix** (ruff B005). Replaced with `removeprefix` after verifying both produce identical output for all six real globs. It surfaced only because ruff was pointed at the file by hand: CI lints `src/ ../data/src/`, which **excludes the api-root test files** — a smaller instance of the same scope-gap family, raised rather than fixed here.

## Verification

- Three mutations fail and the workflow restores byte-identical.
- `ruff` clean on `src/`, `../data/src/`, and on the test file.
- **Full backend suite 659/659** (1101s), including `test_lock_advisories`, `test_npm_advisories`, `test_actions_pinned`, `test_file_sizes`.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `ruff check src/ ../data/src/` clean
- [x] Backend: full suite 659/659; the changed test is registered in `run_tests.py` already
- [x] Web: untouched
- [x] No import cycles introduced (no source files changed)
- [ ] `CHANGELOG.md` entry — **not possible without a version bump**; see below
- [ ] Version bumped in both manifests — **deliberately not**; see below
- [x] No secrets, no competitor names

## No version bump

`main` is **v0.3.1143** with **v0.3.1133** the newest tag: 10 ahead of a bound of 10. Any bump re-breaks `test_release_current`. **v0.3.1143 still needs tagging** — that is the third change in a row to say so.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security scans now also run for pull requests that modify dependency manifests or workflow configuration.
  * Workflow documentation now distinguishes report-only scans from blocking security gates and explains actionable advisory behavior.

* **Tests**
  * Added validation for tracked npm manifests, lock files, workflow path filters, and audited lock-file coverage across pushes and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->