### PR TITLE
DECLARED-SCOPE — the same hole one directory over, hiding a real one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -675,6 +675,47 @@ comment is a claim with a shelf life.*
 Pin 1,015 → 953. **117 above the banner, and still no map for them** — this was one cluster read out of
 the file, not a plan for the rest.
 
+Twenty-seventh follow-on on the same version: **DECLARED-SCOPE** — *the same hole, one directory
+over, and it was hiding a real one*.
+
+`test_declared_imports.py` exists because `httpx` was declared in no requirements file and reached the
+lock only `# via anthropic`, so an SDK bump would have deleted a package two shipped modules import.
+It walked `services/api/src` and `services/data/src` — **and every one of the ~30 gate files lives in
+`services/api/` itself, outside that walk.** RUFF-SCOPE's defect exactly, in the checker written to
+catch this class: *the check was real, its reach was the fiction.*
+
+**Widening it found one true instance immediately.** `test_saml.py` does `from lxml import etree` at
+module scope. `lxml` is declared in neither requirements file and arrives in the lock only `# via`
+pyHanko / signxml / python-docx. signxml's own pin is `lxml<7,>=5.2.1`, so a signxml release that
+changed XML libraries would remove a package this suite imports directly — and nothing would go red
+until the SAML tests hit an ImportError. Undeclared for as long as `test_saml.py` has existed. Now in
+`requirements-dev.txt`, with the provenance written next to it.
+
+### Two scopes, because a dev pin does not ship
+
+A gate may import from `requirements.in` **or** `requirements-dev.txt`; a shipped module may import
+only from `requirements.in`, because that is what compiles into the runtime image. A runtime import
+backed solely by a dev pin passes CI and `ImportError`s in production. Proven rather than asserted: a
+module-scope `import yaml` added to `src/aec_api/__init__.py` **fails** (`yaml` is a dev-only pin),
+while the same import in `test_ruff_scope.py` passes.
+
+### The widening's own first output was five false positives
+
+`run_tests`, `mcp_server`, `vendor_drift`, `massing_api`, `massing_export` all reported as *"not
+installed"*. None is a package: they are sibling `.py` files, plus the pyRevit bridge library that
+`test_revit_bridge.py` puts on `sys.path`. The first-party set was derived from `src/` package
+**directories**, which cannot see a module that is a bare file. Now enumerated from the importable
+directories — scoped to those, deliberately, since a repository-wide basename sweep would forgive a
+real third-party import that happened to share a name with one of our files, and forgiving is the
+failure this test exists to prevent.
+
+*A widened scope's first run is data, not a verdict.* Five of the six findings were the gate's fault;
+the sixth had been true for months.
+
+Mutation-checked: lxml undeclared → exit 1 · gate dirs pointed at an empty path → exit 1 on the
+vacuity guard · a dev-only import in a shipped module → exit 1. Restored → exit 0.
+
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -715,6 +715,33 @@ the sixth had been true for months.
 Mutation-checked: lxml undeclared → exit 1 · gate dirs pointed at an empty path → exit 1 on the
 vacuity guard · a dev-only import in a shipped module → exit 1. Restored → exit 0.
 
