### PR TITLE
A transmittal could not name its recipient, and could not carry a drawing at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased — a transmittal could not name its recipient, and could not carry a drawing at all
+
+**R22-ENTITLEMENT's remaining item was the outbound package, and the blocker the entry named was the
+wrong one.** It said assembling a package to send was impossible because `transmittal.items` is a
+textarea. Re-measured before building: `submittal` has carried a `transmittal` **reference** all
+along, so submittals resolved into a package the whole time — which is precisely what the same
+entry's ④ note had already verified against `…/related`. *The entry contradicted itself in the
+paragraph written to stop it contradicting itself.*
+
+`items` was never the blocker. It was a second, unresolvable copy of a fact the reference already
+owned, and it is now labelled as the note it is: **the contents are the records whose own Transmittal
+field names this one**, because those resolve, appear under Referenced by, and can be counted.
+
+**What was actually missing, measured across all 139 registers.** A transmittal carries drawings,
+sets and documents at least as often as submittals, and **none of those three could name one**.
+`document` and `drawing_set` had no reference field of *any* kind — islands that could not take part
+in a chain at all. And `to_company` was plain text while `company` is a register, so a transmittal
+could not name the party it was addressed to.
+
+Four references close it: `drawing.transmittal`, `drawing_set.transmittal`, `document.transmittal`
+and `transmittal.to_company_ref`. Reference fields went 169 → **173**, islands 49 → **46**.
+
+**No engine changed, and that is the part worth knowing.** `REVERSE_REFS` is derived from
+`reference_fields()` at registry load, so a new reference flows into `related_records`, the Referenced
+by panel and the rollups by itself. The old paragraph's one correct instinct was that this is a schema
+question rather than a workflow one.
+
+**`to_company_ref` sits BESIDE the text, not instead of it.** The MOD-SWEEP established that pattern
+for 74 fields naming a register — add the reference, backfill, retire the text later — and
+`test_module_fields.py` ratchets it: the pair must be adjacent and share a fieldset. Converting in
+place would have been the obvious move and the wrong one; existing transmittals keep the name
+somebody typed.
+
+**Two gates, and they catch different things.** `test_module_fields.py` names the four registers a
+package carries, with a reason each, and asserts every one can point at a transmittal — the set is
+named rather than derived because "what a transmittal carries" is a judgement about the business.
+`test_modules.py` then asserts a real transmittal resolves all four kinds *and* its company
+recipient, because a field that exists proves nothing about whether a package resolves.
+Mutation-checked: removing `drawing.transmittal` fails the schema gate by name and the behavioural one
+with the three kinds it did resolve; removing `document`'s or the recipient link trips the island
+ceiling first, which is why the named checks were verified against a module that keeps its other
+references.
+
+*A test bug worth recording: the first draft created the submittal with a `subject` field it does not
+have, the POST 4xx'd, and the assertion reported a missing submittal — which reads exactly like the
+product defect it was not.* The check now asserts the POST succeeded before asserting what it means.
+
+⚠️ **`drawing_issuance` overlaps this and was deliberately left alone.** It models the same event —
+free-text `recipients`, a purpose, a sheet count — and is still an island. Whether it should link to
+`transmittal`, be fed by it, or be retired is a modelling decision, not a gap to close in passing.
+
 ## Unreleased — the scheduled package now reaches the people it was assembled for
 
 **R24-REPORTS-BY-MOMENT's last remainder, in its own words: *"Delivery (email on a date) is still

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1790,15 +1790,38 @@ stakes we are missing.
   `apps/web/src/portal/register/register.ts` and is replaced by "→ RFI raised" once promoted, because
   a button whose only remaining outcome is a 409 is worse than no button.
 
-  **Remaining: the OUTBOUND submittal package, and the reason is now specific rather than vague.**
-  This line used to name "submittal packages" flatly while the ④ note above said the inbound half had
-  already shipped — the entry contradicted itself. Measured 2026-09-04: the inbound *view* is real
-  (`…/related` returns `incoming`), but assembling a package to send is not, because
-  `modules/transmittal/module.json` types **`items` as a textarea and `to_company` as plain text**.
-  A package's contents are therefore prose no machine can resolve back to the records it names, and
-  its recipient cannot be the agency an `entitlement` names, since that field is free text too.
-  *That is a schema question — reference fields — not a workflow one, which is why reading the
-  workflow surface kept reporting this as done.*
+  ⑥ **the OUTBOUND package, shipped 2026-09-05 — and the blocker named here was the wrong one.**
+  This paragraph said assembling a package to send was impossible because
+  `modules/transmittal/module.json` types **`items` as a textarea**. Re-measured before building:
+  `submittal` has carried a `transmittal` **reference** all along, so submittals resolved into a
+  package the whole time — which is exactly what the ④ note two paragraphs above had already
+  verified against `…/related`. *The entry contradicted itself a second time, in the paragraph
+  written to stop it contradicting itself the first time.* `items` was never the blocker; it was a
+  second, unresolvable copy of a fact the reference already owned, and it is now labelled as the note
+  it is.
+
+  **What was actually missing, measured across all 139 registers.** A transmittal carries drawings,
+  sets and documents at least as often as submittals, and **none of those three could name one** —
+  `document` and `drawing_set` had no reference field of *any* kind, so they were islands that could
+  not take part in a chain at all. And `to_company` was free text while `company` is a register, so a
+  transmittal could not name the party it was addressed to. Four references close it:
+  `drawing.transmittal`, `drawing_set.transmittal`, `document.transmittal`, and
+  `transmittal.to_company_ref`.
+
+  **No engine changed.** `REVERSE_REFS` is derived from `reference_fields()` at registry load, so a
+  new reference flows into `related_records`, the Referenced by panel and the rollups by itself —
+  which is why this was a schema question, the one thing the old paragraph got right.
+  `to_company_ref` sits BESIDE the text as the MOD-SWEEP additive pattern requires rather than
+  converting it, so existing transmittals keep the name somebody typed.
+  `services/api/test_module_fields.py` names the four registers a package carries and asserts each
+  can point at one; `services/api/test_modules.py` asserts a real transmittal resolves all four kinds
+  plus its recipient, because a field that exists still proves nothing about whether a package
+  resolves.
+
+  ⚠️ **`drawing_issuance` overlaps this and was left alone.** It models the same event — `recipients`
+  as free text, a `purpose` select, a sheet count — and is still an island. Whether it should link to
+  `transmittal`, be fed by it, or be retired is a modelling decision about the business, not a gap to
+  close on the way past.
 
   ⚠️ **Two name collisions sit on this item; gap-check on SEMANTICS before touching it.**
   `tiers.py` is **subscription tiers** (free/pro/enterprise), nothing to do with land use — it was

--- a/services/api/modules/document/module.json
+++ b/services/api/modules/document/module.json
@@ -64,6 +64,14 @@
       "label": "Notes",
       "type": "textarea",
       "fieldset": "Notes"
+    },
+    {
+      "name": "transmittal",
+      "label": "Transmittal",
+      "type": "reference",
+      "module": "transmittal",
+      "help": "The transmittal that issued this document — the same link drawings and submittals use, so one package can carry all three.",
+      "fieldset": "Links"
     }
   ],
   "workflow": {

--- a/services/api/modules/drawing/module.json
+++ b/services/api/modules/drawing/module.json
@@ -100,6 +100,14 @@
       "type": "reference",
       "module": "spec_section",
       "fieldset": "Links"
+    },
+    {
+      "name": "transmittal",
+      "label": "Transmittal",
+      "type": "reference",
+      "module": "transmittal",
+      "help": "The transmittal that issued this drawing. Naming it here is what puts the drawing IN the package: a transmittal's contents are the records that point at it, which is how the Referenced by panel and the related feed resolve them.",
+      "fieldset": "Links"
     }
   ],
   "workflow": {

--- a/services/api/modules/drawing_set/module.json
+++ b/services/api/modules/drawing_set/module.json
@@ -61,6 +61,14 @@
       "label": "Purpose / Notes",
       "type": "textarea",
       "fieldset": "Issue"
+    },
+    {
+      "name": "transmittal",
+      "label": "Transmittal",
+      "type": "reference",
+      "module": "transmittal",
+      "help": "The transmittal that issued this set. A set is the usual unit of issue, so this is normally the link that matters rather than one per sheet.",
+      "fieldset": "Issue"
     }
   ],
   "workflow": {

--- a/services/api/modules/transmittal/module.json
+++ b/services/api/modules/transmittal/module.json
@@ -45,6 +45,14 @@
       "fieldset": "Parties"
     },
     {
+      "name": "to_company_ref",
+      "label": "To (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The company this transmittal is addressed to, as a record rather than a typed name — so the recipient can be resolved, reused and reported on. Sits beside the free-text field rather than replacing it: existing transmittals keep the name somebody typed.",
+      "fieldset": "Parties"
+    },
+    {
       "name": "contents",
       "label": "Contents",
       "type": "textarea",
@@ -52,8 +60,9 @@
     },
     {
       "name": "items",
-      "label": "Items",
+      "label": "Items (note)",
       "type": "textarea",
+      "help": "Free text, and NOT the record of what this transmittal carries. The contents are the drawings, sets, documents and submittals whose own Transmittal field names this one — those resolve, appear under Referenced by, and can be counted. Anything typed here is a note beside them, so a package is never assembled out of prose nothing can follow.",
       "fieldset": "Notes"
     }
   ],

--- a/services/api/test_module_fields.py
+++ b/services/api/test_module_fields.py
@@ -111,11 +111,50 @@ for k, m in mods.items():
 refs = sum(1 for m in mods.values() for f in m.get("fields", []) if f["type"] == "reference")
 islands = [k for k, m in mods.items()
            if not any(f["type"] == "reference" for f in m.get("fields", []))]
-assert refs >= 150, f"only {refs} reference fields; the sweep took it from 98 to 152"
-assert len(islands) <= 49, (
-    f"{len(islands)} modules have no reference at all (was 69). A record that points at nothing cannot "
-    "take part in a chain, which is most of what separates a register from a spreadsheet."
+assert refs >= 171, f"only {refs} reference fields; the sweep took it from 98 to 152, TRANSMIT-REFS to 173"
+assert len(islands) <= 46, (
+    f"{len(islands)} modules have no reference at all (was 69, then 49). A record that points at "
+    "nothing cannot take part in a chain, which is most of what separates a register from a "
+    "spreadsheet. TRANSMIT-REFS took three more off the list — `transmittal` itself, which could not "
+    "name the company it was addressed to, and `document` and `drawing_set`, which had no reference "
+    "of any kind and so could not be put in a package."
 )
+
+
+# ---- 5. TRANSMIT-REFS: a package must be able to CARRY what it is sent to carry ------------------
+#
+# R22-ENTITLEMENT's remaining item is the outbound submittal package, and its stated blocker was that
+# `transmittal.items` is a textarea. **That was the wrong blocker.** `submittal.transmittal` was
+# already a reference, so submittals resolved into a package the whole time — the entry's own ④ note
+# had verified exactly that against `…/related`, and its Remaining paragraph contradicted it.
+#
+# What was actually missing is asserted here. A transmittal carries drawings, sets and documents at
+# least as often as submittals, and NONE of those three could name one: `document` and `drawing_set`
+# had no reference field of any kind. A package whose contents cannot point at it is prose.
+#
+# The set is NAMED rather than derived, because "what a transmittal carries" is a judgement about the
+# business, not a fact about the schema — and a derived rule would either miss registers or drag in
+# every module that happens to sit in the Drawings section. Naming it means adding a register here is
+# a deliberate act with a reason, which is the same discipline `NOT_OFFERED` uses in test_routines.py.
+TRANSMITTED = {
+    "submittal": "the original case; its reference predates this rule",
+    "drawing": "a transmittal issues sheets",
+    "drawing_set": "and more often issues the whole set, which is the usual unit of issue",
+    "document": "reports, specs and letters go out under a transmittal too",
+}
+for _k, _why in TRANSMITTED.items():
+    _m = mods[_k]
+    assert any(f["type"] == "reference" and f.get("module") == "transmittal"
+               for f in _m.get("fields", [])), \
+        (f"{_k} cannot name the transmittal that issued it ({_why}), so it can never appear in a "
+         "package: a transmittal's contents ARE the records pointing at it, via REVERSE_REFS.")
+
+# The recipient half. A transmittal addressed to a typed company name cannot be resolved, reused or
+# reported on, and `company` is a register. Kept as the additive pair the sweep established rather
+# than a conversion — rule 4 above asserts the pair is adjacent and shares a fieldset.
+assert any(f["type"] == "reference" and f.get("module") == "company"
+           for f in mods["transmittal"].get("fields", [])), \
+    "a transmittal cannot name the company it is addressed to"
 
 print(f"MOD-SWEEP OK - {len(mods)} modules, {refs} reference fields ({len(islands)} still islands), "
       f"{len(united)} fields carry a declared unit, {len(pairs)} additive text+reference pairs are "

--- a/services/api/test_modules.py
+++ b/services/api/test_modules.py
@@ -346,6 +346,46 @@ with TestClient(app) as c:
     docrev = c.post(f"/projects/{pid}/modules/document/{doc['id']}/revise", headers=H("gc")).json()
     assert docrev["ref"] == "DOC-001.1", docrev.get("ref")
 
+    # Placed AFTER the revise assertions on purpose: those pin `DOC-001.1`, and this block creates a
+    # `document`, so running it earlier renumbered their record to DOC-002 and failed an assertion
+    # that was correct. Test order is state here, not just sequence.
+    # TRANSMIT-REFS: a transmittal is a PACKAGE, and its contents are the records pointing at it.
+    #
+    # R22-ENTITLEMENT called the outbound package blocked because `transmittal.items` is a textarea.
+    # It never was: `submittal.transmittal` already existed, so submittals resolved the whole time.
+    # What was missing is the other three registers a transmittal actually carries — `drawing`,
+    # `drawing_set` and `document`, the last two with no reference field of ANY kind. This asserts
+    # the capability rather than the schema: `test_module_fields.py` checks the fields exist, and a
+    # field that exists still proves nothing about whether a package resolves.
+    tr = c.post(f"/projects/{pid}/modules/transmittal", headers=H("gc"),
+                json={"data": {"subject": "IFC set to the city", "purpose": "For Review"}}).json()
+    co = c.post(f"/projects/{pid}/modules/company", headers=H("gc"),
+                json={"data": {"name": "City of Example — Planning"}}).json()
+    c.patch(f"/projects/{pid}/modules/transmittal/{tr['id']}", headers=H("gc"),
+            json={"to_company_ref": co["id"]})
+    dset = c.post(f"/projects/{pid}/modules/drawing_set", headers=H("gc"),
+                  json={"data": {"name": "Permit Set", "transmittal": tr["id"]}}).json()
+    c.post(f"/projects/{pid}/modules/drawing", headers=H("gc"),
+           json={"data": {"number": "A-101", "title": "Level 1 Plan", "transmittal": tr["id"]}})
+    c.post(f"/projects/{pid}/modules/document", headers=H("gc"),
+           json={"data": {"title": "Zoning narrative", "transmittal": tr["id"]}})
+    # `submittal` requires title + spec_section + type; a POST missing them 4xxs and the record simply
+    # is not there. Worth the comment: the first draft of this sent `subject`, the assertion below
+    # reported "submittal missing", and that reads exactly like the product defect it was not.
+    sbm = c.post(f"/projects/{pid}/modules/submittal", headers=H("gc"),
+                 json={"data": {"title": "Curtain wall shop dwgs", "spec_section": "08 44 13",
+                                "type": "Shop Drawing", "transmittal": tr["id"]}})
+    assert sbm.status_code in (200, 201), sbm.text[:200]
+    trel = c.get(f"/projects/{pid}/modules/transmittal/{tr['id']}/related", headers=H("gc")).json()
+    carried = {r.get("module") for r in trel.get("incoming", [])}
+    assert {"drawing", "drawing_set", "document", "submittal"} <= carried, (
+        "a transmittal must resolve every kind of record it carries, not just submittals", trel)
+    # The recipient resolves as a RECORD, which is the half that makes a package addressable: a typed
+    # company name cannot be reused, reported on, or followed to the rest of that company's history.
+    assert any(o.get("ref") == co["ref"] for o in trel.get("outgoing", [])), trel
+    assert dset["data"]["transmittal"] == tr["id"], dset["data"]
+
+
     # ---- AI Draft RFI (template fallback when no ANTHROPIC_API_KEY) -----------
     d = c.post(f"/projects/{pid}/ai/draft-rfi", headers=H("gc"), json={
         "element": {"ifc_class": "IfcBeam", "name": "B-12", "storey": "Level 3"},


### PR DESCRIPTION
# What & why

**R22-ENTITLEMENT's remaining item was the outbound package — and the blocker the entry named was the wrong one.**

It said assembling a package to send was impossible because `transmittal.items` is a textarea. Re-measured before building:

> `submittal` has carried a `transmittal` **reference** all along, so submittals resolved into a package the whole time — which is exactly what the same entry's ④ note had already verified against `…/related`.

*The entry contradicted itself in the paragraph written to stop it contradicting itself.* `items` was never the blocker. It was a second, unresolvable copy of a fact the reference already owned, and it is now labelled as the note it is.

## What was actually missing, measured across all 139 registers

A transmittal carries drawings, sets and documents at least as often as submittals, and **none of those three could name one.** `document` and `drawing_set` had **no reference field of any kind** — islands that cannot take part in a chain at all. And `to_company` was plain text while `company` is a register, so a transmittal could not name the party it was addressed to.

| register | before | after |
|---|---|---|
| `drawing` | refs to set + spec, none to a transmittal | `drawing.transmittal` |
| `drawing_set` | **island** — no references at all | `drawing_set.transmittal` |
| `document` | **island** — no references at all | `document.transmittal` |
| `transmittal` | **island** — recipient was free text | `transmittal.to_company_ref` → `company` |

Reference fields **169 → 173**, islands **49 → 46**. Both ratchets tightened to the new state, per that file's own rule that every bound records work already done.

## No engine changed, and that is the part worth knowing

`REVERSE_REFS` is derived from `reference_fields()` at registry load, so a new reference flows into `related_records`, the *Referenced by* panel and the rollups **by itself**. That this was a schema question rather than a workflow one is the single thing the old paragraph got right.

## `to_company_ref` sits BESIDE the text, not instead of it

MOD-SWEEP established that pattern for 74 fields naming a register — *add the reference, backfill, retire the text later* — and `test_module_fields.py` ratchets it: the pair must be adjacent and share a fieldset. **Converting in place was the obvious move and the wrong one**; existing transmittals keep the name somebody typed, and `refCell`'s three-way path renders a non-uuid value in full rather than as a link to nothing.

## Two gates, catching different things

- **`test_module_fields.py`** names the four registers a package carries, *with a reason each*, and asserts every one can point at a transmittal. The set is **named rather than derived** because "what a transmittal carries" is a judgement about the business, not a fact about the schema — same discipline as `NOT_OFFERED` in `test_routines.py`.
- **`test_modules.py`** asserts a real transmittal resolves all four kinds **and** its company recipient, because a field that exists proves nothing about whether a package resolves.

**Mutation-checked, including for the right reason.** Removing `drawing.transmittal` fails the schema gate by name and the behavioural one listing the three kinds it did resolve. Removing `document`'s link or the recipient trips the **island ceiling first** — so the named checks were re-verified against a module that keeps its other references. A gate that passes for the wrong reason is not a gate.

## A test bug worth recording

The first draft created the submittal with a `subject` field it does not have. The POST 4xx'd and the assertion reported a missing submittal — **which reads exactly like the product defect it was not.** The check now asserts the POST succeeded before asserting what it means. The block also had to move after the revise assertions, which pin `DOC-001.1`: creating a document earlier renumbered their record and failed a correct assertion.

## Deliberately left alone

⚠️ **`drawing_issuance`** models the same event — free-text `recipients`, a purpose, a sheet count — and is still an island. Whether it should link to `transmittal`, be fed by it, or be retired is a modelling decision about the business, not a gap to close in passing. Recorded in the roadmap rather than acted on.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `python -m ruff check ../..` clean (whole tree)
- [x] Backend: affected + structural gates green — `test_module_fields`, `test_modules`, `test_module_config`, `test_module_schema`, `test_module_rooms`, `test_docs_module_schema`, `test_claude_md_gates`
- [x] Web: 205 files / 2080 tests pass
- [x] No import cycles introduced; **no engine change** — the references flow through `REVERSE_REFS`
- [x] `CHANGELOG.md` entry added; `docs/roadmap.md` corrected
- [ ] Version bumped in both manifests — **N/A, not a release PR**
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added transmittal links for drawings, drawing sets, and documents.
  - Added a structured recipient company link for transmittals.
  - Transmittal details now identify linked contents and recipients more clearly.
  - Clarified that the free-text items field is informational only.

- **Bug Fixes**
  - Improved related-record resolution for transmittal packages, including all supported record types and recipient companies.

- **Documentation**
  - Updated roadmap and changelog entries to reflect outbound package support and corrected prior transmittal information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->