### PR TITLE
The reachability gate counted a docstring as a caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased — the reachability gate counted a docstring as a caller
+
+`test_recipe_reach.py` strips `#`, `//` and `/* */` before deciding whether anything invokes a recipe,
+on the stated principle that **"a mention in a comment is not a call"**. That principle is right. Its
+implementation covered one of the two ways this tree writes prose: **a Python docstring is a string
+literal, not a comment**, so it survived stripping and counted as a caller.
+
+**Six recipes were reported as reachable on prose alone**, and every one was a route *describing what
+you could POST* rather than anything invoking it:
+
+| Recipe | Its only "caller" |
+|---|---|
+| `batch_tag`, `place_type` | `authoring.py` — *"Apply an authoring recipe (set_pset \| batch_tag \| place_type)"*, echoed into the **generated** `schema.d.ts` |
+| `purge_orphan_psets`, `purge_empty_groups` | `authoring_docs.py` — a **dry-run** report whose docstring says *"Run a recipe via `POST /edit`"* |
+| `resolve_wall_joins` | `analysis.py` — *"Resolution is the `resolve_wall_joins` edit recipe"* |
+| `set_spec_link` | `authoring_analysis.py` — *"links with the `set_spec_link` recipe"* |
+
+`UNREACHED` goes **6 → 12**. Nothing was un-wired; the count was wrong.
+
+**The gate that named this class committed it.** DARK-RECIPES was written because a naive reachability
+check counts its own documentation as usage — and then under-counted by six for exactly that reason,
+one layer down. *Stating the correct rule is not the same as implementing its full extent, and nobody
+asked whether "comment" and "prose" were the same set.* The `authoring_docs.py` case is the sharpest:
+a route that reports what a cleanup **would** remove, naming the recipe that applies it, and that
+naming was the only thing making the recipe look reachable. **A dry run is the opposite of a caller.**
+
+Docstrings are now blanked with `ast` rather than a regex — a triple-quoted string is not a regular
+language, and this file's whole subject is checks that look right and measure the wrong thing. An
+unparseable file is returned unchanged, because under-stripping leaves a recipe looking *reachable*,
+which is the safe direction for a check that asserts a gap.
+
+**`apps/web/src/api/schema.d.ts` joins `CATALOGS`.** It is generated from the OpenAPI schema, so its
+`@description` lines are the route docstrings a second time — counting it is the
+registry-read-back-to-itself false positive DARK-RECIPES already fixed once, in a second location.
+
+**Two mutations, in opposite directions, because one alone proves half of it.** Adding an `UNREACHED`
+recipe's name to a route docstring must NOT make it reachable (it does not); adding the same name as
+real code MUST (it does, and the recipe drops off the list). *A stripper that blanked too much would
+pass the first check and quietly report the whole registry as dark.*
+
+**Four of the six are a product gap of the shape this sprint keeps finding: the diagnosis ships and
+the repair does not.** `GET /model/maintenance` reports how many entities each cleanup would remove
+and offers no way to remove them; `analysis.py` detects L/T wall joins and names a resolution nothing
+can invoke. Recorded, not wired — where those controls belong is a product decision.
+
 ## Unreleased — you could put a window in a wall but not a skylight in a roof
 
 `add_roof_window` cuts a full-depth `IfcOpeningElement` through a host `IfcRoof` and fills it with an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,21 @@ real code MUST (it does, and the recipe drops off the list). *A stripper that bl
 pass the first check and quietly report the whole registry as dark.*
 
 **Four of the six are a product gap of the shape this sprint keeps finding: the diagnosis ships and
-the repair does not.** `GET /model/maintenance` reports how many entities each cleanup would remove
-and offers no way to remove them; `analysis.py` detects L/T wall joins and names a resolution nothing
-can invoke. Recorded, not wired — where those controls belong is a product decision.
+the repair does not.** All four, because the first draft said "four" and named three:
+
+| Recipe | The diagnosis that ships without it |
+|---|---|
+| `purge_orphan_psets`, `purge_empty_groups` | `GET /model/maintenance` reports how many entities each cleanup **would** remove, and offers no way to remove them |
+| `resolve_wall_joins` | `analysis.py` detects L/T wall joins and names a resolution nothing can invoke |
+| `set_spec_link` | `GET /spec-links` rolls up linked spec sections **plus the unlinked count**, and says *"Stamp links with the `set_spec_link` recipe"* |
+
+Recorded, not wired — where those controls belong is a product decision.
+
+*A reviewer found the missing fourth. `apps/web/src/api/mep.ts` carries a paragraph about precisely
+this failure — "count the members you looked at, then phrase the result as the whole population … the
+fix is to DERIVE THE COMPLEMENT, not to be more careful" — and it recurred here, in the entry about a
+gate that miscounted. **Stating a cardinal and then enumerating is the tell**: the number and the list
+are two separate claims, and only the list had been checked.*
 
 ## Unreleased — you could put a window in a wall but not a skylight in a roof
 

--- a/docs/authoring-matrix.md
+++ b/docs/authoring-matrix.md
@@ -4,7 +4,7 @@
 
 **96 authoring recipes** across **15 categories**. Every recipe is a GUID-stable server-side pass. **What can invoke one differs per recipe**, and the Reach column says which: `cad+ai` — dispatchable from the CAD command line and the AI planner (12 of 96, the curated `nlauthor.RECIPE_SPECS`); `ui` — invoked by a tool panel, a router or MCP; `superseded` — nothing calls it and nothing should, a reachable recipe authors the same result; `none` — the engine can run it and no surface asks it to.
 
-> ⚠ **6 recipes are reachable from no surface**: `add_connection_assembly`, `convert_length_unit`, `derive_representations`, `program_fit`, `rebase_origin`, `reset_prop_to_type`. They are implemented and tested; they are not something a user can invoke, so they are not coverage. Pinned by `services/api/test_recipe_reach.py`.
+> ⚠ **12 recipes are reachable from no surface**: `add_connection_assembly`, `batch_tag`, `convert_length_unit`, `derive_representations`, `place_type`, `program_fit`, `purge_empty_groups`, `purge_orphan_psets`, `rebase_origin`, `reset_prop_to_type`, `resolve_wall_joins`, `set_spec_link`. They are implemented and tested; they are not something a user can invoke, so they are not coverage. Pinned by `services/api/test_recipe_reach.py`.
 
 > **Superseded** — uncalled, and correctly so: `add_sprinkler` → `add_fire_equipment`. A reachable recipe authors the identical result, so these are duplicate spellings rather than gaps. The equivalence is asserted in `services/api/test_recipe_reach.py`, so an entry stops being true if the two recipes stop agreeing.
 
@@ -97,7 +97,7 @@
 | `execute_ifc_code` | sandboxed ifcopenshell escape hatch | ui |
 | `move_element` | translate | ui |
 | `rename_storey` | rename level | ui |
-| `resolve_wall_joins` | butt-join L/T wall joins | ui |
+| `resolve_wall_joins` | butt-join L/T wall joins | none |
 | `rotate_element` | rotate | ui |
 | `set_extrusion_depth` | push/pull an extrusion depth | ui |
 | `set_profile_dims` | resize an extruded profile in place | ui |
@@ -119,7 +119,7 @@
 | --- | --- | --- |
 | `create_type` | IfcTypeProduct | ui |
 | `edit_type_params` | edit type parameters | ui |
-| `place_type` | type occurrence | ui |
+| `place_type` | type occurrence | none |
 
 ### group (5)
 
@@ -140,7 +140,7 @@
 | `assign_material_set` | IfcMaterialLayerSet | ui |
 | `attach_document` | IfcRelAssociatesDocument | ui |
 | `attach_om_document` | O&M document ref | ui |
-| `batch_tag` | AEC_Tags label | ui |
+| `batch_tag` | AEC_Tags label | none |
 | `classify` | IfcClassificationReference | ui |
 | `derive_representations` | coarse Box/Axis/FootPrint views | none |
 | `ensure_contexts` | representation contexts | ui |
@@ -152,7 +152,7 @@
 | `set_manufacturer_info` | manufacturer psets | ui |
 | `set_props_by_guid` | Pset batch (XLSX round-trip) | ui |
 | `set_pset` | Pset property | ui |
-| `set_spec_link` | Pset_Massing_SpecLink breadcrumb | ui |
+| `set_spec_link` | Pset_Massing_SpecLink breadcrumb | none |
 
 ### lifecycle (3)
 
@@ -175,7 +175,7 @@
 | Recipe | Produces | Reach |
 | --- | --- | --- |
 | `convert_length_unit` | convert the project length unit | none |
-| `purge_empty_groups` | purge empty groups | ui |
-| `purge_orphan_psets` | purge orphaned property sets | ui |
+| `purge_empty_groups` | purge empty groups | none |
+| `purge_orphan_psets` | purge orphaned property sets | none |
 | `rebase_origin` | shift model origin (georeference-preserving) | none |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3008,10 +3008,19 @@ removed. Remaining, in priority order:
   and the same name as real code must (it does) — *a stripper that blanked too much would pass the
   first and report the whole registry as dark.*
 
-  **Four of the six are the sprint's recurring shape — the diagnosis ships, the repair does not.**
-  `GET /projects/{pid}/model/maintenance` reports how many entities each cleanup *would* remove with
-  no way to remove them, and `analysis.py` detects L/T wall joins while naming a resolution nothing
-  can invoke. Recorded, not wired: where those controls belong is a product decision.
+  **Four of the six are the sprint's recurring shape — the diagnosis ships, the repair does not — and
+  here are all four, because the first draft said "four" and named three.** `purge_orphan_psets` and
+  `purge_empty_groups`: `GET /projects/{pid}/model/maintenance` reports how many entities each cleanup
+  *would* remove and offers no way to remove them. `resolve_wall_joins`: `analysis.py` detects L/T wall
+  joins and names a resolution nothing can invoke. `set_spec_link`: `GET /projects/{pid}/spec-links`
+  rolls up linked spec sections **plus the unlinked count** and says "Stamp links with the
+  `set_spec_link` recipe". Recorded, not wired: where those controls belong is a product decision.
+
+  *A reviewer found the missing fourth. `apps/web/src/api/mep.ts` carries a paragraph about exactly
+  this — "count the members you looked at, then phrase the result as the whole population … the fix is
+  to DERIVE THE COMPLEMENT, not to be more careful" — and it happened here inside the entry about a
+  gate that miscounted. **Stating a cardinal and then enumerating is the tell**: the number and the
+  list are two claims, and only the list was checked.*
 
   ✅ **CONTENT-DRAFT, shipped 2026-09-05 — what the corrected measurement actually found.** The 19
   CONTENT-1 items (FF&E · Landscape · Site Logistics) appeared in **neither** affordance: they were

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2987,6 +2987,32 @@ removed. Remaining, in priority order:
   the last step: **a button built, returned, destructured and never appended is invisible with every
   typecheck green**, which `envelopeSection.ts` records the annotation group shipping once already.
 
+  ✅ **DOCSTRING-REACH, shipped 2026-09-05 — the gate that named this class had committed it.**
+  `services/api/test_recipe_reach.py` strips `#`, `//` and `/* */` because *"a mention in a comment is
+  not a call"*. **A Python docstring is a string literal, not a comment**, so it survived — and SIX
+  recipes were counted as reachable on prose alone, every one a route *describing what to POST*:
+  `batch_tag` and `place_type` (`authoring.py`, echoed into the generated `schema.d.ts`),
+  `purge_orphan_psets` and `purge_empty_groups` (`authoring_docs.py`), `resolve_wall_joins`
+  (`analysis.py`), `set_spec_link` (`authoring_analysis.py`). `UNREACHED` **6 → 12**; nothing was
+  un-wired, the count was wrong.
+
+  *The principle was right and the implementation covered one of the two ways this tree writes prose.
+  DARK-RECIPES exists because a naive check counts its own documentation as usage, and then
+  under-counted by six for that exact reason one layer down — **nobody asked whether "comment" and
+  "prose" were the same set.*** Docstrings are blanked with `ast`, not a regex (a triple-quoted string
+  is not a regular language); an unparseable file is returned unchanged, because under-stripping
+  leaves a recipe looking *reachable*, the safe direction for a check asserting a gap.
+  `apps/web/src/api/schema.d.ts` joins `CATALOGS` — generated from those same docstrings, so counting
+  it is the registry-read-back-to-itself false positive fixed once already, in a second location.
+  **Mutated in BOTH directions**: a recipe named in a route docstring must not count (it does not),
+  and the same name as real code must (it does) — *a stripper that blanked too much would pass the
+  first and report the whole registry as dark.*
+
+  **Four of the six are the sprint's recurring shape — the diagnosis ships, the repair does not.**
+  `GET /projects/{pid}/model/maintenance` reports how many entities each cleanup *would* remove with
+  no way to remove them, and `analysis.py` detects L/T wall joins while naming a resolution nothing
+  can invoke. Recorded, not wired: where those controls belong is a product decision.
+
   ✅ **CONTENT-DRAFT, shipped 2026-09-05 — what the corrected measurement actually found.** The 19
   CONTENT-1 items (FF&E · Landscape · Site Logistics) appeared in **neither** affordance: they were
   absent from the draft catalog entirely, so they were the only placeable things in the app that