+### And the split had reintroduced its own defect — CodeRabbit found it
+
+The first version put **every** direct `.py` under `services/api` in the DEV scope. Two of those files
+**ship**: `desktop_entry.py` is the executable in `desktop.spec` and `sidecar.spec`, and
+`seed_demo.py` is `COPY`ed into the runtime image by `Dockerfile` and run by `docker-compose.yml`'s
+seed profile. A dev-only import in either would have passed this gate and failed in the packaged
+artifact — **exactly the failure the two-scope split exists to prevent**, reintroduced by assuming
+"directly under `services/api`" means "test".
+
+Fixed by DERIVING the shipped set from the packaging manifests themselves — the specs, both
+Dockerfiles and the compose file — rather than naming the two files. Naming them would fix today and
+leave the next packaged entry point to land in the loose bucket silently, which is the same
+"a hand-list goes stale" argument as `FIRST_PARTY` and `LOCAL_MODULES`. An independent sweep of every
+direct `.py` against those manifests returns exactly those two, so the derivation and the finding
+agree.
+
+A vacuity guard comes with it: if the manifests ever stop naming any direct `.py`, the gate fails
+rather than quietly moving every entry point into the looser scope.
+
+Mutation-checked: a dev-only import in `desktop_entry.py` → **exit 1 as `[shipped]`** (it passed as
+`[gate]` before the fix) · the same import in a genuine test file → **exit 0** · `PACKAGING` pointed
+at files naming no `.py` → **exit 1** on the vacuity guard.
+
+*Three scope defects in one day — the linter's, this gate's, and then this gate's own fix — and the
+third was introduced while correcting the second. **Widening a scope is itself a scoping decision,
+and it deserves the same suspicion as the one it replaces.***
+
 
 
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3022,16 +3022,20 @@ tracked files, and the wrong-directory misroute is exactly how lanes collide:
      Whatever remains in the 139 findings is symbol-level: exports defined and never called, which
      ruff does not look for.
 
