### PR TITLE
GITLEAKS-BASELINE — the file that silences findings could not run the scanner

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,13 @@ on:
       - "**/package.json"
       - "**/package-lock.json"
       - ".github/workflows/security.yml"
+      # `.gitleaksignore` is READ BY the gitleaks step below, which makes it an audited input of
+      # this workflow exactly as `requirements.lock` is an audited input of the pip gate — and it
+      # could not trigger the workflow that reads it. Third instance of the sentence twenty lines
+      # up ("a scope that excludes its own subject is not a smaller check — it is no check"), and
+      # the first where the excluded subject is the BASELINE: a line added here silences a finding,
+      # and until now nothing re-ran the scanner to show what the silence covers.
+      - ".gitleaksignore"
 
   # THE BLOCKING GATES ABOVE COULD NOT BLOCK A MERGE UNTIL THIS EXISTED. With only `push:`, they
   # fire AFTER a PR lands — they report a merge that already happened. Same shape as
@@ -56,6 +63,7 @@ on:
       - "**/package.json"
       - "**/package-lock.json"
       - ".github/workflows/security.yml"
+      - ".gitleaksignore"   # see the push: list above for why the baseline triggers its own scanner
 
   workflow_dispatch:
 

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -35,3 +35,22 @@
 # test_licensing.py — fabricated MASSING_LICENSE_KEY fixtures driving the tier/expiry paths.
 1528d60ec54371809ed896170b30d5defa478fed:services/api/test_licensing.py:generic-api-key:85
 fc0d7767f57653f3ea235db5abaeb646db79c4a1:services/api/test_licensing.py:generic-api-key:49
+
+# masterBuilder.test.ts — the DEFAULT share-token value in a test fixture factory, "0123456789abcdef":
+# sixteen characters of hex immediately after an identifier named `token`, which is precisely the
+# shape generic-api-key looks for. Not a credential and never issued — the two call sites in that
+# test both OVERRIDE it, so the flagged value was not even the one under assertion. Triaged
+# 2026-09-06: nothing to rotate.
+#
+# TWO fingerprints for ONE fixture, and that is the lesson rather than an accident. The value was
+# introduced on a feature branch (db8d9a79) and again by the SQUASH commit that landed it on main
+# (cf02024c) — a squash re-adds every line as a new diff, so it earns its own fingerprint. Baseline
+# the branch commit alone and the scan stays red on main. Both are needed, and the second only
+# exists after the merge, so this baseline could not have been written correctly before it.
+#
+# The current file no longer matches: the fixture was reshaped to repeated characters, which is why
+# the other two token values in that same test were never flagged. That fix does NOT close these —
+# the strings are in the objects for good — but it stops a future edit to that file re-adding the
+# line and minting a third fingerprint.
+db8d9a79d19791748469e0ab84c4dd4b6c3191b9:apps/web/src/portal/panels/masterBuilder.test.ts:generic-api-key:109
+cf02024cb78d24d5322977ba63d80d0c099840f9:apps/web/src/portal/panels/masterBuilder.test.ts:generic-api-key:109

