### PR TITLE
A file dropzone with no outline, and a chart marker that was never drawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,61 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### a file dropzone with no outline, and a chart marker that was never drawn
+
+Found by asking the pinned-rail question the other way round: **what else does this CSS name that
+nothing defines?** `apps/web/src/style.css` referenced `var(--border)` at six sites, and TypeScript
+referenced five void tokens at thirteen more — none with a fallback, none defined anywhere in the
+tree or set through `setProperty`.
+
+**A `var()` that resolves to nothing does not skip the property.** It makes the declaration invalid
+at computed-value time, so the property takes its *unset* value — inherited for an inherited
+property, initial for everything else. What that costs depends on the **property**, not the token,
+and the two halves came out opposite. Measured in Chromium:
+
+| | before | after |
+|---|---|---|
+| `.att-drop` — the **file dropzone** | `border-style: none`, `width: 0px` | `dashed 1px` |
+| `.att-drop.over` — drag-over feedback | accent colour computed, **0px painted** | `dashed 1px` accent |
+| `.pf-addopt` — outline *is* the button (`background: transparent`) | `none 0px` | `dashed 1px` |
+| `.att-cell`, `.pnav-khint kbd`, `.portal-fieldset-head` | `none 0px` | `solid 1px` |
+| QA/repair row separators (×6, inline in `.ts`) | `none 0px` | `solid 1px` |
+| profile row `background` | `rgba(0, 0, 0, 0)` — none at all | `#25272b` |
+| "Sign out" `color: var(--danger)` | the body colour — **not danger red** | `#d9534f` |
+| Pareto baseline `stroke="var(--fg)"` on a `fill="none"` rect | `none` — **invisible** | `#e7e7e7` |
+
+**Six sites were not defects, and saying so mattered.** `color: var(--fg)` is an *inherited*
+property, so it landed on the ancestor's colour — which is exactly `--text`, which is what it
+wanted. The same token as an SVG `stroke` inherited `none` and erased a chart's baseline marker
+entirely. *Same token, opposite severity, decided by the property.* A rename sweep would have been
+right by luck and wrong in every word of its description.
+
+Tokens mapped to the ones the palette actually defines: `--border`/`--border-subtle` → `--line`,
+`--fg` → `--text`, `--danger` → `--err`, `--bg-elev` → `--panel2`. Only the last is a judgement
+call — the palette has no "elevated" tone, and `--panel2` is its second surface. The dropzone's
+outline is now `--line` as the design system specifies; if it wants more prominence than the system
+border, that is a separate design decision and not this fix's to make.
+
+New gate `apps/web/src/shell/cssVars.ts` + `apps/web/src/shell/cssVars.test.ts`: every `var()`
+without a fallback must name a defined token, and every defined token must be referenced. A
+fallback is always safe and never reported — `var(--x, #ccc)` renders the fallback, and seven tokens
+exist only in that form.
+
+**Its scope is CSS *and* TypeScript, and that is the load-bearing part.** A CSS-only sweep is a
+predicate deciding what to look at: `--err` is declared in `style.css` and referenced only from
+`accountUI.ts`, so a CSS-only "unused token" pass would have called it dead and invited deleting a
+token used in eight places — while thirteen of the nineteen void sites live in `.ts` files, where
+it could not see them at all. Both directions need both sources.
+
+**The first draft of the scan excluded the palette itself and reported every token undefined.** Its
+glob was `apps/web/src/**.css`, which does not match `apps/web/src/style.css` — no intervening
+directory — so `--status-crit`, `--mono` and the rest came back "void". The population now comes
+from `git ls-files`, and the test asserts the file count and that `style.css` is in it, because a
+glob that matches nothing reports a clean tree. Four mutations were run against the finished gate:
+revert the stylesheet fix; make `voidVars()` always return clean; stop treating a fallback as safe;
+narrow the scope back to CSS only. Each reds the tests it should — the last one by flagging `--err`
+as unreferenced, which is the trap it exists to prevent.
+
 ### the pinned rail has been rendering in the bottom-right corner since July
 
 `#pinned-rail` carried `grid-area: pins` from v0.3.764 (2026-07-28) and **no `grid-template-areas`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,27 @@ it could not see them at all. Both directions need both sources.
 glob was `apps/web/src/**.css`, which does not match `apps/web/src/style.css` — no intervening
 directory — so `--status-crit`, `--mono` and the rest came back "void". The population now comes
 from `git ls-files`, and the test asserts the file count and that `style.css` is in it, because a
-glob that matches nothing reports a clean tree. Four mutations were run against the finished gate:
-revert the stylesheet fix; make `voidVars()` always return clean; stop treating a fallback as safe;
-narrow the scope back to CSS only. Each reds the tests it should — the last one by flagging `--err`
-as unreferenced, which is the trap it exists to prevent.
+glob that matches nothing reports a clean tree. **And then the gate failed CI by flagging its own docstring.** The table above writes
+`color: var(--fg)` as prose; a scan of raw text counts that as a reference to a token nothing
+defines. It had passed locally first, which is the part worth keeping: `git ls-files` lists only
+**tracked** files, and when the test first ran `cssVars.ts` was not yet `git add`ed — **so the
+population excluded the one file that would have failed it.** A test now asserts the gate is in its
+own population, because "it passed locally" meant "it never looked at itself".
+
+**The first fix was a character-level comment stripper, and it was worse than the bug.** It tracked
+`'`/`"` strings, and the regex literal `SET_VIA_JS` contains the character class `["']` — so the
+lone `'` opened a "string" that ran on to the next apostrophe several lines away, swallowing a real
+`//` comment inside it. Over 582 TypeScript files a naive tokenizer mis-classifies in *both*
+directions, and the fail-open one — silently eating a live reference — is the one you never see. It
+is replaced by a rule with no string tracking at all: a line whose first non-space characters are
+`//` or `*` is documentation, every other line is scanned as written. Nothing that ships is written
+on such a line.
+
+Four mutations were run against the finished gate: stop ignoring comment lines (this reproduces the
+CI failure); ignore *every* line rather than only comments (the fail-open direction); count test
+fixtures as real sites; and make `voidVars()` always return clean. Each reds the tests it should.
+The earlier round — reverting the stylesheet fix, and narrowing scope back to CSS only, which trips
+on `--err` — still holds.
 
 ### the pinned rail has been rendering in the bottom-right corner since July
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,12 @@ border, that is a separate design decision and not this fix's to make.
 
 New gate `apps/web/src/shell/cssVars.ts` + `apps/web/src/shell/cssVars.test.ts`: every `var()`
 without a fallback must name a defined token, and every defined token must be referenced. A