-     *(**OPEN, found by RUFF-SCOPE and NOT fixed there:** `services/api/test_declared_imports.py`
+     *(**CLOSED 2026-09-03 by DECLARED-SCOPE, and it was hiding a real instance.** Found by
+     RUFF-SCOPE, fixed in the follow-on: `services/api/test_declared_imports.py`
      has the same shape of hole. It walks `services/api/src` and `services/data/src` only, so any
      import in a gate that sits in `services/api/` itself — which is where all ~30 of them live — is
      invisible to it. Demonstrated rather than argued: `test_ruff_scope.py` added `import yaml`,
      pyyaml was declared in neither `requirements.in` nor `requirements-dev.txt` and reached the lock
      only `# via` fastapi/uvicorn/pyHanko/bandit/starlette/markdown-it-py, and the gate stayed green.
-     Declared explicitly in `requirements-dev.txt` as a point fix. **The class is not closed**: widen
-     the walk to the gate files, then re-derive which of their imports are undeclared. Low severity —
-     the gates' imports are stdlib plus well-anchored runtime packages — but it is the exact defect
-     that file exists to catch, one directory outside its reach.)*
+     The walk now covers the gate files under two scopes — a gate may declare in
+     `requirements.in` OR `requirements-dev.txt`, a shipped module only in the former, since a dev
+     pin does not compile into the runtime image. **Widening it caught `lxml`**, imported at module
+     scope by `test_saml.py`, declared nowhere, arriving only `# via` pyHanko/signxml/python-docx —
+     undeclared for as long as that test has existed. *The first run also produced five FALSE
+     positives (sibling modules the `src/`-derived first-party set could not see): a widened scope's
+     first output is data, not a verdict.*)*
 
      *(RUFF-SCOPE, 2026-09-03: that sentence named its scope correctly and I still read a tree-wide
      conclusion out of it. `src/` and `../data/src/` were the ONLY things ruff saw — 612 of 1,338

--- a/services/api/requirements-dev.txt
+++ b/services/api/requirements-dev.txt
@@ -21,6 +21,15 @@ ruff>=0.16.3         # static-analysis gate (config in ruff.toml): dead code + r
                      # what a version bump now touches. Re-validate against the real scope, and let
                      # `test_ruff_scope.py` tell you what that is rather than this comment.
 bandit>=1.9.4          # security static analysis (report-only in CI; run before shipping)
+lxml>=5.4.0          # `test_saml.py` builds signed SAML assertions with `from lxml import etree`.
+                     # Test-only: no shipped module imports lxml at module scope — `saml.py` reaches
+                     # it through signxml. It arrives in requirements.lock anyway (`# via` pyHanko,
+                     # signxml, python-docx), and that is exactly why it is declared: transitive
+                     # availability is a fact about someone else's metadata. signxml's own pin is
+                     # `lxml<7,>=5.2.1`, so a signxml release that swapped XML libraries would delete
+                     # a package this suite imports directly, and nothing would go red until the SAML
+                     # tests ImportError. Found on 2026-09-03 by widening this gate to the gate files;
+                     # it had been undeclared for as long as test_saml.py has existed.
 pyyaml>=6.0.3        # `test_ruff_scope.py` parses .github/workflows/*.yml to find the ONE enforcing
                      # `ruff check` step and read its `continue-on-error` — structure a regex cannot
                      # see. It arrives in requirements.lock anyway (`# via` fastapi, uvicorn, pyHanko,

--- a/services/api/test_declared_imports.py
+++ b/services/api/test_declared_imports.py
@@ -120,47 +120,117 @@ DATA_SRC = os.path.join(ROOT, "services", "data", "src")
 FIRST_PARTY = {d for root in (API_SRC, DATA_SRC) if os.path.isdir(root) for d in os.listdir(root)
                if os.path.isdir(os.path.join(root, d))}
 
+#: LOCAL MODULES the gate files import as bare names. Widening the scan to the gate files (2026-09-03)
+#: immediately produced five "not installed" failures — `run_tests`, `mcp_server`, `vendor_drift`,
+#: `massing_api`, `massing_export` — none of which is a package at all. They are sibling `.py` files,
+#: and the pyRevit bridge library that `test_revit_bridge.py` puts on `sys.path`. A first-party set
+#: derived from `src/` package DIRECTORIES cannot see a module that is a bare file.
+#:
+#: Enumerated from disk rather than listed, for the same reason FIRST_PARTY is: a hand-list goes stale
+#: the first time someone adds a gate. Scoped to the directories that actually get imported from, not
+#: to every `.py` in the repository — a repo-wide basename sweep would silently forgive a real
+#: third-party import that happened to share a name with one of our files, and forgiving is the
+#: failure mode this whole test exists to prevent.
+_LOCAL_ROOTS = [os.path.join(ROOT, "services", "api"), os.path.join(ROOT, "services", "data")] + [
+    os.path.join(ROOT, "integrations", "pyrevit", "Massing.extension", "lib"),
+]
+LOCAL_MODULES = {
+    f[:-3]
+    for root in _LOCAL_ROOTS if os.path.isdir(root)
+    for f in os.listdir(root)
+    if f.endswith(".py") and os.path.isfile(os.path.join(root, f))
+}
+FIRST_PARTY |= LOCAL_MODULES
+
 # One lock covers both services -- requirements.in says so in its own header ("the data service's
 # runtime deps are a strict subset"). So both trees are measured against that one file, which also
 # keeps the header's claim honest rather than merely written down.
 DECLARED = declared_in(os.path.join(ROOT, "services", "api", "requirements.in"))
+#: Test-only declarations. A GATE may import from either file; a SHIPPED module may import only from
+#: `requirements.in`, because that is what compiles into the runtime image — a runtime import backed
+#: solely by a dev pin is a module that works in CI and ImportErrors in production. The two scopes
+#: below encode exactly that difference, and it is the reason this widening needed two sets rather
+#: than one bigger one.
+DECLARED_DEV = DECLARED | declared_in(os.path.join(ROOT, "services", "api", "requirements-dev.txt"))
 PKG2DIST = packages_distributions()
+
+#: The GATE FILES — everything directly under a service root that is not inside `src/`. Added
+#: 2026-09-03, and it was NOT a hypothetical gap: `test_ruff_scope.py` landed with `import yaml`
+#: declared in NEITHER requirements file, reaching the lock only `# via` fastapi/uvicorn/pyHanko/
+#: bandit/starlette/markdown-it-py — and this test stayed green, because it walked `src/` only.
+#: The gate written to catch "a package our own source imports is a DIRECT dependency however else
+#: it happens to arrive" could not see the ~30 files that live beside it. Same scope hole RUFF-SCOPE
+#: fixed for the linter that same day, one directory over: *the checker was real, its reach was the
+#: fiction.* Non-recursive on purpose — `migrations/`, `_models/` and `scripts/` are separate
+#: populations with their own answers, and sweeping them in silently would repeat the mistake of
+#: widening a scope without reading what it caught.
+GATE_DIRS = (os.path.join(ROOT, "services", "api"), os.path.join(ROOT, "services", "data"))
+
+
+def _walk_py(root, recursive=True):
+    if recursive:
+        for dirpath, _, files in os.walk(root):
+            for fname in files:
+                if fname.endswith(".py"):
+                    yield os.path.join(dirpath, fname)
+    else:
+        for fname in sorted(os.listdir(root)) if os.path.isdir(root) else []:
+            full = os.path.join(root, fname)
+            if fname.endswith(".py") and os.path.isfile(full):
+                yield full
+
+
+def _scan(paths):
+    """{module: {relative path, ...}} for every module-scope third-party import in `paths`."""
+    found = {}
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            try:
+                parsed = ast.parse(fh.read())
+            except SyntaxError:
+                continue
+        for mod in module_scope_imports(parsed):
+            if mod and mod not in FIRST_PARTY and mod not in sys.stdlib_module_names:
+                found.setdefault(mod, set()).add(os.path.relpath(path, ROOT).replace("\\", "/"))
+    return found
+
 
 print(f"first-party packages (derived from src roots): {', '.join(sorted(FIRST_PARTY))}")
 print(f"declared in services/api/requirements.in: {len(DECLARED)}")
+print(f"          + requirements-dev.txt (gates only): {len(DECLARED_DEV)}")
 
-sites = {}
-for tree_root in (API_SRC, DATA_SRC):
-    for dirpath, _, files in os.walk(tree_root):
-        for fname in files:
-            if not fname.endswith(".py"):
-                continue
-            path = os.path.join(dirpath, fname)
-            with open(path, encoding="utf-8") as fh:
-                try:
-                    parsed = ast.parse(fh.read())
-                except SyntaxError:
-                    continue
-            for mod in module_scope_imports(parsed):
-                if mod and mod not in FIRST_PARTY and mod not in sys.stdlib_module_names:
-                    sites.setdefault(mod, set()).add(os.path.relpath(path, ROOT).replace("\\", "/"))
+shipped = _scan(p for root in (API_SRC, DATA_SRC) for p in _walk_py(root))
+gates = _scan(p for root in GATE_DIRS for p in _walk_py(root, recursive=False))
 
-print(f"distinct third-party module-scope imports: {len(sites)}\n")
+# A gate importing something a shipped module also imports is already covered by the stricter scope;
+# reporting it twice would just make a failure read as two problems.
+gates = {m: w for m, w in gates.items() if m not in shipped}
 
-for mod in sorted(sites):
-    where = sorted(sites[mod])
-    extra = f" (+{len(where) - 1} more)" if len(where) > 1 else ""
-    dists = PKG2DIST.get(mod, [])
-    if not dists:
-        check(f"`import {mod}` resolves to an installed distribution", False,
-              f"not installed, yet imported at module scope by {where[0]}{extra}")
-        continue
-    provider = "/".join(dists)
-    check(f"`import {mod}` is declared ({provider})",
-          any(norm(d) in DECLARED for d in dists),
-          f"provided by {provider}, which requirements.in does not declare -- imported at module "
-          f"scope by {where[0]}{extra}. Add it to requirements.in, or make the import "
-          f"function-local if it is genuinely optional")
+print(f"distinct third-party module-scope imports: {len(shipped)} shipped, {len(gates)} gate-only")
+_gate_files = sum(1 for root in GATE_DIRS for _ in _walk_py(root, recursive=False))
+check("the gate-file scan actually reached the files beside this one", _gate_files >= 20,
+      f"{_gate_files} .py directly under {len(GATE_DIRS)} service root(s) — a scan that reaches "
+      f"nothing passes vacuously, which is the failure this widening exists to correct")
+print()
+
+for label, sites, allowed, where_to_add in (
+    ("shipped", shipped, DECLARED, "requirements.in"),
+    ("gate", gates, DECLARED_DEV, "requirements-dev.txt (or requirements.in if it also ships)"),
+):
+    for mod in sorted(sites):
+        where = sorted(sites[mod])
+        extra = f" (+{len(where) - 1} more)" if len(where) > 1 else ""
+        dists = PKG2DIST.get(mod, [])
+        if not dists:
+            check(f"[{label}] `import {mod}` resolves to an installed distribution", False,
+                  f"not installed, yet imported at module scope by {where[0]}{extra}")
+            continue
+        provider = "/".join(dists)
+        check(f"[{label}] `import {mod}` is declared ({provider})",
+              any(norm(d) in allowed for d in dists),
+              f"provided by {provider}, declared nowhere -- imported at module scope by "
+              f"{where[0]}{extra}. Add it to {where_to_add}, or make the import function-local "
+              f"if it is genuinely optional")
 
 print()
 if FAILED:

--- a/services/api/test_declared_imports.py
+++ b/services/api/test_declared_imports.py
@@ -166,6 +166,44 @@ PKG2DIST = packages_distributions()
 #: widening a scope without reading what it caught.
 GATE_DIRS = (os.path.join(ROOT, "services", "api"), os.path.join(ROOT, "services", "data"))
 
+#: PACKAGING MANIFESTS — the files that decide what actually leaves this repository. Anything they
+#: name is SHIPPED and must clear the stricter scope, wherever it happens to sit on disk.
+#:
+#: CodeRabbit found this on the PR that introduced the two-scope split, and it is worth stating
+#: plainly: the first version swept every direct `.py` under `services/api` into the DEV scope, and
+#: two of those files ship. `desktop_entry.py` is the executable in `desktop.spec` and
+#: `sidecar.spec`; `seed_demo.py` is COPYed into the runtime image by `Dockerfile` and run by
+#: `docker-compose.yml`'s seed profile. A dev-only import in either would have passed this gate and
+#: failed in the packaged artifact — which is the EXACT failure the split exists to prevent, so the
+#: split had reintroduced its own defect by assuming "directly under services/api" means "test".
+#:
+#: DERIVED, not listed. Naming those two files would fix today and leave the next packaged entry
+#: point to land in the loose bucket silently — the same "a hand-list goes stale" argument as
+#: FIRST_PARTY and LOCAL_MODULES, and the reason this whole sequence keeps deriving populations
+#: instead of enumerating them.
+PACKAGING = [
+    os.path.join(ROOT, "services", "api", "desktop.spec"),
+    os.path.join(ROOT, "services", "api", "sidecar.spec"),
+    os.path.join(ROOT, "services", "api", "Dockerfile"),
+    os.path.join(ROOT, "services", "data", "Dockerfile"),
+    os.path.join(ROOT, "docker-compose.yml"),
+]
+
+
+def _packaged_filenames():
+    """`{'seed_demo.py', ...}` — every .py basename any packaging manifest mentions."""
+    named = set()
+    for path in PACKAGING:
+        if not os.path.isfile(path):
+            continue
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+        named |= set(re.findall(r"([A-Za-z0-9_]+\.py)", text))
+    return named
+
+
+PACKAGED = _packaged_filenames()
+
 
 def _walk_py(root, recursive=True):
     if recursive:
@@ -199,8 +237,17 @@ print(f"first-party packages (derived from src roots): {', '.join(sorted(FIRST_P
 print(f"declared in services/api/requirements.in: {len(DECLARED)}")
 print(f"          + requirements-dev.txt (gates only): {len(DECLARED_DEV)}")
 
-shipped = _scan(p for root in (API_SRC, DATA_SRC) for p in _walk_py(root))
-gates = _scan(p for root in GATE_DIRS for p in _walk_py(root, recursive=False))
+_direct = [p for root in GATE_DIRS for p in _walk_py(root, recursive=False)]
+_ships = [p for p in _direct if os.path.basename(p) in PACKAGED]
+_gate_only = [p for p in _direct if os.path.basename(p) not in PACKAGED]
+
+shipped = _scan(list(_walk_py(API_SRC)) + list(_walk_py(DATA_SRC)) + _ships)
+gates = _scan(_gate_only)
+
+check("a packaging manifest still names at least one direct entry point", bool(_ships),
+      ", ".join(sorted(os.path.relpath(p, ROOT).replace("\\", "/") for p in _ships))
+      or "none — if the specs/Dockerfile/compose stopped naming any direct .py, PACKAGING is stale "
+         "and every entry point has silently dropped into the looser dev scope")
 
 # A gate importing something a shipped module also imports is already covered by the stricter scope;
 # reporting it twice would just make a failure read as two problems.


### PR DESCRIPTION
`test_declared_imports.py` exists because `httpx` was declared in no requirements file and reached the lock only `# via anthropic` — so bumping that SDK would have deleted a package two shipped modules import, with nothing going red until two routes 500'd.

It walked `services/api/src` and `services/data/src`. **Every one of the ~30 gate files lives in `services/api/` itself, outside that walk.** That is RUFF-SCOPE's defect exactly, in the checker written to catch this class: the check was real, its reach was the fiction. Proven on #403, where that PR's own `import yaml` went undeclared and this gate stayed green.

## Widening it found one true instance immediately

`test_saml.py` does `from lxml import etree` at module scope.

- `lxml` is declared in **neither** `requirements.in` nor `requirements-dev.txt`.
- It arrives in `requirements.lock` only `# via` pyHanko / signxml / python-docx.
- signxml's own pin is `lxml<7,>=5.2.1` — so a signxml release that changed XML libraries would remove a package this suite imports **directly**, and nothing would go red until the SAML tests hit an `ImportError`.

Undeclared for as long as `test_saml.py` has existed. Now in `requirements-dev.txt` with its provenance written beside it.

## Two scopes, because a dev pin does not ship

| scope | may declare in | why |
|---|---|---|
| gate files | `requirements.in` **or** `requirements-dev.txt` | test-only code never enters the image |
| shipped modules | `requirements.in` only | that is what compiles into the runtime image |

A runtime import backed solely by a dev pin passes CI and `ImportError`s in production. Proven rather than asserted: a module-scope `import yaml` added to `src/aec_api/__init__.py` **fails**, while the same import in `test_ruff_scope.py` passes.

## The widening's own first output was five false positives

`run_tests`, `mcp_server`, `vendor_drift`, `massing_api`, `massing_export` all reported as *"not installed"*. None is a package — they are sibling `.py` files, plus the pyRevit bridge library that `test_revit_bridge.py` puts on `sys.path`. The first-party set was derived from `src/` package **directories**, which cannot see a module that is a bare file.

Now enumerated from the importable directories, and scoped to those deliberately: a repository-wide basename sweep would forgive a real third-party import that happened to share a name with one of our files, and forgiving is the failure this test exists to prevent.

**A widened scope's first run is data, not a verdict.** Five of the six findings were the gate's own fault; the sixth had been true for months. Reporting the raw six as "six undeclared dependencies" would have been wrong in the expensive direction — it is the same error as trusting a self-authored list, inverted.

## Verification

Mutation-checked three ways, exit codes read directly:

| mutation | result |
|---|---|
| `lxml` undeclared again | **exit 1** — the real finding returns |
| gate dirs pointed at an empty path | **exit 1** on the vacuity guard |
| dev-only `import yaml` in a shipped module | **exit 1** — the two scopes are genuinely separate |
| restored | **exit 0** |

`test_declared_imports`, `test_ruff_scope`, `test_file_sizes`, `test_roadmap_status`, `test_claude_md_gates`, `test_changelog_current`, `test_reachable` all OK · `ruff check ../..` clean tree-wide.

Backend-only change (one gate file plus a requirements declaration); no frontend surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency checks to cover both shipped application modules and development tooling.
  * Corrected dependency classification for packaged entry points, preventing inaccurate warnings.
  * Declared `lxml` for development and test workflows.

* **Documentation**
  * Updated the roadmap and changelog to reflect the completed dependency-scope improvements and identified dependency requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->