--- a/apps/web/src/portal/panels/masterBuilder.test.ts
+++ b/apps/web/src/portal/panels/masterBuilder.test.ts
@@ -105,8 +105,14 @@ describe("R22-PUBLIC-VIEWER — the geometry opt-in is offered, and it is READ",
   });
 
   it("marks which live links grant geometry, so the opt-in can be audited after minting", async () => {
+    // The token values here are deliberately REPEATED characters, not hex-looking ones. A
+    // 16-char high-entropy string after an identifier named `token` is exactly what gitleaks'
+    // generic-api-key rule matches, and this fixture's original "0123456789abcdef" tripped the
+    // full-history scan for real — on a value that is not a credential and never was. The scan
+    // is right to be that blunt; a fixture that happens to look like a secret costs a red build
+    // and a triage, so shape it so it cannot be mistaken for one.
     const tok = (over: Record<string, unknown>) => ({
-      token: "0123456789abcdef", label: null, revoked: false, created_at: null, created_by: null,
+      token: "cccccccccccccccc", label: null, revoked: false, created_at: null, created_by: null,
       view_count: 0, last_viewed_at: null, share_path: "/s", show_payments: false, show_model: false,
       ...over,
     });

--- a/services/api/test_lock_advisories.py
+++ b/services/api/test_lock_advisories.py
@@ -295,6 +295,13 @@ def test_every_audited_path_can_actually_trigger_the_workflow() -> None:
           f"{len(gate.LOCKS)} path(s)")
 
 
+# A line that RUNS gitleaks, as opposed to one that merely mentions it. Anchored at the start of
+# the line or just after a shell operator, so `echo "gitleaks detect"` is prose and
+# `prep && ./gitleaks detect` is a command. The optional prefix allows `./gitleaks`, a bare
+# `gitleaks` on PATH, or any directory.
+_RUNS_GITLEAKS = re.compile(r"(?:^|[;&|])\s*(?:[A-Za-z0-9_.+-]*/)?gitleaks\s+detect(?:\s|$)")
+
+
 def _gitleaks_step_lines() -> list[str]:
     """The EXECUTABLE lines of the step that runs gitleaks — comments stripped.
 
@@ -324,7 +331,7 @@ def _gitleaks_step_lines() -> list[str]:
                 continue
             body = [ln for ln in run.splitlines()
                     if ln.strip() and not ln.strip().startswith("#")]
-            if any("gitleaks detect" in ln for ln in body):
+            if any(_RUNS_GITLEAKS.search(ln) for ln in body):
                 return body
     raise AssertionError(
         "no step in security.yml RUNS `gitleaks detect` — the scanner is gone, or it moved "
@@ -348,7 +355,7 @@ def _gitleaks_invocation() -> str:
     """
     lines = _gitleaks_step_lines()
     for i, line in enumerate(lines):
-        if "gitleaks detect" not in line:
+        if not _RUNS_GITLEAKS.search(line):
             continue
         parts = [line]
         # A future edit may wrap the command across lines; follow trailing-backslash continuations

--- a/services/api/test_lock_advisories.py
+++ b/services/api/test_lock_advisories.py
@@ -295,21 +295,59 @@ def test_every_audited_path_can_actually_trigger_the_workflow() -> None:
           f"{len(gate.LOCKS)} path(s)")
 
 
+def _gitleaks_command_lines() -> list[str]:
+    """The EXECUTABLE lines of the step that runs gitleaks — comments stripped.
+
+    THE FIRST VERSION OF THIS GREPPED THE WHOLE FILE, and CodeRabbit was right to refuse it.
+    `security.yml` mentions gitleaks in fourteen comment lines, one of which names
+    `.gitleaksignore`. So `"gitleaks detect" in text` stayed true with the scanner deleted, and a
+    comment that happened to write `--gitleaks-ignore-path` would have been read as the baseline.
+
+    That is the lesson this file already carries one function up, applied to the wrong text twice:
+    "a gate that greps prose measures the wrong text." `test_ruff_scope.py` learned the same thing
+    when its `re.search` took the first match and a decoy above the real command bypassed it. A
+    check written to catch a scope fiction was itself scoped to prose.
+
+    Worse, the MUTATION MISSED IT TOO. The check "remove `gitleaks detect` from the workflow" was
+    run as a blanket string replace, which rewrote the comments along with the command — so it
+    could not tell the two apart either, and reported a pass that meant nothing. *A mutation that
+    shares the implementation's blind spot confirms it instead of challenging it*; the mutation
+    below now deletes only the command and leaves every comment in place.
+    """
+    import yaml
+    wf = os.path.join(ROOT, ".github", "workflows", "security.yml")
+    with open(wf, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh.read()) or {}
+    for job in (doc.get("jobs") or {}).values():
+        for step in (job or {}).get("steps") or []:
+            run = (step or {}).get("run")
+            if not isinstance(run, str):
+                continue
+            body = [ln for ln in run.splitlines()
+                    if ln.strip() and not ln.strip().startswith("#")]
+            if any("gitleaks detect" in ln for ln in body):
+                return body
+    raise AssertionError(
+        "no step in security.yml RUNS `gitleaks detect` — the scanner is gone, or it moved "
+        "somewhere this check cannot see. Either way asserting a trigger for its baseline is "
+        "worse than not checking at all")
+
+
 def _gitleaks_baseline_path() -> str:
-    """Which file does the gitleaks step read as its baseline? DERIVED from the workflow.
+    """Which file does the gitleaks step read as its baseline? DERIVED from the command it runs.
 
     Not hardcoded, for the same reason `test_ruff_scope.py` parses the ruff command rather than
     naming directories: if the step ever gains an explicit `--gitleaks-ignore-path`, a hardcoded
     `.gitleaksignore` would keep asserting a trigger for a file nothing reads any more, and pass.
+
+    Read from executable lines only — see `_gitleaks_command_lines` for why that distinction is
+    the whole point rather than a tidy-up.
     """
-    wf = os.path.join(ROOT, ".github", "workflows", "security.yml")
-    with open(wf, encoding="utf-8") as fh:
-        text = fh.read()
-    assert "gitleaks detect" in text, (
-        "security.yml no longer runs `gitleaks detect` — this check is asserting a trigger for a "
-        "scanner that is gone, which is worse than not checking at all")
-    m = re.search(r"--gitleaks-ignore-path[= ]+(\S+)", text)
-    return m.group(1).strip("\"'") if m else ".gitleaksignore"
+    for line in _gitleaks_command_lines():
+        m = re.search(r"--gitleaks-ignore-path[=\s]+(\S+)", line)
+        if m:
+            return m.group(1).strip("\"'")
+    return ".gitleaksignore"          # gitleaks' own default when the flag is absent
 
 
 def test_the_gitleaks_baseline_can_trigger_its_own_scanner() -> None:

--- a/services/api/test_lock_advisories.py
+++ b/services/api/test_lock_advisories.py
@@ -295,6 +295,59 @@ def test_every_audited_path_can_actually_trigger_the_workflow() -> None:
           f"{len(gate.LOCKS)} path(s)")
 
 
+def _gitleaks_baseline_path() -> str:
+    """Which file does the gitleaks step read as its baseline? DERIVED from the workflow.
+
+    Not hardcoded, for the same reason `test_ruff_scope.py` parses the ruff command rather than
+    naming directories: if the step ever gains an explicit `--gitleaks-ignore-path`, a hardcoded
+    `.gitleaksignore` would keep asserting a trigger for a file nothing reads any more, and pass.
+    """
+    wf = os.path.join(ROOT, ".github", "workflows", "security.yml")
+    with open(wf, encoding="utf-8") as fh:
+        text = fh.read()
+    assert "gitleaks detect" in text, (
+        "security.yml no longer runs `gitleaks detect` — this check is asserting a trigger for a "
+        "scanner that is gone, which is worse than not checking at all")
+    m = re.search(r"--gitleaks-ignore-path[= ]+(\S+)", text)
+    return m.group(1).strip("\"'") if m else ".gitleaksignore"
+
+
+def test_the_gitleaks_baseline_can_trigger_its_own_scanner() -> None:
+    """The file that SILENCES findings could not run the scanner whose findings it silences.
+
+    Found 2026-09-06, and it is the third instance of this workflow's own sentence: "a check's
+    TRIGGER is part of its scope, and a scope that excludes its own subject is not a smaller check
+    — it is no check." The first was `requirements.lock`, the second the whole `pull_request`
+    event. This one is the sharpest of the three, because `.gitleaksignore` is not merely an input
+    — every line in it SUPPRESSES a real finding. Adding one is the single most consequential edit
+    available in this repository's security surface, and it was the one edit that ran nothing.
+
+    Note what that means for the entry that found this: the two fingerprints baselined on
+    2026-09-06 were verified by running gitleaks 8.30.1 BY HAND, at the pinned version and digest,
+    because no CI job would have run on that commit. That is not a workflow anyone repeats.
+
+    `test_every_audited_path_can_actually_trigger_the_workflow` could not see this: its population
+    is `audit_lock_gate.LOCKS` plus the npm manifests — the inputs of the two *advisory* gates. The
+    gitleaks step has an input too and was in neither list. A coverage check is only as wide as the
+    population behind it, and that population was derived from two of the job's three scanners.
+    """
+    baseline = _gitleaks_baseline_path()
+    tracked = subprocess.run(["git", "ls-files", baseline], cwd=ROOT,
+                             capture_output=True, text=True).stdout.split()
+    assert tracked, (
+        f"the gitleaks step reads {baseline!r} as its baseline, but git does not track that path "
+        f"— a baseline CI cannot see suppresses nothing and hides that it suppresses nothing")
+    on = _triggers()
+    for event in ("push", "pull_request"):
+        globs = list((on.get(event) or {}).get("paths") or [])
+        assert globs, f"no `{event}: paths:` globs parsed"
+        assert _matches_a_glob(baseline, globs), (
+            f"{baseline} is read by the gitleaks step but matches none of security.yml's "
+            f"`{event}` globs {globs} — silencing a finding there would not re-run the scanner, "
+            f"so nothing would ever show what the silence covers")
+    print(f"PASS  the gitleaks baseline can trigger its own scanner on both events   {baseline}")
+
+
 if __name__ == "__main__":
     test_every_exemption_is_dated_and_unexpired()
     test_an_expired_exemption_blocks()
@@ -305,4 +358,5 @@ if __name__ == "__main__":
     test_the_push_and_pull_request_globs_stay_identical()
     test_the_npm_manifests_can_trigger_the_workflow_too()
     test_every_audited_path_can_actually_trigger_the_workflow()
+    test_the_gitleaks_baseline_can_trigger_its_own_scanner()
     print("test_lock_advisories OK")

--- a/services/api/test_lock_advisories.py
+++ b/services/api/test_lock_advisories.py
@@ -295,7 +295,7 @@ def test_every_audited_path_can_actually_trigger_the_workflow() -> None:
           f"{len(gate.LOCKS)} path(s)")
 
 
-def _gitleaks_command_lines() -> list[str]:
+def _gitleaks_step_lines() -> list[str]:
     """The EXECUTABLE lines of the step that runs gitleaks — comments stripped.
 
     THE FIRST VERSION OF THIS GREPPED THE WHOLE FILE, and CodeRabbit was right to refuse it.
@@ -311,8 +311,7 @@ def _gitleaks_command_lines() -> list[str]:
     Worse, the MUTATION MISSED IT TOO. The check "remove `gitleaks detect` from the workflow" was
     run as a blanket string replace, which rewrote the comments along with the command — so it
     could not tell the two apart either, and reported a pass that meant nothing. *A mutation that
-    shares the implementation's blind spot confirms it instead of challenging it*; the mutation
-    below now deletes only the command and leaves every comment in place.
+    shares the implementation's blind spot confirms it instead of challenging it.*
     """
     import yaml
     wf = os.path.join(ROOT, ".github", "workflows", "security.yml")
@@ -333,21 +332,46 @@ def _gitleaks_command_lines() -> list[str]:
         "worse than not checking at all")
 
 
+def _gitleaks_invocation() -> str:
+    """The `gitleaks detect` COMMAND ITSELF, its line-continuations joined.
+
+    A SECOND ROUND OF THE SAME MISTAKE, one notch finer, and CodeRabbit was right again. The
+    version before this narrowed from the whole FILE to the step's executable LINES — and then
+    read the ignore-path flag from any of them. That step runs some two dozen commands, several
+    of them `echo`s that already mention `.gitleaksignore` in their message text. So an `echo`
+    carrying `--gitleaks-ignore-path .gitleaksignore` would have been read as scanner
+    configuration while the real `gitleaks detect` pointed somewhere else entirely, and the check
+    would have validated a trigger for a baseline nothing reads — and passed.
+
+    Narrowing a scope is not the same as narrowing it to the right UNIT. The unit that decides
+    which file gitleaks reads is the invocation, not the step it happens to sit in.
+    """
+    lines = _gitleaks_step_lines()
+    for i, line in enumerate(lines):
+        if "gitleaks detect" not in line:
+            continue
+        parts = [line]
+        # A future edit may wrap the command across lines; follow trailing-backslash continuations
+        # so the flag stays findable, and stop at the first line that does not continue.
+        j = i
+        while parts[-1].rstrip().endswith("\\") and j + 1 < len(lines):
+            j += 1
+            parts.append(lines[j])
+        return " ".join(p.rstrip().rstrip("\\").strip() for p in parts)
+    raise AssertionError("unreachable: _gitleaks_step_lines only returns a step that invokes it")
+
+
 def _gitleaks_baseline_path() -> str:
-    """Which file does the gitleaks step read as its baseline? DERIVED from the command it runs.
+    """Which file does the gitleaks step read as its baseline? DERIVED from the invocation.
 
     Not hardcoded, for the same reason `test_ruff_scope.py` parses the ruff command rather than
     naming directories: if the step ever gains an explicit `--gitleaks-ignore-path`, a hardcoded
     `.gitleaksignore` would keep asserting a trigger for a file nothing reads any more, and pass.
 
-    Read from executable lines only — see `_gitleaks_command_lines` for why that distinction is
-    the whole point rather than a tidy-up.
+    Read from the COMMAND only — see `_gitleaks_invocation` for why the step was too wide a unit.
     """
-    for line in _gitleaks_command_lines():
-        m = re.search(r"--gitleaks-ignore-path[=\s]+(\S+)", line)
-        if m:
-            return m.group(1).strip("\"'")
-    return ".gitleaksignore"          # gitleaks' own default when the flag is absent
+    m = re.search(r"--gitleaks-ignore-path[=\s]+(\S+)", _gitleaks_invocation())
+    return m.group(1).strip("\"'") if m else ".gitleaksignore"   # gitleaks' default with no flag
 
 
 def test_the_gitleaks_baseline_can_trigger_its_own_scanner() -> None:


### PR DESCRIPTION
# What & why

The full-history secret scan is red, and it has been blocking every PR that touches a dependency manifest — `#427` and `#429` were failing on it, on a job called `python` that gives no hint a secret scan is what broke.

The finding is a **false positive with nothing to rotate**: `token: "0123456789abcdef"` at `apps/web/src/portal/panels/masterBuilder.test.ts:109` is the DEFAULT value of a test fixture factory — sixteen characters of hex immediately after an identifier named `token`, which is precisely what gitleaks' `generic-api-key` rule looks for. Both call sites in that test override it, so the flagged value was not even the one under assertion. It arrived with #438. *(Independently re-verified in review against both commits.)*

## Two fingerprints for one fixture

The value was introduced on the feature branch (`db8d9a79`) and **again** by the squash commit that landed it (`cf02024c`) — a squash re-adds every line as a new diff and earns its own fingerprint. Baseline the branch commit alone and main stays red. The second fingerprint only exists *after* the merge, so this baseline could not have been written correctly before it.

The fixture is also reshaped to repeated characters — which is why the other two token values in that same test were never flagged. That does **not** close the findings (the strings are in the objects for good), but it stops a future edit re-adding the line and minting a third.

## The real defect is the trigger, not the fixture

`.gitleaksignore` is read by the gitleaks step, which makes it an audited input of this workflow exactly as `services/api/requirements.lock` is an audited input of the pip gate — and it matched **none** of `security.yml`'s `paths:` globs, on either event. So the one edit that *suppresses a security finding* was the one edit that ran no scan.

