### PR TITLE
A tree, a crane and a desk could not be placed where you were pointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased — a tree, a crane and a desk could not be placed where you were pointing
+
+**And the entry below contains a claim that was wrong, corrected here.** It said thumbnails and
+drag-to-place were "genuinely unshipped". Drag-to-place **ships** — RAIL-DRAG makes every Draw-rail
+row `draggable` (`apps/web/src/viewer/draft/draftPanel.ts`), `apps/web/src/viewer/railDrag.ts`
+handles the protected-mode payload rule, and `apps/web/src/viewer/app.ts` carries the
+`dragover`/`drop` pair that arms the dropped key and places it where it landed. Thumbnails remain
+genuinely unshipped.
+
+*The error is worth more than the correction.* The premise-check looked at **the library palette**,
+found a modal with a coordinate prompt, and concluded about **the app**. The library cannot be
+dragged from — `.result-overlay` is `position: fixed; inset: 0` with a scrim, so there is no drop
+target to reach — but the **Draw rail** could be dragged from all along. That is the same "checked
+the surface whose name matched the noun" mistake `docs/roadmap.md`'s own ⑥ note records having made,
+one entry earlier, in the paragraph written to stop it happening again.
+
+**What the corrected measurement found is a real gap, and it is closed here.** The 19 CONTENT-1 items
+— FF&E, Landscape, Site Logistics — were absent from the draft catalog entirely. Every built-in
+element and every family has been click- **and** drag-placeable from the Draw rail since RAIL-DRAG;
+content appeared only in the Library modal, whose sole placement affordance is a prompt asking for
+*"Location E, N (metres)"*. They were the only placeable things in the product reachable by neither
+affordance.
+
+`contentToDraftElement` mirrors `familyToDraftElement`: a 1-point `place_content` element, keyed
+`content:<key>`, bucketed onto the discipline chip that lists it (FF&E → Architectural, Landscape
+and Site Logistics → Site). **One entry closes both affordances at once** rather than adding a second
+placement path, because `allElements()` feeds the rows, the search, the discipline chips *and*
+`armByKey` — which is the function the viewport's `drop` handler calls. Content therefore also
+inherits what the Library prompt never had: `validatePlacement` refusing an off-model point by name
+while keeping the tool armed, the amber optimistic ghost, the incremental preview, point undo/redo,
+snapping, Esc-to-cancel — and the active-level injection that landed in the entry below.
+
+**No parameter form, asserted rather than assumed.** `place_content` takes `{category, point}` and
+sizes the item from its own catalog entry, so unlike a family there are no dims to override; a form
+here would render inputs the recipe discards. And `build()` sends the catalog **key** as `category`
+— the catalog calls that string `key` and the recipe calls it `category`, and sending the display
+label instead 400s with *"unknown content category"*, so the exact payload is pinned by test.
+
+Mutation-checked: loading content but leaving it out of `allElements()` — the registered-but-unreachable
+shape — fails three tests including both the arm and drag paths; sending the label instead of the key
+fails two; and dropping the unknown-bucket fallback fails the test that exists because an item mapped
+to no discipline would vanish from every chip and read as a catalog that shrank.
+
+**A row label names its bucket — "Tree (Landscape)", "Hoist (Site Logistics)" — and that is not
+decoration.** Measured before shipping: **8 of the 19 content keys already exist as families** (bed,
+chair, desk, planter, shrub, sofa, table, tree), and the row's meta badge strips both `Ifc` and
+`Type`, so a family's `IfcFurnitureType` and a content item's `IfcFurniture` both render as
+"Furniture". Without the bucket the Draw list would show two rows reading exactly **Desk** that
+author different recipes — one a sized family type, one a phased site-content item. The suffix goes
+on all nineteen rather than only the colliding eight, because a label whose shape depends on what
+else happens to be in the catalog changes under the user the day a family is added.
+
+**An existing gate caught a real defect in this change**: `docStranded.test.ts` failed because the
+new flattener had been inserted *between* `contentToDraftElement`'s doc comment and its signature,
+leaving that comment documenting the wrong function. That is precisely the residue DOC-STRAND exists
+to find, found on its author rather than months later.
+
 ## Unreleased — everything placed from the library landed on the ground floor
 
 **Found while premise-checking UX-3's five-item line, and worse than anything on it.**

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -48,7 +48,7 @@ import { LayerManager } from "../tools/layers";
 import { loadSelSets, saveSelSets } from "../tools/selectionSetsStore";
 import { OriginTool } from "../tools/origin";
 import { installDraftPanel, type ArmedDraft, type DraftPanelHandle } from "./draft/draftPanel";
-import { type FamilyDef } from "./draft/draftCatalog";
+import { flattenContentCatalog, type FamilyDef } from "./draft/draftCatalog";
 import { GridOverlay } from "./draft/gridOverlay";
 import { LogisticsOverlay } from "./draft/logisticsOverlay";
 import { DraftProxyLayer } from "./draft/draftProxy";
@@ -1713,9 +1713,9 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
           const cat = await api.familyCatalog();
           return Object.values(cat.categories).flat() as FamilyDef[];
         },
+        fetchContent: async () => flattenContentCatalog(await api.contentCatalog()),
         arm: (a) => { armed = a; armPts.length = 0; setDynBuf(""); },  // re-arm resets the dyn HUD
-        notify,
-        canAuthor: () => !!projectId && hasIfc,
+        notify, canAuthor: () => !!projectId && hasIfc,
       });
     }
 

--- a/apps/web/src/viewer/draft/draftCatalog.test.ts
+++ b/apps/web/src/viewer/draft/draftCatalog.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { DRAFT_ELEMENTS, familyToDraftElement, type FamilyDef } from "./draftCatalog";
+import {
+  contentToDraftElement, DRAFT_ELEMENTS, familyToDraftElement, flattenContentCatalog,
+  type ContentDef, type FamilyDef,
+} from "./draftCatalog";
 
 const byKey = (k: string) => DRAFT_ELEMENTS.find((e) => e.key === k)!;
 
@@ -72,5 +75,87 @@ describe("familyToDraftElement", () => {
     const el = familyToDraftElement(fam);
     const p = el.build([[1, 2]], { width: 0.5, depth: 0.7, height: 0.85 });
     expect(p).toEqual({ family: "toilet", position: [1, 2], dims: [0.5, 0.7, 0.85] });
+  });
+});
+
+/**
+ * CONTENT-DRAFT — the 19 CONTENT-1 items were the only placeable things in the app that could be
+ * neither armed nor dragged.
+ *
+ * `DRAFT_ELEMENTS` and every family have been click- and drag-placeable from the Draw rail since
+ * RAIL-DRAG. Content appeared only in the Library palette, which is a **modal**
+ * (`.result-overlay` is `position: fixed; inset: 0` with a scrim), so nothing could be dragged out
+ * of it and its only placement affordance was a prompt asking for "Location E, N (metres)". You
+ * could not put a tree, a crane or a desk where you were pointing.
+ *
+ * Wrapping content as a `DraftElement` fixes both affordances at once rather than adding a second
+ * placement path: `allElements()` feeds the row buttons, the search, the discipline chips AND
+ * `armByKey`, which is the function the viewport's `drop` handler calls.
+ */
+describe("contentToDraftElement", () => {
+  const tree: ContentDef = {
+    key: "tree", ifc_class: "IfcGeographicElement", phase: null,
+    classification: "23-45 00 00 Landscape", default_dims_m: [3, 3, 6],
+  };
+
+  it("wraps a catalog item as a 1-point place_content element", () => {
+    const el = contentToDraftElement(tree, "Landscape");
+    expect(el.key).toBe("content:tree");
+    expect(el.label).toBe("Tree (Landscape)");
+    expect(el.recipe).toBe("place_content");
+    expect(el.points).toBe(1);
+    expect(el.ifcClass).toBe("IfcGeographicElement");
+  });
+
+  it("has NO params, because place_content sizes from the catalog and takes no dims", () => {
+    // Asserted rather than left implicit: a dims form here would render inputs the recipe discards,
+    // which is a control that looks like it does something and does not.
+    expect(contentToDraftElement(tree, "Landscape").params).toEqual([]);
+  });
+
+  it("build() sends the catalog KEY as `category`, which is what the server names it", () => {
+    // The catalog calls the string `key` and the recipe calls it `category`. Sending the label
+    // instead 400s with "unknown content category" — hence a test on the exact payload.
+    expect(contentToDraftElement(tree, "Landscape").build([[4, 5]], {}))
+      .toEqual({ category: "tree", point: [4, 5] });
+  });
+
+  it("maps each catalog bucket to the discipline chip that lists it", () => {
+    expect(contentToDraftElement(tree, "Landscape").discipline).toBe("Site");
+    expect(contentToDraftElement({ ...tree, key: "hoist" }, "Site Logistics").discipline).toBe("Site");
+    expect(contentToDraftElement({ ...tree, key: "desk" }, "FF&E").discipline).toBe("Architectural");
+    // an unknown bucket must still LIST somewhere — a default of undefined would hide the item from
+    // every chip, which reads as "the catalog shrank" rather than "a bucket was added".
+    expect(contentToDraftElement({ ...tree, key: "x" }, "Newly Added Bucket").discipline).toBe("Site");
+  });
+
+  it("humanises the key AND names the bucket, because 8 of 19 keys collide with a family", () => {
+    // bed, chair, desk, planter, shrub, sofa, table, tree all exist as families too, and the row's
+    // meta badge strips "Ifc"/"Type" so IfcFurnitureType and IfcFurniture both read "Furniture".
+    // Two rows saying "Desk" that author different recipes is the papercut this suffix prevents.
+    expect(contentToDraftElement({ ...tree, key: "site_office" }, "Site Logistics").label)
+      .toBe("Site office (Site Logistics)");
+    expect(contentToDraftElement({ ...tree, key: "desk" }, "FF&E").label).toBe("Desk (FF&E)");
+  });
+
+  it("the hint names the item, not the decorated label", () => {
+    expect(contentToDraftElement(tree, "Landscape").hint).toBe("Click where to place the tree.");
+  });
+});
+
+describe("flattenContentCatalog", () => {
+  it("pairs every item with its bucket", () => {
+    const c: ContentDef = {
+      key: "desk", ifc_class: "IfcFurniture", phase: null, classification: "", default_dims_m: [1, 1, 1],
+    };
+    expect(flattenContentCatalog({ groups: { "FF&E": [c], Landscape: [{ ...c, key: "tree" }] } }))
+      .toEqual([[c, "FF&E"], [{ ...c, key: "tree" }, "Landscape"]]);
+  });
+
+  it("survives an empty or absent groups map rather than throwing into the panel", () => {
+    // The panel loads this lazily and catches, but a throw here would take the whole Draw list with
+    // it on a server that returns a shape we did not expect.
+    expect(flattenContentCatalog({ groups: {} })).toEqual([]);
+    expect(flattenContentCatalog({} as { groups: Record<string, ContentDef[]> })).toEqual([]);
   });
 });

--- a/apps/web/src/viewer/draft/draftCatalog.ts
+++ b/apps/web/src/viewer/draft/draftCatalog.ts
@@ -255,4 +255,63 @@ export function familyToDraftElement(f: FamilyDef): DraftElement {
   };
 }
 
+/** One entry of `GET /content/catalog` — CONTENT-1 site content (logistics, FF&E, landscaping). */
+export interface ContentDef {
+  key: string;
+  ifc_class: string;
+  phase: string | null;
+  classification: string;
+  default_dims_m: number[];
+}
+
+/** The catalog's three buckets, mapped to the discipline chips the draft panel filters by. */
+const DISCIPLINE_BY_CONTENT_GROUP: Record<string, Discipline> = {
+  "FF&E": "Architectural", Landscape: "Site", "Site Logistics": "Site",
+};
+
+/**
+ * Map a catalog content item into a placeable DraftElement (1 point, `place_content`).
+ *
+ * The mirror of `familyToDraftElement`, and it exists because the 19 content items were the only
+ * placeable things in the app reachable by NEITHER arming nor dragging: they appear in the Library
+ * palette, which is a modal (`.result-overlay` is `position: fixed; inset: 0` with a scrim), so its
+ * only placement affordance is a prompt asking the user to type "Location E, N (metres)". Everything
+ * in `DRAFT_ELEMENTS` and every family has been click- and drag-placeable from the Draw rail all
+ * along. Putting content in the same list closes that by construction rather than by a second
+ * implementation: `allElements()` feeds the list, the search, `armByKey` — which the drop handler
+ * calls — and the discipline chips, so one entry here reaches all of them.
+ *
+ * **No `params`.** `place_content` takes `{category, point}` and sizes the item from its own catalog
+ * entry; unlike a family it has no dims to override. An empty list is a shape the form already
+ * supports (`add_grid` ships one), so this needs no panel change.
+ */
+export function contentToDraftElement(c: ContentDef, group: string): DraftElement {
+  const name = c.key.replace(/_/g, " ").replace(/^./, (ch) => ch.toUpperCase());
+  // The bucket is IN the label, and that is not decoration. **8 of the 19 content items share a key
+  // with a family** — bed, chair, desk, planter, shrub, sofa, table, tree — and the row's meta badge
+  // strips both "Ifc" and "Type", so `IfcFurnitureType` (family) and `IfcFurniture` (content) both
+  // render as "Furniture". Without the bucket the Draw list shows two rows reading exactly "Desk"
+  // that author different recipes: one a sized family type, one a phased site-content item. The
+  // suffix is applied to ALL of them rather than only the colliding eight, because a label whose
+  // shape depends on what else happens to be in the catalog changes under you when a family is added.
+  const label = `${name} (${group})`;
+  return {
+    key: `content:${c.key}`, label,
+    discipline: DISCIPLINE_BY_CONTENT_GROUP[group] ?? "Site",
+    ifcClass: c.ifc_class, recipe: "place_content", points: 1,
+    params: [],
+    hint: `Click where to place the ${name.toLowerCase()}.`,
+    // `category` IS the catalog key — the server names that parameter `category` while the catalog
+    // calls the same string `key`, and sending the label instead 400s with "unknown content category".
+    build: (pts) => ({ category: c.key, point: pts[0] }),
+  };
+}
+
+/** Flatten `GET /content/catalog`'s `{groups: {bucket: item[]}}` into [item, bucket] pairs.
+ *  Pure and separate so `app.ts` wires one expression and the reshape can be tested without a DOM. */
+export function flattenContentCatalog(cat: { groups: Record<string, ContentDef[]> }): [ContentDef, string][] {
+  return Object.entries(cat.groups ?? {}).flatMap(([group, items]) =>
+    (items ?? []).map((c) => [c, group] as [ContentDef, string]));
+}
+
 export const DISCIPLINES: Discipline[] = ["Architectural", "Structural", "MEP", "Site"];

--- a/apps/web/src/viewer/draft/draftPanel.test.ts
+++ b/apps/web/src/viewer/draft/draftPanel.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { installDraftPanel, type ArmedDraft } from "./draftPanel";
+import { type ContentDef } from "./draftCatalog";
 import { DRAFT_DRAG_MIME, readDraftDragKey } from "../railDrag";
 
 /**
@@ -15,19 +16,24 @@ import { DRAFT_DRAG_MIME, readDraftDragKey } from "../railDrag";
  * over with a mock that would only assert the mock.
  */
 
-function mount() {
+function mount(content: [ContentDef, string][] = []) {
   const body = document.createElement("div");
   document.body.appendChild(body);
   const armed: (ArmedDraft | null)[] = [];
   const handle = installDraftPanel({
     body,
-    fetchFamilies: () => Promise.resolve([]),
+    fetchFamilies: () => Promise.resolve([]), fetchContent: () => Promise.resolve(content),
     arm: (a) => { armed.push(a); },
     notify: vi.fn((_m: string, _k?: "info" | "success" | "error") => {}),
     canAuthor: () => true,
   });
   return { body, armed, handle };
 }
+
+const TREE: ContentDef = {
+  key: "tree", ifc_class: "IfcGeographicElement", phase: null,
+  classification: "23-45 00 00", default_dims_m: [3, 3, 6],
+};
 
 /** The palette rows — buttons inside the scrolling list, excluding discipline chips. */
 const rows = (body: HTMLElement) =>
@@ -114,5 +120,58 @@ describe("RAIL-DRAG — the palette rows are actually drag sources", () => {
     const row = rows(body)[1] ?? rows(body)[0]!;
     row.click();
     expect(body.querySelectorAll("button.on").length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * CONTENT-DRAFT — content must be reachable through the SAME two affordances as everything else.
+ *
+ * Asserting `contentToDraftElement` returns the right object proves nothing about whether the panel
+ * ever lists it: "the engine exists and nothing calls it" is the defect this file's own header names
+ * as the repo's most-repeated. So these drive the real panel, and the arming case goes through
+ * `armByKey` specifically — the function the viewport's `drop` handler calls — rather than through a
+ * row click, because that is the path a drag actually takes.
+ */
+describe("CONTENT-DRAFT — content lists, arms and drags like any other element", () => {
+  it("lists a content item once its catalog resolves", async () => {
+    const { body } = mount([[TREE, "Landscape"]]);
+    // Landscape → Site, so switch the chip before looking: an item filtered out by the discipline
+    // it was assigned is indistinguishable from an item that never loaded.
+    await Promise.resolve(); await Promise.resolve();
+    const site = [...body.querySelectorAll<HTMLButtonElement>("button")]
+      .find((b) => b.textContent === "Site");
+    expect(site, "no Site discipline chip").toBeTruthy();
+    site!.click();
+    expect(rows(body).map((r) => r.textContent)).toContain("Tree (Landscape)GeographicElement");
+  });
+
+  it("armByKey arms a content item — the path a DROP takes", async () => {
+    const { armed, handle } = mount([[TREE, "Landscape"]]);
+    await Promise.resolve(); await Promise.resolve();
+    expect(handle.armByKey("content:tree")).toBe("Tree (Landscape)");
+    const a = armed.at(-1);
+    expect(a?.recipe).toBe("place_content");
+    expect(a?.points).toBe(1);
+    expect(a?.build([[7, 8]])).toEqual({ category: "tree", point: [7, 8] });
+  });
+
+  it("a content row is draggable and carries its key, like the built-ins", async () => {
+    const { body } = mount([[TREE, "Landscape"]]);
+    await Promise.resolve(); await Promise.resolve();
+    const site = [...body.querySelectorAll<HTMLButtonElement>("button")]
+      .find((b) => b.textContent === "Site");
+    site!.click();
+    const row = rows(body).find((r) => r.textContent?.startsWith("Tree (Landscape)"));
+    expect(row, "the content row is not a drag source").toBeTruthy();
+    const dt = makeDT();
+    row!.dispatchEvent(Object.assign(new Event("dragstart"), { dataTransfer: dt }));
+    expect(readDraftDragKey(dt)).toBe("content:tree");
+    expect(dt.types).toContain(DRAFT_DRAG_MIME);
+  });
+
+  it("an unknown key still refuses, so a stale drag cannot arm the wrong thing", async () => {
+    const { handle } = mount([[TREE, "Landscape"]]);
+    await Promise.resolve(); await Promise.resolve();
+    expect(handle.armByKey("content:no_such_item")).toBeNull();
   });
 });

--- a/apps/web/src/viewer/draft/draftPanel.ts
+++ b/apps/web/src/viewer/draft/draftPanel.ts
@@ -7,8 +7,8 @@
  * catalog in draftCatalog.ts.
  */
 import {
-  DISCIPLINES, DRAFT_ELEMENTS, familyToDraftElement,
-  type Discipline, type DraftElement, type FamilyDef, type ParamDef, type ParamValues,
+  contentToDraftElement, DISCIPLINES, DRAFT_ELEMENTS, familyToDraftElement,
+  type ContentDef, type Discipline, type DraftElement, type FamilyDef, type ParamDef, type ParamValues,
 } from "./draftCatalog";
 import { setDraftDragKey } from "../railDrag";
 
@@ -26,6 +26,8 @@ export interface ArmedDraft {
 export interface DraftPanelDeps {
   body: HTMLElement;
   fetchFamilies: () => Promise<FamilyDef[]>;
+  /** CONTENT-1 items, already flattened to [item, group] pairs — the catalog nests them by bucket. */
+  fetchContent: () => Promise<[ContentDef, string][]>;
   arm: (a: ArmedDraft | null) => void;
   notify: (msg: string, kind?: "info" | "success" | "error") => void;
   canAuthor: () => boolean;
@@ -46,6 +48,7 @@ export function installDraftPanel(deps: DraftPanelDeps): DraftPanelHandle {
   let selected: DraftElement | null = null;
   let armedKey: string | null = null;
   let families: DraftElement[] = [];
+  let content: DraftElement[] = [];
   let familiesLoaded = false;
 
   const intro = el("div", "meta");
@@ -78,7 +81,10 @@ export function installDraftPanel(deps: DraftPanelDeps): DraftPanelHandle {
   const form = el("div"); form.style.marginTop = "4px";   // parameter form + Place button
   body.appendChild(form);
 
-  function allElements(): DraftElement[] { return [...DRAFT_ELEMENTS, ...families]; }
+  // One list, reached by the row buttons, the search box, the discipline chips AND `armByKey` — which
+  // is what the viewport's drop handler calls. Adding content here makes it click- and drag-placeable
+  // in the same edit, rather than by two implementations that can disagree.
+  function allElements(): DraftElement[] { return [...DRAFT_ELEMENTS, ...families, ...content]; }
 
   function renderList() {
     for (const d of DISCIPLINES) chipBtns[d]?.classList.toggle("on", d === discipline);
@@ -169,13 +175,18 @@ export function installDraftPanel(deps: DraftPanelDeps): DraftPanelHandle {
     renderForm();
   }
 
-  // initial paint; families load lazily
+  // initial paint; families and content load lazily. Settled independently on purpose: a content
+  // catalog that 404s on an older server must not take the families down with it, and vice versa.
   renderList();
   void deps.fetchFamilies().then((fs) => {
     families = fs.map(familyToDraftElement);
     familiesLoaded = true;
     renderList();
   }).catch(() => { familiesLoaded = true; renderList(); });
+  void deps.fetchContent().then((cs) => {
+    content = cs.map(([c, group]) => contentToDraftElement(c, group));
+    renderList();
+  }).catch(() => { /* content unavailable — the built-ins and families still list */ });
 
   return {
     onArmCleared() { if (armedKey) { armedKey = null; renderForm(); } },

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2901,8 +2901,31 @@ removed. Remaining, in priority order:
   `add_door`/`add_window` cut the opening into it at the point you clicked; *appendable IFC libraries*
   is `services/data/src/aec_data/families.py` `import_types_from_ifc`, which copies every
   `IfcTypeProduct` out of a third-party IFC, deduped by (class, name), and the palette exposes it.
-  *Thumbnails* and *drag-to-place* are genuinely unshipped — the palette renders label-plus-meta text
-  and places through a modal that asks for "Location E, N (metres)".
+  ⚠️ **That sentence said "*Thumbnails* and *drag-to-place* are genuinely unshipped" and the
+  drag-to-place half was WRONG — corrected 2026-09-05, hours after it was merged.** Drag-to-place
+  ships, as RAIL-DRAG: `apps/web/src/viewer/draft/draftPanel.ts` makes every palette row
+  `draggable` and writes the key with `setDraftDragKey`; `apps/web/src/viewer/railDrag.ts` handles
+  the protected-mode payload rule that makes `dragover` unable to read it; and
+  `apps/web/src/viewer/app.ts` has the `dragover`/`drop` pair that arms the dropped key and places
+  it where it landed.
+
+  *This is the fourth naming-based false blocker this ring has produced, and it is the same mistake
+  the ⑥ note above documents — I checked the surface whose NAME matched the noun ("the library") and
+  concluded about the capability.* The library palette genuinely cannot be dragged from, because it
+  is a modal; the **Draw rail** could be dragged from all along. Checking one surface does not check
+  the app: the population is every placement surface, not the one called "library". **Thumbnails
+  remain genuinely unshipped** — the rows are label plus IFC class as text.
+
+  ✅ **CONTENT-DRAFT, shipped 2026-09-05 — what the corrected measurement actually found.** The 19
+  CONTENT-1 items (FF&E · Landscape · Site Logistics) appeared in **neither** affordance: they were
+  absent from the draft catalog entirely, so they were the only placeable things in the app that
+  could be neither armed nor dragged. You could not put a tree, a crane or a desk where you were
+  pointing — only type "Location E, N (metres)" into the modal. `contentToDraftElement` mirrors
+  `familyToDraftElement`, and because `allElements()` feeds the rows, the search, the discipline
+  chips **and `armByKey` — the function the drop handler calls** — one entry closes clicking and
+  dragging together rather than as two implementations that can disagree. Content carries no
+  parameter form: `place_content` sizes from the catalog and takes no dims, so a dims form would
+  render inputs the recipe discards.
 
   ⚠️ **And the premise-check found something worse than anything on the line — now fixed.**
   `edit_core._first_storey(model, None)` returns the LOWEST storey, and `place_type` containers the


### PR DESCRIPTION
# What & why

The 19 CONTENT-1 items — FF&E, Landscape, Site Logistics — were absent from the draft catalog entirely. Every built-in element and every family has been click- **and** drag-placeable from the Draw rail since RAIL-DRAG; content appeared only in the Library palette, which is a **modal** (`.result-overlay` is `position: fixed; inset: 0` with a scrim), so nothing can be dragged out of it and its only placement affordance is a prompt asking for *"Location E, N (metres)"*. They were the only placeable things in the product reachable by neither affordance — you could not put a tree, a crane or a desk where you were pointing.

`contentToDraftElement` mirrors `familyToDraftElement`: a 1-point `place_content` element keyed `content:<key>`, bucketed onto the discipline chip that lists it. **One entry closes both affordances at once** rather than adding a second placement path, because `allElements()` feeds the rows, the search, the discipline chips *and* `armByKey` — the function the viewport's `drop` handler calls. Content therefore inherits what the modal prompt never had: `validatePlacement` refusing an off-model point by name while keeping the tool armed, the amber optimistic ghost, the incremental preview, point undo/redo, snapping, Esc-to-cancel, and the active-level injection from #449.

## This also corrects a claim merged hours ago

`docs/roadmap.md` said thumbnails and drag-to-place were *"genuinely unshipped"*. **Drag-to-place ships** — `draftPanel.ts` makes every row `draggable`, `railDrag.ts` handles the protected-mode payload rule that stops `dragover` reading it, and `app.ts` carries the `dragover`/`drop` pair that arms the dropped key and places it where it landed.

The premise-check looked at *the library palette*, found a modal with a coordinate prompt, and concluded about *the app*. That is the same **"checked the surface whose name matched the noun"** mistake the roadmap's own ⑥ note records having made — one entry earlier, in the paragraph written to stop it happening again. The library genuinely cannot be dragged from; the Draw rail could be all along. Thumbnails remain genuinely unshipped.

## Two defects caught before shipping

**An existing gate found the first.** `docStranded.test.ts` failed because the new flattener had been inserted *between* `contentToDraftElement`'s doc comment and its signature, leaving that comment documenting the wrong function — precisely the residue DOC-STRAND exists to find, found on its author rather than months later.

**The second was measured rather than assumed.** 8 of the 19 content keys already exist as families (bed, chair, desk, planter, shrub, sofa, table, tree), and the row badge strips both `Ifc` and `Type`, so a family's `IfcFurnitureType` and a content item's `IfcFurniture` both render as "Furniture" — two rows reading exactly **Desk** that author different recipes. Labels now carry the bucket ("Tree (Landscape)", "Hoist (Site Logistics)"), on all nineteen rather than the colliding eight: a label whose shape depends on what else is in the catalog changes under the user the day a family is added.

## Verification

| Check | Result |
|---|---|
| Web typecheck · lint · vitest | clean — **207 files / 2098 tests** |
| ruff (whole tree) | clean |
| Backend suite | **no backend source changed**; doc gates (`test_claude_md_gates`, `test_no_comparative_names`, `test_file_sizes`) pass individually. A full run was still in progress at push time — CI's API test gate is the authority |
| `app.ts` size ratchet | held at exactly **2,508** by folding the new dep onto an existing line |

**Three mutations checked**: loading content but omitting it from `allElements()` — the registered-but-unreachable shape — fails 3 tests including both the arm and drag paths; sending the label instead of the catalog key fails 2; dropping the unknown-bucket fallback fails the test that exists because an item mapped to no discipline would vanish from every chip and read as a catalog that shrank.

**Clean negative:** `KEY_MAP` in `keysDyn.ts` is a fixed two-letter table, so 19 new catalog entries cannot collide with a keyboard shortcut. Content simply isn't bound to one, which is not a regression.

## Not done, and why

**The Library palette still uses its coordinate prompt.** Making it arm instead needs a `closeResult` export from `apps/web/src/ui/result.ts` plus arming from inside a modal — and the palette is also where drag-to-place would live if it ever moved out of the modal. Touching its interaction now, while modal-vs-dockable-panel is an open product question, risks doing it twice.

**True drag-from-the-library remains unshipped and now has a named blocker**: it needs the library out of the modal and into a dockable panel. That is a UI restructure and a product decision, not a sprint slice.

**Thumbnails remain unshipped.** They need a render or a stored image per catalog item — a separate question about where those come from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for placing all 19 CONTENT-1 catalog items from the Draw rail.
  - Content items can be selected, dragged onto the canvas, and placed with the correct catalog details.
  - Content items are organized by discipline and labeled with their catalog category.

- **Bug Fixes**
  - Corrected documentation describing drag-to-place availability and measurement behavior.

- **Documentation**
  - Updated the roadmap and unreleased changelog with CONTENT-1 placement support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->