-fallback is always safe and never reported — `var(--x, #ccc)` renders the fallback, and seven tokens
-exist only in that form.
+reference carrying a fallback is not reported — the token's absence is then not what breaks it, and
+seven tokens here exist only in that form. **That is a claim about the gate, not about CSS:** a
+fallback does not make a declaration valid. Measured — `border: 1px solid var(--nope, #3a3f47)`
+computes `solid 1px`, but `border: 1px solid var(--nope, notacolor)` computes `none 0px`, because
+the substituted value is still checked against the property at computed-value time. Whether a
+fallback suits its property needs a browser, and this gate does not check it.
 
 **Its scope is CSS *and* TypeScript, and that is the load-bearing part.** A CSS-only sweep is a
 predicate deciding what to look at: `--err` is declared in `style.css` and referenced only from

--- a/apps/web/src/account/profileSettings.ts
+++ b/apps/web/src/account/profileSettings.ts
@@ -53,7 +53,7 @@ interface Section { id: string; label: string; build: (body: HTMLElement) => voi
 function row(title: string, detail: string, actionLabel?: string, onClick?: () => void): HTMLElement {
   const el = document.createElement("div");
   el.style.cssText = "display:flex;align-items:center;gap:12px;padding:9px 10px;border:1px solid var(--line);"
-    + "border-radius:7px;background:var(--bg-elev)";
+    + "border-radius:7px;background:var(--panel2)";
   const col = document.createElement("div");
   col.style.cssText = "display:flex;flex-direction:column;gap:2px;min-width:0;flex:1";
   const t = document.createElement("span");
@@ -136,7 +136,7 @@ export function openProfileSettings(deps: ProfileDeps, initial = "profile"): voi
   signOut.className = "tool-btn";
   signOut.textContent = "Sign out";
   signOut.style.cssText = "justify-content:flex-start;width:100%;text-align:left;border:none;"
-    + "background:transparent;margin-top:auto;color:var(--danger)";
+    + "background:transparent;margin-top:auto;color:var(--err)";
   signOut.onclick = () => { close(); actions.signOut(); };
   nav.append(signOut);
 

--- a/apps/web/src/portal/panels/aiassist.ts
+++ b/apps/web/src/portal/panels/aiassist.ts
@@ -293,7 +293,7 @@ export async function renderAiAssist(ctx: PanelContext) {
                 const over = g.packages_without_model_scope.length
                   ? `<div class="meta">Over-scoped (no model elements): ${g.packages_without_model_scope.map(esc).join(", ")}</div>` : "";
                 out.insertAdjacentHTML("beforeend",
-                  `<div style="margin-top:6px;border-top:1px solid var(--border);padding-top:4px"><b>Model coverage</b> <span class="meta">${g.covered_pct}% of ${g.element_count} elements in a package</span>${gapRow}${over}</div>`);
+                  `<div style="margin-top:6px;border-top:1px solid var(--line);padding-top:4px"><b>Model coverage</b> <span class="meta">${g.covered_pct}% of ${g.element_count} elements in a package</span>${gapRow}${over}</div>`);
               }
             } catch { /* no source IFC (409) — scope-gap needs a model; skip silently */ }
           } catch (e) { out.textContent = `leveling failed: ${(e as Error).message}`; }

--- a/apps/web/src/portal/panels/margin.ts
+++ b/apps/web/src/portal/panels/margin.ts
@@ -73,7 +73,7 @@ export async function renderMargin(ctx: PanelContext) {
   body.innerHTML = `<div class="meta">Reconciling budget vs committed vs actual…</div>`;
   ctx.root.appendChild(body);
 
-  const marginCol = (n: number) => n < 0 ? "var(--status-crit)" : n > 0 ? "var(--status-good)" : "var(--fg)";
+  const marginCol = (n: number) => n < 0 ? "var(--status-crit)" : n > 0 ? "var(--status-good)" : "var(--text)";
 
   try {
     const m = await ctx.host.api.marginByCostCode(pid);

--- a/apps/web/src/portal/panels/schedule.ts
+++ b/apps/web/src/portal/panels/schedule.ts
@@ -360,7 +360,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
         const dots = r.scenarios.map((s) => {
           const x = px(s.cost).toFixed(1), y = py(s.duration_days).toFixed(1);
           if (s.rank === rec.rank) return `<circle cx="${x}" cy="${y}" r="5.5" fill="none" stroke="var(--status-good)" stroke-width="2"/><circle cx="${x}" cy="${y}" r="2" fill="var(--status-good)"/>`;
-          if (s.is_baseline) return `<rect x="${(+x - 3).toFixed(1)}" y="${(+y - 3).toFixed(1)}" width="6" height="6" fill="none" stroke="var(--fg)" stroke-width="1.4"/>`;
+          if (s.is_baseline) return `<rect x="${(+x - 3).toFixed(1)}" y="${(+y - 3).toFixed(1)}" width="6" height="6" fill="none" stroke="var(--text)" stroke-width="1.4"/>`;
           return `<circle cx="${x}" cy="${y}" r="${s.pareto ? 3 : 2}" fill="${s.pareto ? "var(--accent, #4a90d9)" : "var(--muted, #999)"}" ${s.pareto ? "" : 'opacity="0.5"'}/>`;
         }).join("");
         const svg = `<svg viewBox="0 0 ${W} ${H}" width="100%" style="max-width:${W}px;font-size:9px" role="img" aria-label="Cost vs duration scatter with Pareto frontier">`

--- a/apps/web/src/portal/panels/selections.ts
+++ b/apps/web/src/portal/panels/selections.ts
@@ -25,7 +25,7 @@ export async function renderSelections(ctx: PanelContext) {
 
       // headline: net over/under
       const head = document.createElement("div"); head.className = "dash-card"; head.style.marginBottom = "10px";
-      const dirCol = s.direction === "over" ? "var(--status-crit)" : s.direction === "under" ? "var(--status-good)" : "var(--fg)";
+      const dirCol = s.direction === "over" ? "var(--status-crit)" : s.direction === "under" ? "var(--status-good)" : "var(--text)";
       const dirLabel = s.direction === "over" ? "over allowance" : s.direction === "under" ? "under allowance (credit)" : "on allowance";
       // UX-CHIPS — the shared chip vocabulary rather than hand-rolled spans. On a cost line an
       // overage is bad and a credit is good, hence goodWhenNegative. The unpriced remainder is
@@ -53,7 +53,7 @@ export async function renderSelections(ctx: PanelContext) {
         const cat = document.createElement("div"); cat.className = "dash-card"; cat.style.marginBottom = "10px";
         cat.innerHTML = `<div class="section-title" style="margin:0 0 4px">By category</div>`
           + s.by_category.map((c) => {
-            const col = c.delta > 0 ? "var(--status-crit)" : c.delta < 0 ? "var(--status-good)" : "var(--fg)";
+            const col = c.delta > 0 ? "var(--status-crit)" : c.delta < 0 ? "var(--status-good)" : "var(--text)";
             return `<div class="meta" style="display:flex;justify-content:space-between;margin:1px 0"><span>${esc(c.category)} <span style="opacity:.6">(${c.count})</span></span>`
               + `<span style="color:${col};font-variant-numeric:tabular-nums">${c.delta >= 0 ? "+" : "−"}${usd(Math.abs(c.delta))}</span></div>`;
           }).join("");

--- a/apps/web/src/shell/cssVars.test.ts
+++ b/apps/web/src/shell/cssVars.test.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { definedVars, unreferencedVars, varRefs, voidVars } from "./cssVars";
+
+/**
+ * CSS-VAR-VOID. `apps/web/src/style.css` referenced `var(--border)` at six sites and TypeScript
+ * referenced five void tokens at thirteen more, none with a fallback, none defined anywhere. A
+ * `var()` that resolves to nothing makes the whole declaration invalid at computed-value time, so
+ * the property falls back to *unset* — and what that costs depends on the property. Measured in
+ * Chromium before the fix:
+ *
+ *   .att-drop         border 1.5px dashed  ->  border-style: none, width: 0px   (a FILE DROPZONE
+ *                     whose only affordance is that outline; `.att-drop.over` computed the accent
+ *                     colour and painted zero pixels of it, so drag-over feedback was dead too)
+ *   .att-cell         border 1px solid     ->  none 0px
+ *   .pf-addopt        border 1px dashed    ->  none 0px   (background:transparent — the outline IS
+ *                                                          the button)
+ *   qaSection rows    border-bottom        ->  none 0px   (x6, plus one in repairPanel)
+ *   profile row       background            ->  rgba(0,0,0,0)
+ *   "Sign out"        color: var(--danger)  ->  the body colour, not danger red
+ *   Pareto baseline   stroke="var(--fg)"    ->  `none`, on a fill="none" rect — INVISIBLE
+ *
+ * **Six sites were NOT defects**, and saying so mattered: `color: var(--fg)` is an inherited
+ * property, so it landed on the ancestor's colour, which is exactly `--text`, which is what it
+ * wanted. The same token as an SVG `stroke` inherited `none` and erased a chart marker. *Same
+ * token, opposite severity, decided by the property* — a rename sweep would have been right by
+ * luck and wrong in its description.
+ */
+const WEB = process.cwd();
+const REPO = join(WEB, "..", "..");
+
+/** Every tracked web source that can define or reference a custom property. */
+function sources(): { file: string; text: string }[] {
+  // Derived from git, not listed. An earlier draft of this scan globbed `apps/web/src/**.css`,
+  // which does NOT match `apps/web/src/style.css` (no intervening directory) — so the palette
+  // itself was excluded and every token in it looked undefined. The population must come from the
+  // index, and the count below must be asserted, or a glob can silently empty it again.
+  const out = execFileSync("git", ["ls-files", "apps/web/**.css", "apps/web/**.html", "apps/web/**.ts"],
+    { cwd: REPO, encoding: "utf8" }).trim().split("\n").filter(Boolean);
+  return out.map((rel) => ({ file: rel, text: readFileSync(join(REPO, rel), "utf8") }));
+}
+
+describe("every var() names a custom property something defines", () => {
+  const src = sources();
+
+  it("scans a plausible number of files — a glob that matches nothing reports a clean tree", () => {
+    expect(src.filter((s) => s.file.endsWith(".css")).length).toBeGreaterThanOrEqual(3);
+    expect(src.filter((s) => s.file.endsWith(".ts")).length).toBeGreaterThan(400);
+    // The palette itself must be in scope. This is the file the first draft silently dropped.
+    expect(src.some((s) => s.file === "apps/web/src/style.css")).toBe(true);
+  });
+
+  it("finds the palette's tokens", () => {
+    const d = definedVars(src);
+    for (const t of ["--text", "--line", "--panel2", "--err", "--accent"]) expect(d.has(t)).toBe(true);
+  });
+
+  it("has no var() without a fallback pointing at a token nothing defines", () => {
+    expect(voidVars(src)).toEqual([]);
+  });
+
+  it("keeps no token that nothing references — the other direction", () => {
+    expect(unreferencedVars(src)).toEqual([]);
+  });
+});
+
+describe("the reader", () => {
+  const S = (text: string, file = "x.css") => [{ file, text }];
+
+  it("treats a fallback as safe — `var(--x, #ccc)` renders the fallback", () => {
+    expect(voidVars(S(`a { color: var(--nope, #ccc); }`))).toEqual([]);
+    expect(varRefs(S(`a { color: var(--nope, #ccc); }`)).withFallback.has("--nope")).toBe(true);
+  });
+
+  it("reports a bare reference to an undefined token", () => {
+    expect(voidVars(S(`a { color: var(--nope); }`)).map((u) => u.name)).toEqual(["--nope"]);
+  });
+
+  it("counts a definition in CSS as covering a reference from TypeScript", () => {
+    // `--err` is declared in style.css and used only from accountUI.ts. A CSS-only scan would call
+    // it dead; a TS-only scan would call it undefined. Both directions need both sources.
+    const src = [
+      { file: "a.css", text: `:root { --err: red; }` },
+      { file: "b.ts", text: `el.style.color = "var(--err)";` },
+    ];
+    expect(voidVars(src)).toEqual([]);
+    expect(unreferencedVars(src)).toEqual([]);
+  });
+
+  it("does NOT count a `--x:` inside a .ts string as a definition", () => {
+    // Only a real CSS declaration or an explicit setProperty defines a token. Otherwise any
+    // TypeScript that happens to build a style string would define away its own bugs.
+    expect(voidVars([{ file: "b.ts", text: `el.style.cssText = "--made-up: red; color: var(--made-up)";` }])
+      .map((u) => u.name)).toEqual(["--made-up"]);
+  });
+
+  it("accepts a token set at runtime through setProperty", () => {
+    expect(voidVars([{ file: "b.ts", text: `el.style.setProperty("--rail-w", w); const s = "var(--rail-w)";` }]))
+      .toEqual([]);
+  });
+
+  it("ignores commented-out CSS definitions, via the shared scanner", () => {
+    expect(voidVars(S(`/* :root { --ghost: red; } */ a { color: var(--ghost); }`)).map((u) => u.name))
+      .toEqual(["--ghost"]);
+  });
+});

--- a/apps/web/src/shell/cssVars.test.ts
+++ b/apps/web/src/shell/cssVars.test.ts
@@ -52,6 +52,14 @@ describe("every var() names a custom property something defines", () => {
     expect(src.some((s) => s.file === "apps/web/src/style.css")).toBe(true);
   });
 
+  it("scans its OWN source — the file that broke it was invisible to it", () => {
+    // This gate passed locally and failed CI on its first push. `git ls-files` lists only TRACKED
+    // files, and cssVars.ts was not `git add`ed when the test first ran, so the scan never saw the
+    // docstring that was about to fail it. The population must contain the gate itself.
+    expect(src.some((s) => s.file === "apps/web/src/shell/cssVars.ts")).toBe(true);
+    expect(src.some((s) => s.file === "apps/web/src/shell/cssVars.test.ts")).toBe(true);
+  });
+
   it("finds the palette's tokens", () => {
     const d = definedVars(src);
     for (const t of ["--text", "--line", "--panel2", "--err", "--accent"]) expect(d.has(t)).toBe(true);
@@ -99,6 +107,25 @@ describe("the reader", () => {
   it("accepts a token set at runtime through setProperty", () => {
     expect(voidVars([{ file: "b.ts", text: `el.style.setProperty("--rail-w", w); const s = "var(--rail-w)";` }]))
       .toEqual([]);
+  });
+
+  it("does not read a doc example as a usage", () => {
+    // Both comment shapes, because the docstrings here use both.
+    expect(voidVars([{ file: "a.ts", text: `// see color: var(--example)\nconst x = 1;` }])).toEqual([]);
+    expect(voidVars([{ file: "a.ts", text: ` * a table row: var(--example)\nconst x = 1;` }])).toEqual([]);
+  });
+
+  it("still reads a real usage on a normal line", () => {
+    // The half that proves the rule above refuses rather than always refusing.
+    expect(voidVars([{ file: "a.ts", text: `el.style.color = "var(--example)";` }]).map((u) => u.name))
+      .toEqual(["--example"]);
+  });
+
+  it("does not lose a live reference to a regex literal containing a quote", () => {
+    // The character-level stripper this replaced tracked quotes, and `["']` in a regex opened a
+    // string that swallowed everything to the next apostrophe — silently hiding real references.
+    const text = `const R = /setProperty\\(\\s*["'](--[-\\w]+)["']/g;\nel.style.color = "var(--example)";`;
+    expect(voidVars([{ file: "a.ts", text }]).map((u) => u.name)).toEqual(["--example"]);
   });
 
   it("ignores commented-out CSS definitions, via the shared scanner", () => {

--- a/apps/web/src/shell/cssVars.ts
+++ b/apps/web/src/shell/cssVars.ts
@@ -22,8 +22,14 @@
  * `fill="none"` rect — made a chart's baseline marker disappear entirely. **Same token, opposite
  * severity, decided by the property.**
  *
- * **A fallback makes it safe**, so `var(--x, #ccc)` is never reported: the fallback is what renders,
- * which is a deliberate and widely used pattern here (7 tokens exist only in that form).
+ * **A fallback is not reported, and that is a statement about THIS GATE, not about CSS.**
+ * `var(--x, #ccc)` carries a fallback, so the token's absence is not what breaks it and the gate
+ * stays quiet. It does **not** follow that the declaration is valid: if the substituted value is
+ * wrong for the property, the declaration is still invalid at computed-value time. Measured —
+ * `border: 1px solid var(--nope, #3a3f47)` computes `solid 1px`, while
+ * `border: 1px solid var(--nope, notacolor)` computes `none 0px`. Checking that a fallback is
+ * *usable by its property* needs a browser, and this gate does not do it. (Seven tokens here exist
+ * only in fallback form.)
  *
  * **Scope is CSS *and* TypeScript, and that is load-bearing.** A CSS-only sweep is a predicate
  * deciding what to look at: `--err` is defined in `style.css` and referenced only from
@@ -70,7 +76,8 @@ export interface VarUse {
   file: string;
 }
 
-/** `var(--name` optionally followed by a comma — the comma is the fallback, and makes it safe. */
+/** `var(--name` optionally followed by a comma — the comma means a fallback, so the token's
+ *  absence cannot be what breaks it. Whether the fallback SUITS the property is not checked here. */
 const VAR_REF = /var\(\s*(--[-\w]+)\s*(,)?/g;
 /** `--name:` at the top of a declaration — only meaningful in CSS, which is why sources differ. */
 const SET_VIA_JS = /setProperty\(\s*["'](--[-\w]+)["']/g;

--- a/apps/web/src/shell/cssVars.ts
+++ b/apps/web/src/shell/cssVars.ts
@@ -1,0 +1,88 @@
+/**
+ * CSS-VAR-VOID — does every `var(--x)` name a custom property something defines?
+ *
+ * The sibling of `gridAreas.ts`, and the same defect class: CSS naming something that does not
+ * exist, silently. Found by running that gate's own scanner over the palette and asking the
+ * question in the other direction.
+ *
+ * **A `var()` that resolves to nothing is not "the property is skipped".** It makes the declaration
+ * *invalid at computed-value time*, which means the property takes its **unset** value — inherited
+ * for an inherited property, initial for everything else. So the damage depends on the PROPERTY,
+ * not on the token, and that is the whole reason this needs a list rather than a rename:
+ *
+ * | property                    | unset value        | measured effect of a void var           |
+ * |-----------------------------|--------------------|------------------------------------------|
+ * | `border: 1px solid var(…)`  | initial            | `border-style: none; width: 0px` — GONE  |
+ * | `background: var(…)`        | initial            | `rgba(0,0,0,0)` — no background          |
+ * | `stroke="var(…)"` (SVG)     | inherited          | `none` — the shape is INVISIBLE          |
+ * | `color: var(…)`             | inherited          | the ancestor's colour — often harmless   |
+ *
+ * The last row is why this gate reports rather than assumes: three `var(--fg)` colour sites landed
+ * on exactly the value they wanted, by inheritance, while a fourth — `--fg` as an SVG `stroke` on a
+ * `fill="none"` rect — made a chart's baseline marker disappear entirely. **Same token, opposite
+ * severity, decided by the property.**
+ *
+ * **A fallback makes it safe**, so `var(--x, #ccc)` is never reported: the fallback is what renders,
+ * which is a deliberate and widely used pattern here (7 tokens exist only in that form).
+ *
+ * **Scope is CSS *and* TypeScript, and that is load-bearing.** A CSS-only sweep is a predicate
+ * deciding what to look at: `--err` is defined in `style.css` and referenced only from
+ * `accountUI.ts`, so a CSS-only "unused token" pass would have called it dead and invited deleting
+ * a live one — while 13 of the 22 void sites found here live in `.ts` files, invisible to it.
+ */
+import { scanDeclarations } from "./gridAreas";
+
+/** A `var()` reference that supplies no fallback, so the token must exist. */
+export interface VarUse {
+  name: string;
+  file: string;
+}
+
+/** `var(--name` optionally followed by a comma — the comma is the fallback, and makes it safe. */
+const VAR_REF = /var\(\s*(--[-\w]+)\s*(,)?/g;
+/** `--name:` at the top of a declaration — only meaningful in CSS, which is why sources differ. */
+const SET_VIA_JS = /setProperty\(\s*["'](--[-\w]+)["']/g;
+
+/** Custom properties a stylesheet declares, plus any set at runtime through `setProperty`. */
+export function definedVars(sources: { file: string; text: string }[]): Set<string> {
+  const out = new Set<string>();
+  for (const { file, text } of sources) {
+    if (file.endsWith(".css")) {
+      for (const d of scanDeclarations(text)) if (d.prop.startsWith("--")) out.add(d.prop);
+    }
+    for (const m of text.matchAll(SET_VIA_JS)) out.add(m[1] as string);
+  }
+  return out;
+}
+
+/** Every `var()` reference, split by whether it carries a fallback. */
+export function varRefs(sources: { file: string; text: string }[]): { needed: VarUse[]; withFallback: Set<string> } {
+  const needed: VarUse[] = [];
+  const withFallback = new Set<string>();
+  for (const { file, text } of sources) {
+    for (const m of text.matchAll(VAR_REF)) {
+      const name = m[1] as string;
+      if (m[2]) withFallback.add(name);
+      else needed.push({ name, file });
+    }
+  }
+  return { needed, withFallback };
+}
+
+/**
+ * The judgement, separate from the extraction so it can be mutated on its own — the lesson
+ * `test_unique_read_guard` paid for, and `gridAreas` re-learned when its own first scanner reported
+ * a clean tree because it had matched nothing.
+ */
+export function voidVars(sources: { file: string; text: string }[]): VarUse[] {
+  const defined = definedVars(sources);
+  return varRefs(sources).needed.filter((u) => !defined.has(u.name));
+}
+
+/** Tokens defined and referenced by nothing at all — the other direction. */
+export function unreferencedVars(sources: { file: string; text: string }[]): string[] {
+  const defined = definedVars(sources);
+  const seen = new Set<string>();
+  for (const { text } of sources) for (const m of text.matchAll(VAR_REF)) seen.add(m[1] as string);
+  return [...defined].filter((d) => !seen.has(d)).sort();
+}

--- a/apps/web/src/shell/cssVars.ts
+++ b/apps/web/src/shell/cssVars.ts
@@ -32,6 +32,38 @@
  */
 import { scanDeclarations } from "./gridAreas";
 
+/**
+ * Drop the lines that are documentation, so a doc example is not read as a usage.
+ *
+ * **This gate failed CI by flagging its own docstring** — the table above writes
+ * `color: var(--fg)` as prose, and a scan of raw text counts it as a reference to a token nothing
+ * defines. It passed *locally* first, which is the more interesting half: `git ls-files` lists only
+ * TRACKED files, and when the test first ran these two files were not yet `git add`ed, **so the
+ * population excluded the one file that would have failed it.**
+ *
+ * **The first fix was a character-level comment stripper, and it was worse.** It tracked `'`/`"`
+ * strings, and the regex literal `SET_VIA_JS` below contains the character class `["']` — so the
+ * lone `'` opened a "string" that ran on until the next apostrophe, several lines away, hiding a
+ * real `//` comment inside it. A naive tokenizer over 582 TypeScript files can mis-classify in
+ * *either* direction, and the fail-open one — swallowing a live reference — is silent.
+ *
+ * So: no tokenizer. A line whose first non-space characters are `//` or `*` is documentation; every
+ * other line is scanned exactly as written. Nothing that ships is written on such a line.
+ */
+export function withoutCommentLines(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => (/^\s*(\/\/|\*|\/\*)/.test(line) ? "" : line))
+    .join("\n");
+}
+
+/** A test file's fixtures are not shipped styles — see `varRefs`. */
+const isTest = (file: string) => /\.test\.[cm]?tsx?$/.test(file);
+
+/** Source as the scanners should see it: TypeScript with its comments removed. */
+const readable = (s: { file: string; text: string }) =>
+  s.file.endsWith(".ts") ? withoutCommentLines(s.text) : s.text;
+
 /** A `var()` reference that supplies no fallback, so the token must exist. */
 export interface VarUse {
   name: string;
@@ -46,11 +78,11 @@ const SET_VIA_JS = /setProperty\(\s*["'](--[-\w]+)["']/g;
 /** Custom properties a stylesheet declares, plus any set at runtime through `setProperty`. */
 export function definedVars(sources: { file: string; text: string }[]): Set<string> {
   const out = new Set<string>();
-  for (const { file, text } of sources) {
-    if (file.endsWith(".css")) {
-      for (const d of scanDeclarations(text)) if (d.prop.startsWith("--")) out.add(d.prop);
+  for (const s of sources) {
+    if (s.file.endsWith(".css")) {
+      for (const d of scanDeclarations(s.text)) if (d.prop.startsWith("--")) out.add(d.prop);
     }
-    for (const m of text.matchAll(SET_VIA_JS)) out.add(m[1] as string);
+    for (const m of readable(s).matchAll(SET_VIA_JS)) out.add(m[1] as string);
   }
   return out;
 }
@@ -59,11 +91,14 @@ export function definedVars(sources: { file: string; text: string }[]): Set<stri
 export function varRefs(sources: { file: string; text: string }[]): { needed: VarUse[]; withFallback: Set<string> } {
   const needed: VarUse[] = [];
   const withFallback = new Set<string>();
-  for (const { file, text } of sources) {
-    for (const m of text.matchAll(VAR_REF)) {
+  for (const s of sources) {
+    // A test file's `var(--nope)` is a FIXTURE, not a style the product ships, so it cannot be a
+    // defect — but it is still a genuine reference, which is why `unreferencedVars` below counts it
+    // and this does not. The asymmetry is deliberate: a token used only by a test is not dead.
+    for (const m of readable(s).matchAll(VAR_REF)) {
       const name = m[1] as string;
       if (m[2]) withFallback.add(name);
-      else needed.push({ name, file });
+      else if (!isTest(s.file)) needed.push({ name, file: s.file });
     }
   }
   return { needed, withFallback };
@@ -83,6 +118,6 @@ export function voidVars(sources: { file: string; text: string }[]): VarUse[] {
 export function unreferencedVars(sources: { file: string; text: string }[]): string[] {
   const defined = definedVars(sources);
   const seen = new Set<string>();
-  for (const { text } of sources) for (const m of text.matchAll(VAR_REF)) seen.add(m[1] as string);
+  for (const s of sources) for (const m of readable(s).matchAll(VAR_REF)) seen.add(m[1] as string);
   return [...defined].filter((d) => !seen.has(d)).sort();
 }

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -945,9 +945,9 @@ body[data-cap-admin="off"] [data-cap="admin"] * { pointer-events: none; }
 .pnav-room > summary.pnav-stage .meta { flex: 1 0 100%; font-size: 10px; font-weight: 400;
   text-transform: none; letter-spacing: 0; color: var(--muted); padding-left: 12px; }
 .pnav-khint { font-size: 11px; color: var(--muted); padding: 8px 4px 4px; user-select: none; }
-.pnav-khint kbd { font: inherit; border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; }
-.pnav-showall { margin-top: 8px; font-size: 12px; color: var(--muted); border-top: 1px solid var(--border); border-radius: 0; padding-top: 8px; }
-.pnav-showall:hover { color: var(--fg); }
+.pnav-khint kbd { font: inherit; border: 1px solid var(--line); border-radius: 3px; padding: 0 4px; }
+.pnav-showall { margin-top: 8px; font-size: 12px; color: var(--muted); border-top: 1px solid var(--line); border-radius: 0; padding-top: 8px; }
+.pnav-showall:hover { color: var(--text); }
 .pnav-showall.active { color: var(--accent); }
 .pnav-filter { margin: 6px 0 4px; width: 100%; }
 .pnav-group { margin-top: 2px; }
@@ -999,18 +999,18 @@ body[data-cap-admin="off"] [data-cap="admin"] * { pointer-events: none; }
 /* F1 — labeled fieldset header inside a module form (groups long forms) */
 .portal-fieldset-head { margin: 14px 0 4px; padding-bottom: 3px; font-size: 11px; font-weight: 700;
   letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted);
-  border-bottom: 1px solid var(--border); }
+  border-bottom: 1px solid var(--line); }
 .portal-fieldset-head:first-child { margin-top: 2px; }
 
 /* E1 — "＋ option" button to extend a select enum inline (admin, no JSON edit) */
 .pf-addopt { margin-top: 3px; align-self: flex-start; font-size: 10px; padding: 1px 7px;
-  border: 1px dashed var(--border); border-radius: 6px; background: transparent;
+  border: 1px dashed var(--line); border-radius: 6px; background: transparent;
   color: var(--muted); cursor: pointer; }
 .pf-addopt:hover { color: var(--accent); border-color: var(--accent); }
 
 /* attachments — image thumbnail gallery + bulk drag-drop dropzone (builder-friendly) */
 .att-gallery { display: flex; flex-wrap: wrap; gap: 6px; margin: 4px 0 6px; }
-.att-cell { display: block; width: 78px; height: 78px; border: 1px solid var(--border); border-radius: 6px;
+.att-cell { display: block; width: 78px; height: 78px; border: 1px solid var(--line); border-radius: 6px;
   overflow: hidden; background: var(--surface, #1a1a1a); text-decoration: none; }
 .att-cell img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .att-cell.att-file { display: flex; flex-direction: column; align-items: center; justify-content: center;
@@ -1019,7 +1019,7 @@ body[data-cap-admin="off"] [data-cap="admin"] * { pointer-events: none; }
 .att-file .att-name { font-size: 9px; color: var(--muted); word-break: break-word; line-height: 1.1;
   max-height: 28px; overflow: hidden; }
 .att-drop { display: flex; flex-direction: column; gap: 2px; align-items: center; justify-content: center;
-  padding: 12px; margin: 4px 0; border: 1.5px dashed var(--border); border-radius: 8px; cursor: pointer;
+  padding: 12px; margin: 4px 0; border: 1.5px dashed var(--line); border-radius: 8px; cursor: pointer;
   color: var(--text); transition: border-color .12s, background .12s; }
 .att-drop:hover { border-color: var(--accent); }
 .att-drop .meta { font-size: 10px; }
@@ -1138,8 +1138,8 @@ body.embed #workspaces { display: none; }
   white-space: nowrap;
 }
 .home-signpost:hover, .home-signpost:focus-visible {
-  color: var(--fg);
-  border-color: var(--fg);
+  color: var(--text);
+  border-color: var(--text);
   background: var(--bg-elev, transparent);
 }
 

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -139,7 +139,7 @@ export function buildQaSection(d: QaDeps): void {
             for (const t of r!.templates) {
               const row = document.createElement("div");
               row.className = "meta";
-              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle);cursor:pointer";
+              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--line);cursor:pointer";
               row.innerHTML = `<b>${escapeHtml(t.name)}</b>`
                 + (t.isolate ? ` · isolate ${escapeHtml(t.isolate)}` : "")
                 + (t.hide_classes?.length ? ` · hides ${t.hide_classes.length}` : "")
@@ -197,7 +197,7 @@ export function buildQaSection(d: QaDeps): void {
             for (const a of list) {
               const row = document.createElement("div");
               row.className = "meta";
-              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle)";
+              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--line)";
               row.innerHTML = `<b>${escapeHtml(a.name || "unnamed")}</b> · ${a.element_count} element(s) · `
                 + `${a.thickness_m}m · R ${a.r_value} (${a.r_value_imperial} imp)`;
               if (a.guids?.length) {
@@ -322,7 +322,7 @@ export function buildQaSection(d: QaDeps): void {
             for (const c of r!.connections.slice(0, 50)) {
               const row = document.createElement("div");
               row.className = "meta";
-              row.style.cssText = "padding:2px 0;border-bottom:1px solid var(--border-subtle);cursor:pointer";
+              row.style.cssText = "padding:2px 0;border-bottom:1px solid var(--line);cursor:pointer";
               row.innerHTML = `${escapeHtml(c.a_class)} ↔ ${escapeHtml(c.b_class)}`
                 + (c.description ? ` · ${escapeHtml(c.description)}` : "");
               row.title = "Select both ends";
@@ -389,7 +389,7 @@ export function buildQaSection(d: QaDeps): void {
             for (const i of r!.issues.slice(0, 100)) {
               const row = document.createElement("div");
               row.className = "meta";
-              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle);cursor:pointer";
+              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--line);cursor:pointer";
               row.innerHTML = `${i.severity === "error" ? "🔴" : "🟡"} <b>${escapeHtml(i.name || i.guid)}</b> `
                 + `· ${escapeHtml(i.ifc_class)} — ${escapeHtml(i.detail)}`;
               row.title = "Select this element";
@@ -513,7 +513,7 @@ export function buildQaSection(d: QaDeps): void {
               const guids = guidsFromSample(w.sample);
               const row = document.createElement("div");
               row.className = "meta";
-              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle)";
+              row.style.cssText = "padding:3px 0;border-bottom:1px solid var(--line)";
               row.innerHTML = `${sev[w.severity] || "⚪"} <b>${escapeHtml(w.label)}</b> · ${w.count}`
                 + (w.note ? ` <span class="meta">${escapeHtml(w.note)}</span>` : "");
               // Only rows that CAN be zoomed to get the affordance. `overlapping_duplicates` groups

--- a/apps/web/src/viewer/tools/repairPanel.ts
+++ b/apps/web/src/viewer/tools/repairPanel.ts
@@ -137,7 +137,7 @@ export function wallJoinsButton(d: RepairDeps): HTMLButtonElement {
         for (const j of r.joins.slice(0, 200)) {
           const line = document.createElement("div");
           line.className = "meta";
-          line.style.cssText = "padding:3px 0;border-bottom:1px solid var(--border-subtle);cursor:pointer";
+          line.style.cssText = "padding:3px 0;border-bottom:1px solid var(--line);cursor:pointer";
           line.innerHTML = `<b>${escapeHtml(j.kind)}</b> at ${j.corner.map((n) => n.toFixed(2)).join(", ")} m`
             + ` — stub <code>${escapeHtml(j.stub)}</code> butts into <code>${escapeHtml(j.through)}</code>`;
           line.title = "Select both walls";

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3091,6 +3091,18 @@ removed. Remaining, in priority order:
   `#statusbar` up to y=742 in a 900px-tall window. Fixed in `apps/web/src/style.css` and gated by
   `apps/web/src/shell/gridAreas.ts` + `apps/web/src/shell/gridAreas.test.ts`.
 
+  **Asking that question in the other direction found nineteen more sites the same day.**
+  `var(--border)`, `--border-subtle`, `--fg`, `--danger` and `--bg-elev` are referenced without a
+  fallback and defined nowhere, so those declarations are invalid at computed-value time: a file
+  dropzone lost the dashed outline that is its whole affordance (and its drag-over highlight
+  computed the accent colour while painting zero pixels of it), a settings row lost its background,
+  a "Sign out" button rendered in body colour rather than danger red, and a Pareto chart's baseline
+  marker — `fill="none"` with a `stroke` that resolved to `none` — was drawn invisibly. Six further
+  sites were NOT defects: `color` is inherited, so they landed on `--text`, which is what they
+  wanted. *Same token, opposite severity, decided by the property.* Gated by
+  `apps/web/src/shell/cssVars.ts` + `apps/web/src/shell/cssVars.test.ts`, over CSS **and**
+  TypeScript — thirteen of the nineteen sites are inline styles a CSS-only scan cannot see.
+
   **The framing of this line was wrong and that is the part worth keeping.** "a11y/mobile pass"
   said the risk was on phones. The defect was **desktop-only** — below 900px the rail is
   `display: none`, so phones were the one viewport rendering correctly. It also read as


### PR DESCRIPTION
# What & why

Found by asking the pinned-rail question from #465 the other way round: **what else does this CSS name that nothing defines?**

`apps/web/src/style.css` referenced `var(--border)` at six sites, and TypeScript referenced five void tokens at thirteen more — **none with a fallback, none defined anywhere in the tree or set through `setProperty`.**

**A `var()` that resolves to nothing does not skip the property.** It makes the declaration invalid at computed-value time, so the property takes its *unset* value — inherited for an inherited property, initial for everything else. What that costs depends on the **property**, not the token. Measured in Chromium:

| | before | after |
|---|---|---|
| `.att-drop` — the **file dropzone** | `border-style: none`, `width: 0px` | `dashed 1px` |
| `.att-drop.over` — drag-over feedback | accent colour computed, **0px painted** | `dashed 1px` accent |
| `.pf-addopt` — the outline *is* the button (`background: transparent`) | `none 0px` | `dashed 1px` |
| `.att-cell`, `.pnav-khint kbd`, `.portal-fieldset-head` | `none 0px` | `solid 1px` |
| QA + repair row separators (×6, inline in `.ts`) | `none 0px` | `solid 1px` |
| profile row `background` | `rgba(0, 0, 0, 0)` — none at all | `#25272b` |
| "Sign out" `color: var(--danger)` | the body colour — **not danger red** | `#d9534f` |
| Pareto baseline `stroke` on a `fill="none"` rect | `none` — **invisible** | `#e7e7e7` |

## Six sites were NOT defects, and saying so mattered

`color: var(--fg)` is an **inherited** property, so those landed on the ancestor's colour — which is exactly `--text`, which is what they wanted. The same token as an SVG `stroke` inherited `none` and erased a chart's baseline marker entirely.

***Same token, opposite severity, decided by the property.*** A rename sweep would have been right by luck and wrong in every word of its description. I originally predicted all nine `--fg` sites were broken; measuring `:hover` is what corrected it. **13 real defects, 6 benign — not 19 defects.**

## The mapping

`--border`/`--border-subtle` → `--line`, `--fg` → `--text`, `--danger` → `--err`, `--bg-elev` → `--panel2`.

Only the last is a judgement call — the palette has no "elevated" tone and `--panel2` is its second surface. The dropzone's outline is now `--line` as the design system specifies; **if it wants more prominence than the system border, that is a separate design decision** and not this fix's to make.

## The gate

`apps/web/src/shell/cssVars.ts` + `apps/web/src/shell/cssVars.test.ts` (14 tests). Every `var()` without a fallback must name a defined token, and every defined token must be referenced.

A reference **carrying a fallback is not reported** — the token's absence is then not what would break it, and seven tokens here exist only in that form. *That is a claim about the gate, not about CSS.* Measured: `border: 1px solid var(--nope, #3a3f47)` computes `solid 1px`, but `border: 1px solid var(--nope, notacolor)` computes `none 0px`, because the substituted value is still checked against the property. Whether a fallback *suits* its property needs a browser, and this gate does not check it — stated in the docstring rather than left to be assumed.

**Its scope is CSS *and* TypeScript, and that is load-bearing.** `--err` is declared in `style.css` and referenced only from `accountUI.ts`, so a CSS-only "unused token" pass would call it dead and invite deleting a token used in eight places — while **thirteen of the nineteen void sites live in `.ts` files**, invisible to it. Both directions need both sources. Test fixtures are exempt from the forward direction (a test's `var(--nope)` is not a shipped style) but still count as *references* for the reverse one, so a token used only by a test is never called dead.

## Three ways this PR broke itself, all in the checking apparatus

The 13-defect finding has been stable since the first measurement. Everything that went wrong was my confidence about what my own tools could see.

1. **The scan excluded the palette.** The first glob was `apps/web/src/**.css`, which does not match `apps/web/src/style.css` — no intervening directory — so every token came back "void". Population now comes from `git ls-files`.
2. **The gate flagged its own docstring, and CI caught it — not me.** It read `color: var(--fg)` out of the explanatory table above. It had passed *locally* because `git ls-files` lists only **tracked** files and the gate's own files were not yet `git add`ed: **the population excluded the one file that would have failed it.** A test now asserts the gate is in its own population.
3. **My first repair was worse than the bug.** A character-level comment stripper tracking `'`/`"` — but the regex literal `SET_VIA_JS` contains the class `["']`, so the lone `'` opened a phantom string that swallowed a live `//` comment several lines away. Over 582 TypeScript files a naive tokenizer mis-classifies in *both* directions, and eating a live reference fails **open**. Replaced by a rule with no string tracking: a line starting `//` or `*` is documentation, every other line is scanned as written.

Four mutations against the finished gate: stop ignoring comment lines (reproduces the CI failure); ignore *every* line rather than only comments (the fail-open direction); count test fixtures as real sites; make `voidVars()` always return clean. Each reds the tests it should.

## Verification

- [x] Every affected site measured in Chromium before and after — `getComputedStyle`, not inference
- [x] Web: typecheck clean, **2196/2196 tests**, eslint clean, **`vite build` clean**
- [x] `test_claude_md_gates` passes (both new files resolve as citations)
- [x] 4 mutations red the gate; population derived from `git ls-files`, not listed
- [x] **No Python source changed** — CSS, TypeScript inline styles, and two docs
- [ ] Version bump — n/a
- [x] No secrets; no competitor names

⚠️ Not verified: the app was not booted end-to-end (that needs the API), so these are per-element measurements against the real stylesheet and the real inline style strings, not screenshots of the running product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA