### PR TITLE
A failed reload threw away the only correct geometry on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ caught — but `reloadModel()` returning `false` fell straight through to `store
 not load **and** the deltas are gone. On a failed reload the deltas are now kept and the message says
 so.
 
+**What "kept" means, corrected after review.** `reloadModel` disposes every model *before* it loads, so
+by the time it returns `false` the delta geometry is gone from the scene whatever this function does.
+The guard preserves the **record** — the rail keeps reporting unbuilt edits and *Rebuild* stays
+available to retry — not the pixels, and the message now points at that action instead of saying
+"deltas kept", which read as a promise the viewport was intact. *The guard was right and its wording
+described a stronger outcome than it delivers* — a much milder instance of the same class as the
+`"geometry rebuilt"` toast it replaced. Making the disposal itself atomic would recover the geometry
+too; that belongs to `loadProjectModel` and is deliberately not in this change.
+
+`commit()` deliberately does the **opposite** on its reconvert path, and the asymmetry is not an
+inconsistency: that path republishes and reconverts, so the pending edits are already in the new base
+— leaving them in the store would strand the rail on "N edits not yet rebuilt" forever. What the two
+share is only the messaging rule: read the boolean, and never claim a rebuild the user cannot see.
+
 **The tests had the same gap, in the same shape.** `deltaCommit.test.ts` covered two of the three
 failure modes — publish returns a non-`done` state, publish throws — and not the third, publish
 succeeds and the reload fails. Both existing tests pass whether or not the reload result is read,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to Massing. Releases are signed, auto-updating desktop build
 (Windows / macOS / Linux); the updater always serves the latest. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## Unreleased — a failed reload threw away the only correct geometry on screen
+
+`deltaCommit.consolidate()` republishes the model, reloads it, and then clears the delta store. Its own
+docstring explains the ordering in detail:
+
+> *The deltas are cleared only AFTER the new base has loaded. Clearing first would blink the elements
+> off screen, and on a failed publish would leave the user with neither the delta nor the rebuild —
+> **the one state in which the deltas are the only correct geometry they have.***
+
+**It guarded the publish and not the reload.** `st !== "done"` returns early, and a thrown request is
+caught — but `reloadModel()` returning `false` fell straight through to `store.clear()` and a
+`"geometry rebuilt"` success. That produces exactly the end state the paragraph forbids: the base did
+not load **and** the deltas are gone. On a failed reload the deltas are now kept and the message says
+so.
+
+**The tests had the same gap, in the same shape.** `deltaCommit.test.ts` covered two of the three
+failure modes — publish returns a non-`done` state, publish throws — and not the third, publish
+succeeds and the reload fails. Both existing tests pass whether or not the reload result is read,
+because neither reaches the reload. *A failure mode with no test is not the same as a failure mode that
+cannot happen, and here the missing test and the missing guard were the same absence.* The third case
+is now covered, and reverting the guard fails it on the exact symptom (deltas cleared, count 0 where it
+must be 1).
+
+**`commit()` forty lines above was already correct** — `const shown = await d.reloadModel()`, and a
+notify that says *"— shown"* only when it did. So this is one module disagreeing with itself, which is
+why keeping the deltas is a correction rather than a new policy.
+
+### A correction to what this repo said about the class
+
+PR #452's commit message and review thread claimed *"a failed reload is the one outcome a user cannot
+detect unaided"*. **That was wrong.** `loadProjectModel` already sets an explicit user-visible status on
+three of its four `return false` paths — *"no published model yet"*, *"published model file is empty"*,
+*"could not read geometry — file is not a Fragments model"*. The fourth is a `!projectId` guard that
+cannot fire from those handlers.
+
+The defect is real but different: **two contradictory signals**, a status line saying the geometry could
+not be read beside a success toast saying the edit is done. *I verified that callers discard the boolean
+and then inferred that the user learns nothing — a check aimed one layer above where the behaviour
+lives, which is the same failure the two entries below are about.* Corrected on the #452 thread, since a
+reviewer had recorded a repo learning partly on that claim; the learning's advice stands, the
+justification did not.
+
 ## Unreleased — the reachability gate counted a docstring as a caller
 
 `test_recipe_reach.py` strips `#`, `//` and `/* */` before deciding whether anything invokes a recipe,

--- a/apps/web/src/viewer/deltaCommit.test.ts
+++ b/apps/web/src/viewer/deltaCommit.test.ts
@@ -310,10 +310,30 @@ describe("consolidate", () => {
     const { d, store, c } = harness({ reloadModel: vi.fn(async () => false) });
     store.add({ modelId: "pv-1", label: "Wall" });
     await c.consolidate();
-    expect(store.count, "the deltas are the only correct geometry left — they must survive").toBe(1);
+    expect(store.count, "the record of unbuilt edits must survive so Rebuild stays available").toBe(1);
     expect(d.refresh).not.toHaveBeenCalled();
-    expect(d.notify).toHaveBeenCalledWith(expect.stringContaining("could not be reloaded"), "error");
+    expect(d.notify).toHaveBeenCalledWith(expect.stringContaining("could not reload"), "error");
     expect(d.notify).not.toHaveBeenCalledWith("geometry rebuilt", "success");
+  });
+
+  it("does not claim the delta GEOMETRY survived a failed reload — only the record does", async () => {
+    // A reviewer read the first version of this guard's message ("deltas kept") as a promise that
+    // the delta models were still on screen. They are not, and cannot be: `reloadModel` disposes
+    // every model BEFORE it loads, so by the time it returns `false` the delta geometry is gone
+    // whatever this function does. Keeping the store preserves the RECORD — the rail still says
+    // there are unbuilt edits and Rebuild stays available to retry — and the message has to say
+    // that rather than imply the viewport is intact.
+    //
+    // *The guard was right and its wording described a stronger outcome than it delivers*, which is
+    // the same class as the "geometry rebuilt" toast it replaced, just much milder. Pinned here so
+    // the message cannot drift back into promising recovered geometry.
+    const { d, c } = harness({ reloadModel: vi.fn(async () => false) });
+    await c.consolidate();
+    const msgs = (d.notify as unknown as { mock: { calls: [string, string?][] } }).mock.calls
+      .map(([m]) => m).join(" | ");
+    expect(msgs, "the message must not imply the delta geometry is still on screen")
+      .not.toMatch(/deltas kept|still shown|geometry kept/i);
+    expect(msgs, "it must point at the action that recovers the view").toMatch(/reopen|rebuild again/i);
   });
 
   it("KEEPS the deltas when the publish request itself throws", async () => {

--- a/apps/web/src/viewer/deltaCommit.test.ts
+++ b/apps/web/src/viewer/deltaCommit.test.ts
@@ -297,6 +297,25 @@ describe("consolidate", () => {
     expect(store.count).toBe(1);
   });
 
+  it("KEEPS the deltas when the publish SUCCEEDS but the model will not reload", async () => {
+    // The third failure mode, and the one the other two hid. `consolidate` guarded the publish
+    // twice — a non-"done" state and a thrown request — and then discarded the deltas on a reload
+    // that returned `false`, which is the same end state both of those tests exist to prevent:
+    // the base did not load AND the deltas are gone.
+    //
+    // `reloadModel` returns a boolean precisely so this case can be told apart from success, and
+    // reading it is the only way to tell — the two tests above pass either way, because they never
+    // reach the reload. *A failure mode with no test is not the same as a failure mode that cannot
+    // happen, and here the missing test and the missing guard were the same absence.*
+    const { d, store, c } = harness({ reloadModel: vi.fn(async () => false) });
+    store.add({ modelId: "pv-1", label: "Wall" });
+    await c.consolidate();
+    expect(store.count, "the deltas are the only correct geometry left — they must survive").toBe(1);
+    expect(d.refresh).not.toHaveBeenCalled();
+    expect(d.notify).toHaveBeenCalledWith(expect.stringContaining("could not be reloaded"), "error");
+    expect(d.notify).not.toHaveBeenCalledWith("geometry rebuilt", "success");
+  });
+
   it("KEEPS the deltas when the publish request itself throws", async () => {
     const { d, store, c } = harness({ publish: vi.fn(async () => { throw new Error("network"); }) });
     store.add({ modelId: "pv-1", label: "Wall" });

--- a/apps/web/src/viewer/deltaCommit.ts
+++ b/apps/web/src/viewer/deltaCommit.ts
@@ -347,7 +347,20 @@ export function deltaCommitter(d: DeltaDeps) {
       await d.publish(true);
       const st = await d.awaitPublish();
       if (st !== "done") { d.notify(`rebuild ${st}`, st === "error" ? "error" : "info"); return; }
-      await d.reloadModel();          // disposeAll() reclaims the delta models with everything else
+      // `reloadModel` returns whether the new base actually LOADED, and the paragraph above is the
+      // reason that matters: clearing the store on a failed reload leaves the user with neither the
+      // delta nor the rebuild — "the one state in which the deltas are the only correct geometry
+      // they have". The publish failure was already guarded a line up; the RELOAD failure was not,
+      // so the invariant this function documents held for one of its two failure modes.
+      //
+      // `commit()` above already gets this right — `const shown = await d.reloadModel()` and a
+      // notify that says "— shown" only when it did. This is the same module disagreeing with itself
+      // forty lines apart, which is why keeping the deltas here is a correction and not a new policy.
+      const shown = await d.reloadModel();   // disposeAll() reclaims the delta models with everything else
+      if (!shown) {
+        d.notify("rebuild published, but the model could not be reloaded — deltas kept", "error");
+        return;
+      }
       d.store.clear();
       d.refresh();
       await d.reloadPins();

--- a/apps/web/src/viewer/deltaCommit.ts
+++ b/apps/web/src/viewer/deltaCommit.ts
@@ -347,18 +347,29 @@ export function deltaCommitter(d: DeltaDeps) {
       await d.publish(true);
       const st = await d.awaitPublish();
       if (st !== "done") { d.notify(`rebuild ${st}`, st === "error" ? "error" : "info"); return; }
-      // `reloadModel` returns whether the new base actually LOADED, and the paragraph above is the
-      // reason that matters: clearing the store on a failed reload leaves the user with neither the
-      // delta nor the rebuild — "the one state in which the deltas are the only correct geometry
-      // they have". The publish failure was already guarded a line up; the RELOAD failure was not,
-      // so the invariant this function documents held for one of its two failure modes.
+      // `reloadModel` returns whether the new base actually LOADED. The publish failure was guarded
+      // a line up; the RELOAD failure was not, so the invariant this function documents held for one
+      // of its two failure modes — a failed reload fell through to `store.clear()` and a "geometry
+      // rebuilt" success, telling the user the rebuild worked while the screen showed nothing.
       //
-      // `commit()` above already gets this right — `const shown = await d.reloadModel()` and a
-      // notify that says "— shown" only when it did. This is the same module disagreeing with itself
-      // forty lines apart, which is why keeping the deltas here is a correction and not a new policy.
-      const shown = await d.reloadModel();   // disposeAll() reclaims the delta models with everything else
+      // **What this guard does and does not recover.** `reloadModel` calls `disposeAll()` before it
+      // loads, so by the time it returns `false` the delta geometry is gone from the scene no matter
+      // what this function does. Keeping the store therefore preserves the RECORD, not the pixels —
+      // the rail keeps saying there are unbuilt edits, and "Rebuild" stays available to retry. That
+      // is the useful state; clearing would report a clean, finished model over an empty viewport.
+      // (Making the disposal itself atomic — not tearing down the old models until the new one is
+      // known to load — would recover the pixels too, but it belongs to `loadProjectModel`, not
+      // here, and is deliberately not in this change.)
+      //
+      // `commit()` forty lines above deliberately does the OPPOSITE on its reconvert path, and the
+      // asymmetry is not an inconsistency: that path republishes and reconverts, so the pending
+      // edits are IN the new base — leaving them in the store would strand the rail on "N edits not
+      // yet rebuilt" forever. What `commit()` shares with this function is only the messaging rule:
+      // read the boolean, and never claim a rebuild the user cannot see.
+      const shown = await d.reloadModel();
       if (!shown) {
-        d.notify("rebuild published, but the model could not be reloaded — deltas kept", "error");
+        d.notify("rebuild published, but the viewer could not reload it — reopen the model, or rebuild again",
+                 "error");
         return;
       }
       d.store.clear();


### PR DESCRIPTION
# What & why

`deltaCommit.consolidate()` republishes the model, reloads it, then clears the delta store. Its own
docstring explains the ordering:

> *The deltas are cleared only AFTER the new base has loaded. Clearing first would blink the elements
> off screen, and on a failed publish would leave the user with neither the delta nor the rebuild —
> **the one state in which the deltas are the only correct geometry they have.***

**It guarded the publish and not the reload.** A non-`"done"` state returns early, and a thrown request
is caught — but `reloadModel()` returning `false` fell straight through to `store.clear()` and a
`"geometry rebuilt"` success. That produces exactly the end state the paragraph forbids: **the base did
not load and the deltas are gone.** On a failed reload they are now kept and the message says so.

### The tests had the same gap, in the same shape

`deltaCommit.test.ts` covered two of three failure modes and not the third:

| Failure mode | Covered before |
|---|---|
| publish returns a non-`done` state | ✅ |
| the publish request throws | ✅ |
| **publish succeeds, reload returns `false`** | ❌ |

Both existing tests pass whether or not the reload result is read, **because neither reaches the
reload**. *A failure mode with no test is not the same as a failure mode that cannot happen, and here
the missing test and the missing guard were the same absence.* Reverting the guard fails the new test on
the exact symptom — deltas cleared, `count` 0 where it must be 1.

### Why this is a correction, not a new policy

`commit()` forty lines above already does it right: `const shown = await d.reloadModel()`, and a notify
that says *"— shown"* only when it did. One module disagreeing with itself.

## A correction to what this repo said about the class

**PR #452's commit message and review thread claimed *"a failed reload is the one outcome a user cannot
detect unaided"*. That was wrong**, and it is worth stating plainly because it is now in merged history.

`loadProjectModel` already sets an explicit, user-visible status on **three of its four** `return false`
paths — *"no published model yet"*, *"published model file is empty — republish from source IFC"*,
*"could not read geometry — file is not a Fragments model"*. The fourth is a `!projectId` guard that
cannot fire from those handlers.

So the defect is real but different and milder: **two contradictory signals** — a status line saying the
geometry could not be read, beside a success toast saying the edit is done. *I verified that callers
discard the boolean and then inferred that the user learns nothing — a check aimed one layer above where
the behaviour lives, which is the same failure #451 and #453 were about, committed while writing about
it.* Corrected on the #452 thread, since a reviewer recorded a repo learning partly on that claim; the
learning's advice stands, my justification for it did not.

**What this means for the wider sweep:** the ~15-site "report success over a stale viewer" sweep I
scoped is now smaller and lower priority, because the central authoring path
(`authorAndReload → committer.commit`) is already correct and the status line already carries the
failure. What remains is removing contradictions at sites that bypass that path — worth doing, not
urgent, and explicitly **not** in this PR.

Two more corrections to my own earlier derivation, recorded so the numbers are not trusted twice: the
six `app.ts` "call sites" I listed are **dependency injection** (`loadProjectModel: () => loadProjectModel()`),
not calls; and four `authoringSection.ts` sites report `publish: ${state}`, which is *accurate* about
the publish and silent about the view — a different, milder shape.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Web: typecheck clean; eslint clean on both changed files; **208 files / 2107 tests pass**
- [x] Mutation-checked: reverting the guard fails the new test on the exact symptom
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added (newest at top)
- [x] Backend: unchanged by this diff (no Python touched)
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pending changes are now preserved when rebuilding the model fails, keeping the **Rebuild** option available.
  - Users now receive an accurate error notification with guidance to reopen the model or try rebuilding again.
  - The app no longer reports a successful rebuild when reloading the model fails.

- **Tests**
  - Added coverage for the scenario where publishing succeeds but model reloading fails.

- **Documentation**
  - Updated the changelog to document the corrected behavior and recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->