### PR TITLE
Wire the three reachable recipes DARK-RECIPES found — and the one that was never a gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased — you could put a window in a wall but not a skylight in a roof
+
+`add_roof_window` cuts a full-depth `IfcOpeningElement` through a host `IfcRoof` and fills it with an
+`IfcWindow` of PredefinedType `SKYLIGHT`. It has worked since the R17 DORMER slice, it is covered by
+`services/api/test_roof_window.py` down to the void/fill relations and GUID stability across a
+re-open — and no user could invoke it. The viewer has had *"Add door to selected wall"* and *"Add
+window to selected wall"* the whole time.
+
+**Two independent descriptions each said a shipped tool had a missing twin, and neither was a check.**
+The coverage matrix entry read *"the roof counterpart of the wired `add_door`/`add_window`"*; the
+engine function's own docstring says *"the flat-roof counterpart of the wall-hosted `add_opening`"*.
+Prose noticing an asymmetry is not the same as anything failing because of it.
+
+It is now **☀ Skylight in selected roof** on the envelope section, beside the curtain wall — select
+the roof, click where it goes, give width × length. `UNREACHED` goes 7 → 6.
+
+**One behavioural difference had to be handled rather than copied.** `add_door` and `add_window`
+centre themselves on the host when no position is given; `add_roof_window` indexes `p["position"]`
+with no default, so the wall tools' "click optional" pattern would have produced a server error on a
+button press instead of a skylight. The tool requires the point and says what to do about it.
+
+**It went into `envelopeSection.ts`, not `app.ts`.** `services/api/test_file_sizes.py` pins
+`apps/web/src/viewer/app.ts` at 2,508 lines and a decomposition ratchet only ratchets one way, so a
+new tool there would have been paid for by unwinding an extraction. `app.ts` changes by two
+identifiers on two existing lines and stays at exactly 2,508.
+
+**A new gate came out of the wiring, and it generalises past this change.**
+`apps/web/src/viewer/tools/sectionButtonsWired.test.ts` asserts that every member of every `*Buttons`
+interface a section module exports is both destructured **and passed to an `append`** in `app.ts`.
+`envelopeSection.ts`'s own comment says its interface is *"named so re-ordering cannot silently
+re-map them"* — that guards the order, and nothing guarded the last step. **A button that is built,
+returned, destructured and never appended is invisible with every typecheck green**, which
+`envelopeSection.ts`'s docstring records the annotation group shipping once already: *"the same
+silent-inert failure `qaSection.ts` shipped"*. `tsc` is satisfied by the destructure and a unit test
+is satisfied by calling the handler; only the DOM tree knows. Derived from the interfaces rather than
+a list — the failure mode is somebody adding a button and forgetting the second half — and it carries
+a control asserting the derivation still finds all three interfaces, because a regex that stops
+matching passes every assertion vacuously.
+
 ## Unreleased — MEP runs could only be joined two elements at a time, and a system's discipline could never be corrected
 
 Two of the ten recipes the entry below named as reachable from nothing are real capabilities, and both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,62 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased — MEP runs could only be joined two elements at a time, and a system's discipline could never be corrected
+
+Two of the ten recipes the entry below named as reachable from nothing are real capabilities, and both
+are now on the MEP systems panel.
+
+**Auto-connect.** `auto_connect_mep` welds every unconnected MEP pair whose connection points coincide
+within a tolerance, in one pass — nearest pairs first, each element joining at most as many pairs as it
+has free ports, so a second run changes nothing. Until now the only way to connect anything was
+`connectMep`: pick one element, pick another, connect. That is fine for a joint and hopeless for a
+model, and the panel it sits on has been reporting *"**N** floating element(s)"* the whole time with no
+way to act on the number. The new button sits beside that count and reports what it welded — including
+`0`, which is a real answer (everything already joined, or nothing within tolerance) and is worded as
+one rather than as a bare "done".
+
+**Retype a system.** `set_system_predefined` stamps a named `IfcDistributionSystem`'s discipline.
+Authoring already sets it — but only on the system's **first** assignment, and `_assign_to_system`'s own
+docstring says *"first author wins; retag via `set_system_predefined`"*. That retag path existed in the
+engine and in no product surface, so a system that arrived untyped from an import, or was created before
+its discipline was decided, stayed untyped permanently — while the panel displayed the discipline, the
+by-discipline rollup counted it, and the fire-protection checks keyed off it. Each system row now
+carries a retype action.
+
+**The third was never a gap, and that is the finding.** `add_sprinkler` is not missing a caller for want
+of wiring: `add_fire_equipment(kind="sprinkler")` resolves through the same `add_mep_terminal` to the
+same `IfcFireSuppressionTerminal`/`SPRINKLER` at the same size on the same *Fire Protection* system with
+`discipline="fire"`, and has been on the viewer's 🧯 button since MEP-FP. Wiring it would have added a
+second control authoring a byte-identical element.
+
+*A reachability sweep answers "does anything call this?", which is one question short of "can a user do
+this?" — the same shape of gap the entry below was written to close, one layer further in.* So
+`SUPERSEDED` now sits beside `UNREACHED` in `authoring_matrix.py`, the matrix carries a fourth `reach`
+value, and the published table and the in-app coverage panel report the two classes separately: a
+duplicate counted among the gaps understates coverage and invites work that would ship a redundant
+control. `UNREACHED` goes 10 → 7.
+
+**The supersession is asserted against what the recipes author, not against how they read.**
+`test_recipe_reach.py` runs both on a fixture model and compares (IFC class, PredefinedType, system
+name, system PredefinedType) — every attribute that distinguishes one MEP terminal from another; without
+the system and discipline it would pass on two elements landing on different systems, which is most of
+what these recipes are for. Change `_FIRE_EQUIPMENT["sprinkler"]` and the gate names the divergence and
+says the recipe is a real capability again. The `UNREACHED`/`SUPERSEDED` split is checked for
+disjointness and for jointly covering the derived uncalled set, so neither can quietly absorb the other.
+
+**A gate had to be narrowed to say the thing it meant.** `docsPublished.test.ts` rejects any public doc
+whose opening contains "superseded" — a proxy for *"this document declares itself a working note"*. The
+generated matrix now labels a set of **recipes** superseded, which is a claim about them and not about
+the file, and the same latent false positive was already sitting in `docs/internal/security-roadmap.md`
+("this one is **not** a superseded snapshot" — a negation read as a confession), unfired only because it
+is internal. The rule now ignores lines naming a backticked code identifier: a status banner announces
+the document's own condition and cites nothing else. That is a heuristic and is labelled as one — so the
+narrowing carries a **positive control** that re-runs the predicate over the archived notes the
+un-narrowed rule catches and fails if any is no longer recognised. *An empty result means "nothing
+leaked" and "the predicate stopped working" equally, and a narrowing is exactly when the second becomes
+likely.* (Written first over the whole archive, which reported 6 missed — all 6 of which had never
+matched: that assertion was testing the archive's filing, not the predicate.)
+
 ## Unreleased — the coverage matrix counted ten capabilities no user could invoke
 
 `edit.RECIPES` holds **96** authoring recipes, and `authoring_matrix.py` publishes them as the

--- a/apps/web/src/api/authoring.ts
+++ b/apps/web/src/api/authoring.ts
@@ -314,6 +314,7 @@ export function withAuthoring<TBase extends Ctor<HttpCore>>(Base: TBase) {
       return this.json<{
         recipe_count: number; category_count: number; uncategorized: string[];
         cad_ai_count: number; unreached_count: number; unreached: string[];
+        superseded_count: number; superseded: Record<string, string>;
         by_category: Record<string, {
           count: number;
           recipes: { recipe: string; category: string; produces: string; reach: "cad+ai" | "ui" | "none" }[];

--- a/apps/web/src/api/mep.ts
+++ b/apps/web/src/api/mep.ts
@@ -17,9 +17,21 @@
  *  in `authoring_matrix.py` (11 `create-mep` + 3 `edit-mep`, less these two), and they split:
  *    - **nine** are driven from viewer code through the generic recipe path in
  *      `viewer/draft/draftCatalog.ts` and `viewer/tools/mepSection.ts` — never client methods to move;
- *    - **three — `add_sprinkler`, `auto_connect_mep`, `set_system_predefined` — are referenced
+ *    - **three — `add_sprinkler`, `auto_connect_mep`, `set_system_predefined` — were referenced
  *      NOWHERE in `apps/web/src`.** Backend recipes with no web exposure at all. Recorded, not fixed:
  *      wiring a capability is not an extraction slice's business.
+ *
+ *  **MEP-AUTOCONNECT closed that, and only two of the three were capabilities.** `autoConnectMep` and
+ *  `setSystemDiscipline` (below) are new typed methods, so the split is now nine on the generic path,
+ *  two here, and one that should never be wired: **`add_sprinkler` is superseded, not missing.**
+ *  `add_fire_equipment(kind="sprinkler")` resolves through the same `add_mep_terminal` to the same
+ *  `IfcFireSuppressionTerminal`/`SPRINKLER` at the same size on the same Fire Protection system with
+ *  `discipline="fire"` — and it has shipped on the 🧯 button since MEP-FP. Wiring `add_sprinkler` would
+ *  have added a second control authoring a byte-identical element. *The list above counted three gaps
+ *  because it derived reachability and stopped; **"nothing calls it" and "no user can do it" are
+ *  different questions**, and only the second one is a defect. The equivalence is asserted in
+ *  `services/api/test_recipe_reach.py` rather than asserted here, so the supersession fails loudly if
+ *  either recipe's class, predefined type, system or discipline drifts away from the other.*
  *
  *  *This paragraph said "the other nine" until review. Nine was the number I had ENUMERATED (the
  *  viewer-driven ones); twelve is the number that REMAIN. **THIRD CONSECUTIVE SLICE, THIRD DISGUISE,
@@ -172,6 +184,24 @@ export function withMep<TBase extends Ctor<NeedsEditIfc>>(Base: TBase) {
   addMepFitting(pid: string, ifcClass: string, point: [number, number],
                 opts: { predefined?: string; size?: number; system?: string } = {}, publish = true) {
     return this.editIfc(pid, "add_mep_fitting", { ifc_class: ifcClass, point, ...opts }, publish);
+  }
+  /** W10-4: weld every unconnected MEP pair whose connection points coincide, in one pass.
+   *
+   *  The bulk complement to `connectMep`, which joins exactly two elements the user picked. `tolerance`
+   *  is in metres and defaults to the engine's 0.05; nearest pairs go first and each element joins at
+   *  most as many pairs as it has free ports, so a second run over the same model welds nothing. */
+  autoConnectMep(pid: string, tolerance?: number, publish = true) {
+    return this.editIfc(pid, "auto_connect_mep",
+                        tolerance === undefined ? {} : { tolerance }, publish);
+  }
+  /** (Re)stamp a named distribution system's discipline via its `PredefinedType`.
+   *
+   *  `discipline` takes either a word the engine maps (`fire`, `hvac`, `plumbing`, `electrical`,
+   *  `comms`…) or a raw `IfcDistributionSystemEnum` value. This is the retag path: authoring stamps a
+   *  system's type on FIRST assignment only, so a system that arrived untyped — an import, or one
+   *  created before its discipline was known — cannot be corrected any other way. */
+  setSystemDiscipline(pid: string, system: string, discipline: string, publish = true) {
+    return this.editIfc(pid, "set_system_predefined", { system, discipline }, publish);
   }
   };
 }

--- a/apps/web/src/portal/panels/standards.ts
+++ b/apps/web/src/portal/panels/standards.ts
@@ -602,6 +602,17 @@ export async function renderModelAnalysis(ctx: PanelContext) {
           u.textContent = `No caller: ${mx.unreached.join(", ")}`;
           am.appendChild(u);
         }
+        // Superseded recipes are uncalled too, and listing them beside the gaps would overstate the
+        // gap count — they are a second name for something the product already does, not a hole in it.
+        // Shown separately for the same reason the count above excludes them.
+        const sup = Object.entries(mx.superseded ?? {});
+        if (sup.length) {
+          const v = el("div", "meta");
+          v.style.cssText = "font-size:10px;opacity:.75";
+          v.textContent = `Superseded (a reachable recipe authors the same result): `
+            + sup.map(([dup, live]) => `${dup} → ${live}`).join(", ");
+          am.appendChild(v);
+        }
         const rows = Object.entries(mx.by_category).map(([cat, v]) => [cat, v.count]);
         if (rows.length) am.appendChild(table(["Category", "Recipes"], rows));
     }).catch(fail(am));

--- a/apps/web/src/shell/docsPublished.test.ts
+++ b/apps/web/src/shell/docsPublished.test.ts
@@ -151,14 +151,55 @@ describe("internal notes live under docs/internal/", () => {
       /\bsuperseded\b/i,
       /\bNothing here is built yet\b/i,
     ];
-    const leaked = DOC_PATHS.filter((p) => {
-      if (isInternal(p)) return false;
+
+    /** Lines that could be a status banner ABOUT THIS DOCUMENT — the thing the markers stand in for.
+     *
+     * A banner announces the document's own condition and names nothing else; a line that cites a
+     * `code.identifier` is making a claim about that identifier instead. Both false positives this
+     * had were the second kind: `docs/authoring-matrix.md` labels a set of RECIPES superseded by
+     * other recipes, and `docs/internal/security-roadmap.md` says it is "not a superseded snapshot"
+     * — a negation, which the word-anywhere rule reads as a confession. The second one has never
+     * fired only because it happens to be internal, so the narrowing removes a latent failure as
+     * well as an actual one.
+     *
+     * This is a heuristic and worth naming as one: it trades a class of false positive for the
+     * possibility that a real banner cites a path. `bannerCandidates` is proved against every known
+     * true positive below rather than argued for here — the check that a narrowing did not open a
+     * hole belongs in the test, not in a comment claiming it did not. */
+    const bannerCandidates = (text: string) =>
+      text.split("\n").filter((line) => !/`[^`]+`/.test(line)).join("\n");
+
+    const declaresItselfAWorkingNote = (p: string) => {
       // Only the opening matters: roadmap.md discusses superseded items throughout its body.
+      const head = read(resolve(REPO, p)).split("\n").slice(0, 12).join("\n");
+      return markers.some((m) => m.test(bannerCandidates(head)));
+    };
+
+    const leaked = DOC_PATHS.filter((p) => !isInternal(p) && declaresItselfAWorkingNote(p));
+    expect(leaked, `these declare themselves working notes but would be published: ${leaked.join(", ")}`)
+      .toEqual([]);
+
+    // POSITIVE CONTROL. The filter above returns [] both when nothing leaks and when the predicate
+    // has stopped detecting anything at all, and those two look identical from the outside — which is
+    // the failure mode a narrowing invites. So the control is the set the UN-narrowed rule catches
+    // under `docs/internal/archive/`: within the archive, `bannerCandidates` must subtract nothing.
+    //
+    // Derived from the raw markers rather than listed by filename, so it tracks the archive instead of
+    // going stale beside it. It is deliberately NOT the whole archive — most files there were archived
+    // for reasons other than declaring themselves superseded, and asserting over all of them tested
+    // the archive's filing rather than this predicate. (Written that way first: it reported 6 missed,
+    // and all 6 had never matched the original markers either.)
+    const bannerCarrying = DOC_PATHS.filter((p) => {
+      if (!p.startsWith("docs/internal/archive/")) return false;
       const head = read(resolve(REPO, p)).split("\n").slice(0, 12).join("\n");
       return markers.some((m) => m.test(head));
     });
-    expect(leaked, `these declare themselves working notes but would be published: ${leaked.join(", ")}`)
-      .toEqual([]);
+    expect(bannerCarrying.length, "no archived self-declared working notes to check the predicate "
+      + "against — the control is empty, so it proves nothing").toBeGreaterThan(3);
+    const missed = bannerCarrying.filter((p) => !declaresItselfAWorkingNote(p));
+    expect(missed, `narrowing the rule to lines that name no code identifier stopped it recognising `
+      + `these archived working notes, so a leak of the same shape would now go unreported: `
+      + `${missed.join(", ")}`).toEqual([]);
   });
 });
 

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -2016,7 +2016,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
       // being a different concern with a different risk profile). The annotation group was tried
       // first and REJECTED — it writes to `annotGuide`/`guideWired` and mutates the live three.js
       // scene, so it is not renderer-free and this recipe does not fit it.
-      const { curtainBtn, slopeBtn, meshBtn } = buildEnvelopeSection({
+      const { curtainBtn, skylightBtn, slopeBtn, meshBtn } = buildEnvelopeSection({
         toolBtn2, api, pid, projectId, notify, container,
         loadProjectModel, reloadModelPins, waitForPublish, authorAndReload,
         lastPoint: () => lastPoint, selectedGuid: () => selectedGuid,
@@ -2079,7 +2079,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
 
       const advWrap = document.createElement("div");
       advWrap.style.cssText = "display:flex;flex-direction:column;gap:inherit";
-      advWrap.append(detailBtn, autoDetailBtn, basePlateBtn, shearTabBtn, rebarBtn, cageChkBtn, bbsBtn, mepFittingBtn, fireBtn, faBtn, commsBtn, riserBtn, mepSysBtn, sizeCalcBtn, curtainBtn, slopeBtn, meshBtn, ifcCodeBtn);
+      advWrap.append(detailBtn, autoDetailBtn, basePlateBtn, shearTabBtn, rebarBtn, cageChkBtn, bbsBtn, mepFittingBtn, fireBtn, faBtn, commsBtn, riserBtn, mepSysBtn, sizeCalcBtn, curtainBtn, skylightBtn, slopeBtn, meshBtn, ifcCodeBtn);
 
       // UX-1b: surface the interactive annotation tools + the content library as their own labelled groups
       // (the Annotate + Library ribbon groups), instead of burying them in the Advanced-fabrication fold.

--- a/apps/web/src/viewer/tools/envelopeSection.ts
+++ b/apps/web/src/viewer/tools/envelopeSection.ts
@@ -98,10 +98,16 @@ export function buildEnvelopeSection(d: EnvelopeDeps): EnvelopeButtons {
       label: "Width × length in metres (the opening cut through the roof)", value: "0.9, 1.2" });
     if (!size) return;
     // `noUncheckedIndexedAccess` types these as `number | undefined`, and `w > 0` does not narrow
-    // that away — so read them as numbers with a NaN default and let the positivity check reject it.
+    // that away — so read them as numbers with a NaN default and let the guard reject it.
+    //
+    // FINITE, not merely positive: `Number("Infinity")` is `Infinity`, which passes `w > 0` and would
+    // reach the engine as a skylight of infinite extent. NaN fails `> 0` and Infinity does not, so
+    // the two bad inputs need two different tests. (Review finding on this PR, verified in node.)
     const dims = size.split(/[,x×]/).map((v) => Number(v.trim()));
     const w = dims[0] ?? NaN, l = dims[1] ?? NaN;
-    if (!(w > 0) || !(l > 0)) { d.notify("enter a positive width and length", "error"); return; }
+    if (!Number.isFinite(w) || !Number.isFinite(l) || !(w > 0) || !(l > 0)) {
+      d.notify("enter a positive width and length", "error"); return;
+    }
     await d.authorAndReload("add_roof_window",
       { roof_guid: guid, position: [pt.x, -pt.z], width: w, length: l }, "skylight");
   });

--- a/apps/web/src/viewer/tools/envelopeSection.ts
+++ b/apps/web/src/viewer/tools/envelopeSection.ts
@@ -56,6 +56,7 @@ export interface EnvelopeDeps {
 /** The three envelope buttons, named so re-ordering cannot silently re-map them. */
 export interface EnvelopeButtons {
   curtainBtn: HTMLButtonElement;
+  skylightBtn: HTMLButtonElement;
   slopeBtn: HTMLButtonElement;
   meshBtn: HTMLButtonElement;
 }
@@ -78,6 +79,35 @@ export function buildEnvelopeSection(d: EnvelopeDeps): EnvelopeButtons {
   });
   curtainBtn.title = "Author an IfcCurtainWall along a line — vertical mullions + horizontal transoms + "
     + "glazing panels on a bays×rows grid, aggregated as one assembly (LOD 350/400). GUID-stable.";
+
+  // R17 DORMER: a skylight through the selected roof. `app.ts` has had "add door to selected wall"
+  // and "add window to selected wall" since the opening recipes landed; `add_roof_window` is the
+  // roof-hosted counterpart — its own docstring calls itself "the flat-roof counterpart of the
+  // wall-hosted add_opening" — and shipped with no way to invoke it.
+  const skylightBtn = d.toolBtn2("☀ Skylight in selected roof", async () => {
+    const guid = d.selectedGuid();
+    if (!guid) { d.notify("select the roof first, then place the skylight", "error"); return; }
+    // The plan point is REQUIRED here, unlike the wall openings. `add_door`/`add_window` centre
+    // themselves on the host when no position is given; `add_roof_window` indexes p["position"] with
+    // no default, so sending nothing is a server error rather than a sensible default. Refuse here,
+    // where the message can say what to do about it.
+    const pt = d.lastPoint();
+    if (!pt) { d.notify("click where the skylight goes on the roof, then press this", "error"); return; }
+    if (!d.projectId) { d.notify("connect a project with a source IFC to author", "error"); return; }
+    const size = await askText("Skylight", {
+      label: "Width × length in metres (the opening cut through the roof)", value: "0.9, 1.2" });
+    if (!size) return;
+    // `noUncheckedIndexedAccess` types these as `number | undefined`, and `w > 0` does not narrow
+    // that away — so read them as numbers with a NaN default and let the positivity check reject it.
+    const dims = size.split(/[,x×]/).map((v) => Number(v.trim()));
+    const w = dims[0] ?? NaN, l = dims[1] ?? NaN;
+    if (!(w > 0) || !(l > 0)) { d.notify("enter a positive width and length", "error"); return; }
+    await d.authorAndReload("add_roof_window",
+      { roof_guid: guid, position: [pt.x, -pt.z], width: w, length: l }, "skylight");
+  });
+  skylightBtn.title = "Cut a skylight through the selected IfcRoof at the last-clicked plan point — a "
+    + "full-depth IfcOpeningElement voiding the roof, filled with an IfcWindow of PredefinedType "
+    + "SKYLIGHT. The roof-hosted counterpart of the door and window tools, which host on a wall.";
 
   // B3 — sloped-top wall (parapet slope / shed / gable): rebuild the selected wall's top to slope
   // from start_height → end_height.
@@ -141,5 +171,5 @@ export function buildEnvelopeSection(d: EnvelopeDeps): EnvelopeButtons {
   meshBtn.title = "Author an element from a raw triangle mesh (IfcTriangulatedFaceSet) — the escape "
     + "hatch for geometry the parametric recipes can't express.";
 
-  return { curtainBtn, slopeBtn, meshBtn };
+  return { curtainBtn, skylightBtn, slopeBtn, meshBtn };
 }

--- a/apps/web/src/viewer/tools/mepSection.ts
+++ b/apps/web/src/viewer/tools/mepSection.ts
@@ -312,7 +312,34 @@ export function buildMepSection(d: MepDeps): MepButtons {
           } catch (e) { d.notify(`connect failed: ${(e as Error).message}`, "error"); }
         });
       });
-      cw.append(pick, doConn); body.appendChild(cw);
+      // W10-4: the bulk complement to the two-step pick. `connectMep` welds ONE pair the user chose;
+      // a model drawn run-by-run leaves as many open joints as it has runs, and picking them off in
+      // pairs is the work this button exists to not do.
+      const autoBtn = d.toolBtn2("🧲 Auto-connect coincident ports", async () => {
+        const tolText = await askText("Auto-connect MEP", {
+          label: "Weld ports that coincide within this many metres", value: "0.05" });
+        if (!tolText) return;
+        const tol = parseFloat(tolText.trim());
+        if (!isFinite(tol) || tol <= 0) { d.notify("enter a tolerance greater than zero", "error"); return; }
+        await withLoading(d.container, "auto-connecting MEP ports + republishing", async () => {
+          try {
+            const r = (await d.api.autoConnectMep(d.pid, tol, true)) as { count?: number };
+            const n = Number(r?.count ?? 0);
+            const state = await d.waitForPublish(d.projectId!);
+            if (state === "done") await d.loadProjectModel();
+            // Zero is a real answer, not a failure: every coincident pair may already be welded, or
+            // nothing may be within tolerance. Say which number came back rather than only "done".
+            d.notify(n ? `connected ${n} pair(s) within ${tol} m` : `no unconnected pairs within ${tol} m`,
+                     n ? "success" : "info");
+            if (state !== "done") d.notify(`publish ${state}`, state === "error" ? "error" : "info");
+            mepConnectFrom = null; await d.reloadModelPins();
+          } catch (e) { d.notify(`auto-connect failed: ${(e as Error).message}`, "error"); }
+        });
+      });
+      autoBtn.title = "Weld every unconnected MEP element pair whose connection points coincide within a "
+        + "tolerance, in one pass — the bulk form of the two-step connect. Nearest pairs first, and each "
+        + "element joins at most as many pairs as it has free ports, so running it twice changes nothing.";
+      cw.append(pick, doConn, autoBtn); body.appendChild(cw);
       if (c!.dangling.length) {
         const iso = d.toolBtn2("◎ Isolate floating elements in 3D", () => { void d.layerMgr.isolateGuids(c!.dangling.map((d) => d.guid)); });
         body.appendChild(iso);
@@ -413,6 +440,35 @@ export function buildMepSection(d: MepDeps): MepButtons {
           { k: "  segments · fittings · terminals", v: `${sy.segments} · ${sy.fittings} · ${sy.terminals}` },
           { k: "  elements with open ports", v: String(sy.elements_with_open_ports) },
         ]));
+        // Authoring stamps a system's discipline on FIRST assignment only and never revises it, so an
+        // imported system, or one created before its discipline was decided, stays untyped for the life
+        // of the model. This is the only path that revises it — the engine's own note says "retag via
+        // set_system_predefined", and until now nothing in the product could.
+        const tag = d.toolBtn2(sy.predefined_type ? `🏷 Retype ${sy.name}` : `🏷 Set discipline for ${sy.name}`,
+          async () => {
+            const disc = await askText(`Discipline for ${sy.name}`, {
+              label: "hvac · plumbing · electrical · fire · comms · lighting · drainage · exhaust — "
+                + "or a raw IfcDistributionSystemEnum value",
+              value: sy.discipline || "hvac" });
+            if (!disc) return;
+            await withLoading(d.container, "retyping the system + republishing", async () => {
+              try {
+                const r = (await d.api.setSystemDiscipline(
+                  d.pid, sy.name, disc.trim(), true)) as { predefined_type?: string };
+                const state = await d.waitForPublish(d.projectId!);
+                if (state === "done") await d.loadProjectModel();
+                d.notify(`${sy.name} is now ${r?.predefined_type ?? disc.trim()}`
+                  + (state === "done" ? "" : ` — publish ${state}`),
+                  state === "error" ? "error" : "success");
+                await d.reloadModelPins();
+              } catch (e) { d.notify(`retype failed: ${(e as Error).message}`, "error"); }
+            });
+          });
+        tag.title = `Stamp ${sy.name}'s IfcDistributionSystem PredefinedType — the discipline the system `
+          + "browser, the by-discipline rollup and the fire-protection checks all read. Authoring only "
+          + "sets it when the system is first created, so this is what corrects an untyped or "
+          + "mis-typed one.";
+        body.appendChild(tag);
       }
       if (s.unassigned.segments || s.unassigned.fittings) {
         body.appendChild(resultNote(`⚠ Unassigned to any system: <b>${s.unassigned.segments}</b> segment(s), `

--- a/apps/web/src/viewer/tools/mepSection.ts
+++ b/apps/web/src/viewer/tools/mepSection.ts
@@ -326,12 +326,17 @@ export function buildMepSection(d: MepDeps): MepButtons {
             const r = (await d.api.autoConnectMep(d.pid, tol, true)) as { count?: number };
             const n = Number(r?.count ?? 0);
             const state = await d.waitForPublish(d.projectId!);
-            if (state === "done") await d.loadProjectModel();
+            // `loadProjectModel` returns whether the re-tessellation SUCCEEDED. Ignoring it reports a
+            // clean result over a viewer still showing the pre-edit model — the edit is committed and
+            // what you are looking at is stale, which is the one outcome a user cannot detect
+            // unaided. (Review finding on this PR.)
+            const shown = state === "done" ? await d.loadProjectModel() : false;
             // Zero is a real answer, not a failure: every coincident pair may already be welded, or
             // nothing may be within tolerance. Say which number came back rather than only "done".
             d.notify(n ? `connected ${n} pair(s) within ${tol} m` : `no unconnected pairs within ${tol} m`,
                      n ? "success" : "info");
             if (state !== "done") d.notify(`publish ${state}`, state === "error" ? "error" : "info");
+            else if (!shown) d.notify("connected, but the viewer could not reload — reopen the model", "error");
             mepConnectFrom = null; await d.reloadModelPins();
           } catch (e) { d.notify(`auto-connect failed: ${(e as Error).message}`, "error"); }
         });
@@ -456,10 +461,13 @@ export function buildMepSection(d: MepDeps): MepButtons {
                 const r = (await d.api.setSystemDiscipline(
                   d.pid, sy.name, disc.trim(), true)) as { predefined_type?: string };
                 const state = await d.waitForPublish(d.projectId!);
-                if (state === "done") await d.loadProjectModel();
+                // Same reload contract as the auto-connect above: a false result means the retype
+                // committed and the viewer is stale.
+                const shown = state === "done" ? await d.loadProjectModel() : false;
                 d.notify(`${sy.name} is now ${r?.predefined_type ?? disc.trim()}`
-                  + (state === "done" ? "" : ` — publish ${state}`),
-                  state === "error" ? "error" : "success");
+                  + (state === "done" ? (shown ? "" : " — the viewer could not reload, reopen the model")
+                                      : ` — publish ${state}`),
+                  state === "error" || (state === "done" && !shown) ? "error" : "success");
                 await d.reloadModelPins();
               } catch (e) { d.notify(`retype failed: ${(e as Error).message}`, "error"); }
             });

--- a/apps/web/src/viewer/tools/sectionButtonsWired.test.ts
+++ b/apps/web/src/viewer/tools/sectionButtonsWired.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * SKYLIGHT — a button that is BUILT is not a button a user can press.
+ *
+ * `R39-DECOMP-VIEWER` moved groups of viewer tools out of `app.ts` into section modules. Each
+ * returns its buttons through a named interface, and `envelopeSection.ts`'s own comment says why:
+ * *"named so re-ordering cannot silently re-map them"*. That protects the ORDER. Nothing protected
+ * the last step — `app.ts` has to destructure each button and then append it to a container, and a
+ * button that is constructed, returned, destructured and never appended is invisible with every
+ * typecheck green.
+ *
+ * That is not hypothetical here. `envelopeSection.ts`'s docstring records the annotation group
+ * shipping exactly this way once: *"the same silent-inert failure `qaSection.ts` shipped"*. A tool
+ * whose handler is perfect and whose element is in no DOM tree behaves identically to one that was
+ * never written, and no existing check could tell them apart — `tsc` is satisfied by the
+ * destructure, and the button's own unit test is satisfied by calling its handler.
+ *
+ * So: for every `*Buttons` interface a section module exports, every member must be **destructured
+ * from the builder call** and **passed to an `append`** in `app.ts`. Derived from the interfaces
+ * rather than from a list, so a button added to a section is covered the day it is added — the
+ * failure mode is precisely that somebody adds one and forgets the second half.
+ */
+const REPO = resolve(__dirname, "../../../../..");
+const APP = readFileSync(resolve(REPO, "apps/web/src/viewer/app.ts"), "utf8");
+const TOOLS = resolve(REPO, "apps/web/src/viewer/tools");
+
+/** `{ Interface name -> declared button field names }` for every section module that exports one. */
+function declaredButtonSets(): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  for (const file of ["envelopeSection.ts", "fabricationSection.ts", "mepSection.ts"]) {
+    const src = readFileSync(resolve(TOOLS, file), "utf8");
+    const m = src.match(/export interface (\w*Buttons) \{([\s\S]*?)\n\}/);
+    if (!m) continue;
+    const fields = [...m[2]!.matchAll(/^\s*(\w+)\s*:/gm)].map((f) => f[1]!);
+    out.set(`${file} ${m[1]}`, fields);
+  }
+  return out;
+}
+
+/** Every `append(...)` / `appendChild(...)` argument list in `app.ts`, concatenated. */
+const APPENDED = [...APP.matchAll(/\.append(?:Child)?\(([^;]*?)\)/g)].map((m) => m[1]!).join(",");
+
+describe("every button a section module returns is wired into app.ts", () => {
+  const sets = declaredButtonSets();
+
+  it("finds the section button interfaces to check", () => {
+    // A control on the derivation itself: if the regex stops matching, every assertion below
+    // vacuously passes over an empty map. This is the same failure the file is about — a check
+    // that has quietly stopped checking looks exactly like a check that has nothing to report.
+    expect([...sets.keys()].length, "no *Buttons interfaces found — the derivation broke").toBe(3);
+    for (const [name, fields] of sets) {
+      expect(fields.length, `${name} parsed with no fields`).toBeGreaterThan(0);
+    }
+  });
+
+  for (const [name, fields] of sets) {
+    it(`${name}: every button is destructured and appended`, () => {
+      const notDestructured = fields.filter((f) => !new RegExp(`\\b${f}\\b`).test(APP));
+      expect(notDestructured, `${name} declares these, but app.ts never names them: `
+        + `${notDestructured.join(", ")}`).toEqual([]);
+
+      const notAppended = fields.filter((f) => !new RegExp(`\\b${f}\\b`).test(APPENDED));
+      expect(notAppended, `${name} declares these and app.ts destructures them, but they are `
+        + `passed to no append() — built, returned, and in no DOM tree, which is indistinguishable `
+        + `from not existing: ${notAppended.join(", ")}`).toEqual([]);
+    });
+  }
+});

--- a/docs/authoring-matrix.md
+++ b/docs/authoring-matrix.md
@@ -4,7 +4,7 @@
 
 **96 authoring recipes** across **15 categories**. Every recipe is a GUID-stable server-side pass. **What can invoke one differs per recipe**, and the Reach column says which: `cad+ai` — dispatchable from the CAD command line and the AI planner (12 of 96, the curated `nlauthor.RECIPE_SPECS`); `ui` — invoked by a tool panel, a router or MCP; `superseded` — nothing calls it and nothing should, a reachable recipe authors the same result; `none` — the engine can run it and no surface asks it to.
 
-> ⚠ **7 recipes are reachable from no surface**: `add_connection_assembly`, `add_roof_window`, `convert_length_unit`, `derive_representations`, `program_fit`, `rebase_origin`, `reset_prop_to_type`. They are implemented and tested; they are not something a user can invoke, so they are not coverage. Pinned by `services/api/test_recipe_reach.py`.
+> ⚠ **6 recipes are reachable from no surface**: `add_connection_assembly`, `convert_length_unit`, `derive_representations`, `program_fit`, `rebase_origin`, `reset_prop_to_type`. They are implemented and tested; they are not something a user can invoke, so they are not coverage. Pinned by `services/api/test_recipe_reach.py`.
 
 > **Superseded** — uncalled, and correctly so: `add_sprinkler` → `add_fire_equipment`. A reachable recipe authors the identical result, so these are duplicate spellings rather than gaps. The equivalence is asserted in `services/api/test_recipe_reach.py`, so an entry stops being true if the two recipes stop agreeing.
 
@@ -35,7 +35,7 @@
 | `add_railing` | IfcRailing | ui |
 | `add_ramp` | IfcRamp | ui |
 | `add_roof` | IfcRoof | ui |
-| `add_roof_window` | IfcWindow (SKYLIGHT) voiding a roof | none |
+| `add_roof_window` | IfcWindow (SKYLIGHT) voiding a roof | ui |
 | `add_stair` | IfcStair | ui |
 
 ### create-opening (2)

--- a/docs/authoring-matrix.md
+++ b/docs/authoring-matrix.md
@@ -2,9 +2,11 @@
 
 > Generated from `edit.RECIPES` by `authoring_matrix.to_markdown()` — do not hand-edit; re-run the generator (or `GET /reference/authoring-matrix`) after adding a recipe.
 
-**96 authoring recipes** across **15 categories**. Every recipe is a GUID-stable server-side pass. **What can invoke one differs per recipe**, and the Reach column says which: `cad+ai` — dispatchable from the CAD command line and the AI planner (12 of 96, the curated `nlauthor.RECIPE_SPECS`); `ui` — invoked by a tool panel, a router or MCP; `none` — the engine can run it and no surface asks it to.
+**96 authoring recipes** across **15 categories**. Every recipe is a GUID-stable server-side pass. **What can invoke one differs per recipe**, and the Reach column says which: `cad+ai` — dispatchable from the CAD command line and the AI planner (12 of 96, the curated `nlauthor.RECIPE_SPECS`); `ui` — invoked by a tool panel, a router or MCP; `superseded` — nothing calls it and nothing should, a reachable recipe authors the same result; `none` — the engine can run it and no surface asks it to.
 
-> ⚠ **10 recipes are reachable from no surface**: `add_connection_assembly`, `add_roof_window`, `add_sprinkler`, `auto_connect_mep`, `convert_length_unit`, `derive_representations`, `program_fit`, `rebase_origin`, `reset_prop_to_type`, `set_system_predefined`. They are implemented and tested; they are not something a user can invoke, so they are not coverage. Pinned by `services/api/test_recipe_reach.py`.
+> ⚠ **7 recipes are reachable from no surface**: `add_connection_assembly`, `add_roof_window`, `convert_length_unit`, `derive_representations`, `program_fit`, `rebase_origin`, `reset_prop_to_type`. They are implemented and tested; they are not something a user can invoke, so they are not coverage. Pinned by `services/api/test_recipe_reach.py`.
+
+> **Superseded** — uncalled, and correctly so: `add_sprinkler` → `add_fire_equipment`. A reachable recipe authors the identical result, so these are duplicate spellings rather than gaps. The equivalence is asserted in `services/api/test_recipe_reach.py`, so an entry stops being true if the two recipes stop agreeing.
 
 ### create-structure (13)
 
@@ -63,7 +65,7 @@
 | `add_mep_terminal` | IfcDuct/PipeTerminal | ui |
 | `add_pipe` | IfcPipeSegment | ui |
 | `add_riser` | vertical MEP riser | ui |
-| `add_sprinkler` | IfcFireSuppressionTerminal | none |
+| `add_sprinkler` | IfcFireSuppressionTerminal | superseded |
 | `add_wire` | IfcCableSegment | ui |
 
 ### create-content (5)
@@ -107,9 +109,9 @@
 
 | Recipe | Produces | Reach |
 | --- | --- | --- |
-| `auto_connect_mep` | coincident-port auto-connect sweep | none |
+| `auto_connect_mep` | coincident-port auto-connect sweep | ui |
 | `connect_mep` | port-to-port connection | ui |
-| `set_system_predefined` | system predefined type | none |
+| `set_system_predefined` | system predefined type | ui |
 
 ### type (3)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2963,6 +2963,30 @@ removed. Remaining, in priority order:
   by RUNNING both recipes and comparing (class, PredefinedType, system, system type), not by reading
   them — so it fails the moment the two stop agreeing, and the recipe becomes a real gap again.
 
+  ✅ **SKYLIGHT, shipped 2026-09-05 — a window in a wall, but never a skylight in a roof.**
+  `add_roof_window` voids a host `IfcRoof` and fills the opening with an `IfcWindow`/`SKYLIGHT`. It
+  has worked since R17 DORMER and `services/api/test_roof_window.py` covers it down to the void/fill
+  relations and GUID stability across a re-open — while the viewer shipped *"Add door to selected
+  wall"* and *"Add window to selected wall"* and no roof counterpart. **Two independent descriptions
+  each said a shipped tool had a missing twin** — the matrix entry ("the roof counterpart of the wired
+  `add_door`/`add_window`") and the engine docstring ("the flat-roof counterpart of the wall-hosted
+  `add_opening`") — *and neither was a check, so the asymmetry sat there through both.* Now
+  **☀ Skylight in selected roof** on the envelope section. `UNREACHED` 7 → 6.
+
+  *One difference was handled rather than copied:* the wall openings centre themselves when no
+  position is given, but `add_roof_window` indexes `p["position"]` with no default, so copying the
+  "click optional" pattern would have turned a button press into a server error. *And it went into
+  `apps/web/src/viewer/tools/envelopeSection.ts`, not `apps/web/src/viewer/app.ts`* — the ratchet in
+  `services/api/test_file_sizes.py` only moves one way, so a new tool in `app.ts` would have been paid
+  for by unwinding an extraction; `app.ts` stays at exactly 2,508.
+
+  **The gate it produced outlives the item.**
+  `apps/web/src/viewer/tools/sectionButtonsWired.test.ts` asserts every member of every `*Buttons`
+  interface a section module exports is destructured **and appended** in `app.ts`. The interfaces
+  were "named so re-ordering cannot silently re-map them" — that guards ORDER, and nothing guarded
+  the last step: **a button built, returned, destructured and never appended is invisible with every
+  typecheck green**, which `envelopeSection.ts` records the annotation group shipping once already.
+
   ✅ **CONTENT-DRAFT, shipped 2026-09-05 — what the corrected measurement actually found.** The 19
   CONTENT-1 items (FF&E · Landscape · Site Logistics) appeared in **neither** affordance: they were
   absent from the draft catalog entirely, so they were the only placeable things in the app that

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2943,6 +2943,26 @@ removed. Remaining, in priority order:
   are plausibly internal, and inventing ten buttons would be worse than reporting ten honest states.
   `services/api/test_recipe_reach.py` derives the set and fails when the matrix disagrees.
 
+  ✅ **MEP-AUTOCONNECT, shipped 2026-09-05 — and it corrected the entry above.** Three of the ten were
+  MEP. Two were real capabilities and are now on the MEP systems panel: `auto_connect_mep` welds every
+  coincident MEP pair in one pass (the panel had been reporting *"N floating element(s)"* with no way
+  to act on it — the only connect was pick-one-pick-another), and `set_system_predefined` retypes a
+  system's discipline (authoring stamps it on FIRST assignment only, and `_assign_to_system`'s own
+  docstring says *"retag via set_system_predefined"* — a path that existed in the engine and on no
+  surface, so an imported or untyped system stayed untyped permanently).
+
+  **The third was never a gap.** `add_sprinkler` is authored identically by
+  `add_fire_equipment(kind="sprinkler")` — same `add_mep_terminal`, same
+  `IfcFireSuppressionTerminal`/`SPRINKLER`, same size, same *Fire Protection* system, same
+  `discipline="fire"` — which has been on the viewer's 🧯 button since MEP-FP. *A reachability sweep
+  answers "does anything call this?", one question short of "can a user do this?": the same shape of
+  gap the entry above closes, one layer further in. Reporting a duplicate among the gaps understates
+  coverage and invites shipping a redundant control.* So `authoring_matrix.SUPERSEDED` sits beside
+  `UNREACHED`, the matrix carries a fourth `reach` value, and the published table and the in-app
+  coverage panel report the two classes apart. `UNREACHED` goes 10 → 7. The supersession is asserted
+  by RUNNING both recipes and comparing (class, PredefinedType, system, system type), not by reading
+  them — so it fails the moment the two stop agreeing, and the recipe becomes a real gap again.
+
   ✅ **CONTENT-DRAFT, shipped 2026-09-05 — what the corrected measurement actually found.** The 19
   CONTENT-1 items (FF&E · Landscape · Site Logistics) appeared in **neither** affordance: they were
   absent from the draft catalog entirely, so they were the only placeable things in the app that
@@ -3850,6 +3870,10 @@ verbs, with a command bar as the escape hatch to everything); and **role-shaped 
   these two): nine are driven from viewer code through the generic recipe path, and three
   (`add_sprinkler`, `auto_connect_mep`, `set_system_predefined`) are referenced nowhere in
   `apps/web/src` at all — backend recipes with no web exposure, recorded rather than fixed.
