### PR TITLE
MONEY-SCOPE: the gate meant to catch PENNY-SPLIT could not see it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### six more money figures round the way an invoice rounds — and a 0% retainage stays 0%
+
+The previous entry fixed one line. The check that was supposed to cover the whole tree could not
+see it: it scanned three named files and required the word "retain" on the line, and the line it
+missed said `ret_pct`. Reading the source structurally instead found five more places computing
+money to the cent with the wrong rounding — the GMP budget's overhead, fee and contingency lines,
+earned value against the model, and work-in-progress retainage.
+
+**A contract that holds no retainage now reports none.** Work-in-progress treated an explicit 0%
+retainage as a missing one and substituted the 5% default, so a project the owner agreed to hold
+nothing on showed retainage held — on a $40,000 billing, $2,000 that does not exist. That figure
+drives over- and under-billing, which posts to the ledger.
+
 ### a subcontractor billing row no longer contradicts itself by a penny
 
 The subcontractor billing summary reported `billed`, `retainage` and `paid` for each subcontract,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1883,6 +1883,18 @@ the only item here with real scope.
   the predicate in both directions: it must find the form that defeated the old scan, still find the
   form the old scan caught, and NOT flag a display percentage rounded to 1dp.
 
+  ⚠️ **And the replacement scan repeated the lesson one layer along, caught in review.** The old
+  predicate depended on a NAME (`retain`) and the site that survived used an abbreviation. The
+  structural replacement dropped the name — and still depended on a syntactic FORM, reading
+  `n.args[1]`, so `round(x, ndigits=2)` slipped through. That is valid Python and returns the *same*
+  HALF-EVEN answer (measured: `round(2.675, ndigits=2)` is 2.67), so a site written that way would
+  be exactly the defect, invisible to the gate written to catch it. `_ndigits` now reads the
+  argument **however it was passed**, and the keyword form is a fourth probe.
+
+  *Dropping one kind of brittleness is not the same as being robust.* Three drafts of this predicate
+  now: lexical → structural-but-positional → structural. Each was a real improvement and each still
+  had a spelling in it.
+
   ✅ **PENNY-SPLIT — the v0.3.969 money fix missed a line IN A FUNCTION IT EDITED, shipped
   2026-09-08.** This entry records that `round()` on floats disagreed with `payapp`'s HALF-UP and
   that `cost.py` and `routers/cost.py` were converted. `routers/cost.py::subcontractor_billing` was

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1848,6 +1848,41 @@ the only item here with real scope.
 
   **The requisition half is untouched** and still needs the per-site decision described below.
 
+  ✅ **MONEY-SCOPE — the gate that was supposed to catch PENNY-SPLIT could not SEE it, shipped
+  2026-09-08.** `services/api/test_money_spine.py` opens *"One rounding convention for retainage,
+  asserted at every site that computes it."* Both halves of that were false:
+
+  * it scanned a **hardcoded list of three files** — `cost.py`, `routers/cost.py`, `payapp.py`;
+  * its predicate required the literal substring **`retain` on the line**, and the surviving site
+    reads `round(row["paid"] + amt * (1 - ret_pct / 100), 2)`. It matched `round(` and `/ 100` and
+    was missed, because **`ret_pct` does not contain `retain`**.
+
+  **The third term was a spelling, and the site that survived used an abbreviation.** Measured, not
+  inferred: the predicate was run against both historical lines and reports MISSED on one, SEEN on
+  the other.
+
+  A name-free AST scan — `round(<expression dividing by 100>, 2)`, over every file — found **five
+  more sites in three files the old list never named**: `project_budget.py` ×3 (the GMP's overhead,
+  fee and contingency, where fee COMPOUNDS on overhead), `evm.py` (earned value in dollars, and its
+  severity is stated as LOW rather than implied — `model_pct` is already 1dp, so the penny sits
+  below its own input's precision), and `wip.py` — **retainage, this gate's own subject, in a file
+  it did not read.**
+
+  ⚠️ **And `wip.py` carried a second, worse defect the rounding sweep walked into.** It computed
+  `g703_retainage or (DEFAULT_RETAINAGE / 100 * billed)`, and `or` treats an EXPLICIT 0% as absent.
+  `cost.py:49` records this exact shape under the name FIN-SUITE-BLIND and fixed it there; **this is
+  the instance that survived**, in the engine whose own comment says `billed` drives over/under-
+  billing and posts back to the ledger. Mutation-measured: a 0%-retainage contract billing $40,000
+  reported **$2,000** held. *A named, already-fixed class is not closed until its population is
+  derived — three sweeps in a row have now found a survivor of one.*
+
+  🔒 **The gate now asserts its own SCOPE, not just its verdict.** With the tree clean, narrowing
+  the scan back to three files would pass silently — which is precisely how it spent two releases
+  reporting a tree it was not reading. It pins the population to every `.py` under `aec_api` and
+  names the six modules that must be inside it, so a narrowing reds the build. Three probes prove
+  the predicate in both directions: it must find the form that defeated the old scan, still find the
+  form the old scan caught, and NOT flag a display percentage rounded to 1dp.
+
   ✅ **PENNY-SPLIT — the v0.3.969 money fix missed a line IN A FUNCTION IT EDITED, shipped
   2026-09-08.** This entry records that `round()` on floats disagreed with `payapp`'s HALF-UP and
   that `cost.py` and `routers/cost.py` were converted. `routers/cost.py::subcontractor_billing` was

--- a/services/api/src/aec_api/evm.py
+++ b/services/api/src/aec_api/evm.py
@@ -23,6 +23,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from . import modules as me
+from . import money
 from .timeutil import utc_today
 
 _PERIOD_DAYS = {"week": 7.0, "month": 30.44}
@@ -284,8 +285,12 @@ def model_ev(db: Session, pid: str, data_date: str | None = None) -> dict[str, A
     snap = snapshot(db, pid, data_date)
     bac = snap["totals"]["bac"]
     ev_sched = snap["totals"]["ev"]
-    ev_model = round(bac * model_pct / 100, 2)
-    divergence = round(ev_sched - ev_model, 2)                 # + = schedule ahead of physical install
+    # MONEY-SCOPE — `bac` is money, so this quantizes to cents under one convention like the rest of
+    # the tree. Severity here is LOW and worth saying so: `model_pct` is already rounded to 1dp
+    # above, so the penny sits well below the precision of its own input, and the `> 0.05 * bac`
+    # flag below cannot turn on it. It is moved for one convention, not because it was wrong.
+    ev_model = money.retainage(bac, model_pct)
+    divergence = money.q2(ev_sched - ev_model)                 # + = schedule ahead of physical install
     # Only compare against the model once field verification exists — with zero verified elements the
     # model EV is 0 by definition, and flagging "front-loaded" then would falsely accuse an un-surveyed job.
     has_field_data = tracked > 0

--- a/services/api/src/aec_api/project_budget.py
+++ b/services/api/src/aec_api/project_budget.py
@@ -241,9 +241,12 @@ def gmp_budget(db: Session, pid: str, proforma_hard: float | None = None) -> dic
     oh_pct, fee_pct, cont_pct = _n(pcd.get("overhead_pct")), _n(pcd.get("fee_pct")), _n(pcd.get("contingency_pct"))
     gmp_value = _n(pcd.get("value"))
 
-    overhead_amt = round(cost_of_work * oh_pct / 100, 2)
-    fee_amt = round((cost_of_work + overhead_amt) * fee_pct / 100, 2)
-    contingency_amt = round(direct["budget"] * cont_pct / 100, 2)
+    # MONEY-SCOPE — these are the GMP's own markup lines, and `fee_amt` COMPOUNDS on `overhead_amt`,
+    # so a half-cent taken the wrong way propagates rather than staying local. `round()` is
+    # ROUND_HALF_EVEN; a contract rounds half away from zero, which is what `money.retainage` does.
+    overhead_amt = money.retainage(cost_of_work, oh_pct)
+    fee_amt = money.retainage(cost_of_work + overhead_amt, fee_pct)
+    contingency_amt = money.retainage(direct["budget"], cont_pct)
     overhead = _category("overhead", f"Overhead ({oh_pct}%)", [_line("Home-office overhead", overhead_amt)])
     fee = _category("fee", f"Fee / Profit ({fee_pct}%)", [_line("Fee", fee_amt)])
     contingency = _category("contingency", f"GC Contingency ({cont_pct}%)", [_line("Contingency", contingency_amt)])

--- a/services/api/src/aec_api/wip.py
+++ b/services/api/src/aec_api/wip.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
-from . import cost
+from . import cost, money
 from . import modules as me
 from .models import Project
 
@@ -121,11 +121,23 @@ def schedule(db: Session, pid: str, method: str = "cost-to-cost", with_model: bo
     # over/under-billing, which `accounting.journal_entries` then posts back as the WIP-ADJ revenue-
     # recognition line, so one refused invoice moves the ledger twice by two different routes.
     from .project_budget import OWNER_INVOICE_NOT_BILLED
-    billed = round(me.sum_field(db, "owner_invoice", pid, "amount",
-                                exclude_states=list(OWNER_INVOICE_NOT_BILLED))
-                   if "owner_invoice" in me.TABLES else 0.0, 2)
-    retainage = round(cost.g703(db, pid)["totals"].get("retainage", 0.0)
-                      or (cost.DEFAULT_RETAINAGE / 100 * billed), 2)
+    billed = money.q2(me.sum_field(db, "owner_invoice", pid, "amount",
+                                   exclude_states=list(OWNER_INVOICE_NOT_BILLED))
+                      if "owner_invoice" in me.TABLES else 0.0)
+    # MONEY-SCOPE — `or` treated an EXPLICIT 0% retainage as an absent one (cost.py:49 records the
+    # same shape under the name FIN-SUITE-BLIND), so a contract the owner agreed to hold nothing on
+    # reported 5% of everything billed as retainage held. The comment above says `billed` drives
+    # over/under-billing, which posts to the ledger, so an invented figure moves it twice.
+    #
+    # The condition is COMPLETED WORK, not the mere existence of an SOV: retainage is withheld from
+    # what has been earned, so a schedule of values with nothing completed has no basis to state one
+    # and the estimate is the only answer available. With work completed, the SOV's figure is
+    # authoritative INCLUDING when it is zero. (The first draft of this keyed on `sov["lines"]` and
+    # broke `test_wip`, which bills against an SOV that records no progress — an existing test
+    # catching a predicate that was right about the defect and too broad about the remedy.)
+    sov = cost.g703(db, pid)
+    retainage = (money.q2(sov["totals"].get("retainage", 0.0)) if sov["totals"].get("completed")
+                 else money.q2(cost.DEFAULT_RETAINAGE / 100 * billed))
 
     cost_pct = cost_to_date / estimated_cost if estimated_cost else 0.0
     cost_pct = max(0.0, min(1.0, cost_pct))

--- a/services/api/test_money_spine.py
+++ b/services/api/test_money_spine.py
@@ -94,16 +94,35 @@ def main() -> int:
                    and isinstance(n.right, ast.Constant) and n.right.value == 100
                    for n in ast.walk(node))
 
+    def _ndigits(call: ast.Call):
+        """`round()`'s second argument, however it was PASSED — positionally or as `ndigits=`.
+
+        `round(x, ndigits=2)` is valid Python and returns the same HALF-EVEN answer as
+        `round(x, 2)` (measured: `round(2.675, ndigits=2)` is 2.67). The first version of this scan
+        read `n.args[1]` and missed it — **which is this file's own lesson one turn later.** The old
+        predicate depended on a NAME and the surviving site used an abbreviation; the replacement
+        dropped the name and still depended on a syntactic FORM. A reviewer caught it.
+        """
+        for kw in call.keywords:
+            if kw.arg == "ndigits":
+                return kw.value
+        return call.args[1] if len(call.args) >= 2 else None
+
     def scan(text: str) -> list[int]:
         """Line numbers where money is quantized to cents by `round()` over a percentage."""
         try:
             tree = ast.parse(text)
         except SyntaxError:
             return []
-        return [n.lineno for n in ast.walk(tree)
-                if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "round"
-                and len(n.args) == 2 and isinstance(n.args[1], ast.Constant) and n.args[1].value == 2
-                and _divides_by_100(n.args[0])]
+        out = []
+        for n in ast.walk(tree):
+            if not (isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                    and n.func.id == "round" and n.args):
+                continue
+            nd = _ndigits(n)
+            if isinstance(nd, ast.Constant) and nd.value == 2 and _divides_by_100(n.args[0]):
+                out.append(n.lineno)
+        return out
 
     # **Prove the scan before believing it.** A clean report over a clean tree is indistinguishable
     # from a broken detector, and this exact file already shipped one that could not see the defect
@@ -111,9 +130,14 @@ def main() -> int:
     PRE_FIX_PAID = 'x = round(paid + amt * (1 - ret_pct / 100), 2)'      # PENNY-SPLIT, no "retain"
     PRE_FIX_RETAINAGE = 'x = round(completed * retainage_pct / 100, 2)'  # what the old scan caught
     DISPLAY_PCT = 'x = round(100 * done / total, 1)'                     # a percentage, not money
+    KEYWORD_FORM = 'x = round(amt * pct / 100, ndigits=2)'               # same result, other spelling
     check("the scan finds the form that DEFEATED the old lexical one",
           scan(PRE_FIX_PAID) == [1],
           "`ret_pct` contains no 'retain'; the old predicate required that substring and missed it")
+    check("...and the KEYWORD form, which the first structural draft also missed",
+          scan(KEYWORD_FORM) == [1],
+          "round(x, ndigits=2) is valid Python and returns the same HALF-EVEN answer — "
+          "a reviewer caught this file repeating its own lesson one layer along")
     check("...and still finds the form the old one did catch — the twin",
           scan(PRE_FIX_RETAINAGE) == [1])
     check("...and does NOT flag a display percentage rounded to 1dp",

--- a/services/api/test_money_spine.py
+++ b/services/api/test_money_spine.py
@@ -70,28 +70,76 @@ def main() -> int:
           not mismatch,
           f"{len(CASES)} cases, no disagreement" if not mismatch else f"DIVERGED on {mismatch}")
 
-    # --- every site now uses it, read from the source ------------------------------------------------
+    # --- every site now uses it, DERIVED from the source ---------------------------------------
     #
     # The point of this file is that ONE site kept the old arithmetic for two releases while the
-    # release note said the tree was done. So the population is read, not remembered.
+    # release note said the tree was done. So the population is read, not remembered — and until
+    # MONEY-SCOPE it was remembered anyway, twice over:
+    #
+    #   1. It scanned a HARDCODED list of three files. Five more sites lived outside them —
+    #      `evm.py`, `project_budget.py` (x3) and `wip.py`, the last of them computing retainage,
+    #      which is this file's own subject.
+    #   2. Its predicate required the literal substring "retain" ON THE LINE. The site PENNY-SPLIT
+    #      fixed reads `round(row["paid"] + amt * (1 - ret_pct / 100), 2)` — it matched `round(`
+    #      and `/ 100` and was MISSED, because `ret_pct` does not contain "retain".
+    #
+    # **The third term was a spelling, and the site that survived used an abbreviation.** The scan
+    # is now structural: `round(<expression containing a division by 100>, 2)`, over every file,
+    # naming nothing. A variable rename cannot hide from it.
+    import ast
     from pathlib import Path
-    src = Path(__file__).resolve().parent / "src" / "aec_api"
-    offenders = []
-    for rel in ("cost.py", "routers/cost.py", "payapp.py"):
-        for i, line in enumerate((src / rel).read_text(encoding="utf-8").splitlines(), 1):
-            stripped = line.strip()
-            if stripped.startswith("#") or stripped.startswith('"'):
-                continue                  # a comment describing the old form is not the old form
-            if "round(" in line and "/ 100" in line and "retain" in line.lower():
-                offenders.append(f"{rel}:{i}")
-    check("no site computes retainage with float round() any more",
-          not offenders,
-          f"{offenders}" if offenders else "cost.py, routers/cost.py and payapp.py all quantize")
 
-    planted = "x = round(amt * retainage_pct / 100, 2)"
-    check("...and the scan can still SEE that form — the twin",
-          "round(" in planted and "/ 100" in planted and "retain" in planted.lower(),
-          "a source scan that matches nothing reports every tree as clean")
+    def _divides_by_100(node: ast.AST) -> bool:
+        return any(isinstance(n, ast.BinOp) and isinstance(n.op, ast.Div)
+                   and isinstance(n.right, ast.Constant) and n.right.value == 100
+                   for n in ast.walk(node))
+
+    def scan(text: str) -> list[int]:
+        """Line numbers where money is quantized to cents by `round()` over a percentage."""
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            return []
+        return [n.lineno for n in ast.walk(tree)
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "round"
+                and len(n.args) == 2 and isinstance(n.args[1], ast.Constant) and n.args[1].value == 2
+                and _divides_by_100(n.args[0])]
+
+    # **Prove the scan before believing it.** A clean report over a clean tree is indistinguishable
+    # from a broken detector, and this exact file already shipped one that could not see the defect
+    # it was named for. Both historical forms must be found; a display percentage must not be.
+    PRE_FIX_PAID = 'x = round(paid + amt * (1 - ret_pct / 100), 2)'      # PENNY-SPLIT, no "retain"
+    PRE_FIX_RETAINAGE = 'x = round(completed * retainage_pct / 100, 2)'  # what the old scan caught
+    DISPLAY_PCT = 'x = round(100 * done / total, 1)'                     # a percentage, not money
+    check("the scan finds the form that DEFEATED the old lexical one",
+          scan(PRE_FIX_PAID) == [1],
+          "`ret_pct` contains no 'retain'; the old predicate required that substring and missed it")
+    check("...and still finds the form the old one did catch — the twin",
+          scan(PRE_FIX_RETAINAGE) == [1])
+    check("...and does NOT flag a display percentage rounded to 1dp",
+          scan(DISPLAY_PCT) == [],
+          "a scan that matches everything is as useless as one that matches nothing")
+
+    src = Path(__file__).resolve().parent / "src" / "aec_api"
+    files = sorted(src.rglob("*.py"))
+    offenders = [f"{f.relative_to(src)}:{ln}" for f in files
+                 for ln in scan(f.read_text(encoding="utf-8"))]
+    check("no site in aec_api quantizes money to cents with float round()",
+          not offenders,
+          f"{offenders}" if offenders
+          else f"scanned {len(files)} files, structurally, naming nothing")
+
+    # **Assert the SCOPE, not only the verdict.** With the tree clean, narrowing this scan back to a
+    # handful of files would pass silently — which is exactly how it spent two releases reporting a
+    # tree it was not reading. So the population is pinned to the whole package: every module that
+    # holds money must be inside it, and the four that historically did are named as a floor.
+    scanned = {str(f.relative_to(src)) for f in files}
+    must_reach = {"cost.py", "routers/cost.py", "payapp.py", "wip.py",
+                  "evm.py", "project_budget.py"}
+    check("the scan reaches every module, not a remembered handful",
+          must_reach <= scanned and len(files) > 100,
+          f"{len(files)} files; missing {sorted(must_reach - scanned)}" if must_reach - scanned
+          else f"{len(files)} files, including the 3 the old scan listed and the 3 it did not")
 
     # --- the absence rule a truthiness test breaks -----------------------------------------------------
     check("an explicit 0% rate is honoured, not replaced by the default",

--- a/services/api/test_penny_split.py
+++ b/services/api/test_penny_split.py
@@ -140,5 +140,31 @@ with TestClient(app) as c:
           partly["billed"] == 2.50 and partly["retainage"] == 0.13 and partly["paid"] == 0.0,
           f"{partly} — the identity above is scoped to fully-paid subs, not universal")
 
+# ---- MONEY-SCOPE: a 0% retainage contract, in a second engine ---------------------------------
+#
+# Lives here rather than in its own file because it is the same claim one layer along — a money row
+# must report what the project actually holds. `wip.py` computed
+#
+#     round(g703_totals.get("retainage", 0.0) or (DEFAULT_RETAINAGE / 100 * billed), 2)
+#
+# and `or` treats an EXPLICIT 0% as an absent one. `cost.py:49` records this exact shape under the
+# name FIN-SUITE-BLIND and fixed it there; this is the instance that survived, in the engine whose
+# own comment says `billed` drives over/under-billing and posts back to the ledger. The SOV's answer
+# is now used whenever an SOV exists; the estimate is a fallback for having no schedule of values,
+# not for a schedule that legitimately holds nothing.
+zpid = c.post("/projects", json={"name": "Zero Retainage", "number": "ZR-1"}).json()["id"]
+mk(c, zpid, "sov", {"item_no": "01", "description": "Sitework", "scheduled_value": 100_000,
+                    "completed_this": 40_000, "retainage_pct": 0})
+mk(c, zpid, "owner_invoice", {"number": "INV-1", "amount": 40_000, "period": "2026-01"})
+wip = c.get(f"/projects/{zpid}/wip").json()
+check("the WIP fixture actually billed something",
+      wip.get("billed_to_date") == 40_000.0,
+      f"billed_to_date={wip.get('billed_to_date')} — with nothing billed the 5% fallback would be "
+      "0 anyway and the assertion below would pass on the broken code")
+check("WIP honours an explicit 0% retainage instead of substituting the 5% default",
+      wip.get("retainage") == 0.0,
+      f"retainage={wip.get('retainage')} on a 0%-retainage contract billing "
+      f"{wip.get('billed_to_date')} — the pre-fix `or` would report 5% of billed")
+
 print(("FAILED: " + "; ".join(FAILED)) if FAILED else "test_penny_split OK")
 raise SystemExit(1 if FAILED else 0)


### PR DESCRIPTION
# What & why

`services/api/test_money_spine.py` opens: *"One rounding convention for retainage, asserted at **every site** that computes it."* Both halves of that were false.

- It scanned a **hardcoded list of three files** — `cost.py`, `routers/cost.py`, `payapp.py`.
- Its predicate required the literal substring **`retain` on the line**. The site #473 just fixed reads `round(row["paid"] + amt * (1 - ret_pct / 100), 2)` — it matched `round(` **and** `/ 100`, and was missed, because **`ret_pct` does not contain `retain`**.

**The third term was a spelling, and the site that survived used an abbreviation.** Measured, not inferred — the old predicate run against both historical lines reports `MISSED` on one and `SEEN` on the other.

## Five more sites, in three files the old list never named

A name-free AST scan — `round(<expression dividing by 100>, 2)` over *every* file:

| site | what it is | severity |
|---|---|---|
| `project_budget.py` ×3 | the GMP's overhead, fee and contingency — **fee compounds on overhead** | same class as #473 |
| `evm.py` | earned value in dollars | **low, and stated as such**: `model_pct` is already 1dp, so the penny sits below its own input's precision and the `> 5%` flag can't turn on it |
| `wip.py` | **retainage — this gate's own subject, in a file it did not read** | same class as #473 |

## And `wip.py` carried a worse defect the rounding sweep walked into

It computed `g703_retainage or (DEFAULT_RETAINAGE / 100 * billed)`, and `or` treats an **explicit 0%** as absent. `cost.py:49` records this exact shape under the name **FIN-SUITE-BLIND** and fixed it there; this is the instance that survived — in the engine whose own comment says `billed` drives over/under-billing and posts back to the ledger.

**Mutation-measured: a 0%-retainage contract billing $40,000 reported $2,000 held.**

**My first fix for it was too broad, and an existing test caught that.** I keyed on `sov["lines"]`, which broke `test_wip` — it bills against an SOV recording no progress. The right condition is **completed work**: retainage is withheld from what has been *earned*, so a schedule of values with nothing completed has no basis to state one and the estimate is the only answer available. With work completed the SOV is authoritative, *including when it says zero*.

## The gate now asserts its own SCOPE, not only its verdict

With the tree clean, narrowing the scan back to three files would pass silently — which is precisely how it spent two releases reporting a tree it wasn't reading. It now pins the population to every `.py` under `aec_api` and names the six modules that must be inside it. Three probes prove the predicate **in both directions**: it must find the form that defeated the old scan, still find the form the old scan caught, and **not** flag a display percentage rounded to 1dp.

*A named, already-fixed class is not closed until its population is derived — three sweeps running have now each found a survivor of one.*

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree)
- [x] Backend: affected `test_*.py` pass — **680/680 suites, exit 0**. Four mutations checked: scan blinded, scan narrowed to 3 files, `wip` fix reverted, and the pre-fix probe.
- [x] Web: not applicable — no files under `apps/web/` are touched
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; `R43-MASSINGBILL-CORE` roadmap entry extended
- [ ] Version bump — not a release PR
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Financial amounts now consistently round to the nearest cent.
  * Work-in-progress reports honor explicitly configured 0% retainage.
  * Retainage is no longer replaced by a default percentage when no retainage is held.

* **Tests**
  * Expanded automated coverage for cent-based rounding and zero-retainage scenarios.
  * Broadened validation across financial calculations, including positional and keyword rounding cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->