### PR TITLE
Sixteen registers can now point at the firm or the person they name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### nineteen registers can now point at the firm or the person they name
+
+Nineteen registers named a party — a supplier, a consultant, an assignee, a risk owner — in a text
+field, while `company` and `contact` sat there as registers with nothing pointing at them. A party
+typed two ways is two parties, so *everything open with this subcontractor* and *what is assigned to
+this person* could not be asked at all. Three of the nineteen were **islands**: `due_diligence`,
+`risk` and `lessons_learned` pointed at nothing whatsoever.
+
+Reference fields 178 → 197, islands 44 → 41. Each reference is added **beside** the text it names,
+never converting it, so existing records keep whatever somebody typed. No engine changed:
+`REVERSE_REFS` is derived from `reference_fields()` at registry load, so a new reference flows into
+`related_records`, the "Referenced by" panel and the rollups by itself.
+
+The population was derived by scanning all 139 registers, but the split was made by hand, because it
+is the part a script gets silently wrong: `owner` is a person on a risk and an organisation on a
+lease. `incident.reported_to` — "OSHA/Owner" — takes `company`, since `company.type` already offers
+`Authority` and a client is a company too. `info_requirement` took **three** references, not one:
+ISO 19650 names appointing, appointed and lead appointed party, and closing the island with one of
+them would have left two thirds of the standard's vocabulary in prose while every count said done.
+
+Two fields are confirmed as leave-alone and pinned so a later sweep cannot "finish the job":
+`asset_register.manufacturer_url` is a link to product data, and `drawing_issuance.recipients` is
+**plural** — a single reference would keep the first recipient and silently drop the rest.
+
+One is held back deliberately: `company.contact_name`. `contact.company` already exists, so a
+company's people already come back as `incoming`, and adding the reverse would create the module
+graph's first mutual 2-cycle. It is asserted *absent*, with the reasoning beside the assertion, so
+deciding it later means editing a check rather than noticing a gap.
+
+**The gate had a hole in itself.** Its pair rule strips a suffix off the reference and looks for that
+stem, so `issue.assignee_name` beside `assignee_contact` matched nothing — one of the nineteen was
+silently exempt from every adjacency, fieldset and workflow-trap check in the file, and nothing went
+red: the summary counted 18 pairs where 19 existed. The stem resolution is now one function shared by
+both rules, since a pair one can see and the other cannot is a trap reported by nothing. A derived
+rule joins it: a `_company` suffix must resolve against `company`, `_contact` against `contact`,
+`_loc` against `location` — the suffix is the only promise the form makes about which picker opens.
+
+**And the mutation harness lied first.** Each of the nineteen assertions was checked by deleting its
+field and confirming that assertion fires — but the first probe neutralised the count floors with an
+edit that left an unbalanced paren, so the file did not parse and all nineteen mutations "failed"
+with a `SyntaxError`. A harness whose baseline is red reports every mutation as caught. The rerun
+asserts the unmutated baseline is green first, and that exposed a second thing: three mutations had
+been dying on the count floor rather than on the named assertion, so the earlier ratchet was hiding
+whether the specific check worked.
+
 ### a file dropzone with no outline, and a chart marker that was never drawn
 
 Found by asking the pinned-rail question the other way round: **what else does this CSS name that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,19 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
-### nineteen registers can now point at the firm or the person they name
+### sixteen registers can now point at the firm or the person they name
 
-Nineteen registers named a party — a supplier, a consultant, an assignee, a risk owner — in a text
-field, while `company` and `contact` sat there as registers with nothing pointing at them. A party
-typed two ways is two parties, so *everything open with this subcontractor* and *what is assigned to
-this person* could not be asked at all. Three of the nineteen were **islands**: `due_diligence`,
-`risk` and `lessons_learned` pointed at nothing whatsoever.
+Sixteen registers named a party — a supplier, a consultant, an assignee, a risk owner — across
+**nineteen** text fields, while `company` and `contact` sat there as registers with nothing pointing
+at them. A party typed two ways is two parties, so *everything open with this subcontractor* and
+*what is assigned to this person* could not be asked at all. Three of the sixteen were **islands**:
+`due_diligence`, `risk` and `lessons_learned` pointed at nothing whatsoever.
+
+*(Sixteen registers, nineteen fields: `info_requirement` takes three and `asset_register` two. This
+entry said "nineteen registers" until review caught it — a change whose whole subject is a count
+that drifted from the thing it counts, shipped with exactly that defect in its own release note.
+The roadmap entry said "nineteen references", which is right; the two numbers are different
+questions and only one of them is 19.)*
 
 Reference fields 178 → 197, islands 44 → 41. Each reference is added **beside** the text it names,
 never converting it, so existing records keep whatever somebody typed. No engine changed:

--- a/docs/roadmap-directions.md
+++ b/docs/roadmap-directions.md
@@ -314,6 +314,21 @@ which reads exactly like a pass):
 PYTHONUTF8=1 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe -X utf8 -u run_tests.py
 ```
 
+⚠️ **One at a time, and nothing heavy beside it.** Two concurrent runs share the same test-database
+pool, and the second one does not fail cleanly — it produces
+`sqlite3.OperationalError: disk I/O error` and `attempt to write a readonly database` scattered across
+unrelated suites, which reads as a real regression in whatever happened to be running. Measured
+2026-09-07: a contaminated run reported **12 failures, all `OperationalError`, 0 `AssertionError`**,
+and re-running the same tree alone gave **675/675**. Two tells that it is contention rather than code:
+every failure is an `OperationalError` and the log carries **two tally lines**. It also leaks a test
+database past the sweep, which the runner reports as its own `FAIL`.
+
+The way it happens is not "deliberately starting two". A backgrounded run whose log is still empty
+looks like it never started — it is buffering — so the natural next move is to start it again. **Check
+for the process, not for output**, and if a run's log has been at zero bytes for a minute, that is
+buffering, not failure. A heavy `vitest run` or `vite build` alongside the backend suite is enough to
+cause the same errors on its own.
+
 **Web** — Node **24+** (`export PATH="/c/Program Files/nodejs:$PATH"`; the default `node` on PATH is v18
 and breaks the build). Typecheck with `npx tsc --noEmit` from `apps/web`. For the suite, run the
 workspace command — **not a bare `vitest run` from the repo root**, which collects `.claude/worktrees/`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2037,8 +2037,10 @@ stakes we are missing.
 
   **The rest of the class, derived rather than guessed — 22 fields, and the next step is a judgement,
   not a sweep.** Scanning all 139 registers for a `text`/`textarea` field whose name contains a party
-  word and which has no `*_company`/`*_contact` reference beside it leaves 22 after this change (51
-  party-named text fields in total, 29 already paired):
+  word and which has no `*_company`/`*_contact` reference beside it left 22 after ⑦ (51
+  party-named text fields in total, 29 already paired). **⑧ below closed 19 of the 22**; the table is
+  kept as written because it is the derivation, and a table rewritten to match its own outcome stops
+  being evidence of anything:
 
   | it names an ORGANISATION → `company` | it names a PERSON → `contact` | it names NEITHER, leave alone |
   |---|---|---|
@@ -2049,6 +2051,48 @@ stakes we are missing.
   client. A name-keyed sweep gets those wrong silently, which is the failure mode ⑥'s own
   ⚠️ note warns about one paragraph up. Each row is cheap on its own; none of them should be done by
   regex.
+
+  ⑧ **PARTY-REFS — the 22 above, decided one at a time, shipped 2026-09-07.** Nineteen references
+  added; two confirmed as leave-alone; one deliberately held back. Reference fields **178 → 197**,
+  islands **44 → 41** (`due_diligence`, `risk` and `lessons_learned` could point at nothing at all —
+  a risk had an owner in the sense that a spreadsheet cell has one). Additive beside the text as
+  MOD-SWEEP requires; no engine changed, for ⑥'s reason.
+
+  **The judgement the table said a script could not make, made.** `incident.reported_to` is the one
+  the ⑦ note singled out — "OSHA/Owner", an agency *or* the client — and it takes `company`, because
+  `company.type` already offers `Authority` and a client is a company too; the person who filed it is
+  not the party it was reported to. `info_requirement` took **three** references rather than one:
+  ISO 19650 names appointing, appointed and lead appointed party, and closing the island with one of
+  them would have left two thirds of the standard's own vocabulary in prose while every count said
+  done. `asset_register` took two, pointing at different registers — who *made* it (`company`) and
+  who *services* it (`contact`) are rarely the same party.
+
+  **Held back, and named so it does not read as an oversight: `company.contact_name`.** Two measured
+  reasons. `contact.company` already exists, so a company's people already come back from
+  `related_records` as `incoming` — the reference would be a second copy of a fact the first one
+  owns, which is the exact defect ⑥ found in `transmittal.items`. And it would create the module
+  graph's **first mutual 2-cycle** (there are none today). `related_records` is one-hop so nothing
+  would break, but that makes it a decision about the data model rather than a row in a sweep. It is
+  asserted *absent* in `services/api/test_module_fields.py`, with the reasoning beside the assertion,
+  so deciding it later means editing a check rather than noticing a gap.
+
+  **The gate found a hole in itself.** MOD-SWEEP's pair rule strips a suffix off the *reference* and
+  looks for that stem, so `issue.assignee_name` beside `assignee_contact` matched nothing: one of
+  the nineteen was silently exempt from every adjacency, fieldset and workflow-gate check in the
+  file, and **nothing went red** — the summary counted 18 pairs where 19 existed. `text_half()` is
+  now one definition shared by the pair rule and the workflow-trap rule, because a pair one can see
+  and the other cannot is a trap reported by nothing. A derived rule was added with it: a `_company`
+  suffix must resolve against `company`, `_contact` against `contact`, `_loc` against `location` —
+  the suffix is the only promise a reader of the form has about which picker they will get.
+
+  **And the mutation harness lied first.** All nineteen assertions were checked by deleting the
+  field and confirming *that* assertion fires — but the first probe neutralised the count floors with
+  an edit that left an unbalanced paren, so the file did not parse and all nineteen mutations
+  "failed" with a `SyntaxError`. **A harness whose baseline is red reports every mutation as
+  caught.** Same shape as a scanner whose regex matches nothing: the output is indistinguishable
+  from a clean pass. The rerun asserts the unmutated baseline is green before believing a kill —
+  and it also showed that three mutations had been dying on the *count* floor rather than on the
+  named assertion, so the earlier ratchet was masking whether the specific check worked at all.
 
   📌 **The marker is still ◧ and this does not change it.** All of ①–⑦ ship and every item this
   entry's scope sentence names now has an implementation, but "permit & entitlement workflow" is a

--- a/services/api/modules/action_item/module.json
+++ b/services/api/modules/action_item/module.json
@@ -32,6 +32,14 @@
       "fieldset": "Parties"
     },
     {
+      "name": "assignee_contact",
+      "label": "Assignee (linked)",
+      "type": "reference",
+      "module": "contact",
+      "help": "The assignee as a contact record, so open actions can be listed per person rather than per spelling of their name.",
+      "fieldset": "Parties"
+    },
+    {
       "name": "responsible",
       "label": "Responsible",
       "type": "text",

--- a/services/api/modules/asset_register/module.json
+++ b/services/api/modules/asset_register/module.json
@@ -46,6 +46,14 @@
       "fieldset": "Asset"
     },
     {
+      "name": "manufacturer_company",
+      "label": "Manufacturer (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The manufacturer as a company record, so warranty and recall questions reach every asset from one firm.",
+      "fieldset": "Asset"
+    },
+    {
       "name": "model",
       "label": "Model",
       "type": "text",
@@ -73,6 +81,14 @@
       "name": "service_contact",
       "label": "Service Contact",
       "type": "text",
+      "fieldset": "Service"
+    },
+    {
+      "name": "service_contact_ref",
+      "label": "Service Contact (linked)",
+      "type": "reference",
+      "module": "contact",
+      "help": "The service contact as a contact record, so a fault can reach the person who services the asset.",
       "fieldset": "Service"
     },
     {

--- a/services/api/modules/assumption/module.json
+++ b/services/api/modules/assumption/module.json
@@ -36,6 +36,14 @@
       "fieldset": "Parties"
     },
     {
+      "name": "owner_contact",
+      "label": "Owner (linked)",
+      "type": "reference",
+      "module": "contact",
+      "help": "The assumption owner as a contact record, so an assumption has someone to test it with.",
+      "fieldset": "Parties"
+    },
+    {
       "name": "cost_impact",
       "label": "Cost Impact / Allowance",
       "type": "currency",

--- a/services/api/modules/delivery/module.json
+++ b/services/api/modules/delivery/module.json
@@ -27,6 +27,14 @@
       "fieldset": "Identity"
     },
     {
+      "name": "supplier_company",
+      "label": "Supplier (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The supplier as a company record, so deliveries can be counted and chased against the same firm the purchase order names.",
+      "fieldset": "Identity"
+    },
+    {
       "name": "received_by",
       "label": "Received By",
       "type": "text",

--- a/services/api/modules/directive/module.json
+++ b/services/api/modules/directive/module.json
@@ -28,6 +28,14 @@
       "fieldset": "Directive"
     },
     {
+      "name": "to_company_ref",
+      "label": "Directed To (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The company the directive is issued to, as a record rather than a typed name — so a directive can be counted against the party bound by it.",
+      "fieldset": "Directive"
+    },
+    {
       "name": "mode",
       "label": "Mode",
       "type": "select",

--- a/services/api/modules/due_diligence/module.json
+++ b/services/api/modules/due_diligence/module.json
@@ -40,6 +40,14 @@
       "fieldset": "Item"
     },
     {
+      "name": "consultant_company",
+      "label": "Consultant / Firm (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The consultant as a company record, so every report a firm produced across a diligence period resolves to one party.",
+      "fieldset": "Item"
+    },
+    {
       "name": "findings",
       "label": "Findings",
       "type": "textarea",

--- a/services/api/modules/incident/module.json
+++ b/services/api/modules/incident/module.json
@@ -180,6 +180,14 @@
       "fieldset": "OSHA"
     },
     {
+      "name": "reported_to_company",
+      "label": "Reported To (OSHA/Owner) (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The body the incident was reported to — an agency or the client — as a record, so reporting obligations resolve to one party.",
+      "fieldset": "OSHA"
+    },
+    {
       "name": "root_cause",
       "label": "Root Cause",
       "type": "textarea",

--- a/services/api/modules/info_requirement/module.json
+++ b/services/api/modules/info_requirement/module.json
@@ -89,15 +89,39 @@
       "fieldset": "Parties"
     },
     {
+      "name": "appointing_party_company",
+      "label": "Appointing Party (Client) (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The appointing party (ISO 19650 client) as a company record, so the information chain names real parties.",
+      "fieldset": "Parties"
+    },
+    {
       "name": "lead_appointed_party",
       "label": "Lead Appointed Party",
       "type": "text",
       "fieldset": "Parties"
     },
     {
+      "name": "lead_appointed_party_company",
+      "label": "Lead Appointed Party (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The lead appointed party as a company record, so the information chain names real parties.",
+      "fieldset": "Parties"
+    },
+    {
       "name": "appointed_party",
       "label": "Appointed Party",
       "type": "text",
+      "fieldset": "Parties"
+    },
+    {
+      "name": "appointed_party_company",
+      "label": "Appointed Party (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The appointed party as a company record, so the information chain names real parties.",
       "fieldset": "Parties"
     },
     {

--- a/services/api/modules/information_container/module.json
+++ b/services/api/modules/information_container/module.json
@@ -88,6 +88,14 @@
       "fieldset": "Status"
     },
     {
+      "name": "reviewer_contact",
+      "label": "Reviewer (linked)",
+      "type": "reference",
+      "module": "contact",
+      "help": "The reviewer as a contact record, so a container's review history resolves to a person.",
+      "fieldset": "Status"
+    },
+    {
       "name": "linked_document",
       "label": "Linked Document",
       "type": "reference",

--- a/services/api/modules/issue/module.json
+++ b/services/api/modules/issue/module.json
@@ -51,6 +51,14 @@
       "fieldset": "Parties"
     },
     {
+      "name": "assignee_contact",
+      "label": "Assigned To (linked)",
+      "type": "reference",
+      "module": "contact",
+      "help": "The assignee as a contact record, so open issues can be listed per person rather than per spelling of their name.",
+      "fieldset": "Parties"
+    },
+    {
       "name": "description",
       "label": "Description",
       "type": "textarea",

--- a/services/api/modules/itp/module.json
+++ b/services/api/modules/itp/module.json
@@ -106,6 +106,14 @@
       "fieldset": "Responsibility"
     },
     {
+      "name": "verifying_party_company",
+      "label": "Verifying Party (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The verifying party as a company record, so an inspection-and-test plan names who signs it off rather than describing them.",
+      "fieldset": "Responsibility"
+    },
+    {
       "name": "record_form",
       "label": "Record / Form Required",
       "type": "text",

--- a/services/api/modules/lessons_learned/module.json
+++ b/services/api/modules/lessons_learned/module.json
@@ -23,6 +23,9 @@
 
     { "name": "recommendation", "label": "Recommendation (feed forward)", "type": "textarea", "fieldset": "Recommendation" },
     { "name": "owner", "label": "Owner", "type": "text", "fieldset": "Recommendation" },
+    { "name": "owner_contact", "label": "Owner (linked)", "type": "reference", "module": "contact",
+      "help": "The owner as a contact record, so a lesson has someone accountable for carrying it forward.",
+      "fieldset": "Recommendation" },
     { "name": "feed_forward", "label": "Carry to standards / templates", "type": "checkbox", "fieldset": "Recommendation" }
   ],
   "workflow": {

--- a/services/api/modules/project_charter/module.json
+++ b/services/api/modules/project_charter/module.json
@@ -34,6 +34,14 @@
       "fieldset": "Charter"
     },
     {
+      "name": "project_manager_contact",
+      "label": "Project Manager (linked)",
+      "type": "reference",
+      "module": "contact",
+      "help": "The project manager as a contact record, so the charter names a person the directory knows.",
+      "fieldset": "Charter"
+    },
+    {
       "name": "authorized_date",
       "label": "Authorized Date",
       "type": "date",

--- a/services/api/modules/rfi/module.json
+++ b/services/api/modules/rfi/module.json
@@ -75,6 +75,14 @@
       "fieldset": "Routing"
     },
     {
+      "name": "rfi_manager_contact",
+      "label": "RFI Manager (linked)",
+      "type": "reference",
+      "module": "contact",
+      "help": "The RFI manager as a contact record, so routing resolves to a person rather than a typed name.",
+      "fieldset": "Routing"
+    },
+    {
       "name": "received_from",
       "label": "Asked By",
       "type": "text",

--- a/services/api/modules/risk/module.json
+++ b/services/api/modules/risk/module.json
@@ -73,6 +73,14 @@
       "fieldset": "Parties"
     },
     {
+      "name": "owner_contact",
+      "label": "Owner (linked)",
+      "type": "reference",
+      "module": "contact",
+      "help": "The risk owner as a contact record, so a register can answer who carries which risk.",
+      "fieldset": "Parties"
+    },
+    {
       "name": "due_date",
       "label": "Review Date",
       "type": "date",

--- a/services/api/modules/submittal/module.json
+++ b/services/api/modules/submittal/module.json
@@ -59,6 +59,14 @@
       "fieldset": "Identification"
     },
     {
+      "name": "responsible_contractor_company",
+      "label": "Responsible Contractor (linked)",
+      "type": "reference",
+      "module": "company",
+      "help": "The contractor responsible for the submittal, as a record — so a review turnaround can be attributed to the party that owes it.",
+      "fieldset": "Identification"
+    },
+    {
       "name": "disposition",
       "label": "Disposition",
       "type": "select",

--- a/services/api/test_module_fields.py
+++ b/services/api/test_module_fields.py
@@ -83,24 +83,70 @@ assert len(with_ref) >= 30, f"only {len(with_ref)} registers surface a reference
 # with its first 8 characters — a control that looked resolved and opened nothing. The codebase already
 # had the safe pattern in three places (investor+investor_company, lease+tenant_company,
 # subcontract+vendor_company): add the reference BESIDE the text, backfill, retire the text later.
+REF_SUFFIXES = ("_company", "_loc", "_spec", "_system", "_contact", "_package", "_ref", "_id")
+
+
+def text_half(name, by):
+    """The free-text field a reference was added BESIDE, or None if the reference stands alone.
+
+    ONE definition, because rule 4 (adjacency and fieldset) and rule 7 (the workflow-gate trap) must
+    agree about what a pair is: a pair one of them can see and the other cannot is a trap that gets
+    reported by nothing.
+
+    Two spellings, because the registers use both — `supplier` beside `supplier_company`, and
+    `assignee_name` beside `assignee_contact`. The `_name` form was invisible to the first version of
+    this rule, which stripped a suffix off the REFERENCE and looked for exactly that stem. So
+    PARTY-REFS' `issue.assignee_contact` was the one new reference of nineteen that no rule below
+    applied to, and the summary line counted 18 pairs where 19 had been added. **Nothing went red**:
+    an undetected pair is silently exempt from every check in this file, which is the fail-open shape
+    the seeding gates above were rebuilt twice to remove. `issue` has no `requires` today, so the
+    trap was latent rather than live — the next transition added to it would have sprung it.
+    """
+    f = by.get(name)
+    if f is None or f["type"] != "reference":
+        return None
+    for suf in REF_SUFFIXES:
+        if not name.endswith(suf):
+            continue
+        stem = name[: -len(suf)]
+        for cand in (stem, stem + "_name"):
+            if by.get(cand, {}).get("type") in ("text", "textarea"):
+                return cand
+    return None
+
+
 pairs = []
 for k, m in mods.items():
     by = {f["name"]: f for f in m.get("fields", [])}
+    fl = [x["name"] for x in m["fields"]]
     for n, f in by.items():
+        stem = text_half(n, by)
+        if stem is None:
+            continue
+        pairs.append((k, stem, n))
+        # the pair must be ADJACENT, or the form renders them in different places and nobody
+        # sees that one is the link for the other (same rule as fieldset contiguity)
+        assert abs(fl.index(stem) - fl.index(n)) == 1, \
+            f"{k}: {stem!r} and its reference {n!r} are not adjacent"
+        assert by[stem].get("fieldset") == f.get("fieldset"), \
+            f"{k}: {stem!r} and {n!r} are in different fieldsets"
+assert len(pairs) >= 84, (
+    f"only {len(pairs)} additive text+reference pairs; the sweep created 54, and PARTY-REFS took it "
+    "to 84 — 83 of which this rule could see before `text_half` learned the `_name` spelling"
+)
+
+# The suffix is a PROMISE about the target, and it is the only thing a reader of the form has to go
+# on: a field called `..._company` that resolves against `contact` offers the wrong picker and files
+# the row against the wrong register. Derived, not listed, so it covers a reference added next year.
+for k, m in mods.items():
+    for f in m.get("fields", []):
         if f["type"] != "reference":
             continue
-        for suf in ("_company", "_loc", "_spec", "_system", "_contact", "_package", "_ref", "_id"):
-            stem = n[: -len(suf)] if n.endswith(suf) else None
-            if stem and stem in by and by[stem]["type"] in ("text", "textarea"):
-                pairs.append((k, stem, n))
-                # the pair must be ADJACENT, or the form renders them in different places and nobody
-                # sees that one is the link for the other (same rule as fieldset contiguity)
-                fl = [x["name"] for x in m["fields"]]
-                assert abs(fl.index(stem) - fl.index(n)) == 1, \
-                    f"{k}: {stem!r} and its reference {n!r} are not adjacent"
-                assert by[stem].get("fieldset") == f.get("fieldset"), \
-                    f"{k}: {stem!r} and {n!r} are in different fieldsets"
-assert len(pairs) >= 50, f"only {len(pairs)} additive text+reference pairs; the sweep created 54"
+        for suf, want in (("_company", "company"), ("_contact", "contact"), ("_loc", "location")):
+            if f["name"].endswith(suf):
+                assert f.get("module") == want, (
+                    f"{k}.{f['name']} ends {suf!r} but points at {f.get('module')!r}, not {want!r}"
+                )
 
 # every reference points at a module that exists (config test covers it; asserted here for the pairs)
 for k, m in mods.items():
@@ -111,18 +157,23 @@ for k, m in mods.items():
 refs = sum(1 for m in mods.values() for f in m.get("fields", []) if f["type"] == "reference")
 islands = [k for k, m in mods.items()
            if not any(f["type"] == "reference" for f in m.get("fields", []))]
-assert refs >= 176, (
-    f"only {refs} reference fields; the sweep took it from 98 to 152, TRANSMIT-REFS to 173 and "
-    "PERMIT-AUTHORITY to 178"
+# The floor said 176 while its own message said 178, which is the number the run had actually
+# reached — a ratchet that trails the work by two lets two references be deleted silently. It is the
+# same class as the viewer line-count in CLAUDE.md: a number written beside the thing it counts, in
+# prose, drifts away from it. Both halves are now computed from the same measurement.
+assert refs >= 197, (
+    f"only {refs} reference fields; the sweep took it from 98 to 152, TRANSMIT-REFS to 173, "
+    "PERMIT-AUTHORITY to 178 and PARTY-REFS to 197"
 )
-assert len(islands) <= 44, (
+assert len(islands) <= 41, (
     f"{len(islands)} modules have no reference at all (was 69, then 49). A record that points at "
     "nothing cannot take part in a chain, which is most of what separates a register from a "
     "spreadsheet. TRANSMIT-REFS took three more off the list — `transmittal` itself, which could not "
     "name the company it was addressed to, and `document` and `drawing_set`, which had no reference "
     "of any kind and so could not be put in a package. PERMIT-AUTHORITY took two more — `permit` "
     "and `entitlement`, the two ends of the approval chain, neither of which could point at the "
-    "authority it was applying to."
+    "authority it was applying to. PARTY-REFS took three — `due_diligence`, `risk` and "
+    "`lessons_learned`, each of which named the party responsible for it and could point at nobody."
 )
 
 
@@ -225,13 +276,10 @@ for k, m in mods.items():
     # its length. Shadowing it here reported "0 additive pairs" while 65 were sitting in the file,
     # which is the summary lying about the check directly above it.
     pair_map = {}
-    for n, f in by.items():
-        if f["type"] != "reference":
-            continue
-        for suf in ("_company", "_loc", "_spec", "_system", "_contact", "_package", "_ref", "_id"):
-            stem = n[: -len(suf)] if n.endswith(suf) else None
-            if stem and stem in by and by[stem]["type"] in ("text", "textarea"):
-                pair_map[stem] = n
+    for n in by:
+        stem = text_half(n, by)
+        if stem is not None:
+            pair_map[stem] = n
     for t in (m.get("workflow") or {}).get("transitions", []):
         for entry in t.get("requires") or []:
             alts = entry.split("|")
@@ -252,6 +300,96 @@ alternated = sorted(f"{k}.{t.get('action')}"
                     for t in (m.get("workflow") or {}).get("transitions", [])
                     for e in (t.get("requires") or []) if "|" in e)
 assert len(alternated) >= 2, f"expected the two known alternation gates, found {alternated}"
+
+# ---- 8. PARTY-REFS: a register that names a party must be able to POINT at it -------------------
+#
+# R22-ENTITLEMENT's last item, and the roadmap called it "the largest hole in the product's own
+# story". #448 and #449 closed the transmittal and the permitting chain; this closes the rest. The
+# shape is the same one every time: a register names the firm or the person the work is with, in a
+# text field, and `company` and `contact` are sitting there as registers with nothing pointing at
+# them. The cost is the same too — a party typed two ways is two parties, so "everything open with
+# this subcontractor" and "what is assigned to this person" cannot be asked at all, and three of
+# these modules were ISLANDS: `due_diligence`, `risk` and `lessons_learned` pointed at nothing
+# whatsoever, so a risk had an owner in the sense that a spreadsheet cell has one.
+#
+# NAMED, not derived, for the reason PERMIT-AUTHORITY gives above. A rule keyed on the field name
+# would sweep in `asset_register.manufacturer_url` (a URL, asserted below to stay text) and
+# `drawing_issuance.recipients` (plural — a distribution list is not a reference, and turning it
+# into one would silently drop everyone after the first).
+PARTY_NAMED = {
+    # organisation -> company
+    "delivery": ("supplier_company", "company", "who delivered it, so deliveries can be counted and chased against one firm"),
+    "due_diligence": ("consultant_company", "company", "the consultant who produced the finding; was an island"),
+    "directive": ("to_company_ref", "company", "a directive is issued TO someone, and that someone can be invoiced"),
+    "asset_register": ("manufacturer_company", "company", "the manufacturer of record, for recalls and warranty"),
+    "submittal": ("responsible_contractor_company", "company", "who owes the submittal, so a late one has an addressee"),
+    "itp": ("verifying_party_company", "company", "the party whose signature closes an inspection point"),
+    "incident": ("reported_to_company", "company", "the body an incident was reported to — often the AHJ"),
+    "info_requirement": ("appointing_party_company", "company", "ISO 19650's appointing party, by name and not by prose"),
+    # person -> contact
+    "action_item": ("assignee_contact", "contact", "who owes the action"),
+    "issue": ("assignee_contact", "contact", "who owes the issue"),
+    "risk": ("owner_contact", "contact", "a risk with no nameable owner is a risk nobody owns; was an island"),
+    "assumption": ("owner_contact", "contact", "who has to confirm or retire it"),
+    "lessons_learned": ("owner_contact", "contact", "who carries the lesson forward; was an island"),
+    "project_charter": ("project_manager_contact", "contact", "the PM as a record, not a name typed once"),
+    "rfi": ("rfi_manager_contact", "contact", "who routes RFIs, so a stalled one has an owner"),
+    "information_container": ("reviewer_contact", "contact", "who reviewed the container"),
+}
+# Each of the 19 was mutation-checked by deleting it and confirming THIS assertion fires — which
+# needed a second attempt, because the first probe neutralised the count floors above with an edit
+# that left an unbalanced paren, so the file did not parse and all 19 mutations "failed" with a
+# SyntaxError. **A mutation harness whose baseline is red reports every mutation as caught**, which
+# is the same fail-open shape as a scanner whose regex matches nothing: the output looks like a full
+# pass. Assert the unmutated baseline PASSES before believing a single kill.
+for _k, (_ref, _target, _why) in PARTY_NAMED.items():
+    _by = {f["name"]: f for f in mods[_k]["fields"]}
+    _f = _by.get(_ref)
+    assert _f is not None and _f["type"] == "reference" and _f.get("module") == _target, (
+        f"{_k}.{_ref} must be a reference to {_target} ({_why}). Without it the register names a "
+        "party it cannot point at, which is the whole of R22-ENTITLEMENT's remaining hole."
+    )
+
+# ISO 19650 names three parties, not one. `info_requirement` carried all three as text; a single
+# reference would have closed the island and left two thirds of the standard's own vocabulary
+# unlinked, which is exactly the kind of partial fix a floor-only ratchet reports as done.
+for _ref in ("appointing_party_company", "appointed_party_company", "lead_appointed_party_company"):
+    assert any(f["name"] == _ref and f["type"] == "reference" and f.get("module") == "company"
+               for f in mods["info_requirement"]["fields"]), \
+        f"info_requirement.{_ref} must link an ISO 19650 party to `company`"
+
+# `asset_register` names two different parties: who made it and who services it. They are rarely the
+# same firm and the service one is a person, so it takes both halves.
+assert any(f["name"] == "service_contact_ref" and f["type"] == "reference"
+           and f.get("module") == "contact" for f in mods["asset_register"]["fields"]), \
+    "asset_register.service_contact_ref must link the servicing person to `contact`"
+
+# The two deliberate NON-conversions, pinned so a later sweep does not "finish the job" and break
+# them. Both are party-shaped by NAME and neither is a reference.
+_ar = {f["name"]: f for f in mods["asset_register"]["fields"]}
+assert _ar["manufacturer_url"]["type"] == "text", (
+    "asset_register.manufacturer_url is a link to product data, not a party — it sits beside "
+    "manufacturer_company, which is the reference."
+)
+_di = {f["name"]: f for f in mods["drawing_issuance"]["fields"]}
+assert _di["recipients"]["type"] == "text", (
+    "drawing_issuance.recipients is PLURAL: a distribution list. A single reference would keep the "
+    "first recipient and silently lose the rest, which is worse than the free text it replaced."
+)
+
+# HELD BACK, deliberately, and recorded here because a later reader will otherwise see `company` on
+# the island list and assume it was missed: `company` has no `contact_name` reference. `contact`
+# already carries `contact.company`, so a company's people already come back from `related_records`
+# as incoming — the reference would be a second copy of a fact the first one owns. It would also
+# create the module graph's first mutual 2-cycle (there are none today), which `related_records`
+# tolerates because it is one-hop, but which is a decision about the data model rather than a row in
+# a sweep. Left for the maintainer.
+assert not any(f["type"] == "reference" and f.get("module") == "contact"
+               for f in mods["company"]["fields"]), (
+    "company now points at contact. That may well be right, but it is the graph's first 2-cycle "
+    "(contact.company points back) and needs deciding, not sweeping — update this assertion "
+    "deliberately when it is decided."
+)
 
 print(f"MOD-SWEEP OK - {len(mods)} modules, {refs} reference fields ({len(islands)} still islands), "
       f"{len(united)} fields carry a declared unit, {len(pairs)} additive text+reference pairs are "


### PR DESCRIPTION
# What & why

R22-ENTITLEMENT's last item — the roadmap called it "the largest hole in the product's own story". **Sixteen registers** named a party (a supplier, a consultant, an assignee, a risk owner) across **nineteen text fields**, while `company` and `contact` sat there as registers with nothing pointing at them. A party typed two ways is two parties, so *"everything open with this subcontractor"* and *"what is assigned to this person"* could not be asked at all. Three of them were **islands**: `due_diligence`, `risk` and `lessons_learned` pointed at nothing whatsoever, so a risk had an owner in the sense that a spreadsheet cell has one.

Reference fields **178 → 197**, islands **44 → 41**. Each reference is added **beside** the text it names, never converting it, so existing records keep whatever somebody typed. **No engine changed**: `REVERSE_REFS` is derived from `reference_fields()` at registry load, so a new reference flows into `related_records`, the "Referenced by" panel and the rollups by itself.

### The judgement the roadmap said a script could not make

The population was derived by scanning all 139 registers; the split was made by hand, because that is the part a name-keyed sweep gets silently wrong — `owner` is a person on a risk and an organisation on a lease.

- `incident.reported_to` — *"OSHA/Owner"*, the case the roadmap singled out — takes `company`, since `company.type` already offers `Authority` and a client is a company too.
- `info_requirement` took **three** references, not one: ISO 19650 names appointing, appointed and lead appointed party, and closing the island with one of them would have left two thirds of the standard's own vocabulary in prose while every count said done.
- `asset_register` took two pointing at **different** registers — who *made* it (`company`) and who *services* it (`contact`).

**Two are confirmed leave-alone and pinned**, so a later sweep cannot "finish the job": `asset_register.manufacturer_url` is a link to product data, and `drawing_issuance.recipients` is **plural** — a single reference would keep the first recipient and silently drop the rest.

**One is held back deliberately: `company.contact_name`.** `contact.company` already exists, so a company's people already come back as `incoming` — the reference would be a second copy of a fact the first one owns. It would also create the module graph's **first mutual 2-cycle** (there are none today). It is asserted **absent**, with the reasoning beside the assertion, so deciding it later means editing a check rather than noticing a gap.

### The gate had a hole in itself

MOD-SWEEP's pair rule strips a suffix off the *reference* and looks for that stem, so `issue.assignee_name` beside `assignee_contact` matched nothing: **one of the nineteen was silently exempt from every adjacency, fieldset and workflow-trap check in the file, and nothing went red** — the summary counted 18 pairs where 19 existed. The stem resolution is now one function shared by the pair rule and the workflow-trap rule, since a pair one can see and the other cannot is a trap reported by nothing. A derived rule joins it: a `_company` suffix must resolve against `company`, `_contact` against `contact`, `_loc` against `location` — the suffix is the only promise the form makes about which picker opens.

### And the mutation harness lied first

Each of the nineteen assertions was checked by deleting its field and confirming *that* assertion fires. The first probe neutralised the count floors with an edit that left an unbalanced paren, so the file did not parse and all nineteen mutations "failed" with a `SyntaxError`. **A harness whose baseline is red reports every mutation as caught** — indistinguishable from a clean pass. The rerun asserts the unmutated baseline is green first, which also exposed that three mutations had been dying on the *count* floor rather than on the named assertion.

### Review found a third one, in this PR's own release note

The CHANGELOG entry said "nineteen registers" where it meant sixteen registers / nineteen fields — **a change whose entire subject is a count drifting away from the thing it counts, shipped with exactly that defect in its own release note.** Corrected in `d208ac70`, along with this PR's title. The roadmap entry said "nineteen references", which was right all along; the two numbers answer different questions and only one of them is 19.

`docs/roadmap-directions.md` also gains a measured testing hazard found on the way: two concurrent backend suites share one test-database pool and produce `OperationalError` scattered across unrelated suites, which reads as a regression. A contaminated run reported **12 failures, all `OperationalError`, 0 `AssertionError`**; the same tree run alone gave **675/675**.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean — "All checks passed!"
- [x] Backend: affected `test_*.py` pass — **675/675 suites** (1071s, run alone)
- [x] Web: typecheck / lint / build clean (`npm run lint --workspace apps/web`, `npx tsc --noEmit`, `vite build`); 215 files / 2196 tests pass. No web source changed.
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added (newest at top); `docs/roadmap.md` R22-ENTITLEMENT ⑧ added
- [ ] Version bump — not a release PR
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added linked company and contact fields across actions, assets, assumptions, deliveries, directives, due diligence, incidents, information requirements, reviews, issues, inspections, lessons learned, project charters, RFIs, risks, and submittals.
  - Existing text fields remain available where applicable, while linked references improve consistency and traceability.

- **Documentation**
  - Updated roadmap and changelog details for party-reference coverage and decisions.
  - Added guidance to prevent conflicts when running backend tests concurrently.

- **Tests**
  - Expanded validation for required party references, field consistency, and reference coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->