+  **MEP-AUTOCONNECT closed all three (2026-09-05), and only two by wiring:** `auto_connect_mep` and
+  `set_system_predefined` are now typed methods on this mixin, and `add_sprinkler` turned out to be
+  authored identically by the already-shipped `add_fire_equipment(kind="sprinkler")` — a duplicate,
+  not a gap. So the split is nine on the generic path, two here, one superseded.
   *This said "the other nine" until review: nine was what I had ENUMERATED, twelve is what REMAINS.
   Third consecutive slice, third disguise, one defect — count the members you looked at, then phrase
   the result as the whole population. The fix is to DERIVE THE COMPLEMENT, not to be more careful.* `services/api/test_mep_systems.py` covers both AMONG other MEP recipes, so

--- a/services/api/src/aec_api/authoring_matrix.py
+++ b/services/api/src/aec_api/authoring_matrix.py
@@ -119,7 +119,6 @@ _MAP: dict[str, tuple[str, str]] = {
 # it stays internal for now, not a place to park work: the gate makes the decision visible.
 #
 #   add_connection_assembly  steel connection plate + bolts + IfcRelConnectsWithRealizingElements
-#   add_roof_window          skylight through a roof — the roof counterpart of the wired add_door/add_window
 #   convert_length_unit      project length unit (mm/m/ft), rescaling so real size is unchanged
 #   derive_representations   coarse Box/Axis/FootPrint views derived from Body geometry
 #   program_fit              headcount program -> zoned + auto-furnished spaces
@@ -135,8 +134,15 @@ _MAP: dict[str, tuple[str, str]] = {
 # MEP-AUTOCONNECT then took all three off the list, and only two of them by wiring. `auto_connect_mep`
 # and `set_system_predefined` are now typed client methods invoked from the MEP systems panel. The
 # third is the finding: **`add_sprinkler` was never a missing capability.** See SUPERSEDED below.
+#
+# SKYLIGHT took `add_roof_window` off the list (2026-09-05). It was the entry whose own description
+# named its counterpart — "the roof counterpart of the wired add_door/add_window" — and the engine
+# function's docstring says the same thing from the other side: "the flat-roof counterpart of the
+# wall-hosted add_opening". *Two descriptions, written independently, both said a shipped tool had a
+# missing twin; neither was a check, so the asymmetry sat there.* It is now on the envelope section
+# beside the curtain wall.
 UNREACHED: frozenset[str] = frozenset({
-    "add_connection_assembly", "add_roof_window", "convert_length_unit", "derive_representations",
+    "add_connection_assembly", "convert_length_unit", "derive_representations",
     "program_fit", "rebase_origin", "reset_prop_to_type",
 })
 

--- a/services/api/src/aec_api/authoring_matrix.py
+++ b/services/api/src/aec_api/authoring_matrix.py
@@ -16,6 +16,15 @@ invoke.
 So each row now carries `reach`, and `UNREACHED` names what nothing can invoke.
 `services/api/test_recipe_reach.py` derives that set from the tree and fails when this file disagrees,
 so the honest form of the claim cannot rot back into the confident one.
+
+**MEP-AUTOCONNECT then found the correction had a second layer.** Two of the ten — `auto_connect_mep`
+and `set_system_predefined` — were wired and are now `ui`. The third, `add_sprinkler`, turned out never
+to have been a gap: `add_fire_equipment(kind="sprinkler")` authors the identical element and has
+shipped on a button all along. It is in `SUPERSEDED`, not `UNREACHED`, and the difference is not
+bookkeeping. *A reachability sweep answers "does anything call this?", which is one question short of
+"can a user do this?" — the same shape of mistake this file was written to fix, one layer further in.
+Listing a duplicate among the gaps understates coverage and invites work that would ship a second
+control for an outcome users already had.*
 """
 from __future__ import annotations
 
@@ -111,25 +120,42 @@ _MAP: dict[str, tuple[str, str]] = {
 #
 #   add_connection_assembly  steel connection plate + bolts + IfcRelConnectsWithRealizingElements
 #   add_roof_window          skylight through a roof — the roof counterpart of the wired add_door/add_window
-#   add_sprinkler            IfcFireSuppressionTerminal
-#   auto_connect_mep         route segments between MEP terminals
 #   convert_length_unit      project length unit (mm/m/ft), rescaling so real size is unchanged
 #   derive_representations   coarse Box/Axis/FootPrint views derived from Body geometry
 #   program_fit              headcount program -> zoned + auto-furnished spaces
 #   rebase_origin            shift the model origin, preserving georeferencing
 #   reset_prop_to_type       drop an instance override so the type value shows through — the UI ships
 #                            `set_element_pset`, which is the OTHER half of that pair
-#   set_system_predefined    set an IfcSystem's PredefinedType
 #
 # Three of these — add_sprinkler, auto_connect_mep, set_system_predefined — were already found by
 # SCALE-SEAM (93) and recorded in a doc comment in `apps/web/src/api/mep.ts`: "referenced NOWHERE in
 # apps/web/src. Backend recipes with no web exposure at all. Recorded, not fixed." That note was right
 # and had no way to stay right. It is now a check.
+#
+# MEP-AUTOCONNECT then took all three off the list, and only two of them by wiring. `auto_connect_mep`
+# and `set_system_predefined` are now typed client methods invoked from the MEP systems panel. The
+# third is the finding: **`add_sprinkler` was never a missing capability.** See SUPERSEDED below.
 UNREACHED: frozenset[str] = frozenset({
-    "add_connection_assembly", "add_roof_window", "add_sprinkler", "auto_connect_mep",
-    "convert_length_unit", "derive_representations", "program_fit", "rebase_origin",
-    "reset_prop_to_type", "set_system_predefined",
+    "add_connection_assembly", "add_roof_window", "convert_length_unit", "derive_representations",
+    "program_fit", "rebase_origin", "reset_prop_to_type",
 })
+
+# Recipes that nothing invokes AND nothing should: a reachable recipe already authors the identical
+# result, so wiring these would put a second control behind the same outcome. This is a distinct verdict
+# from UNREACHED — that one says "a capability no user can reach", which is a defect; this one says
+# "a duplicate spelling of a capability users already have", which is not.
+#
+# The distinction is the whole point of separating the two sets. A reachability sweep answers "does
+# anything call it?" and stops there; it cannot tell a gap from a synonym, so it reports both as gaps
+# and invites work on the synonym. `test_recipe_reach.py` asserts the equivalence itself — the IFC
+# class, predefined type, system and discipline both recipes land on — so an entry here stops being
+# true the moment the two stop agreeing, and the recipe falls back to being a real gap.
+SUPERSEDED: dict[str, str] = {
+    # add_fire_equipment(kind="sprinkler") resolves through the same add_mep_terminal to the same
+    # IfcFireSuppressionTerminal/SPRINKLER on the same "Fire Protection" system with discipline "fire",
+    # and has been on the viewer's 🧯 button since MEP-FP.
+    "add_sprinkler": "add_fire_equipment",
+}
 
 _CATEGORY_ORDER = ["create-structure", "create-enclosure", "create-opening", "create-space",
                    "create-mep", "create-content", "annotate", "edit", "edit-mep", "type", "group",
@@ -147,9 +173,20 @@ def matrix() -> dict[str, Any]:
     for name in recipes:
         cat, produces = _MAP.get(name, ("uncategorized", ""))
         # `cad+ai` reaches the command line and the planner; `ui` is invoked by a panel, a router or
-        # MCP; `none` means the engine can run it and nothing asks it to.
-        reach = "cad+ai" if name in specs else ("none" if name in UNREACHED else "ui")
+        # MCP; `superseded` is authored identically by a reachable recipe; `none` means the engine can
+        # run it and nothing asks it to. `superseded` is checked BEFORE `none` on purpose: both are
+        # uncalled, and reporting a duplicate as a gap is what invites someone to close it.
+        if name in specs:
+            reach = "cad+ai"
+        elif name in SUPERSEDED:
+            reach = "superseded"
+        elif name in UNREACHED:
+            reach = "none"
+        else:
+            reach = "ui"
         row = {"recipe": name, "category": cat, "produces": produces, "reach": reach}
+        if reach == "superseded":
+            row["superseded_by"] = SUPERSEDED[name]
         rows.append(row)
         by_cat.setdefault(cat, []).append(row)
     ordered = {c: by_cat[c] for c in _CATEGORY_ORDER if c in by_cat}
@@ -161,14 +198,18 @@ def matrix() -> dict[str, Any]:
         "cad_ai_count": len(specs),
         "unreached_count": len(UNREACHED),
         "unreached": sorted(UNREACHED),
+        "superseded_count": len(SUPERSEDED),
+        "superseded": {k: SUPERSEDED[k] for k in sorted(SUPERSEDED)},
         "uncategorized": [r["recipe"] for r in by_cat.get("uncategorized", [])],
         "by_category": {c: {"count": len(v), "recipes": v} for c, v in ordered.items()},
         "note": ("Live from the edit.RECIPES registry — a newly-added recipe appears here automatically "
                  "(uncategorized until mapped). Every recipe is a GUID-stable server-side pass. What "
                  "can INVOKE one differs per recipe and is stated per row: `cad+ai` is dispatchable "
                  f"from the CAD command line and the AI planner ({len(specs)} of {len(recipes)}, the "
-                 "curated nlauthor.RECIPE_SPECS); `ui` is invoked by a panel, a router or MCP; `none` "
-                 "means the engine can run it and no surface asks it to."),
+                 "curated nlauthor.RECIPE_SPECS); `ui` is invoked by a panel, a router or MCP; "
+                 "`superseded` means nothing calls it and nothing should, because a reachable recipe "
+                 "authors the identical result; `none` means the engine can run it and no surface asks "
+                 "it to — the only one of the four that is a gap."),
     }
 
 
@@ -186,13 +227,22 @@ def to_markdown() -> str:
            f"`cad+ai` — dispatchable from the CAD command line and the AI planner "
            f"({m['cad_ai_count']} of {m['recipe_count']}, the curated `nlauthor.RECIPE_SPECS`); "
            "`ui` — invoked by a tool panel, a router or MCP; "
-           "`none` — the engine can run it and no surface asks it to.",
+           "`superseded` — nothing calls it and nothing should, a reachable recipe authors the same "
+           "result; `none` — the engine can run it and no surface asks it to.",
            ""]
     if m["unreached"]:
         out += [f"> ⚠ **{m['unreached_count']} recipes are reachable from no surface**: "
                 + ", ".join(f"`{r}`" for r in m["unreached"])
                 + ". They are implemented and tested; they are not something a user can invoke, so "
                   "they are not coverage. Pinned by `services/api/test_recipe_reach.py`.",
+                ""]
+    if m["superseded"]:
+        out += ["> **Superseded** — uncalled, and correctly so: "
+                + ", ".join(f"`{k}` → `{v}`" for k, v in m["superseded"].items())
+                + ". A reachable recipe authors the identical result, so these are duplicate spellings "
+                  "rather than gaps. The equivalence is asserted in "
+                  "`services/api/test_recipe_reach.py`, so an entry stops being true if the two "
+                  "recipes stop agreeing.",
                 ""]
     for cat, data in m["by_category"].items():
         out.append(f"### {cat} ({data['count']})")

--- a/services/api/test_recipe_reach.py
+++ b/services/api/test_recipe_reach.py
@@ -111,27 +111,92 @@ assert len(specs) < len(recipes), (
     "natural language and this gate's premise is void — rewrite it rather than deleting it."
 )
 
-unreached = sorted(r for r in recipes if r not in specs and not callers(r))
+uncalled = sorted(r for r in recipes if r not in specs and not callers(r))
 
-# ---- the pinned set ------------------------------------------------------------------------------
-# NAMED in `authoring_matrix.UNREACHED` and asserted equal here, so the published matrix cannot claim
-# a capability the product cannot reach. Adding a recipe with no caller fails this until it is either
-# wired or deliberately listed — which is the point: the listing is a decision, not an oversight.
-assert unreached == sorted(authoring_matrix.UNREACHED), (
-    "the matrix's UNREACHED set disagrees with the tree.\n"
-    f"  derived from the tree : {unreached}\n"
-    f"  named in the matrix   : {sorted(authoring_matrix.UNREACHED)}\n"
-    "A recipe that gained a caller must come OFF the list; one added without a caller must go ON it "
-    "(or be wired). The matrix is published as a maturity claim — it may not count what no user can "
-    "invoke."
+# ---- the pinned sets -----------------------------------------------------------------------------
+# The uncalled set splits in two, and the split is the point. `UNREACHED` is a capability no user can
+# reach — a defect, listed deliberately rather than fixed. `SUPERSEDED` is a duplicate spelling of a
+# capability users already have through another recipe — not a defect, and wiring it would ship a
+# second control for the same outcome.
+#
+# **The two must be disjoint and must together cover the tree**, so neither can absorb the other
+# quietly. Adding a recipe with no caller fails this until it is wired, listed as a gap, or shown to
+# be a duplicate — and the last of those is not a free escape, because the equivalence is asserted
+# below against what the two recipes actually author.
+superseded = authoring_matrix.SUPERSEDED
+assert not (set(superseded) & set(authoring_matrix.UNREACHED)), (
+    f"a recipe is in both UNREACHED and SUPERSEDED: {sorted(set(superseded) & set(authoring_matrix.UNREACHED))}"
+)
+assert uncalled == sorted(set(authoring_matrix.UNREACHED) | set(superseded)), (
+    "the matrix's UNREACHED + SUPERSEDED sets disagree with the tree.\n"
+    f"  uncalled, derived from the tree : {uncalled}\n"
+    f"  UNREACHED named in the matrix   : {sorted(authoring_matrix.UNREACHED)}\n"
+    f"  SUPERSEDED named in the matrix  : {sorted(superseded)}\n"
+    "A recipe that gained a caller must come OFF both; one added without a caller must go ON one of "
+    "them (or be wired). The matrix is published as a maturity claim — it may not count what no user "
+    "can invoke, and it may not report a duplicate as a gap."
 )
 
-# The matrix must SAY so, not merely hold the set.
+# ---- the supersession claim, checked against what the recipes AUTHOR -----------------------------
+# `SUPERSEDED` asserts that a reachable recipe produces the identical result. That is a claim about
+# behaviour, so it is checked by running both and comparing products — not by reading the two lambdas
+# and finding them similar. If `add_fire_equipment` ever stopped resolving "sprinkler" to the same
+# class, predefined type, system and discipline, `add_sprinkler` would silently become a real gap
+# while still sitting in the set that says it is not one.
+#
+# The comparison covers every attribute that distinguishes one MEP terminal from another: without the
+# system and discipline it would pass on two elements that land on different systems, which is most of
+# what these recipes are for.
+if superseded:
+    import tempfile
+
+    import ifcopenshell
+
+    from aec_data import massing  # type: ignore
+
+    _tmp = os.path.join(tempfile.mkdtemp(prefix="supersede_"), "m.ifc")
+    massing.generate_blank_ifc(_tmp, name="Supersession", storeys=1, storey_height=4.0, ground_size=40.0)
+    _model = ifcopenshell.open(_tmp)
+
+    def _fingerprint(guid: str) -> tuple:
+        """(IFC class, PredefinedType, system name, system PredefinedType) for an authored element."""
+        el = next((e for e in _model.by_type("IfcProduct") if e.GlobalId == guid), None)
+        assert el is not None, f"no element with GUID {guid!r}"
+        sys_name = sys_type = None
+        for rel in (getattr(el, "HasAssignments", None) or []):
+            grp = getattr(rel, "RelatingGroup", None)
+            if grp is not None and grp.is_a("IfcDistributionSystem"):
+                sys_name, sys_type = grp.Name, getattr(grp, "PredefinedType", None)
+        return el.is_a(), getattr(el, "PredefinedType", None), sys_name, sys_type
+
+    def _guid_of(result) -> str:
+        return result if isinstance(result, str) else result["guid"]
+
+    for dup, live in sorted(superseded.items()):
+        assert dup in edit.RECIPES and live in edit.RECIPES, (dup, live)
+        a = _fingerprint(_guid_of(edit.RECIPES[dup](_model, {"point": [2.0, 2.0]})))
+        # The live recipe is invoked the way the product invokes it — `add_fire_equipment` takes the
+        # kind as a parameter, and "sprinkler" is what the 🧯 button defaults to and sends.
+        b = _fingerprint(_guid_of(edit.RECIPES[live](_model, {"kind": "sprinkler", "point": [4.0, 2.0]})))
+        assert a == b, (
+            f"{dup!r} is listed as superseded by {live!r}, but they author different elements:\n"
+            f"  {dup:<20} -> {a}\n  {live:<20} -> {b}\n"
+            "(class, PredefinedType, system name, system PredefinedType). If this is a deliberate "
+            f"divergence then {dup!r} is a real capability again — move it to UNREACHED, or wire it."
+        )
+
+# The matrix must SAY so, not merely hold the sets.
 m = authoring_matrix.matrix()
+unreached = sorted(authoring_matrix.UNREACHED)
 assert m["unreached_count"] == len(unreached), (m["unreached_count"], len(unreached))
+assert m["superseded_count"] == len(superseded), (m["superseded_count"], len(superseded))
+assert m["superseded"] == dict(sorted(superseded.items())), m["superseded"]
 by_recipe = {r["recipe"]: r for cat in m["by_category"].values() for r in cat["recipes"]}
 for r in unreached:
     assert by_recipe[r]["reach"] == "none", (r, by_recipe[r])
+for r, live in superseded.items():
+    assert by_recipe[r]["reach"] == "superseded", (r, by_recipe[r])
+    assert by_recipe[r].get("superseded_by") == live, (r, by_recipe[r])
 for r in sorted(specs):
     assert by_recipe[r]["reach"] == "cad+ai", (r, by_recipe[r])
 
@@ -150,12 +215,16 @@ for text in (m["note"], authoring_matrix.to_markdown()):
         assert claim not in text, (
             f"the published matrix claims {claim!r} of every recipe. RECIPE_SPECS — what the CAD line "
             f"and the planner actually dispatch from — names {len(specs)} of {len(recipes)}, and "
-            f"{len(unreached)} have no caller at all."
+            f"{len(uncalled)} have no caller at all."
         )
 
 print(f"RECIPE-REACH OK - {len(recipes)} recipes; {len(specs)} dispatchable from the CAD line and AI "
-      f"planner (RECIPE_SPECS is CURATED, not derived); {len(unreached)} reachable from no surface at "
-      f"all and named in authoring_matrix.UNREACHED: {', '.join(unreached) or '(none)'}. Reachability "
-      "is derived by finding a CALLER outside the catalogs and the engine, because a recipe listed in "
-      "the coverage matrix is registered, not reachable — counting the matrix as a caller reported "
-      "every candidate as reached, which is this check measuring the registry against itself.")
+      f"planner (RECIPE_SPECS is CURATED, not derived); {len(uncalled)} with no caller, split into "
+      f"{len(unreached)} reachable from no surface and named in authoring_matrix.UNREACHED "
+      f"({', '.join(unreached) or '(none)'}) and {len(superseded)} SUPERSEDED — uncalled because a "
+      "reachable recipe authors the identical element, asserted by running both and comparing what "
+      f"they produce ({', '.join(f'{k} -> {v}' for k, v in sorted(superseded.items())) or '(none)'}). "
+      "Reachability is derived by finding a CALLER outside the catalogs and the engine, because a "
+      "recipe listed in the coverage matrix is registered, not reachable — counting the matrix as a "
+      "caller reported every candidate as reached, which is this check measuring the registry against "
+      "itself.")


### PR DESCRIPTION
# What & why

Follow-on to #451, which named ten authoring recipes reachable from no surface and deliberately left
them listed. This takes four off that list: **three by wiring them**, and one by establishing it was
never a capability gap in the first place. `UNREACHED` goes **10 → 6**.

## The three that were real capabilities

**`auto_connect_mep` — one-click bulk connect.** Welds every unconnected MEP pair whose connection
points coincide within a tolerance, in one pass: nearest pairs first, each element joining at most as
many pairs as it has free ports, so a second run changes nothing. Until now the only connect was
`connectMep` — pick one element, pick another — which is fine for a joint and hopeless for a model
drawn run-by-run. The panel it sits on has been reporting *"**N** floating element(s)"* the whole time
with no way to act on the number. The new button sits beside that count and reports what it welded,
**including `0`**, which is a real answer (everything already joined, or nothing within tolerance) and
is worded as one rather than as a bare "done".

**`set_system_predefined` — retype a system's discipline.** Authoring already stamps it, but only on a
system's **first** assignment; `_assign_to_system`'s own docstring says *"first author wins; retag via
`set_system_predefined`"*. That retag path existed in the engine and on no product surface, so a system
that arrived untyped from an import — or was created before its discipline was decided — stayed untyped
permanently, while the panel displayed the discipline, the by-discipline rollup counted it, and the
fire-protection checks keyed off it. Each system row now carries a retype action.

**`add_roof_window` — a skylight in a roof.** Cuts a full-depth `IfcOpeningElement` through a host
`IfcRoof` and fills it with an `IfcWindow`/`SKYLIGHT`. Working since the R17 DORMER slice and covered by
`services/api/test_roof_window.py` down to the void/fill relations and GUID stability across a re-open
— while the viewer shipped *"Add door to selected wall"* and *"Add window to selected wall"* and no
roof counterpart. **Two independent descriptions each said a shipped tool had a missing twin** — the
matrix entry (*"the roof counterpart of the wired `add_door`/`add_window`"*) and the engine docstring
(*"the flat-roof counterpart of the wall-hosted `add_opening`"*) — *and neither was a check, so the
asymmetry sat through both.*

Two things there were decided rather than copied. The position is **required** here, unlike the wall
openings which centre themselves, so copying their "click optional" pattern would have turned a button
press into a server error; the tool refuses without a point and says what to do. And it went into
`envelopeSection.ts`, **not `app.ts`** — the ratchet in `services/api/test_file_sizes.py` only moves one
way, so a new tool in `app.ts` would have been paid for by unwinding an extraction. `app.ts` changes by
two identifiers on two existing lines and stays at exactly **2,508**.

## The one that was never a gap, which is the finding

`add_fire_equipment(kind="sprinkler")` resolves through the same `add_mep_terminal` to the same
`IfcFireSuppressionTerminal`/`SPRINKLER` at the same size on the same *Fire Protection* system with
`discipline="fire"` — and has been on the viewer's 🧯 button since MEP-FP. Wiring `add_sprinkler` would
have added a second control authoring a byte-identical element.

*A reachability sweep answers "does anything call this?", which is one question short of "can a user do
this?" — the same shape of gap #451 was written to close, one layer further in.* So
`authoring_matrix.SUPERSEDED` now sits beside `UNREACHED`, the matrix carries a fourth `reach` value,
and the published table and in-app coverage panel report the classes separately: a duplicate counted
among the gaps understates coverage and invites work that would ship a redundant control.

**The supersession is asserted against what the recipes author, not how they read.**
`test_recipe_reach.py` runs both on a fixture model and compares `(IFC class, PredefinedType, system
name, system PredefinedType)` — every attribute that distinguishes one MEP terminal from another;
without the system and discipline it would pass on two elements landing on different systems, which is
most of what these recipes are for. The `UNREACHED`/`SUPERSEDED` split is checked for disjointness and
for jointly covering the derived uncalled set, so neither can quietly absorb the other.

## Two gates, one new and one narrowed

**New — `sectionButtonsWired.test.ts`.** Every member of every `*Buttons` interface a section module
exports must be destructured **and passed to an `append`** in `app.ts`. Those interfaces were *"named
so re-ordering cannot silently re-map them"* — that guards ORDER, and nothing guarded the last step:
**a button built, returned, destructured and never appended is invisible with every typecheck green**,
which `envelopeSection.ts` records the annotation group shipping once already (*"the same silent-inert
failure `qaSection.ts` shipped"*). `tsc` is satisfied by the destructure; a unit test is satisfied by
calling the handler; only the DOM tree knows. Derived over all three section modules rather than from a
list, with a control asserting the derivation still finds them — a regex that stops matching passes
every assertion vacuously.

**Narrowed — `docsPublished.test.ts`.** It rejects any public doc whose opening contains "superseded",
a proxy for *"this document declares itself a working note"*. The generated matrix now labels a set of
**recipes** superseded, which is a claim about them and not about the file; and the same latent false
positive already sat in `docs/internal/security-roadmap.md` (*"this one is **not** a superseded
snapshot"* — a negation read as a confession), unfired only because it is internal. The rule now ignores
lines naming a backticked code identifier: a status banner announces the document's own condition and
cites nothing else. That is a heuristic and is labelled as one, so it carries a **positive control**
re-running the predicate over the archived notes the un-narrowed rule catches. *An empty result means
"nothing leaked" and "the predicate stopped working" equally, and a narrowing is exactly when the second
becomes likely.* Written first over the whole archive, which reported 6 missed — all 6 of which had
never matched the original markers either: that assertion was testing the archive's filing, not the
predicate.

## Mutations run, all four caught

- `_FIRE_EQUIPMENT["sprinkler"]` → `HOSEREEL`: the gate names the divergence and says the recipe is a
  real capability again.
- Unwire `autoConnectMep`: derived set disagrees with `UNREACHED ∪ SUPERSEDED`.
- Neuter the narrowed doc predicate: the positive control fires.
- Drop `skylightBtn` from the `append`: named as built-but-in-no-DOM-tree.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (the WHOLE tree)
- [x] Backend: full local suite **668/668 suites passed, 0 failures** (1105s, run from `services/api`).
      Measured on `d517d763`; the skylight commit adds no backend test, and `test_recipe_reach.py`,
      `test_authoring_matrix.py` and `test_claude_md_gates.py` were re-run directly on the current head
- [x] Web: typecheck + eslint clean; **208 files / 2106 tests pass** on the current head
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entries added (newest at top); roadmap updated — the DARK-RECIPES entry, the
      SCALE-SEAM (93) note that recorded the three MEP recipes, and a new SKYLIGHT entry
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **“Skylight in selected roof”** tool with roof selection, placement, and dimension validation.
  - Added **Auto-connect** for MEP systems, including tolerance settings and connection results.
  - Added **Retype a system** actions for updating system type and discipline.

- **Improvements**
  - Authoring coverage now identifies superseded recipes and shows their active replacements.
  - Improved feedback when MEP operations cannot reload the project model.
  - Updated authoring documentation and roadmap to reflect available tools and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->