That is the third instance of this workflow's own sentence — *"a check's TRIGGER is part of its scope, and a scope that excludes its own subject is not a smaller check — it is no check"* — after `requirements.lock` and the missing `pull_request` event. It is the sharpest of the three, because every line in a baseline suppresses a real finding.

`test_every_audited_path_can_actually_trigger_the_workflow` could not see it: its population is `audit_lock_gate.LOCKS` plus the npm manifests — the inputs of the two **advisory** gates. The job has a third scanner, and its input was in neither list. *A coverage check is only as wide as the population behind it.*

Adding `.gitleaksignore` to the globs also makes this change **self-verifying**: it is the first commit whose own baseline edit runs the scanner that reads it.

## Three review rounds: one defect at four widths

CodeRabbit found the new gate three times, and was right every time. The scope was narrowed once per round, and each time it was still one level too wide:

| round | scope of the check | what still satisfied it |
|---|---|---|
| 0 | the whole workflow **file** | any of 14 gitleaks **comment** mentions |
| 1 | the gitleaks **step's** executable lines | an `echo` in that step carrying the flag |
| 2 | the line **mentioning** `gitleaks detect` | `echo "gitleaks detect"` above the real command |
| 3 | the line that **runs** `gitleaks detect` | — |

Round 3 is the severe one: with the scanner *replaced* by `echo "gitleaks detect --source=. would run here"`, the round-2 version still derived `.gitleaksignore` and **passed over a workflow containing no scanner at all** — the exact condition the check exists to refuse.

`_RUNS_GITLEAKS` now requires the **command position**: start of line or just after a shell operator, optional path prefix, then `gitleaks detect`. Both the step selection and the invocation selection use it.

**The mutations were the real failure, not the parser.** Each round I wrote mutations to *confirm* the fix just made rather than to attack it, so they landed adjacent to the weakness instead of on it — round 2's decoy carried the *flag* but not the phrase `gitleaks detect`, so it was never a candidate invocation and the loop stepped past it correctly. *A mutation that shares the implementation's blind spot confirms it instead of challenging it.* Every one of the four widths was found by an adversarial reader asking "what else satisfies this?", and none by me.

## Mutations

Each measured, with the superseded version's answer recorded where it differs.

| mutation | result |
|---|---|
| drop `.gitleaksignore` from the `push` globs only | fails, naming the event |
| drop it from the `pull_request` globs only | fails, naming the event |
| point the step at a baseline nothing tracks | fails on the tracked check |
| delete **only** the `./gitleaks detect` line, all 24 gitleaks comment mentions intact | fails — *round-0 passed* |
| a *comment* naming `--gitleaks-ignore-path a-decoy.txt` | ignored → `.gitleaksignore` |
| an *`echo`* carrying the flag above the real command | ignored → `.gitleaksignore` — *round-1 derived `decoy.txt`* |
| `echo "gitleaks detect"` above a real command using `real.txt` | `real.txt` — *round-2 derived `.gitleaksignore`, wrong and passing* |
| scanner **replaced** by an echo naming it, no real invocation anywhere | raises — *round-2 derived `.gitleaksignore`, passing over nothing* |
| a real command chained after a decoy via `&&` | `chained.txt` |
| the command wrapped across a backslash continuation, flag on line two | `wrapped.txt` |
| a real `--gitleaks-ignore-path custom-baseline.txt` on the command | honoured, then fails the tracked-path check |

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean
- [x] Backend: affected `test_*.py` pass — `test_lock_advisories` 9/9; full suite **668/668**
- [x] Web: typecheck and eslint clean; the affected suite `masterBuilder.test.ts` 5/5
- [x] No import cycles introduced
- [ ] `CHANGELOG.md` entry — none: no shipped behaviour changes, this is a CI gate plus a test fixture
- [ ] Version bump — n/a, not a release PR
- [x] No secrets: gitleaks 8.30.1 over 2,372 commits reports **no leaks** on this branch. No competitor names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA