### PR TITLE
The scheduled package now reaches the people it was assembled for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased — the scheduled package now reaches the people it was assembled for
+
+**R24-REPORTS-BY-MOMENT's last remainder, in its own words: *"Delivery (email on a date) is still
+open; this is the assemble half."*** A routine assembled the owner's monthly package and left it in
+the job tray. The reason to schedule it is that nobody has to remember it, so that was most of a
+feature. A routine now carries `deliver_to` and a finished scheduled run mails its artifact.
+
+**The blocker was one layer below the prose again.** `POST …/jobs/{id}/deliver` and `mailer.py` both
+shipped — but **every line of the delivery lived inside the route function**: recipient
+normalisation, the 25-recipient and 15 MB caps, the size-before-read, the message build, the
+per-recipient status map, the audit. A worker has no request and no `Depends`, and an
+`HTTPException` raised from a background thread turns a delivery problem into a 500 nobody sees. The
+reusable half is now `artifact_delivery.py`; the route keeps only what is about HTTP — the "is this
+artifact ready" refusals, which are answers to a question only an outside caller asks. Refusals are
+raised as `DeliveryRefused` carrying the status the route already used, so `test_artifact_deliver.py`
+— which drives the real route — is what proves the extraction changed nothing.
+
+**Three rules.**
+
+* **Delivery never changes a job's state.** The artifact was produced; that is what the job was for.
+  A refused address or an SMTP outage is recorded under `result["delivery"]` and the job stays
+  `done`. Marking it `error` would make the next sweep treat a package that exists as one that
+  failed, and re-assembling a report because an email bounced is the wrong repair.
+* **Only jobs carrying a `routine_id` deliver.** That keeps `deliver_to` from becoming an
+  undocumented side-channel on `POST /projects/{pid}/jobs`, whose `params` are caller-supplied. An
+  editor who synthesises both gains nothing they lack — the deliver route is open to the same role
+  and the audit records the same actor either way.
+* **It runs inside the heartbeat, before the state flips.** `_Heartbeat` only refreshes rows still
+  `running`, so delivering after `state = "done"` would let the claim go stale during a conversation
+  that can take minutes, and the reaper would re-queue a job that had already sent.
+
+**The guarantee is at-least-once, stated rather than discovered.** A crash between the last
+`send_email` and the commit re-mails on recovery. Exactly-once needs a sent-marker committed before
+the send, which trades a duplicate package for a silently un-sent one — the worse failure for a
+deliverable somebody is waiting on.
+
+**The default is off.** An empty `deliver_to` is no delivery, not an empty send, and it is asserted.
+
+**Tested by running the real worker on the real job the sweep enqueued**, with only
+`mailer.send_email` swapped for a recorder — the same lesson the previous entry was written from,
+applied one layer further out: a test that asserted `deliver_to` reached `params` would pass just as
+happily if nothing ever mailed it. Thirteen checks, mutation-verified three ways — removing the
+delivery call fails five, removing the `routine_id` guard fails the side-channel check alone, and
+letting a delivery failure propagate fails the three that say the job stays `done`.
+
+**It also corrects a claim that had reached four files.** *"There is no scheduler of any kind in this
+tree"* was recorded as false in `docs/roadmap.md` earlier the same day, and was still stated as fact
+in a comment in `routers/jobs.py`, in the docstring of `test_artifact_deliver.py`, and in a released
+changelog entry. Only the *library* half was ever true — no APScheduler, croniter or cron in
+`requirements.in` — while `R22-ROUTINES` had hand-rolled the capability under a different heading.
+*Searching for a dependency and concluding there was no capability is what let every copy read true
+against the same grep.* The released entry keeps its wording with a dated correction beneath it,
+because a shipped changelog is a record rather than a place to rewrite history.
+
 ## Unreleased — a report package can now be scheduled, and the blocker was in the browser
 
 **Closes the gap the entry below named as the honest remaining work.** "The owner's monthly package,
@@ -479,6 +533,14 @@ send. The delivery is audited — a file leaving the system is what an audit log
 
 **Not shipped, deliberately: the SCHEDULED half.** There is no scheduler of any kind in this tree,
 so choosing in-process versus external cron is a deployment decision, not a wiring task.
+
+> ⚠️ **Corrected 2026-09-05.** The sentence above is false and is left standing because a released
+> entry is a record of what shipped, not a place to rewrite history. `R22-ROUTINES` had already
+> hand-rolled a scheduler under a different heading, and scheduled report packages ship in a later
+> release. Only the *library* claim was ever true — no APScheduler, croniter or cron in
+> `requirements.in` — and what remains a deployment decision is narrower than this says: what invokes
+> the sweep on a cadence. This claim reached four files; searching for a dependency and concluding
+> there was no capability is what let each copy read true.
 
 ## v0.3.1143 (2026-09-01) — SCALE-SEAM ㉝, Last-Planner onto schedule.ts
 

--- a/apps/web/src/ui/jobTray.test.ts
+++ b/apps/web/src/ui/jobTray.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Job, JobState } from "../api/types";
 import {
   activeCount, createJobPoller, hasArtifact, humanDuration, isActive, jobElapsed,
-  jobLabel, jobSummary, mountJobTray, renderJobTray, sortJobs,
+  deliverySummary, jobLabel, jobSummary, mountJobTray, renderJobTray, sortJobs,
 } from "./jobTray";
 
 /**
@@ -332,5 +332,54 @@ describe("the tray is actually reachable", () => {
     const host = document.createElement("div");
     renderJobTray(host, [J({ state: "done", result: { artifact_key: "k" } })], {});
     expect([...host.querySelectorAll("button")].some((b) => b.textContent === "Send")).toBe(false);
+  });
+});
+
+/**
+ * A scheduled delivery has no audience at the moment it happens.
+ *
+ * A person clicking **Send** sees the per-recipient result in the response. A routine firing on its
+ * cadence has nobody watching, so the only place the outcome can surface is the row — and an owner
+ * package that quietly did not send looks exactly like one that did. These assert the row says.
+ */
+describe("a scheduled delivery is visible on the row that did it", () => {
+  const withDelivery = (delivery: unknown) =>
+    J({ state: "done", result: { artifact_key: "k", delivery } });
+
+  it("says nothing at all when no delivery was asked for", () => {
+    expect(jobSummary(J({ state: "done", result: { artifact_key: "k" } }))).toBe("done");
+    expect(deliverySummary(J({ state: "done", result: null }))).toBe("");
+  });
+
+  it("reports a clean send by how many actually went", () => {
+    expect(jobSummary(withDelivery({ recipients: 2, results: { sent: ["a@x", "b@x"] } })))
+      .toBe("done · emailed 2");
+  });
+
+  it("NAMES the states that are not `sent`, because they need different fixes", () => {
+    // `disabled` means no SMTP is configured; `error` means it is and the send failed. Collapsing
+    // them into "some failed" would hide which one somebody is looking at.
+    expect(jobSummary(withDelivery({ results: { sent: ["a@x"], disabled: ["b@x"], error: ["c@x"] } })))
+      .toBe("done · emailed 1 of 3 (1 disabled, 1 error)");
+  });
+
+  it("surfaces a refusal and a thrown failure distinctly", () => {
+    expect(jobSummary(withDelivery({ refused: "at least one recipient is required", status: 422 })))
+      .toBe("done · not sent: at least one recipient is required");
+    expect(jobSummary(withDelivery({ error: "OSError: smtp unreachable" })))
+      .toBe("done · send failed: OSError: smtp unreachable");
+  });
+
+  it("stays `done` throughout — a bounced address is not a failed job", () => {
+    // The same rule the server applies: it leaves the job `done` and records the problem here,
+    // because the artifact exists either way and re-running the report is the wrong repair.
+    for (const d of [{ error: "x" }, { refused: "y" }, { results: { error: ["a@x"] } }]) {
+      expect(jobSummary(withDelivery(d)).startsWith("done")).toBe(true);
+    }
+  });
+
+  it("ignores a malformed delivery record rather than rendering junk", () => {
+    expect(jobSummary(withDelivery("not-an-object"))).toBe("done");
+    expect(jobSummary(withDelivery({ results: {} }))).toBe("done");
   });
 });

--- a/apps/web/src/ui/jobTray.ts
+++ b/apps/web/src/ui/jobTray.ts
@@ -118,7 +118,43 @@ export function jobSummary(j: Job): string {
   if (j.state === "error") return j.error ? j.error.slice(0, 140) : "failed";
   if (j.state === "queued") return "queued";
   if (j.state === "running") return "running";
-  return "done";
+  return "done" + deliverySummary(j);
+}
+
+/**
+ * What a SCHEDULED delivery did, appended to a finished row — `""` when there was none.
+ *
+ * A routine can name recipients, and the worker mails the artifact and records the outcome under
+ * `result.delivery`. Recording it and showing nothing would be the fault the rest of this feature is
+ * built to avoid: an owner package that quietly did not send looks exactly like one that did, and
+ * the person who set the routine up is the last to find out. A person clicking **Send** sees the
+ * result immediately; nobody is watching when a cadence fires, so the row has to say.
+ *
+ * `done` stays the prefix in every case. The delivery is something the job ALSO did — a bounced
+ * address does not make the package a failure, which is the same rule the server applies when it
+ * leaves the job `done` and puts the error here instead.
+ */
+export function deliverySummary(j: Job): string {
+  const d = j.result && typeof j.result === "object"
+    ? (j.result as Record<string, unknown>)["delivery"] : null;
+  if (!d || typeof d !== "object") return "";
+  const rec = d as Record<string, unknown>;
+  if (typeof rec["refused"] === "string") return ` · not sent: ${rec["refused"]}`;
+  if (typeof rec["error"] === "string") return ` · send failed: ${rec["error"]}`;
+  const results = (rec["results"] && typeof rec["results"] === "object"
+    ? rec["results"] : {}) as Record<string, string[]>;
+  // Counted from the per-address map rather than from `recipients`, because "how many were asked"
+  // and "how many went" are different numbers and the second is the one worth a line in a tray.
+  const sent = (results["sent"] || []).length;
+  const total = Object.values(results).reduce((n, xs) => n + (xs || []).length, 0);
+  if (!total) return "";
+  if (sent === total) return ` · emailed ${sent}`;
+  // Naming the non-sent states rather than saying "some failed": `disabled` (no SMTP configured)
+  // and `error` are different problems with different fixes, and the tray is where somebody decides
+  // which one they are looking at.
+  const rest = Object.keys(results).filter((k) => k !== "sent" && (results[k] || []).length)
+    .map((k) => `${(results[k] || []).length} ${k}`).join(", ");
+  return ` · emailed ${sent} of ${total}${rest ? ` (${rest})` : ""}`;
 }
 
 /** `done` **and** the handler parked something downloadable. Artifact kinds set `artifact_key`. */

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2217,6 +2217,30 @@ refute one, so this goes first even though it is the least visible.
   alternative; it is a Report Center change rather than a scheduler one, and it is recorded in
   `report_moments.py` as chosen-against rather than overlooked.
 
+  ✅ **DELIVERY SHIPPED, and it was this entry's own last remainder** — *"Delivery (email on a date)
+  is still open; this is the assemble half."* Assembling the owner's package on a cadence and leaving
+  it in the job tray is most of a feature, because the reason to schedule it is that nobody has to
+  remember. A routine now carries `deliver_to`, and a finished scheduled run mails its artifact.
+
+  The blocker was again one layer below where the prose put it. `POST …/jobs/{id}/deliver` and
+  `mailer.py` both shipped — but **every line of the delivery lived inside the route function**: the
+  recipient normalisation, the two caps, the size-before-read, the message build, the per-recipient
+  status map and the audit. A worker has no request and no `Depends`, and an `HTTPException` raised
+  from a background thread is a 500 nobody sees. So the reusable half moved to
+  `services/api/src/aec_api/artifact_delivery.py` and the route kept only what is genuinely about
+  HTTP — the "is this artifact ready" refusals. `services/api/test_artifact_deliver.py` drives the
+  real route and is what proves the extraction changed no behaviour.
+
+  **Three rules, and one property worth a reader's attention.** Delivery never changes a job's state
+  (the artifact exists; a bounced address is not a failed run, and re-assembling a report because an
+  email bounced is the wrong repair). Only jobs carrying a `routine_id` deliver, so `deliver_to` is
+  not an undocumented side-channel on an endpoint whose `params` are caller-supplied. It runs inside
+  the heartbeat, before the state flips, because `_Heartbeat` only refreshes rows still `running`.
+  And the guarantee is **at-least-once**: a crash between the last send and the commit re-mails on
+  recovery. Exactly-once needs a sent-marker committed before sending, which trades a duplicate
+  package for a silently un-sent one — the worse failure for a deliverable somebody is waiting on.
+  Stated here rather than discovered later.
+
   Still open and genuinely a **deployment decision**: what invokes the sweep on a cadence — in-process
   versus external cron hitting the endpoint. That is unchanged and still not taken here. The Job row
   is already the record that a pack ran.

--- a/services/api/modules/routine/module.json
+++ b/services/api/modules/routine/module.json
@@ -51,6 +51,13 @@
       "fieldset": "Routine"
     },
     {
+      "name": "deliver_to",
+      "label": "Email the result to",
+      "type": "text",
+      "help": "Optional. Addresses separated by commas, semicolons or spaces; at most 25. When set, a finished run's artifact is emailed to them automatically — leave it empty and the run only lands in the job tray. Only kinds that produce a file have anything to send. A delivery that fails does not fail the run: the outcome is recorded on the job.",
+      "fieldset": "Routine"
+    },
+    {
       "name": "cadence",
       "label": "Cadence",
       "type": "select",

--- a/services/api/src/aec_api/artifact_delivery.py
+++ b/services/api/src/aec_api/artifact_delivery.py
@@ -1,0 +1,120 @@
+"""Mailing a finished job's artifact — the part both the route and the worker need.
+
+R24-REPORTS-BY-MOMENT. `POST /projects/{pid}/jobs/{job_id}/deliver` has done this since v0.3.1144,
+and every line of it lived INSIDE the route function: the recipient normalisation, the two caps, the
+size-before-read, the message build, the per-recipient status map and the audit record. That is fine
+while a person clicking **Send** is the only way an artifact leaves.
+
+It stopped being fine when routines learned to schedule a report package. A scheduled package is
+assembled by the worker and then sits in the job tray, and *the whole point of scheduling the owner's
+monthly package is that nobody has to remember it*. The worker cannot call a FastAPI route function:
+it has no request, no `Depends`, and raising `HTTPException` from a background thread converts a
+delivery problem into a 500 nobody sees. So the reusable half moves here and the route keeps only the
+half that is genuinely about HTTP.
+
+**What stayed in the route, deliberately.** The "is this artifact ready" refusals — 404 for a job in
+another project, 409 while it is queued or running, 404 when it produced no artifact — are answers to
+a question only an outside caller asks. The worker is holding the job it just ran; it knows.
+
+**Refusals are raised, not returned.** `DeliveryRefused` carries the status the route already used,
+so the HTTP behaviour is unchanged and `test_artifact_deliver.py` — which drives the real route —
+is what proves the extraction did not alter it. The worker catches the same exception and records it
+on the job row instead.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+#: A synchronous SMTP conversation per recipient with a 15-second timeout, so an unbounded list is a
+#: request that occupies a worker for hours. The cap is a REFUSAL, not a silent trim: quietly
+#: dropping recipients is the failure an empty-list refusal exists to avoid, one level up.
+MAX_RECIPIENTS = 25
+
+#: Checked BEFORE the object is read. `storage.get` materialises the whole thing, so checking
+#: `len(data)` afterwards spends the memory on exactly the payload being refused — and concurrent
+#: callers multiply it.
+MAX_BYTES = 15 * 1024 * 1024
+
+
+class DeliveryRefused(Exception):
+    """A refusal with the HTTP status the route has always used for it.
+
+    Carrying the status here rather than raising `HTTPException` is what lets the worker share this
+    code: it catches the same exception and writes `detail` onto the job row, where a scheduled
+    delivery's failure is visible without anyone watching a response.
+    """
+
+    def __init__(self, status: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status, self.detail = status, detail
+
+
+def recipients(to: Any) -> list[str]:
+    """Normalise, de-duplicate and cap a recipient list, or raise `DeliveryRefused`.
+
+    De-duplication is case-insensitive on the whole address: SMTP domains are not case-sensitive and
+    the local part is not worth guessing at. The caller's order is preserved so a response reads the
+    way the request was written.
+    """
+    addrs = list(dict.fromkeys(a.strip() for a in (to or []) if isinstance(a, str) and a.strip()))
+    seen: set[str] = set()
+    addrs = [a for a in addrs if not (a.lower() in seen or seen.add(a.lower()))]
+    if not addrs:
+        raise DeliveryRefused(422, "at least one recipient is required")
+    if len(addrs) > MAX_RECIPIENTS:
+        raise DeliveryRefused(422, f"at most {MAX_RECIPIENTS} recipients per delivery "
+                                   f"({len(addrs)} given)")
+    return addrs
+
+
+def artifact_in(result: Any) -> tuple[str, str, str]:
+    """`(storage key, filename, media type)` from a job result, or raise `DeliveryRefused`.
+
+    Reads the RESULT rather than the Job row on purpose. The worker delivers while the row is still
+    `running` — the heartbeat that holds its claim is scoped to that state — so a check against
+    `state == "done"` would refuse every scheduled delivery. The route checks the state itself,
+    before calling this.
+    """
+    res = result if isinstance(result, dict) else {}
+    key = res.get("artifact_key")
+    if not key:
+        raise DeliveryRefused(404, "job has no artifact")
+    return (str(key), str(res.get("filename") or "artifact.bin"),
+            str(res.get("media_type") or "application/octet-stream"))
+
+
+def send(db, *, job_id: str, kind: str, project_id: str, result: Any, addrs: list[str],
+         actor: str, intro: str, note: str = "", path: str = "") -> dict[str, Any]:
+    """Mail one job's artifact to `addrs`; returns the per-recipient status map, and audits the send.
+
+    `intro` is the first line of the body and is the caller's, because *who sent this* differs: a
+    person clicking Send is "alice@… sent you", a routine firing on its cadence is "the monthly
+    routine produced". Neither is a good default for the other, and a body that says a person sent
+    something they did not is worse than a plain one.
+
+    A file leaving the system is what an audit log is for, so the audit is written here rather than
+    left to each caller to remember.
+    """
+    from . import audit, mailer, storage
+
+    key, fname, media = artifact_in(result)
+    if not storage.exists(key):
+        raise DeliveryRefused(404, "job has no artifact")
+    nbytes = storage.size(key)
+    if nbytes > MAX_BYTES:
+        raise DeliveryRefused(413, f"artifact is {nbytes} bytes; the delivery cap is {MAX_BYTES}")
+    data = storage.get(key)
+
+    subject = f"{kind.replace('_', ' ')}: {fname}"
+    body = (f"{intro}\n\n" + (note.strip() + "\n\n" if note.strip() else "")
+            + f"Generated by job {job_id} ({kind}).\n")
+    att = [(fname, data, media)]
+    results: dict[str, list[str]] = {}
+    for addr in addrs:
+        results.setdefault(mailer.send_email(addr, subject, body, None, att), []).append(addr)
+    audit.record(db, action="job.artifact.deliver", actor=actor, method="POST",
+                 path=path or f"/projects/{project_id}/jobs/{job_id}/deliver",
+                 detail={"kind": kind, "filename": fname, "bytes": len(data),
+                         "recipients": len(addrs)})
+    return {"smtp_configured": mailer.smtp_configured(), "filename": fname,
+            "bytes": len(data), "results": results}

--- a/services/api/src/aec_api/artifact_delivery.py
+++ b/services/api/src/aec_api/artifact_delivery.py
@@ -45,6 +45,7 @@ class DeliveryRefused(Exception):
     """
 
     def __init__(self, status: int, detail: str) -> None:
+        """`status` is the HTTP code the route raises for this refusal; `detail` is its message."""
         super().__init__(detail)
         self.status, self.detail = status, detail
 

--- a/services/api/src/aec_api/jobs.py
+++ b/services/api/src/aec_api/jobs.py
@@ -195,6 +195,22 @@ class _Heartbeat:
                 log.debug("job %s: heartbeat failed", self._job_id, exc_info=True)
 
 
+#: Param keys the SERVER owns. A caller may not supply them, and `routers/jobs.py` strips them from
+#: a request body before writing its own.
+#:
+#: `project_id` and `actor` were already server-written-last, which was enough while nothing but
+#: identity depended on them. `routine_id` and `deliver_to` changed that: together they make the
+#: worker mail a finished artifact, so a caller who could forge them could aim a delivery.
+#:
+#: **That was not a privilege escalation and it is still worth closing.** Enqueue and the deliver
+#: route are both `require_role("editor")`, so an editor who forged these gained exactly what the
+#: deliver route already gave them, attributed to the same audited actor. The problem is that the
+#: safety of one endpoint rested on the ROLE GATE OF ANOTHER, with nothing stating the dependency:
+#: harden `deliver_artifact` to admin — plausible for a route that mails files out of the system —
+#: and this path silently stays at editor. Stripping makes it structural instead of an argument.
+SERVER_ONLY_PARAMS = ("project_id", "actor", "routine_id", "deliver_to")
+
+
 def _split_recipients(raw: Any) -> list[str]:
     """A routine's `deliver_to` field as a list. Accepts a list, or one string of separated addresses.
 

--- a/services/api/src/aec_api/jobs.py
+++ b/services/api/src/aec_api/jobs.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import threading
 import traceback
 from collections.abc import Callable
@@ -194,6 +195,76 @@ class _Heartbeat:
                 log.debug("job %s: heartbeat failed", self._job_id, exc_info=True)
 
 
+def _split_recipients(raw: Any) -> list[str]:
+    """A routine's `deliver_to` field as a list. Accepts a list, or one string of separated addresses.
+
+    The register stores it as free text because an address list is not a picklist, so it arrives
+    however the person typed it — commas, semicolons or newlines. Splitting on all three is not
+    cleverness, it is the difference between a routine that delivers and one that reports an
+    unroutable address nobody can see is really two.
+    """
+    if isinstance(raw, list):
+        return [str(a) for a in raw]
+    if not isinstance(raw, str) or not raw.strip():
+        return []
+    return [part for part in re.split(r"[,;\s]+", raw.strip()) if part]
+
+
+def _deliver_if_requested(db: Session, j: Job, res: Any) -> Any:
+    """Mail a finished SCHEDULED job's artifact, and fold the outcome into its result.
+
+    R24-REPORTS-BY-MOMENT's last remainder. Assembling the owner's monthly package on a cadence and
+    leaving it in the job tray is most of a feature: the whole reason to schedule it is that nobody
+    has to remember. This is the step that makes "the owner package, every month, in their inbox"
+    true.
+
+    THREE RULES, and the first is the one that matters:
+
+    1.  **Delivery NEVER changes the job's state.** The artifact was produced; that is what the job
+        was for. A refused address or an SMTP outage is recorded under `result["delivery"]` and the
+        job stays `done`. Marking it `error` would make the next sweep treat a package that exists
+        as one that failed, and re-assembling a report because an email bounced is the wrong repair.
+    2.  **Only jobs that came from a routine deliver.** `deliver_to` is meaningless without a
+        `routine_id`, and requiring both keeps this from becoming an undocumented side-channel on
+        `POST /projects/{pid}/jobs`, whose `params` are caller-supplied. (An editor who synthesises
+        both gains nothing they lack: the deliver ROUTE is open to the same role, and the audit
+        records the same actor either way — `params["actor"]` is written by the server in both
+        paths.)
+    3.  **It runs INSIDE the heartbeat, before the state flips.** `_Heartbeat` only refreshes rows
+        that are still `running`, so delivering after `state = "done"` would leave the claim to go
+        stale during a conversation that can take minutes, and the reaper would re-queue a job that
+        had already finished — and already sent.
+
+    **The guarantee is at-least-once, deliberately and not silently.** If the process dies between
+    the last `send_email` and the commit below, recovery re-runs the job and mails again. Making it
+    exactly-once needs a sent-marker committed before the send, which trades a duplicate package for
+    a silently un-sent one — the worse failure for a deliverable somebody is waiting on.
+    """
+    params = j.params or {}
+    if not params.get("routine_id"):
+        return res
+    raw = _split_recipients(params.get("deliver_to"))
+    if not raw:
+        return res
+    from . import artifact_delivery
+    window = params.get("window_start")
+    try:
+        addrs = artifact_delivery.recipients(raw)
+        out = artifact_delivery.send(
+            db, job_id=j.id, kind=j.kind, project_id=j.project_id or "", result=res, addrs=addrs,
+            actor=str(params.get("actor") or "scheduler"),
+            intro=(f"Scheduled routine delivery from project {j.project_id}"
+                   + (f" for the window starting {window}." if window else ".")))
+        report: dict[str, Any] = {"recipients": len(addrs), "results": out["results"],
+                                  "smtp_configured": out["smtp_configured"]}
+    except artifact_delivery.DeliveryRefused as e:
+        report = {"refused": e.detail, "status": e.status}
+    except Exception as e:                       # noqa: BLE001 — rule 1: the job stays done
+        log.warning("job %s: scheduled delivery failed: %s", j.id, e, exc_info=True)
+        report = {"error": f"{e.__class__.__name__}: {e}"}
+    return {**res, "delivery": report} if isinstance(res, dict) else res
+
+
 def _run_one(SessionLocal) -> bool:
     """Claim + run one job. Returns False when the queue is empty."""
     db = SessionLocal()
@@ -215,7 +286,12 @@ def _run_one(SessionLocal) -> bool:
                         result = fn(db, j.params or {})
                 else:
                     result = fn(db, j.params or {})
-            j.result = result if isinstance(result, (dict, list)) else {"value": result}
+                # Built and delivered inside the heartbeat, then assigned ONCE. Mutating `j.result`
+                # in place after assignment would not reliably mark the JSON column dirty, so the
+                # delivery report could be sent and then not recorded.
+                res = result if isinstance(result, (dict, list)) else {"value": result}
+                res = _deliver_if_requested(db, j, res)
+            j.result = res
             j.state = "done"
         except Exception as e:  # noqa: BLE001 — the job row carries the failure; the worker never dies
             j.state = "error"

--- a/services/api/src/aec_api/routers/jobs.py
+++ b/services/api/src/aec_api/routers/jobs.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from .. import audit, rbac
+from .. import rbac
 from ..db import get_db
 from ..models import Job
 from ..rbac import require_role
@@ -93,14 +93,19 @@ def job_artifact(pid: str, job_id: str, db: Session = Depends(get_db),
 
 
 # R24-REPORTS-BY-MOMENT — "scheduled AND SHARED, not just downloaded" is the entry's own remainder,
-# and the two halves have different blockers. SHARED is unblocked and lands here: the mailer already
+# and the two halves had different blockers. SHARED is unblocked and lands here: the mailer already
 # ships (stdlib smtplib, a Settings "Test connection" button, a digest route that sends real mail),
-# it just had no way to carry a file. SCHEDULED is not here on purpose — it needs a recurring-trigger
-# record AND a runner, and there is no scheduler of any kind in this tree (no APScheduler, croniter
-# or cron), so choosing one is a deployment decision rather than a wiring task.
-_DELIVER_MAX_BYTES = 15 * 1024 * 1024
-_DELIVER_MAX_RECIPIENTS = 25
-
+# it just had no way to carry a file.
+#
+# ⚠️ THIS COMMENT USED TO SAY "there is no scheduler of any kind in this tree (no APScheduler,
+# croniter or cron)". THAT WAS FALSE, and it is the third copy of the claim to be corrected — the
+# roadmap entry carried it, `test_artifact_deliver.py` carried it, and so did the changelog. The
+# LIBRARY half is true and always was: none of those three is in `requirements.in`. But R22-ROUTINES
+# hand-rolled a scheduler under a different item's name — `routines.py` (cadences, `window_start`,
+# `due`, `from_project`), `routines_run.py`, a persisted `routine` register — and scheduled report
+# packages ship today. A claim phrased as a search for a DEPENDENCY answered a question about a
+# CAPABILITY, and then propagated to three files because each copy read true against the same
+# grep.
 
 @router.post("/projects/{pid}/jobs/{job_id}/deliver")
 def deliver_artifact(pid: str, job_id: str, to: list[str] = Body(..., embed=True),
@@ -116,8 +121,14 @@ def deliver_artifact(pid: str, job_id: str, to: list[str] = Body(..., embed=True
 
     Returns a per-recipient status map (`sent` / `disabled` / `error`) in the same shape as the
     notification digest, so an unconfigured deployment reports `disabled` instead of failing.
+
+    **The body of this is in `artifact_delivery`, because the worker needs it too.** A scheduled
+    report package is assembled with nobody watching, and it has to reach its recipients by the same
+    caps, the same de-duplication and the same audit record — a second copy of those would be a
+    second thing to keep in step. What stays here is only the part that is about HTTP: the readiness
+    refusals above, and turning a `DeliveryRefused` back into the status it has always carried.
     """
-    from .. import mailer, storage
+    from .. import artifact_delivery, storage
     j = db.get(Job, job_id)
     if j is None or j.project_id != pid:
         raise HTTPException(404, "job not found")
@@ -127,44 +138,16 @@ def deliver_artifact(pid: str, job_id: str, to: list[str] = Body(..., embed=True
     key = res.get("artifact_key") if isinstance(res, dict) else None
     if j.state != "done" or not key or not storage.exists(key):
         raise HTTPException(404, "job has no artifact" + (f" (state {j.state}: {j.error})" if j.error else ""))
-    # Normalise, de-duplicate (case-insensitively — SMTP domains are not case-sensitive and the
-    # local part is not worth guessing at), and preserve the caller's order so the response reads
-    # the way the request was written. `dict.fromkeys` does both in one pass.
-    addrs = list(dict.fromkeys(a.strip() for a in to if isinstance(a, str) and a.strip()).keys())
-    seen: set[str] = set()
-    addrs = [a for a in addrs if not (a.lower() in seen or seen.add(a.lower()))]
-    if not addrs:
-        raise HTTPException(422, "at least one recipient is required")
-    # Each address is a SYNCHRONOUS SMTP conversation with a 15-second timeout, so an unbounded
-    # list is a request that occupies a worker for hours. The cap is a refusal, not a silent trim:
-    # quietly dropping recipients is the failure the 422 above exists to avoid, one level up.
-    if len(addrs) > _DELIVER_MAX_RECIPIENTS:
-        raise HTTPException(422, f"at most {_DELIVER_MAX_RECIPIENTS} recipients per delivery "
-                                 f"({len(addrs)} given)")
-
-    # Size BEFORE read. `storage.get` materialises the whole object, and an artifact job can park a
-    # large geometry export, so checking `len(data)` afterwards means the memory has already been
-    # spent on exactly the payload being refused — and concurrent callers multiply it.
-    nbytes = storage.size(key)
-    if nbytes > _DELIVER_MAX_BYTES:
-        raise HTTPException(413, f"artifact is {nbytes} bytes; the delivery cap is {_DELIVER_MAX_BYTES}")
-    data = storage.get(key)
-    fname = res.get("filename") or "artifact.bin"
-    subject = f"{j.kind.replace('_', ' ')}: {fname}"
-    body = (f"{user} sent you {fname} from project {pid}.\n\n"
-            + (note.strip() + "\n\n" if note.strip() else "")
-            + f"Generated by job {job_id} ({j.kind}).\n")
-    att = [(fname, data, res.get("media_type") or "application/octet-stream")]
-    results: dict[str, list[str]] = {}
-    for addr in addrs:
-        results.setdefault(mailer.send_email(addr, subject, body, None, att), []).append(addr)
-    audit.record(db, action="job.artifact.deliver", actor=user, method="POST",
-                 path=f"/projects/{pid}/jobs/{job_id}/deliver",
-                 detail={"kind": j.kind, "filename": fname, "bytes": len(data),
-                         "recipients": len(addrs)})
+    try:
+        addrs = artifact_delivery.recipients(to)
+        out = artifact_delivery.send(db, job_id=job_id, kind=j.kind, project_id=pid, result=res,
+                                     addrs=addrs, actor=user,
+                                     intro=f"{user} sent you {res.get('filename') or 'artifact.bin'} "
+                                           f"from project {pid}.", note=note)
+    except artifact_delivery.DeliveryRefused as e:
+        raise HTTPException(e.status, e.detail) from e
     db.commit()
-    return {"smtp_configured": mailer.smtp_configured(), "filename": fname,
-            "bytes": len(data), "results": results}
+    return out
 
 
 @router.get("/projects/{pid}/jobs")

--- a/services/api/src/aec_api/routers/jobs.py
+++ b/services/api/src/aec_api/routers/jobs.py
@@ -40,15 +40,22 @@ def enqueue_job(pid: str, kind: str = Body(..., embed=True),
     from .. import audit, jobs
     _require_kind_role(db, pid, actor, kind)
     try:
-        # `project_id` and `actor` are written LAST, after the caller's params, so neither can be
-        # overridden from the request body. `project_id` was already server-set; `actor` is new and
-        # is the half that matters. A handler sees only `params` -- never the Job row -- so the
-        # moment any kind needs to know WHO ran it, `params["actor"]` becomes an identity claim, and
-        # a caller-supplied one would be believed. `clash_federated` is the first kind that reads it
-        # (`clash_intel.coordinate` records the actor and their party role against every coordination
-        # issue it creates), which is why this moved from "harmless" to "load-bearing" in one commit.
-        j = jobs.enqueue(db, kind, pid, {**(params or {}), "project_id": pid, "actor": actor},
-                         actor=actor)
+        # Server-owned keys are STRIPPED from the caller's params, then written. `project_id` and
+        # `actor` were previously only written last, which stops an override and was enough while
+        # identity was all that rested on them. A handler sees only `params` -- never the Job row --
+        # so the moment any kind needs to know WHO ran it, `params["actor"]` becomes an identity
+        # claim, and a caller-supplied one would be believed. `clash_federated` is the first kind
+        # that reads it (`clash_intel.coordinate` records the actor and their party role against
+        # every coordination issue it creates), which is why this moved from "harmless" to
+        # "load-bearing" in one commit.
+        #
+        # `routine_id` and `deliver_to` then joined them and write-last was no longer enough, because
+        # nothing here writes those: together they make the worker MAIL the finished artifact, so a
+        # forged pair could aim a delivery. Stripping is what makes the rule structural — see
+        # `jobs.SERVER_ONLY_PARAMS` for why "an editor could do this through the deliver route
+        # anyway" was true and still not a good enough guarantee to rest on.
+        clean = {k: v for k, v in (params or {}).items() if k not in jobs.SERVER_ONLY_PARAMS}
+        j = jobs.enqueue(db, kind, pid, {**clean, "project_id": pid, "actor": actor}, actor=actor)
     except ValueError as e:
         raise HTTPException(400, str(e)) from e
     if kind in _KIND_MIN_ROLE:                       # privileged kinds get the same audit trail as

--- a/services/api/src/aec_api/routines.py
+++ b/services/api/src/aec_api/routines.py
@@ -48,7 +48,7 @@ CADENCES: dict[str, str] = {
 #: JOB needs are named here rather than passed through by default, and `routines_run` is what knows
 #: what to do with them. The scheduler stays ignorant of job kinds: it carries these, it never
 #: interprets them.
-JOB_PARAM_FIELDS = ("moment",)
+JOB_PARAM_FIELDS = ("moment", "deliver_to")
 
 STATUS_DUE = "due"
 STATUS_NOT_DUE = "not_due"

--- a/services/api/src/aec_api/routines_run.py
+++ b/services/api/src/aec_api/routines_run.py
@@ -72,6 +72,12 @@ def job_params(kind: str, row: dict) -> tuple[dict[str, Any], str | None, str | 
     """
     from . import report_moments
 
+    # Carried for every kind, because "email me the result" is not specific to one job. It is passed
+    # through rather than validated here: a malformed address list is a delivery problem, and
+    # refusing to ASSEMBLE the package because of it would withhold the artifact somebody wanted over
+    # a fault in who gets told about it. `jobs._deliver_if_requested` records the outcome on the row.
+    deliver = {"deliver_to": row["deliver_to"]} if row.get("deliver_to") else {}
+
     moment = row.get("moment")
     if kind == "report_package":
         if not moment:
@@ -80,12 +86,12 @@ def job_params(kind: str, row: dict) -> tuple[dict[str, Any], str | None, str | 
         if str(moment) not in report_moments.MOMENTS:
             return {}, (f"unknown report moment {str(moment)!r}; "
                         f"known: {sorted(report_moments.MOMENTS)}"), None
-        return report_moments.package_params(str(moment)), None, None
+        return {**report_moments.package_params(str(moment)), **deliver}, None, None
     if moment:
-        return {}, None, (f"this routine names the report moment {str(moment)!r}, which only "
-                          f"report_package uses; {kind} takes no parameters, so it was ignored "
-                          "rather than silently changing what ran")
-    return {}, None, None
+        return deliver, None, (f"this routine names the report moment {str(moment)!r}, which only "
+                               f"report_package uses; {kind} takes no parameters, so it was ignored "
+                               "rather than silently changing what ran")
+    return deliver, None, None
 
 
 def in_flight_kinds(db, project_id: str) -> set[str]:

--- a/services/api/test_artifact_deliver.py
+++ b/services/api/test_artifact_deliver.py
@@ -6,8 +6,10 @@ which already ship: `mailer.py` sends real mail and `POST .../notifications/dige
 assemble-then-send surface. What was actually missing was smaller and more specific: the mailer had
 no way to carry a FILE. That is what this covers.
 
-The SCHEDULED half is deliberately not here: it needs a recurring-trigger record and a runner, and
-this tree has no scheduler of any kind, so picking one is a deployment decision.
+The SCHEDULED half is not here — it is in `test_routines_run.py`, and this line used to explain its
+absence with "this tree has no scheduler of any kind", which was false when written. `routines.py`
+and `routines_run.py` are a scheduler; what is genuinely still a deployment decision is only what
+INVOKES the sweep on a cadence (in-process versus external cron hitting the endpoint).
 
 Run: PYTHONPATH=src ./.venv/bin/python test_artifact_deliver.py"""
 import os

--- a/services/api/test_jobs.py
+++ b/services/api/test_jobs.py
@@ -83,6 +83,28 @@ with TestClient(app) as c:
     assert c.post(f"/projects/{pid}/jobs", json={"kind": "nope"}).status_code == 400
     assert c.get(f"/projects/{other}/jobs/{jid}").status_code == 404, "cross-project job access"
 
+    # SERVER-OWNED PARAMS ARE STRIPPED FROM THE REQUEST BODY, not merely overwritten afterwards.
+    #
+    # `project_id` and `actor` were always written last, which stops an override. `routine_id` and
+    # `deliver_to` are different: nothing here writes them, and TOGETHER THEY MAKE THE WORKER MAIL
+    # THE FINISHED ARTIFACT (`jobs._deliver_if_requested`). A caller who could set both could aim a
+    # delivery by forging a routine that does not exist.
+    #
+    # It was never a privilege escalation — enqueue and the deliver route are both editor, so this
+    # bought an editor nothing the deliver route already gave them, under the same audited actor.
+    # It is closed anyway because the SAFETY OF ONE ENDPOINT RESTED ON THE ROLE GATE OF ANOTHER with
+    # nothing stating the dependency: tighten `deliver_artifact` to admin, a plausible hardening for
+    # a route that mails files out of the system, and this path silently stays at editor. This
+    # asserts the structural version, so the argument no longer has to hold.
+    forged = c.post(f"/projects/{pid}/jobs", json={"kind": "echo", "params": {
+        "b": 2, "routine_id": "forged", "deliver_to": "attacker@example.test",
+        "project_id": other, "actor": "somebody-else"}})
+    assert forged.status_code == 201, forged.text[:200]
+    fp = c.get(f"/projects/{pid}/jobs/{forged.json()['id']}").json()["params"]
+    assert "routine_id" not in fp and "deliver_to" not in fp, ("forged delivery params survived", fp)
+    assert fp["project_id"] == pid and fp["actor"] != "somebody-else", ("server keys not owned", fp)
+    assert fp["b"] == 2, ("a caller's own params must still arrive", fp)
+
     _wait(jid)
     got = c.get(f"/projects/{pid}/jobs/{jid}").json()
     assert got["state"] == "done" and got["result"]["echo"]["a"] == 1, got

--- a/services/api/test_routines_run.py
+++ b/services/api/test_routines_run.py
@@ -261,6 +261,118 @@ check("  named for the moment, and holding every report that moment lists",
       and _artifact.get("reports") == report_moments.MOMENTS["owner_monthly"][2],
       (_artifact.get("filename"), _artifact.get("reports")))
 
+# --- 8. A SCHEDULED ARTIFACT REACHES ITS RECIPIENTS ------------------------------------------------
+#
+# R24-REPORTS-BY-MOMENT's last remainder. Section 7 proved a scheduled package ASSEMBLES; assembling
+# it and leaving it in the job tray is most of a feature, because the whole reason to schedule the
+# owner's monthly package is that nobody has to remember it.
+#
+# These run the REAL worker (`jobs._run_one`) on the REAL job the sweep enqueued, with only
+# `mailer.send_email` swapped for a recorder — the same lesson section 7 was written from, applied
+# one layer further out. A test that asserted `deliver_to` reached `params` would pass just as
+# happily if nothing ever mailed it.
+from aec_api import mailer  # noqa: E402
+
+_sent: list = []
+_real_send = mailer.send_email
+
+
+def _recording_send(to, subject, body, html=None, attachments=None):
+    _sent.append({"to": to, "subject": subject, "attachments": attachments})
+    return "sent"
+
+
+def _run_next() -> None:
+    """Claim and run exactly one queued job on a fresh session, the way the worker does."""
+    jobs._run_one(SessionLocal)
+    db.expire_all()                      # this session predates the worker's commit
+
+
+def _drain_to_done() -> None:
+    db.query(Job).filter(Job.state.in_(("queued", "running"))).update({"state": "done"},
+                                                                     synchronize_session=False)
+    db.commit()
+
+
+DELIVER = datetime(2026, 8, 11, 9, 0, tzinfo=timezone.utc)
+mailer.send_email = _recording_send
+try:
+    _drain_to_done()
+    r_mail = routine("Owner package, mailed", "report_package", moment="owner_monthly",
+                     deliver_to="owner@example.test, lender@example.test")
+    r_quiet = routine("Owner package, tray only", "echo")
+    eighth = routines_run.run_due(db, PID, now=DELIVER, actor="scheduler")
+    _mail_job = {e["routine_id"]: e["job_id"] for e in eighth["enqueued"]}
+
+    check("the sweep carries the routine's recipients into the job",
+          "deliver_to" in (db.query(Job).filter(Job.id == _mail_job[r_mail]).one().params or {}),
+          sorted(db.query(Job).filter(Job.id == _mail_job[r_mail]).one().params or {}))
+
+    for _ in range(len(eighth["enqueued"])):
+        _run_next()
+
+    _mj = db.query(Job).filter(Job.id == _mail_job[r_mail]).one()
+    _qj = db.query(Job).filter(Job.id == _mail_job[r_quiet]).one()
+    _delivery = (_mj.result or {}).get("delivery") or {}
+
+    check("A SCHEDULED PACKAGE IS MAILED, not just left in the tray", len(_sent) == 2,
+          [s["to"] for s in _sent])
+    check("  to the addresses the routine named, parsed out of one text field",
+          sorted(s["to"] for s in _sent) == ["lender@example.test", "owner@example.test"],
+          sorted(s["to"] for s in _sent))
+    check("  with the assembled PDF actually attached, not an empty notification",
+          bool(_sent) and _sent[0]["attachments"]
+          and _sent[0]["attachments"][0][0] == "owner_monthly.pdf"
+          and len(_sent[0]["attachments"][0][1]) > 1000,
+          _sent[0]["attachments"][0][:1] if _sent and _sent[0]["attachments"] else None)
+    check("  and the outcome is recorded on the job, so a silent non-delivery is impossible",
+          _delivery.get("recipients") == 2 and _delivery.get("results") == {"sent": [
+              "owner@example.test", "lender@example.test"]}, _delivery)
+    check("  while the job itself is done — delivery is not what the job was for",
+          _mj.state == "done", (_mj.state, _mj.error))
+
+    check("A ROUTINE THAT NAMES NOBODY MAILS NOBODY — the default is off",
+          "delivery" not in (_qj.result or {}), (_qj.result or {}).get("delivery"))
+
+    # Rule 2: `deliver_to` is not a side-channel on the public enqueue endpoint. Without a
+    # routine_id — which only the sweep sets — the worker does not mail, whatever params say.
+    _sent.clear()
+    _direct = jobs.enqueue(db, "echo", PID, {"project_id": PID, "deliver_to": "nobody@example.test"},
+                           actor="tester")
+    _run_next()
+    check("A JOB WITH RECIPIENTS BUT NO ROUTINE DOES NOT MAIL — params are caller-supplied",
+          _sent == [] and "delivery" not in (db.query(Job).filter(Job.id == _direct.id).one().result or {}),
+          _sent)
+
+    # Rule 1: the artifact was produced; a mail failure must not turn that into a failed run.
+    _sent.clear()
+    _boom = routine("Package, SMTP down", "report_package", moment="lender_draw",
+                    deliver_to="x@example.test")
+    _drain_to_done()
+    mailer.send_email = lambda *a, **k: (_ for _ in ()).throw(OSError("smtp unreachable"))
+    ninth = routines_run.run_due(db, PID, now=datetime(2026, 8, 12, 9, 0, tzinfo=timezone.utc),
+                                 actor="scheduler")
+    for _ in range(len(ninth["enqueued"])):
+        _run_next()
+    _bj = db.query(Job).filter(
+        Job.id == {e["routine_id"]: e["job_id"] for e in ninth["enqueued"]}[_boom]).one()
+    check("A DELIVERY FAILURE LEAVES THE JOB DONE — the package exists either way",
+          _bj.state == "done", (_bj.state, _bj.error))
+    check("  and the failure is on the row rather than swallowed",
+          "smtp unreachable" in str(((_bj.result or {}).get("delivery") or {}).get("error")),
+          (_bj.result or {}).get("delivery"))
+    check("  with the artifact still recorded, so it can be re-sent by hand",
+          bool((_bj.result or {}).get("artifact_key")), sorted(_bj.result or {}))
+finally:
+    mailer.send_email = _real_send
+
+check("recipients are split on commas, semicolons and newlines — however someone typed them",
+      jobs._split_recipients("a@x.test, b@x.test; c@x.test\nd@x.test")
+      == ["a@x.test", "b@x.test", "c@x.test", "d@x.test"],
+      jobs._split_recipients("a@x.test, b@x.test; c@x.test\nd@x.test"))
+check("  and an empty field is no delivery, not an empty send",
+      jobs._split_recipients("") == [] and jobs._split_recipients(None) == [])
+
 db.close()
 engine.dispose()
 

--- a/services/api/test_routines_run.py
+++ b/services/api/test_routines_run.py
@@ -278,6 +278,12 @@ _real_send = mailer.send_email
 
 
 def _recording_send(to, subject, body, html=None, attachments=None):
+    """Stand in for `mailer.send_email`, recording what would have been sent and reporting success.
+
+    Only the SMTP call is faked. Everything above it — the sweep, the worker, the handler, the
+    delivery core's caps and de-duplication — is the real code path, which is the point: the
+    interesting failures live there, not in smtplib.
+    """
     _sent.append({"to": to, "subject": subject, "attachments": attachments})
     return "sent"
 
@@ -289,6 +295,11 @@ def _run_next() -> None:
 
 
 def _drain_to_done() -> None:
+    """Finish every outstanding job, so the next sweep is not blocked by an earlier section's queue.
+
+    `run_due` skips a routine whose KIND already has queued or running work — correct behaviour, and
+    it would otherwise make these sections depend on the order the ones above them left things in.
+    """
     db.query(Job).filter(Job.state.in_(("queued", "running"))).update({"state": "done"},
                                                                      synchronize_session=False)
     db.commit()


### PR DESCRIPTION
# What & why

**R24-REPORTS-BY-MOMENT's last remainder, in its own words:** *"Delivery (email on a date) is still open; this is the assemble half."*

#446 taught a routine to assemble the owner's monthly package. It then left it in the job tray. The reason to schedule something is that nobody has to remember it, so that was most of a feature.

## The blocker was one layer below the prose, again

`POST …/jobs/{id}/deliver` and `mailer.py` both shipped. But **every line of the delivery lived inside the route function** — recipient normalisation, the 25-recipient and 15 MB caps, the size-before-read, the message build, the per-recipient status map, the audit.

A worker has no request and no `Depends`, and an `HTTPException` raised from a background thread turns a delivery problem into a 500 nobody sees.

So the reusable half moved to `services/api/src/aec_api/artifact_delivery.py`, and the route kept only what is genuinely about HTTP: the *"is this artifact ready"* refusals, which answer a question only an outside caller asks — the worker is holding the job it just ran. `DeliveryRefused` carries the status the route already used, so **`test_artifact_deliver.py`, which drives the real route, is what proves the extraction changed no behaviour.**

## Three rules

| rule | why |
|---|---|
| **Delivery never changes a job's state** | The artifact was produced; that is what the job was for. A bounced address or an SMTP outage goes under `result["delivery"]` and the job stays `done`. Marking it `error` would make the next sweep treat a package that exists as one that failed — and re-assembling a report because an email bounced is the wrong repair. |
| **Only jobs carrying a `routine_id` deliver** | Keeps `deliver_to` from becoming an undocumented side-channel on `POST /projects/{pid}/jobs`, whose `params` are caller-supplied. An editor who synthesises both gains nothing they lack: the deliver route is open to the same role, and the audit records the same actor either way. |
| **It runs inside the heartbeat, before the state flips** | `_Heartbeat` only refreshes rows still `running`. Delivering after `state = "done"` would let the claim go stale during a conversation that can take minutes, and the reaper would re-queue a job that had already sent. |

## The guarantee is at-least-once — stated, not discovered

A crash between the last `send_email` and the commit re-mails on recovery. Exactly-once needs a sent-marker committed *before* the send, which trades a duplicate package for a silently un-sent one — **the worse failure for a deliverable somebody is waiting on.** Flagged here so it is a decision rather than a surprise.

**The default is off.** An empty `deliver_to` is no delivery, not an empty send, and that is asserted.

## Tested by running the real worker, not by checking the params

`test_routines_run.py` section 8 drives `jobs._run_one` on the real job the sweep enqueued, with only `mailer.send_email` swapped for a recorder. That is #446's own lesson applied one layer further out: **a test asserting `deliver_to` reached `params` would pass just as happily if nothing ever mailed it.**

Thirteen backend checks, mutation-verified three ways:

- removing the delivery call → **5 fail**
- removing the `routine_id` guard → the side-channel check fails, alone
- letting a delivery failure propagate → the **3** that say the job stays `done` fail, reporting state `error`

## The outcome is visible, not just recorded

`jobTray`'s summary now reports what a scheduled delivery did — `emailed 2`, or `emailed 1 of 3 (1 disabled, 1 error)`, naming those states separately because they need different fixes. Recording it and showing nothing would be this feature's own failure mode: a package that quietly did not send looks exactly like one that did, and nobody is watching when a cadence fires. 6 web tests, mutation-checked.

## It also corrects a claim that had reached four files

*"There is no scheduler of any kind in this tree"* was recorded as false in `docs/roadmap.md` earlier the same day — and was still stated as fact in a comment in `routers/jobs.py`, in the docstring of `test_artifact_deliver.py`, and in a released `CHANGELOG.md` entry.

Only the **library** half was ever true — no APScheduler, croniter or cron in `requirements.in` — while `R22-ROUTINES` had hand-rolled the capability under a different heading. *Searching for a dependency and concluding there was no capability is what let every copy read true against the same grep.*

The released changelog entry keeps its wording with a dated correction beneath it: a shipped changelog is a record, not a place to rewrite history.

## Still open, and genuinely a deployment decision

What invokes the sweep on a cadence — in-process versus external cron hitting the endpoint. Unchanged, and not taken here.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `python -m ruff check ../..` clean (whole tree)
- [x] Backend: affected + structural gates green — `test_routines_run`, `test_routines`, `test_jobs`, `test_artifact_deliver`, `test_reachable` (364/369, the new module counted), `test_route_reachability`, `test_file_sizes`, `test_declared_imports`, `test_claude_md_gates`, `test_ruff_scope`
- [x] Web: 205 files / 2080 tests pass; `tsc --noEmit` and eslint clean
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; `docs/roadmap.md` updated
- [ ] Version bumped in both manifests — **N/A, not a release PR**
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled report runs can email completed artifacts to configured recipients.
  * Configure up to 25 email addresses using commas, semicolons, or spaces.
  * Delivery results are recorded and shown in completed job summaries, including sent, refused, and failed statuses.
  * Delivery failures do not change the run’s completed status.
* **Documentation**
  * Updated roadmap and changelog entries to document scheduled artifact delivery and delivery guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->