### PR TITLE
FIELD-POISON: one capture the server refuses jammed the whole offline queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### a field capture the server refuses no longer blocks the ones behind it
+
+Offline field capture queued everything and retried everything. Any failure re-queued the item
+unchanged, with no distinction between a server that was unreachable and a server that had answered
+"no". So a capture the server will never accept — a validation failure, or a worker removed from the
+project between capturing and reconnecting — was resent on every reconnect for as long as the app
+was installed. The sync badge never cleared, the queue sheet showed the item as merely "pending"
+with no reason, and the worker's only recourse was to discard captures one at a time until the badge
+went away, guessing which one was poisoned.
+
+A permanent refusal is now recorded on the item with the reason, and that item is not retried again.
+It is **not discarded** — the capture stays in the queue, marked, so the person who took it decides
+what happens to it. The sheet counts pending and refused separately and says why each refusal
+happened; **Sync now** stops being blocked by items that cannot sync.
+
+The rule for "permanent" is deliberately narrow: a 4xx other than 408 and 429, both of which
+explicitly invite a retry. Everything else — offline, DNS, 5xx, a proxy dropping the connection —
+stays a retry, because **guessing "permanent" wrongly loses a field worker's capture, and guessing
+"transient" wrongly only costs another attempt.** The asymmetry sets the default, not a judgement
+about which failures are more likely.
+
+The status had to become reachable first. The API client threw `Error("POST /path -> 400")`, which
+puts the status somewhere only a string match can read; a classifier keyed on that spelling is the
+brittleness the rounding-scan work had just finished removing elsewhere. `HttpError` now carries the
+status as a field, extends `Error`, and keeps the identical message — so it is additive and no
+existing `catch` had to change.
+
 ### six more money figures round the way an invoice rounds — and a 0% retainage stays 0%
 
 The previous entry fixed one line. The check that was supposed to cover the whole tree could not

--- a/apps/web/src/api/httpCore.ts
+++ b/apps/web/src/api/httpCore.ts
@@ -11,6 +11,24 @@ const DEFAULT_API = import.meta.env.VITE_API_URL ?? (import.meta.env.DEV ? "http
 /** Handle for a resilient SSE subscription (see `HttpCore.liveStream`). */
 export interface LiveStream { readonly connected: boolean; close(): void }
 
+/** An HTTP failure that still carries its STATUS, not only a message describing it.
+ *
+ *  `json()` has always thrown `Error("POST /path -> 400")`, which puts the status somewhere only a
+ *  string parse can reach. A caller that needs to tell a PERMANENT rejection from a transient one —
+ *  the offline field queue is the first, and re-queueing a 400 forever is what it did — would have
+ *  had to match on the message text. That is the same brittleness MONEY-SCOPE removed from a
+ *  different scan: a predicate keyed on a spelling breaks the moment the spelling changes.
+ *
+ *  It extends `Error` and keeps the identical message, so every existing `catch` keeps working and
+ *  nothing has to be migrated. Callers that care about the status opt in.
+ */
+export class HttpError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
 export class HttpCore {
   private token = localStorage.getItem("aec-token") || "";
   constructor(protected baseUrl = DEFAULT_API) {}
@@ -60,7 +78,7 @@ export class HttpCore {
       ...init,
       headers: { "Content-Type": "application/json", ...this.authHeaders(), ...(init?.headers || {}) },
     });
-    if (!res.ok) throw new Error(`${init?.method ?? "GET"} ${path} -> ${res.status}`);
+    if (!res.ok) throw new HttpError(`${init?.method ?? "GET"} ${path} -> ${res.status}`, res.status);
     return res.json() as Promise<T>;
   }
 

--- a/apps/web/src/field/field.ts
+++ b/apps/web/src/field/field.ts
@@ -5,6 +5,7 @@
  * (and on load). Pairs with the PWA/Capacitor build so it's usable as an installed app in the field.
  */
 import type { ApiClient } from "../api/client";
+import { HttpError } from "../api/httpCore";
 import { currentIdentity, ownedByMe } from "../api/identity";
 import { toast } from "./../ui/feedback";
 import { attachDictation } from "./dictate";
@@ -22,6 +23,9 @@ export interface QueuedCapture {
   filename?: string;
   label?: string;      // human type label, for the queue-review list
   owner?: string;      // who captured this; absent on entries from before scoping
+  /** Why the server refused this permanently. Set only for a rejection that RETRYING CANNOT FIX,
+   *  so the review sheet can say what happened instead of showing it as forever-pending. */
+  rejected?: string;
 }
 
 interface GeoFix { lat: number; lon: number; acc: number; }
@@ -240,14 +244,22 @@ export class FieldCapture {
       + "border-radius:14px 14px 0 0;padding:18px;width:100%;max-width:520px;display:flex;flex-direction:column;gap:8px;max-height:92vh;overflow:auto";
     const render = () => {
       const q = loadQueue();
-      card.innerHTML = `<div style="font-weight:650;font-size:16px">🗂 Offline queue — ${q.length} pending</div>`;
+      const pending = q.filter((x) => !x.rejected).length;
+      const refused = q.length - pending;
+      card.innerHTML = `<div style="font-weight:650;font-size:16px">🗂 Offline queue — ${pending} pending`
+        + `${refused ? ` · ${refused} refused` : ""}</div>`;
       if (!q.length) card.insertAdjacentHTML("beforeend", `<div class="meta">All caught up — nothing queued.</div>`);
       for (const it of q) {
         const rowEl = document.createElement("div");
         rowEl.style.cssText = "display:flex;align-items:center;gap:8px;border-top:1px solid var(--line,#2b2d31);padding:8px 0";
         const geo = it.data.gps_lat ? ` · 📍 ${it.data.gps_lat},${it.data.gps_lon}` : "";
-        rowEl.innerHTML = `<span style="font-size:18px">${it.photo ? "🖼" : "📝"}</span>`
-          + `<span style="flex:1;font-size:13px">${(it.label || it.module)} — ${String(it.data.subject || "").slice(0, 60)}${geo}</span>`;
+        // A refused capture says WHY. It is still here — never discarded on the worker's behalf —
+        // but it is no longer retried, so it cannot hold the rest of the queue behind it.
+        const why = it.rejected
+          ? `<div style="font-size:12px;color:var(--danger,#e5534b)">⚠ ${it.rejected} — retrying will not help</div>`
+          : "";
+        rowEl.innerHTML = `<span style="font-size:18px">${it.rejected ? "⚠" : it.photo ? "🖼" : "📝"}</span>`
+          + `<span style="flex:1;font-size:13px">${(it.label || it.module)} — ${String(it.data.subject || "").slice(0, 60)}${geo}${why}</span>`;
         const del = document.createElement("button"); del.className = "tool-btn"; del.textContent = "✕"; del.title = "Discard";
         del.onclick = () => { saveQueue(loadQueue().filter((x) => x.id !== it.id)); this.refreshBadge(); render(); };
         rowEl.append(del); card.append(rowEl);
@@ -255,7 +267,7 @@ export class FieldCapture {
       const actions = document.createElement("div"); actions.style.cssText = "display:flex;gap:8px;justify-content:flex-end;margin-top:8px";
       const close = document.createElement("button"); close.className = "tool-btn"; close.textContent = "Close"; close.onclick = () => ov.remove();
       const sync = document.createElement("button"); sync.className = "file-btn"; sync.textContent = navigator.onLine ? "Sync now" : "Offline";
-      sync.disabled = !navigator.onLine || !q.length;
+      sync.disabled = !navigator.onLine || !pending;
       sync.onclick = async () => { sync.disabled = true; sync.textContent = "Syncing…"; await this.flush(); render(); };
       actions.append(close, sync); card.append(actions);
     };
@@ -272,18 +284,42 @@ export class FieldCapture {
     if (!q.length) return;
     const remaining: QueuedCapture[] = [];
     let synced = 0;
-    for (const item of q) {
+    let rejected = 0;
+    for (const item of q.filter((x) => !x.rejected)) {
       try {
         const rec = await this.api.createModuleRecord(item.pid, item.module, { data: item.data });
         if (item.photo) await this.api.uploadAttachment(item.pid, item.module, rec.id,
           dataUrlToFile(item.photo, item.filename || "field.jpg"));
         synced++;
-      } catch { remaining.push(item); }
+      } catch (e) {
+        const why = permanentRejection(e);
+        if (why) { remaining.push({ ...item, rejected: why }); rejected++; }
+        else remaining.push(item);
+      }
     }
-    saveQueue(remaining);
+    // Items already marked rejected are carried through untouched: not retried, not discarded.
+    saveQueue([...q.filter((x) => x.rejected), ...remaining]);
     this.refreshBadge();
     if (synced) toast(`Synced ${synced} field capture${synced > 1 ? "s" : ""}`, "success");
+    if (rejected) toast(`${rejected} capture${rejected > 1 ? "s" : ""} refused — open the queue to see why`, "error");
   }
+}
+
+/** Why the server will NEVER accept this capture, or null if the failure is worth retrying.
+ *
+ *  4xx means the request itself is wrong — a validation failure, or the capturer no longer has
+ *  access to the project — and repeating it byte for byte cannot change the answer. 408 and 429 are
+ *  the exceptions: both explicitly invite a retry. Everything else (offline, DNS, 5xx, a proxy
+ *  eating the connection) is transient by default, because **guessing "permanent" wrongly loses a
+ *  field worker's capture, and guessing "transient" wrongly only costs another attempt.** The
+ *  asymmetry decides the default.
+ */
+function permanentRejection(e: unknown): string | null {
+  const status = e instanceof HttpError ? e.status : 0;
+  if (status < 400 || status >= 500 || status === 408 || status === 429) return null;
+  if (status === 403 || status === 401) return "No longer permitted on this project";
+  if (status === 404) return "The project or module no longer exists";
+  return `Refused by the server (${status})`;
 }
 
 function label(text: string, control: HTMLElement): HTMLElement {

--- a/apps/web/src/field/fieldQueue.test.ts
+++ b/apps/web/src/field/fieldQueue.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { identityScope } from "../api/identity";
-import { type QueuedCapture, loadAll, loadQueue, saveQueue } from "./field";
+import { HttpError } from "../api/httpCore";
+import { FieldCapture, type QueuedCapture, loadAll, loadQueue, saveQueue } from "./field";
 
 const signInAs = (t: string) => localStorage.setItem("aec-token", t);
 const capture = (id: string, owner?: string): QueuedCapture =>
@@ -59,5 +60,92 @@ describe("field captures on a shared tablet", () => {
   it("corrupt storage reads as empty rather than throwing", () => {
     localStorage.setItem("aec-field-queue", "{not json");
     expect(loadQueue()).toEqual([]);
+  });
+});
+
+describe("FIELD-POISON — a capture the server will never accept", () => {
+  // The queue used to re-push EVERY failure, so a 400 was retried on every reconnect: the badge
+  // never cleared, the review sheet showed it as merely "pending", and the worker's only recourse
+  // was a bare ✕ with nothing saying why. Worse, a poisoned item sat in front of the good ones.
+  //
+  // The asymmetry that decides the design: calling a transient failure permanent LOSES a field
+  // worker's capture; calling a permanent one transient costs one more request. So only a 4xx that
+  // cannot change on repeat is treated as final — and even then the item is KEPT, marked with a
+  // reason, never silently discarded.
+  const mkApi = (fail: (item: QueuedCapture) => Error | null) => {
+    const created: string[] = [];
+    return {
+      created,
+      createModuleRecord: async (pid: string, module: string, body: { data: Record<string, unknown> }) => {
+        const err = fail({ id: String(body.data.subject), pid, module, data: body.data });
+        if (err) throw err;
+        created.push(String(body.data.subject));
+        return { id: `rec-${body.data.subject}` };
+      },
+      uploadAttachment: async () => ({}),
+    };
+  };
+
+  const queue = (...subjects: string[]) =>
+    subjects.map((s) => ({ id: s, pid: "p1", module: "punchlist", data: { subject: s } }));
+
+  /** `flush()` is only reachable after `mount()` in the app — the badge hangs off the FAB that
+   *  mount creates — so the tests drive that lifecycle rather than reaching past it. Mounting on an
+   *  empty queue is a no-op flush, so the fixture is queued afterwards. */
+  const mounted = (api: unknown) => {
+    document.body.innerHTML = "";
+    const fc = new FieldCapture(api as never, () => "p1");
+    fc.mount();
+    return fc;
+  };
+
+  it("a 400 does not hold the good captures behind it", async () => {
+    const api = mkApi((it) => (it.id === "poison" ? new HttpError("POST -> 400", 400) : null));
+    const fc = mounted(api);
+    saveQueue(queue("poison", "good") as QueuedCapture[]);
+    await fc.flush();
+
+    expect(api.created).toEqual(["good"]);                       // the good one went through
+    const left = loadQueue();
+    expect(left.map((x) => x.id)).toEqual(["poison"]);           // only the refused one remains
+    expect(left[0]?.rejected).toBeTruthy();                      // ...and it says why
+  });
+
+  it("a refused capture is not retried again, but is never discarded either", async () => {
+    const api = mkApi(() => new HttpError("POST -> 400", 400));
+    const fc = mounted(api);
+    saveQueue(queue("poison") as QueuedCapture[]);
+    await fc.flush();
+    const afterFirst = loadQueue();
+
+    // second flush: the server is not asked again, and the capture is still there for the worker
+    const api2 = mkApi(() => { throw new Error("must not be called for an already-refused item"); });
+    await mounted(api2).flush();
+    expect(api2.created).toEqual([]);
+    expect(loadQueue()).toEqual(afterFirst);
+  });
+
+  it("a 5xx or a network drop stays a plain retry — losing a capture is the worse error", async () => {
+    let attempts = 0;
+    const api = mkApi(() => { attempts++; return attempts === 1 ? new HttpError("POST -> 503", 503) : null; });
+    const fc = mounted(api);
+    saveQueue(queue("flaky") as QueuedCapture[]);
+    await fc.flush();
+    expect(loadQueue()[0]?.rejected).toBeUndefined();            // not marked final
+    await fc.flush();
+    expect(api.created).toEqual(["flaky"]);                      // and it lands on the retry
+    expect(loadQueue()).toEqual([]);
+  });
+
+  it("408 and 429 invite a retry and are NOT treated as final", async () => {
+    for (const status of [408, 429]) {
+      const api = mkApi(() => new HttpError(`POST -> ${status}`, status));
+      const fc = mounted(api);
+      saveQueue(queue(`s${status}`) as QueuedCapture[]);
+      await fc.flush();
+      const [only] = loadQueue();
+      expect(only, `status ${status}: the fixture must leave exactly one item`).toBeDefined();
+      expect(only?.rejected, `status ${status}`).toBeUndefined();
+    }
   });
 });

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2651,7 +2651,7 @@ is recorded. Filed under Decisions below.
 | 09 | tools panel mixes verbs with analyses | *(none)* | ✅ **v0.3.848** — `R24-TOOLS-SPLIT` cut the 1087-line `qa` section in two; Analyse is its own rail item |
 | 10 | finance numbers have no provenance | R24-TRACE-UI | 🟡 v0.3.775 shipped trace for *cost coverage*; the proforma chain (IRR ← NOI ← rent roll ← area ← GUID) — the audit's actual demo — is not built |
 | 11 | density | R24-DENSITY | ✅ **SHIPPED v0.3.996** — three steps on registers (`DENSITY_ROW_PX`), not dashboards only |
-| 12 | mobile is a bottom sheet in a desktop IA | R24-FIELD-MODE | ◧ **v0.3.1001–1008** — mode, 56 px, strip, dictation, capture landing, **room tabs hidden in field mode**. Portal home rewrite still Lane A |
+| 12 | mobile is a bottom sheet in a desktop IA | R24-FIELD-MODE | ◧ **v0.3.1001–1008** — mode, 56 px, strip, dictation, capture landing, **room tabs hidden in field mode**, **a refused capture no longer jams the offline queue**. Portal home rewrite still Lane A |
 | 13 | search is scoped to modules | R24-CMDK-VERBS | ✅ **v0.3.946** — verbs, elements, reports and an assistant fallback; `apps/web/src/ui/paletteProviders.ts`. Fixed a second defect on the way: async hits were `concat`ed onto an already-grouped list, so a record landed under a **second** RECORDS heading below Modules |
 | 14 | empty states | R24-EMPTY-GUIDE | ✅ **verified done 2026-08-14** — the "24 lines, 'no project' only" reading is stale by a wide margin. `apps/web/src/ui/empty.ts` is 156 lines and R36-EMPTY-STATE shipped the hard part: a register with no rows distinguishes **none / filtered / failed**, because those send a reader to three different places and rendering them identically was the defect. Plus acronym-safe nouns ("No rfis yet" was the bug), `textContent` throughout since the name and the error body are untrusted, and `data-empty` so a test can assert WHICH kind was decided. Curated hints in `apps/web/src/ui/emptyGuide.ts` (157 lines), wired at two `register.ts` call sites, covered by `apps/web/src/ui/empty.test.ts` and `apps/web/src/ui/emptyGuide.test.ts` |
 | 15 | charts have no grammar | *(none)* | ✅ **SHIPPED v0.3.1002** — no-data, ticks/legend/currency, then series vs status (`SERIES_PALETTE` / `STATUS_*` in `apps/web/src/ui/charts.ts`) |
@@ -2711,6 +2711,27 @@ refute one, so this goes first even though it is the least visible.
   Slice ②: field-mode CSS beats the FAB's inline 52 px. Slice ③: with a project open, field mode
   **lands on the capture sheet** (`shouldOpenCaptureHome`). Slice ④: `#workspaces` is hidden while
   the mode is on, so the seven-room tablist is not field home. Replacing the portal shell is Lane A.
+  **Slice ⑤ — FIELD-POISON: the offline queue could not be emptied.** Premise-checking this entry
+  found `apps/web/src/field/field.ts`'s flush doing `catch { remaining.push(item) }` — every failure
+  re-queued, with **no distinction between a server that was unreachable and a server that had
+  answered "no"**. One capture the server will never accept (a validation failure, or a worker
+  removed from the project between capturing and reconnecting) was resent on every reconnect
+  forever; the badge never cleared, and the review sheet showed it as *pending* with no reason, so
+  the only recourse was discarding captures one at a time until the badge went away. A permanent
+  refusal is now recorded on the item with its reason and not retried — **and not discarded**: the
+  worker decides. `apps/web/src/field/fieldQueue.test.ts` gates the behaviour, not the spelling: a
+  400 must not hold good captures behind it, a refused item must be neither retried nor lost, and
+  5xx/408/429 must stay retries.
+  **The design is decided by an asymmetry, not by a probability**: guessing "permanent" wrongly
+  loses a field worker's capture; guessing "transient" wrongly costs one more attempt. So the
+  permanent set is the narrow one (4xx except 408/429) and everything else defaults to retry.
+  It needed a *structural* signal first. `json()` threw ``Error(`POST /path -> 400`)``, putting the
+  status where only a string match could reach it — the exact spelling-dependence MONEY-SCOPE had
+  just removed from the rounding scan, one directory over. `apps/web/src/api/httpCore.ts` now
+  exports `HttpError`, carrying `status` as a field while extending `Error` with the identical
+  message, so it is purely additive and none of the ~50 existing `catch` sites changed. *A
+  classifier is only as good as the signal it is allowed to see; parsing a message would have
+  shipped the same brittleness under a new name.*
 - 🟡 **R24-REPORTS-BY-MOMENT** — **grouping SHIPPED v0.3.785; assemble SHIPPED v0.3.1015; a package is
   now SCHEDULABLE — only the deployment decision below is left.** The catalog was
   **56 reports under 18 group headings, six holding a single report**. Seven packages now sit above


### PR DESCRIPTION
> **Note**
> Body below mirrors `.github/pull_request_template.md`.

# What & why

`apps/web/src/field/field.ts` flushed the offline capture queue with `catch { remaining.push(item) }`
— every failure re-queued the item unchanged, with **nothing distinguishing a server that was
unreachable from a server that had answered "no"**. So a capture the server will never accept (a
validation failure, or a worker removed from the project between capturing on site and reconnecting)
was resent on every reconnect for as long as the app stayed installed: the sync badge never cleared,
the review sheet showed the item as merely *pending* with no reason, and the worker's only recourse
was discarding captures one at a time until the badge went away, guessing which one was poisoned.
Found by premise-checking **R24-FIELD-MODE**, which this lands as slice ⑤.

A permanent refusal is now recorded on the item with its reason and skipped on later flushes. It is
**not discarded** — the capture stays in the queue, marked, and the person who took it decides. The
sheet counts pending and refused separately, prints the reason per item, and **Sync now** is enabled
on pending work rather than on queue length.

The permanent set is deliberately narrow: a 4xx other than 408 and 429, both of which explicitly
invite a retry. Everything else — offline, DNS, 5xx, a proxy dropping the connection — stays a retry,
because **guessing "permanent" wrongly loses a field worker's capture, and guessing "transient"
wrongly costs one more request.** The asymmetry sets the default, not a judgement about which
failures are more likely.

The status had to become *readable* first. `json()` threw ``Error(`POST /path -> 400`)``, which puts
the status where only a string match can reach it — the same spelling-dependence
`services/api/test_money_spine.py` had just finished removing from the rounding scan, one directory
over. `apps/web/src/api/httpCore.ts` now exports `HttpError` carrying `status` as a field while
extending `Error` with the identical message, so the change is purely additive and none of the ~50
existing `catch` sites moved.

`apps/web/src/field/fieldQueue.test.ts` gates the **behaviour**, not the spelling: a 400 must not hold
good captures behind it; a refused item must be neither retried nor lost; a 5xx must land on the
retry; 408/429 must not be marked final. Four mutations checked, including the dangerous direction —
treating every failure as permanent, which loses captures — and that one is caught.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree — "All checks passed!")
- [x] Backend: full suite from `services/api` via `run_tests.py` — **680/680 suites passed** (1118s
      wall, 3 parallel; 0 databases and 0 storage dirs left behind). No backend source changed;
      `test_claude_md_gates.py` re-run for the new roadmap citations (448 across 4 docs, all resolve)
- [x] Web: `npm run typecheck && npm run lint && npm run build` clean; `npx vitest run src/field/` 26/26
- [x] No import cycles introduced (`no-import-cycles.test.ts` passes)
- [x] `CHANGELOG.md` entry added (newest at top); `docs/roadmap.md` R24-FIELD-MODE slice ⑤ + lane row 12
- [ ] Version bumped in both manifests — n/a, not a release PR (matching #472–#474)
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Offline sync queues now distinguish permanently refused captures from temporary failures.
  * Permanently refused captures are retained with a reason and are no longer retried or discarded.
  * Other failures, including server errors, timeouts, and rate limits, continue to retry.
  * A refused capture no longer blocks successfully syncable captures from being uploaded.

* **User Interface**
  * Queue review now shows separate pending and refused counts.
  * Refused captures display the reason they could not be synced.
  * Sync controls reflect the number of pending captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->