--- a/services/api/src/aec_api/authoring_matrix.py
+++ b/services/api/src/aec_api/authoring_matrix.py
@@ -119,12 +119,20 @@ _MAP: dict[str, tuple[str, str]] = {
 # it stays internal for now, not a place to park work: the gate makes the decision visible.
 #
 #   add_connection_assembly  steel connection plate + bolts + IfcRelConnectsWithRealizingElements
+#   batch_tag                stamp a Pset value across many elements at once
 #   convert_length_unit      project length unit (mm/m/ft), rescaling so real size is unchanged
 #   derive_representations   coarse Box/Axis/FootPrint views derived from Body geometry
+#   place_type               place an occurrence of an existing IfcTypeObject
 #   program_fit              headcount program -> zoned + auto-furnished spaces
+#   purge_empty_groups       delete groups with no members — GET /model/maintenance reports what it
+#                            WOULD remove and offers no way to remove it
+#   purge_orphan_psets       delete property sets attached to nothing — same dry-run-only story
 #   rebase_origin            shift the model origin, preserving georeferencing
 #   reset_prop_to_type       drop an instance override so the type value shows through — the UI ships
 #                            `set_element_pset`, which is the OTHER half of that pair
+#   resolve_wall_joins       butt L/T wall joins — `analysis.py` DETECTS them and names this as the
+#                            resolution, which nothing can invoke
+#   set_spec_link            stamp the Pset_Massing_SpecLink breadcrumb
 #
 # Three of these — add_sprinkler, auto_connect_mep, set_system_predefined — were already found by
 # SCALE-SEAM (93) and recorded in a doc comment in `apps/web/src/api/mep.ts`: "referenced NOWHERE in
@@ -141,9 +149,21 @@ _MAP: dict[str, tuple[str, str]] = {
 # wall-hosted add_opening". *Two descriptions, written independently, both said a shipped tool had a
 # missing twin; neither was a check, so the asymmetry sat there.* It is now on the envelope section
 # beside the curtain wall.
+# DOCSTRING-REACH (2026-09-05) added SIX to this list without anything being un-wired, because the
+# gate had been counting a DOCSTRING as a caller. `test_recipe_reach.py` stripped `#`, `//` and
+# `/* */` on the principle that "a mention in a comment is not a call" — and a Python docstring is a
+# string literal, so it survived. Every one of the six was a ROUTE DESCRIBING what to POST:
+# `authoring.py` ("recipe: set_pset | batch_tag | place_type"), `authoring_docs.py` (a dry-run
+# maintenance report naming the cleanup recipes), `analysis.py` and `authoring_analysis.py`.
+#
+# *The principle was right and the implementation covered one of the two ways this tree writes
+# prose. A gate can state the correct rule and still measure the wrong set — which is the same shape
+# as the defect this whole file exists to catch, one level down.* Four of the six are a product gap
+# of a familiar kind: the DIAGNOSIS ships and the REPAIR does not.
 UNREACHED: frozenset[str] = frozenset({
-    "add_connection_assembly", "convert_length_unit", "derive_representations",
-    "program_fit", "rebase_origin", "reset_prop_to_type",
+    "add_connection_assembly", "batch_tag", "convert_length_unit", "derive_representations",
+    "place_type", "program_fit", "purge_empty_groups", "purge_orphan_psets", "rebase_origin",
+    "reset_prop_to_type", "resolve_wall_joins", "set_spec_link",
 })
 
 # Recipes that nothing invokes AND nothing should: a reachable recipe already authors the identical

--- a/services/api/test_recipe_reach.py
+++ b/services/api/test_recipe_reach.py
@@ -33,6 +33,7 @@ of silently inflating a maturity claim.
 
 Run: PYTHONPATH=src ./.venv/bin/python test_recipe_reach.py
 """
+import ast
 import os
 import re
 import subprocess
@@ -52,6 +53,11 @@ CATALOGS = (
     "__pycache__",
     "docs/authoring-matrix.md",      # generated FROM the matrix
     "services/data/src/aec_data/",   # the engine: the definition and its dispatch table
+    # GENERATED from the OpenAPI schema, so its `@description` lines ARE the route docstrings a
+    # second time. Counting it is false positive (1) in a second location — the check reading a
+    # description of the registry and calling it a caller. It is the only generated file under
+    # `apps/web/src`, which is why it needs naming rather than a pattern.
+    "apps/web/src/api/schema.d.ts",
 )
 
 SEARCHED = (
@@ -61,8 +67,55 @@ SEARCHED = (
 )
 
 
-def _code(src: str) -> str:
-    """Source with comments removed — `//`, `/* */` and `#`.
+def _docstrings_blanked(src: str, path: str) -> str:
+    """Python source with every DOCSTRING body blanked out.
+
+    **A docstring is prose, exactly like a comment — but it is a string literal, so stripping
+    comments does not touch it.** `_code()` below removes `#`, `//` and `/* */` on the stated
+    principle that "a mention in a comment is not a call". That principle was right and its
+    implementation covered one of the two ways this codebase writes prose.
+
+    Six recipes were counted as reachable on a docstring alone, and every one was a route
+    describing what you could POST rather than a caller invoking it:
+
+      * `authoring.py` — "Apply an authoring recipe (set_pset | batch_tag | place_type)"
+      * `authoring_docs.py` — a DRY-RUN maintenance report whose docstring says "Run a recipe via
+        `POST /projects/&#123;pid&#125;/edit` with `recipe: purge_orphan_psets | purge_empty_groups`"
+      * `analysis.py` — "Resolution is the `resolve_wall_joins` edit recipe"
+      * `authoring_analysis.py` — "links with the `set_spec_link` recipe"
+
+    *The `authoring_docs.py` one is the sharpest: a route that reports what a cleanup WOULD remove,
+    naming the recipe that applies it, and the naming was the only thing making that recipe look
+    reachable. A dry run is the opposite of a caller.*
+
+    Parsed with `ast` rather than matched with a regex, because a triple-quoted string is not a
+    regular language and this file's whole subject is checks that look right and measure the wrong
+    thing. A file that cannot be parsed is returned unchanged — under-stripping keeps a recipe
+    looking reachable, which is the SAFE direction for a gate that is asserting a gap.
+    """
+    if not path.endswith(".py"):
+        return src
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return src
+    lines = src.split("\n")
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) \
+           and isinstance(first.value.value, str) and first.end_lineno:
+            for i in range(first.lineno - 1, min(first.end_lineno, len(lines))):
+                lines[i] = ""
+    return "\n".join(lines)
+
+
+def _code(src: str, path: str = "") -> str:
+    """Source with PROSE removed — `//`, `/* */`, `#`, and Python docstrings.
 
     **A mention in a comment is not a call**, and this gate learned that the same way the two
     false positives in the docstring were learned: a mutation that swapped a recipe out of its
@@ -72,11 +125,18 @@ def _code(src: str) -> str:
     `apps/web/src/viewer/tools/accessorNotCollapsed.test.ts` states the general rule this is the
     third instance of: a gate that greps source must strip comments, or its own documentation
     becomes its evidence.
+
+    **DOCSTRING-REACH found the fourth instance, inside this very file.** Stripping comments and
+    stopping there was itself an example of the defect: the rule is "prose is not a call", and
+    `#`/`//`/`/* */` is only one of the two ways prose is written in this tree. See
+    `_docstrings_blanked`. *Getting the principle right does not mean the implementation covers it —
+    the gate that named this class went on to under-count by six because nobody asked whether
+    "comment" and "prose" were the same set.*
     """
     src = re.sub(r"/\*[\s\S]*?\*/", "", src)
     src = re.sub(r"^\s*#.*$", "", src, flags=re.M)          # python comment lines
     src = re.sub(r"(?<![:\w])//.*$", "", src, flags=re.M)    # js line comments, sparing https://
-    return src
+    return _docstrings_blanked(src, path)
 
 
 def callers(recipe: str) -> list[str]:
@@ -92,7 +152,7 @@ def callers(recipe: str) -> list[str]:
             continue
         try:
             with open(f, encoding="utf-8", errors="ignore") as fh:
-                if word.search(_code(fh.read())):
+                if word.search(_code(fh.read(), f)):
                     hits.append(f)
         except OSError:
             hits.append(f)          # unreadable: assume it counts rather than under-report


### PR DESCRIPTION
# What & why

`services/api/test_recipe_reach.py` (shipped in #451) strips `#`, `//` and `/* */` before deciding
whether anything invokes a recipe, on the stated principle that **"a mention in a comment is not a
call"**. That principle is right. Its implementation covered one of the two ways this tree writes
prose: **a Python docstring is a string literal, not a comment**, so it survived stripping and counted
as a caller.

**Six recipes were reported reachable on prose alone**, and every one was a route *describing what you
could POST*:

| Recipe | Its only "caller" |
|---|---|
| `batch_tag`, `place_type` | `authoring.py` — *"Apply an authoring recipe (set_pset \| batch_tag \| place_type)"*, echoed into the **generated** `schema.d.ts` |
| `purge_orphan_psets`, `purge_empty_groups` | `authoring_docs.py` — a **dry-run** report saying *"Run a recipe via `POST /edit`"* |
| `resolve_wall_joins` | `analysis.py` — *"Resolution is the `resolve_wall_joins` edit recipe"* |
| `set_spec_link` | `authoring_analysis.py` — *"links with the `set_spec_link` recipe"* |

**`UNREACHED` goes 6 → 12. Nothing was un-wired; the count was wrong.** Each of the six was verified by
hand before being moved, not taken from the sweep.

### The gate that named this class committed it

#451 exists because a naive reachability check counts its own documentation as usage — and it then
under-counted by six for exactly that reason, one layer down. *Stating the correct rule is not the same
as implementing its full extent, and nobody asked whether "comment" and "prose" were the same set.*

The `authoring_docs.py` case is the sharpest: a route that reports what a cleanup **would** remove,
naming the recipe that applies it — and that naming was the only thing making the recipe look
reachable. **A dry run is the opposite of a caller.**

### Two decisions worth stating

- **Docstrings are blanked with `ast`, not a regex.** A triple-quoted string is not a regular language,
  and this file's whole subject is checks that look right and measure the wrong thing. An unparseable
  file is returned **unchanged**, because under-stripping leaves a recipe looking *reachable* — the
  safe direction for a check that asserts a gap.
- **`apps/web/src/api/schema.d.ts` joins `CATALOGS`.** It is generated from the OpenAPI schema, so its
  `@description` lines are the route docstrings a second time. Counting it is the
  registry-read-back-to-itself false positive #451 already fixed once, in a second location.

### Mutated in both directions

One direction alone proves half of it:

- an `UNREACHED` recipe's name added to a route **docstring** must NOT make it reachable — it does not;
- the same name added as **real code** MUST — it does, and the recipe drops off the list.

*A stripper that blanked too much would pass the first check and quietly report the whole registry as
dark.* That is the failure this pair exists to exclude.

### A product finding, recorded rather than acted on

**Four of the six are the shape this sprint keeps hitting: the diagnosis ships and the repair does
not.** `GET /projects/{pid}/model/maintenance` reports how many entities each cleanup would remove and
offers no way to remove them; `analysis.py` detects L/T wall joins while naming a resolution nothing can
invoke. Where those controls belong is a product decision, so they are listed, not wired.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `python -m ruff check` clean on both changed files
- [x] Backend: full local suite **668/668 suites passed, 0 failures** (1068s, run from `services/api`);
      both mutations verified in both directions
- [x] Web: unchanged by this diff (no `apps/web` source touched; `schema.d.ts` is referenced by name in
      a Python tuple, not modified)
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added (newest at top); roadmap item updated
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recipe reachability reporting so documentation text is not counted as actual usage.
  - Correctly identifies six additional recipes as unreachable, increasing the reported total from 6 to 12.

- **Documentation**
  - Updated the authoring matrix and roadmap with corrected reachability status.
  - Documented four diagnosis-without-repair recipe gaps.

- **Tests**
  - Added coverage confirming that recipe names in documentation do not affect reachability, while real usage does.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->