### PR TITLE
RESP-ORPHAN: the RACI banner said "complete" over a grid with nothing in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### the responsibility matrix stops telling you it is complete when it is not
+
+Load a second starter template into a RACI matrix that already has rows and the columns changed
+under them. The earlier rows survived — the dialog promises they will — but every letter on them was
+now keyed to a role column that no longer existed, so those rows rendered as blank lines. And the
+validation banner still said **"Every activity has exactly one Accountable and at least one
+Responsible"**, because it counted assignments the grid had no cell to draw.
+
+Validity is now counted over the columns you can actually see, so a row whose letters have been
+orphaned reads as what it is: no Accountable, no Responsible. The letters are not lost — the banner
+names the columns they are stranded on, and offers to **restore those columns** (nothing was
+deleted, so bringing them back makes the assignments visible again) or to **clear them** if they are
+genuinely finished with.
+
+Applying a template no longer replaces your columns either: when the matrix already has rows, the
+template's roles are merged in after yours instead of taking their place. If that would push past
+the sixteen-column limit the whole thing is refused before anything is written, rather than
+truncating and orphaning the very rows it was about to create.
+
 ### you can now see which property values this element overrides — and put them back
 
 The viewer has always let you set a property on a selected element. It has never shown you that a

--- a/apps/web/src/portal/panels/raciValidation.test.ts
+++ b/apps/web/src/portal/panels/raciValidation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import CASES from "./raciValidationCases.json";
+import { orphanedRoles, validateMatrix } from "./raciValidation";
+import type { ResponsibilityMatrix } from "../../api/client";
+
+/**
+ * RESP-ORPHAN — the rule, and the parity fixture the server has to agree with.
+ *
+ * `raciValidationCases.json` is shared ground: the same rule is implemented in
+ * `services/api/src/aec_api/responsibility.py::_validate`, and the two had already drifted apart —
+ * the client counted every assignment while the grid renders only the current columns, so a row
+ * whose letters were all orphaned reported itself complete over a visibly blank line.
+ *
+ * The cases are read from the file rather than written inline **so that the file is load-bearing**.
+ * A fixture nothing reads is a fixture that can rot; `runs every parity case` fails if the file
+ * empties out, for the same reason the derivation checks elsewhere in this repo floor their
+ * populations — a check that has quietly stopped checking looks exactly like one with nothing to
+ * report.
+ */
+
+interface Case {
+  name: string;
+  roles: string[];
+  doer: string;
+  rows: { ref: string; activity: string; assignments: Record<string, string> }[];
+  expect: {
+    clean: boolean;
+    missing: { ref: string; activity: string; count: number }[];
+    noR: { ref: string; activity: string }[];
+    unknown: string[];
+    load: Record<string, number>;
+  };
+}
+
+// TS infers a union of the literal shapes from the JSON, which does not widen to `Case` — the fixture is
+// validated by the assertions below and by the Python side reading the same file, not by this cast.
+const cases = (CASES as unknown as { cases: Case[] }).cases;
+
+function matrix(c: Case): ResponsibilityMatrix {
+  return {
+    mode: c.doer === "D" ? "DACI" : "RACI",
+    letters: c.doer === "D" ? ["D", "A", "C", "I"] : ["R", "A", "C", "I"],
+    doer: c.doer,
+    roles: c.roles,
+    rows: c.rows.map((r) => ({
+      id: r.ref, ref: r.ref, activity: r.activity,
+      phase: null, category: null, milestone: null, reference: null,
+      assignments: r.assignments,
+    })),
+    count: c.rows.length,
+    validation: { missing_accountable: [], no_responsible: [], unknown_role: [],
+      accountable_load: {}, clean: true },
+    summary: { activities: c.rows.length, clean: true, issues: 0 },
+  };
+}
+
+describe("the RACI rule is computed over the columns the user can see", () => {
+  it("has parity cases to run", () => {
+    // The fixture is the contract with the Python side; an empty one would let every assertion
+    // below pass over nothing.
+    expect(cases.length, "raciValidationCases.json has no cases").toBeGreaterThanOrEqual(5);
+  });
+
+  for (const c of cases) {
+    it(`${c.name}`, () => {
+      const v = validateMatrix(matrix(c));
+      expect(v.clean).toBe(c.expect.clean);
+      expect(v.missing).toEqual(c.expect.missing);
+      expect(v.noR).toEqual(c.expect.noR);
+      expect(orphanedRoles(v)).toEqual([...c.expect.unknown].sort());
+      expect(v.load).toEqual(c.expect.load);
+    });
+  }
+
+  it("an orphaned assignment is reported with the letter it still carries", () => {
+    // `unknown` is not just a list of role names: the letter is what tells the user whether the
+    // invisible cell was an Accountable they are about to lose or an Informed they will not miss.
+    const v = validateMatrix(matrix({
+      name: "x", roles: ["Owner"], doer: "R",
+      rows: [{ ref: "R-9", activity: "Closeout", assignments: { Owner: "A", "Old Sub": "R" } }],
+      expect: { clean: true, missing: [], noR: [], unknown: [], load: {} },
+    }));
+    expect(v.unknown).toEqual([{ ref: "R-9", activity: "Closeout", role: "Old Sub", letter: "R" }]);
+  });
+
+  it("survives a partial payload", () => {
+    // The offline demo snapshot lacks this endpoint and the panel normalises around it; the
+    // validator must not throw on the way through.
+    const bare = { mode: "RACI", doer: "R" } as unknown as ResponsibilityMatrix;
+    expect(validateMatrix(bare).clean).toBe(true);
+  });
+});

--- a/apps/web/src/portal/panels/raciValidation.ts
+++ b/apps/web/src/portal/panels/raciValidation.ts
@@ -1,0 +1,71 @@
+import type { ResponsibilityMatrix } from "../../api/client";
+
+/**
+ * RESP-ORPHAN — the RACI rule, computed over the columns the user can actually SEE.
+ *
+ * ## Why this exists as its own module
+ *
+ * The rule lives in two languages and cannot be deduplicated across that boundary. The server
+ * computes it in `services/api/src/aec_api/responsibility.py::_validate` and returns it as
+ * `matrix.validation`; the panel needs it again locally because a cell edit repaints the banner
+ * without a round-trip. Two copies of one rule is a defect waiting to happen, and it already had:
+ * the panel's inline copy counted `Object.values(r.assignments)` — **every** assignment — while the
+ * grid renders only `m.roles`.
+ *
+ * A role column can go away under rows that reference it. `apply_template` appends rows and used to
+ * replace the columns; removing or renaming a column patches each row one request at a time, so a
+ * failure part-way leaves the rest behind. Either way an assignment can end up keyed by a role that
+ * is not a column — and it is then **invisible**, because the grid has no cell to draw it in. The
+ * old count still saw it, so a row whose every letter had been orphaned reported *"exactly one
+ * Accountable and at least one Responsible"* while the user looked at a blank line.
+ *
+ * So: `missing`/`noR` are counted over VISIBLE assignments only, and the orphans are reported
+ * separately as `unknown` rather than discarded — that list is the only thing that explains why the
+ * row looks empty. `load` is likewise over visible columns, since crediting a role that is not in
+ * the matrix overstates a real person's ownership.
+ *
+ * ## Parity is asserted, not assumed
+ *
+ * `raciValidation.test.ts` runs the cases in `raciValidationCases.json`, and
+ * `services/api/test_responsibility.py` is where the same rule is proved server-side. The shared
+ * fixture is what stops the two implementations drifting apart again; extracting this function from
+ * the panel is what makes it testable at all.
+ */
+export interface RaciVerdict {
+  /** Rows without exactly one Accountable, counted over visible columns. */
+  missing: { ref: string | null; activity: string; count: number }[];
+  /** Rows with no doer (R in RACI, D in DACI), counted over visible columns. */
+  noR: { ref: string | null; activity: string }[];
+  /** Assignments keyed by a role that is not a column — invisible in the grid. */
+  unknown: { ref: string | null; activity: string; role: string; letter: string }[];
+  /** How many activities each visible role is Accountable for. */
+  load: Record<string, number>;
+  /** The rule verdict. Orphans are reported but do not by themselves make a row invalid. */
+  clean: boolean;
+}
+
+export function validateMatrix(m: ResponsibilityMatrix): RaciVerdict {
+  const roles = new Set(m.roles ?? []);
+  const missing: RaciVerdict["missing"] = [];
+  const noR: RaciVerdict["noR"] = [];
+  const unknown: RaciVerdict["unknown"] = [];
+  const load: Record<string, number> = {};
+  for (const r of m.rows ?? []) {
+    const entries = Object.entries(r.assignments ?? {});
+    const visible = entries.filter(([role]) => roles.has(role));
+    const a = visible.filter(([, v]) => v === "A").length;
+    const d = visible.filter(([, v]) => v === m.doer).length;
+    if (a !== 1) missing.push({ ref: r.ref ?? null, activity: r.activity, count: a });
+    if (d < 1) noR.push({ ref: r.ref ?? null, activity: r.activity });
+    for (const [role, letter] of entries) {
+      if (!roles.has(role)) unknown.push({ ref: r.ref ?? null, activity: r.activity, role, letter });
+      else if (letter === "A") load[role] = (load[role] ?? 0) + 1;
+    }
+  }
+  return { missing, noR, unknown, load, clean: !missing.length && !noR.length };
+}
+
+/** The distinct role names that rows reference but the matrix has no column for. */
+export function orphanedRoles(v: RaciVerdict): string[] {
+  return [...new Set(v.unknown.map((u) => u.role))].sort();
+}

--- a/apps/web/src/portal/panels/raciValidation.ts
+++ b/apps/web/src/portal/panels/raciValidation.ts
@@ -44,6 +44,15 @@ export interface RaciVerdict {
   clean: boolean;
 }
 
+/**
+ * Role columns a matrix may carry. **Mirrors `MAX_ROLES` in
+ * `services/api/src/aec_api/responsibility.py`**, which truncates any longer list rather than
+ * refusing it — so a caller that sends more silently loses the tail. `test_responsibility.py`
+ * asserts the two constants agree, because a client guard set to the wrong number is worse than
+ * no guard: it would refuse valid restores while still letting the real overflow through.
+ */
+export const MAX_ROLES = 16;
+
 export function validateMatrix(m: ResponsibilityMatrix): RaciVerdict {
   const roles = new Set(m.roles ?? []);
   const missing: RaciVerdict["missing"] = [];

--- a/apps/web/src/portal/panels/raciValidationCases.json
+++ b/apps/web/src/portal/panels/raciValidationCases.json
@@ -1,0 +1,64 @@
+{
+  "_comment": "RESP-ORPHAN parity fixture. The RACI rule exists in TWO implementations that cannot be deduplicated across the language boundary: services/api/src/aec_api/responsibility.py::_validate and apps/web/src/portal/panels/raciValidation.ts::validateMatrix. They already disagreed once — the client counted every assignment while the grid renders only the current columns — so these cases are the shared ground both must land on. Add a case here when the rule changes, and change both sides.",
+  "cases": [
+    {
+      "name": "clean row",
+      "roles": ["Owner", "GC / PM"],
+      "doer": "R",
+      "rows": [{ "ref": "R-1", "activity": "Shop drawings", "assignments": { "Owner": "A", "GC / PM": "R" } }],
+      "expect": { "clean": true, "missing": [], "noR": [], "unknown": [], "load": { "Owner": 1 } }
+    },
+    {
+      "name": "every letter orphaned onto removed columns",
+      "roles": ["Client", "Task Team"],
+      "doer": "R",
+      "rows": [{ "ref": "R-1", "activity": "Author models", "assignments": { "Architect/EOR": "A", "Sub": "R" } }],
+      "expect": {
+        "clean": false,
+        "missing": [{ "ref": "R-1", "activity": "Author models", "count": 0 }],
+        "noR": [{ "ref": "R-1", "activity": "Author models" }],
+        "unknown": ["Architect/EOR", "Sub"],
+        "load": {}
+      }
+    },
+    {
+      "name": "rule satisfied on visible cells but an orphan remains",
+      "roles": ["Owner", "GC / PM"],
+      "doer": "R",
+      "rows": [{ "ref": "R-1", "activity": "RFIs", "assignments": { "Owner": "A", "GC / PM": "R", "Sub": "C" } }],
+      "expect": {
+        "clean": true,
+        "missing": [],
+        "noR": [],
+        "unknown": ["Sub"],
+        "load": { "Owner": 1 }
+      }
+    },
+    {
+      "name": "two Accountables on visible columns",
+      "roles": ["Owner", "GC / PM"],
+      "doer": "R",
+      "rows": [{ "ref": "R-1", "activity": "Budget", "assignments": { "Owner": "A", "GC / PM": "A" } }],
+      "expect": {
+        "clean": false,
+        "missing": [{ "ref": "R-1", "activity": "Budget", "count": 2 }],
+        "noR": [{ "ref": "R-1", "activity": "Budget" }],
+        "unknown": [],
+        "load": { "Owner": 1, "GC / PM": 1 }
+      }
+    },
+    {
+      "name": "DACI — the doer letter is D, and an orphaned D does not count",
+      "roles": ["Approver", "Driver"],
+      "doer": "D",
+      "rows": [{ "ref": "R-1", "activity": "Pick a facade", "assignments": { "Approver": "A", "Old Driver": "D" } }],
+      "expect": {
+        "clean": false,
+        "missing": [],
+        "noR": [{ "ref": "R-1", "activity": "Pick a facade" }],
+        "unknown": ["Old Driver"],
+        "load": { "Approver": 1 }
+      }
+    }
+  ]
+}

--- a/apps/web/src/portal/panels/responsibility.test.ts
+++ b/apps/web/src/portal/panels/responsibility.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PanelContext } from "../panelContext";
+import { renderResponsibility } from "./responsibility";
+
+/**
+ * RESP-ORPHAN — the claim about the SCREEN, not about the rule.
+ *
+ * `raciValidation.test.ts` proves the verdict is computed over visible columns. That is a claim
+ * about a FUNCTION. This is the claim about the PANEL: a validator that returns the right answer
+ * into a banner still painting "✅ Every activity has exactly one Accountable" would satisfy the
+ * first test completely and leave the user looking at the same lie.
+ *
+ * The distinction has bitten this repo before — a button built, returned, destructured and appended
+ * to nothing typechecks perfectly — so these assertions drive the real DOM and read what is on it.
+ */
+
+const el = () => document.createElement("div");
+
+const ORPHANED = {
+  mode: "RACI", letters: ["R", "A", "C", "I"], doer: "R",
+  roles: ["Client", "Task Team"],
+  rows: [{ id: "1", ref: "RESP-001", activity: "Author models",
+    phase: null, category: null, milestone: null, reference: null,
+    assignments: { "Architect/EOR": "A", "GC / PM": "R" } }],
+  count: 1,
+  validation: { missing_accountable: [], no_responsible: [], unknown_role: [],
+    accountable_load: {}, clean: true },
+  summary: { activities: 1, clean: true, issues: 0 },
+};
+
+/**
+ * The row satisfies the rule on its VISIBLE columns and still carries a letter on one that is gone.
+ *
+ * Added because the first draft of this file could not express it: `ORPHANED` has every letter
+ * orphaned, so `clean` is already false and the early return is never reached — mutating the
+ * banner's orphan guard away left all four tests green. A fixture that cannot reach the branch
+ * reports the check as passing, which is the same shape as the defect under test.
+ */
+const CLEAN_BUT_ORPHANED = {
+  ...ORPHANED,
+  rows: [{ ...ORPHANED.rows[0]!,
+    assignments: { Client: "A", "Task Team": "R", "Architect/EOR": "C" } }],
+};
+
+const CLEAN = {
+  ...ORPHANED,
+  roles: ["Client", "Task Team"],
+  rows: [{ ...ORPHANED.rows[0]!, assignments: { Client: "A", "Task Team": "R" } }],
+};
+
+const flush = async () => { for (let i = 0; i < 6; i++) await Promise.resolve(); };
+
+function ctx(matrix: unknown, over: Record<string, unknown> = {}) {
+  const api = {
+    responsibilityMatrix: vi.fn().mockResolvedValue(structuredClone(matrix)),
+    responsibilityTemplates: vi.fn().mockResolvedValue({ templates: [] }),
+    setResponsibilityConfig: vi.fn().mockResolvedValue({ roles: [], mode: "RACI" }),
+    applyResponsibilityTemplate: vi.fn().mockResolvedValue({ created: 0 }),
+    updateModuleRecord: vi.fn().mockResolvedValue({}),
+    createModuleRecord: vi.fn().mockResolvedValue({ id: "x" }),
+    deleteModuleRecord: vi.fn().mockResolvedValue({}),
+    ...over,
+  };
+  const c: PanelContext = {
+    root: el(),
+    host: { projectId: () => "p1", api } as unknown as PanelContext["host"],
+    mods: [], activeKey: "responsibility",
+    bar: (title: string) => { const b = el(); b.textContent = title; return b; },
+    buildNav: () => undefined, renderHome: async () => undefined, openModule: async () => undefined,
+    navigate: () => undefined, hasDest: () => true,
+  } as unknown as PanelContext;
+  return { c, api };
+}
+
+describe("the RACI banner answers for assignments the grid cannot show", () => {
+  it("does NOT claim the matrix is complete when every letter is on a removed column", async () => {
+    // This is the defect verbatim: `apply_template` swapped the columns under an existing row, so
+    // the row rendered blank and the banner called it complete.
+    const { c } = ctx(ORPHANED);
+    await renderResponsibility(c); await flush();
+    const text = c.root.textContent ?? "";
+    expect(text, "the banner asserted completeness over an unshowable row")
+      .not.toContain("✅ Every activity has exactly one Accountable");
+    expect(text).toContain("Architect/EOR");
+    expect(text).toContain("GC / PM");
+    expect(text).toMatch(/no longer has/);
+  });
+
+  it("does NOT claim completeness when the rule passes but an orphan remains", async () => {
+    // The narrow branch: `clean` is true and there is still a letter the grid cannot draw. The
+    // ✅ has to answer for it, or the panel is silently dropping a "C" the user assigned.
+    const { c } = ctx(CLEAN_BUT_ORPHANED);
+    await renderResponsibility(c); await flush();
+    const text = c.root.textContent ?? "";
+    expect(text, "the ✅ was painted over an assignment the grid cannot show")
+      .not.toContain("✅ Every activity has exactly one Accountable");
+    expect(text).toContain("Architect/EOR");
+  });
+
+  it("still shows the ✅ when the matrix really is clean", async () => {
+    // Without this the test above passes for the wrong reason — a banner that never says ✅ at all
+    // would satisfy it, and that is a different defect rather than a fix.
+    const { c } = ctx(CLEAN);
+    await renderResponsibility(c); await flush();
+    expect(c.root.textContent ?? "").toContain("✅ Every activity has exactly one Accountable");
+  });
+
+  it("offers to restore the missing columns, and asks for exactly them", async () => {
+    const { c, api } = ctx(ORPHANED);
+    await renderResponsibility(c); await flush();
+    const restore = [...c.root.querySelectorAll("button")]
+      .find((b) => (b.textContent ?? "").includes("Restore"));
+    expect(restore, "no restore control was rendered").toBeTruthy();
+    restore!.click(); await flush();
+    expect(api.setResponsibilityConfig).toHaveBeenCalledTimes(1);
+    const [, roles] = api.setResponsibilityConfig.mock.calls[0]!;
+    // the existing columns are kept and the orphans are appended — restoring must not drop columns
+    expect(roles).toEqual(["Client", "Task Team", "Architect/EOR", "GC / PM"]);
+  });
+
+  it("does not offer a repair when there is nothing to repair", async () => {
+    const { c } = ctx(CLEAN);
+    await renderResponsibility(c); await flush();
+    const buttons = [...c.root.querySelectorAll("button")].map((b) => b.textContent ?? "");
+    expect(buttons.some((t) => t.includes("Restore"))).toBe(false);
+    expect(buttons.some((t) => t.includes("Clear them"))).toBe(false);
+  });
+});

--- a/apps/web/src/portal/panels/responsibility.test.ts
+++ b/apps/web/src/portal/panels/responsibility.test.ts
@@ -15,6 +15,14 @@ import { renderResponsibility } from "./responsibility";
  * to nothing typechecks perfectly — so these assertions drive the real DOM and read what is on it.
  */
 
+// The clear path is behind a confirmation. jsdom never clicks it, so the real `confirmModal`
+// leaves a promise pending forever and the test reads as "the button did nothing" — which is
+// indistinguishable from the defect. Auto-confirm so the assertions are about the clear itself.
+vi.mock("../../ui/modal", () => ({
+  confirmModal: () => Promise.resolve(true),
+  promptModal: () => Promise.resolve(null),
+}));
+
 const el = () => document.createElement("div");
 
 const ORPHANED = {
@@ -117,6 +125,56 @@ describe("the RACI banner answers for assignments the grid cannot show", () => {
     const [, roles] = api.setResponsibilityConfig.mock.calls[0]!;
     // the existing columns are kept and the orphans are appended — restoring must not drop columns
     expect(roles).toEqual(["Client", "Task Team", "Architect/EOR", "GC / PM"]);
+  });
+
+  it("refuses a Restore that would overflow the column cap, rather than truncating", async () => {
+    // Raised in review, and it is this item's own defect through its own repair button: set_config
+    // TRUNCATES a longer list and returns 200 with the visible roles first, so the orphans fall off
+    // the tail and the banner reloads clean over assignments that are still stranded.
+    const WIDE = {
+      ...ORPHANED,
+      roles: Array.from({ length: 16 }, (_, i) => `Role ${i}`),   // exactly at the cap
+    };
+    const { c, api } = ctx(WIDE);
+    await renderResponsibility(c); await flush();
+    const restore = [...c.root.querySelectorAll("button")]
+      .find((b) => (b.textContent ?? "").includes("Restore")) as HTMLButtonElement | undefined;
+    expect(restore, "the restore control should still be shown, explaining why it cannot run")
+      .toBeTruthy();
+    expect(restore!.disabled, "restore must not be armed when it cannot fit").toBe(true);
+    expect(restore!.title).toMatch(/16-column limit/);
+    restore!.click(); await flush();
+    expect(api.setResponsibilityConfig, "an over-long restore must not reach the server")
+      .not.toHaveBeenCalled();
+  });
+
+  it("re-reads after a partial clear instead of showing state the server refused", async () => {
+    // Each row is its own PATCH. On a mid-loop failure the panel must not keep rendering the
+    // in-memory assignments it optimistically emptied. Raised in review.
+    const TWO_ROWS = {
+      ...ORPHANED,
+      rows: [
+        { ...ORPHANED.rows[0]!, id: "1", ref: "RESP-001" },
+        { ...ORPHANED.rows[0]!, id: "2", ref: "RESP-002" },
+      ],
+      count: 2,
+    };
+    let calls = 0;
+    const { c, api } = ctx(TWO_ROWS, {
+      updateModuleRecord: vi.fn().mockImplementation(() => {
+        calls += 1;
+        return calls === 1 ? Promise.resolve({}) : Promise.reject(new Error("500"));
+      }),
+    });
+    await renderResponsibility(c); await flush();
+    const reads = api.responsibilityMatrix.mock.calls.length;
+    const clear = [...c.root.querySelectorAll("button")]
+      .find((b) => (b.textContent ?? "").includes("Clear them")) as HTMLButtonElement | undefined;
+    expect(clear).toBeTruthy();
+    clear!.click(); await flush(); await flush();
+    expect(api.responsibilityMatrix.mock.calls.length,
+      "a partial failure must re-read, not leave the panel ahead of the server")
+      .toBeGreaterThan(reads);
   });
 
   it("does not offer a repair when there is nothing to repair", async () => {

--- a/apps/web/src/portal/panels/responsibility.test.ts
+++ b/apps/web/src/portal/panels/responsibility.test.ts
@@ -59,9 +59,20 @@ const CLEAN = {
 
 const flush = async () => { for (let i = 0; i < 6; i++) await Promise.resolve(); };
 
-function ctx(matrix: unknown, over: Record<string, unknown> = {}) {
+/**
+ * A FRESH clone on every read, because the panel mutates what it was handed.
+ *
+ * `mockResolvedValue(structuredClone(m))` captures ONE object and hands the same instance back to
+ * every read. The clear handler assigns `r.assignments = keep` before awaiting, so a reload after a
+ * failed PATCH re-read the row the client had already emptied — and a test asserting "the panel
+ * shows what the server has" could not fail, because the mock had no server state distinct from the
+ * client's. Raised in review. Cloning per call means client mutation can never leak back, and
+ * `queue` lets a test state what the server holds on the NEXT read.
+ */
+function ctx(matrix: unknown, over: Record<string, unknown> = {}, queue: unknown[] = []) {
   const api = {
-    responsibilityMatrix: vi.fn().mockResolvedValue(structuredClone(matrix)),
+    responsibilityMatrix: vi.fn().mockImplementation(() =>
+      Promise.resolve(structuredClone(queue.length ? queue.shift() : matrix))),
     responsibilityTemplates: vi.fn().mockResolvedValue({ templates: [] }),
     setResponsibilityConfig: vi.fn().mockResolvedValue({ roles: [], mode: "RACI" }),
     applyResponsibilityTemplate: vi.fn().mockResolvedValue({ created: 0 }),
@@ -159,13 +170,23 @@ describe("the RACI banner answers for assignments the grid cannot show", () => {
       ],
       count: 2,
     };
+    // What the SERVER holds after the first PATCH commits and the second is rejected: row 1 cleared,
+    // row 2 still carrying its orphaned letters. Queued as a distinct response, because asserting
+    // only that a re-read happened proves nothing about what the re-read showed — raised in review.
+    const AFTER_PARTIAL = {
+      ...TWO_ROWS,
+      rows: [
+        { ...TWO_ROWS.rows[0]!, assignments: {} },
+        { ...TWO_ROWS.rows[1]! },
+      ],
+    };
     let calls = 0;
     const { c, api } = ctx(TWO_ROWS, {
       updateModuleRecord: vi.fn().mockImplementation(() => {
         calls += 1;
         return calls === 1 ? Promise.resolve({}) : Promise.reject(new Error("500"));
       }),
-    });
+    }, [TWO_ROWS, AFTER_PARTIAL]);
     await renderResponsibility(c); await flush();
     const reads = api.responsibilityMatrix.mock.calls.length;
     const clear = [...c.root.querySelectorAll("button")]
@@ -175,6 +196,13 @@ describe("the RACI banner answers for assignments the grid cannot show", () => {
     expect(api.responsibilityMatrix.mock.calls.length,
       "a partial failure must re-read, not leave the panel ahead of the server")
       .toBeGreaterThan(reads);
+    // ...and the re-read must be what is RENDERED: the row the server still holds is still reported.
+    const text = c.root.textContent ?? "";
+    expect(text, "the banner must still report the orphan the server did not clear")
+      .toMatch(/no longer has/);
+    expect(text).toContain("Architect/EOR");
+    expect(text, "a partial clear is not a clean matrix")
+      .not.toContain("✅ Every activity has exactly one Accountable");
   });
 
   it("does not offer a repair when there is nothing to repair", async () => {

--- a/apps/web/src/portal/panels/responsibility.ts
+++ b/apps/web/src/portal/panels/responsibility.ts
@@ -1,4 +1,5 @@
 import type { ResponsibilityMatrix, RespRow } from "../../api/client";
+import { orphanedRoles, validateMatrix } from "./raciValidation";
 import { escapeHtml as esc, toast } from "../../ui/feedback";
 import { confirmModal, promptModal } from "../../ui/modal";
 import { noProjectHtml } from "../../ui/empty";
@@ -55,25 +56,14 @@ export async function renderResponsibility(ctx: PanelContext) {
     render(m);
   };
 
-  // patch one record's assignments (a cell edit) — local re-validate keeps the banner instant.
+  // patch one record's assignments (a cell edit). The banner repaints from `validateMatrix`
+  // rather than a round-trip, which is why that rule exists client-side at all — see
+  // `raciValidation.ts` for why it is a shared-fixture parity problem rather than duplication.
   const saveCell = async (row: RespRow, role: string, letter: string) => {
     if (letter) row.assignments[role] = letter; else delete row.assignments[role];
     try { await api.updateModuleRecord(pid, "responsibility", row.id, { assignments: row.assignments }); }
     catch { toast("Couldn't save that change", "error"); }
   };
-
-  function localValidation(m: ResponsibilityMatrix) {
-    const missing: { activity: string; count: number }[] = [];
-    const noR: { activity: string }[] = [];
-    for (const r of m.rows) {
-      const vals = Object.values(r.assignments);
-      const a = vals.filter((v) => v === "A").length;
-      const d = vals.filter((v) => v === m.doer).length;
-      if (a !== 1) missing.push({ activity: r.activity, count: a });
-      if (d < 1) noR.push({ activity: r.activity });
-    }
-    return { missing, noR, clean: !missing.length && !noR.length };
-  }
 
   function render(m: ResponsibilityMatrix) {
     const isRaci = m.mode === "RACI";
@@ -172,11 +162,52 @@ export async function renderResponsibility(ctx: PanelContext) {
     tb.append(csvBtn);
     body.append(tb);
 
+    // --- RESP-ORPHAN repair ----------------------------------------------------------------------
+    // Two ways out, and restoring is offered first because it is the non-destructive one: the
+    // letters are still on the records, so bringing the columns back makes them visible again with
+    // nothing lost. Clearing is the deliberate discard, and it says how many it will drop.
+    function orphanRepair(m: ResponsibilityMatrix, orphans: string[]): HTMLElement {
+      const row = el("div"); row.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;margin-top:6px";
+      const restore = el("button", "tool-btn") as HTMLButtonElement;
+      restore.textContent = `↩ Restore ${orphans.length} column(s)`;
+      restore.title = `Add ${orphans.join(", ")} back as columns so their assignments show again`;
+      restore.onclick = async () => {
+        restore.disabled = true;
+        try { await api.setResponsibilityConfig(pid, [...m.roles, ...orphans], m.mode); void load(); }
+        catch { toast("Couldn't restore those columns", "error"); restore.disabled = false; }
+      };
+      const clear = el("button", "tool-btn") as HTMLButtonElement;
+      clear.textContent = "🗑 Clear them";
+      clear.title = "Delete the assignments on those columns from every row";
+      clear.onclick = async () => {
+        if (!(await confirmModal(`Clear assignments on ${orphans.length} removed column(s)?`,
+          "The letters on those columns are deleted from every row. This cannot be undone."))) return;
+        clear.disabled = true;
+        try {
+          for (const r of m.rows) {
+            const keep = Object.fromEntries(
+              Object.entries(r.assignments).filter(([role]) => !orphans.includes(role)));
+            if (Object.keys(keep).length !== Object.keys(r.assignments).length) {
+              r.assignments = keep;
+              await api.updateModuleRecord(pid, "responsibility", r.id, { assignments: keep });
+            }
+          }
+          void load();
+        } catch { toast("Couldn't clear those assignments", "error"); clear.disabled = false; }
+      };
+      row.append(restore, clear);
+      return row;
+    }
+
     // --- validation banner ----------------------------------------------------------------------
     const banner = el("div"); banner.id = "resp-banner"; body.append(banner);
     const paintBanner = () => {
-      const v = localValidation(m);
-      if (v.clean) {
+      const v = validateMatrix(m);
+      const orphans = orphanedRoles(v);
+      // The ✅ has to answer for the orphans too. A row can satisfy the rule on its visible cells
+      // and still carry letters on columns that are gone; calling that "complete" without saying so
+      // is the same silence the count itself used to keep.
+      if (v.clean && !orphans.length) {
         banner.className = "meta"; banner.style.cssText = "margin-bottom:8px;color:var(--status-good)";
         banner.textContent = m.rows.length ? "✅ Every activity has exactly one Accountable and at least one Responsible."
           : "";
@@ -189,7 +220,16 @@ export async function renderResponsibility(ctx: PanelContext) {
       if (none.length) parts.push(`<div>⚠️ <b>No ${isRaci ? "Accountable" : "Approver"}</b> — every row needs exactly one: ${none.join(", ")}</div>`);
       if (dup.length) parts.push(`<div>⚠️ <b>More than one ${isRaci ? "Accountable" : "Approver"}</b>: ${dup.join(", ")}</div>`);
       if (v.noR.length) parts.push(`<div>⚠️ <b>No ${isRaci ? "Responsible" : "Driver"}</b> — needs at least one doer: ${v.noR.map((x) => esc(x.activity)).join(", ")}</div>`);
+      // RESP-ORPHAN — the finding that explains a blank row. Without it the grid shows an empty
+      // line and nothing anywhere says the letters still exist.
+      if (orphans.length) {
+        parts.push(`<div>⚠️ <b>${v.unknown.length} assignment(s) on ${orphans.length} column(s) `
+          + `this matrix no longer has</b> — they are stored but cannot be shown: `
+          + `${orphans.map(esc).join(", ")}. Restore the columns to see them, or clear them to drop `
+          + `them for good.</div>`);
+      }
       banner.innerHTML = `<div class="meta" style="font-size:12px">${parts.join("")}</div>`;
+      if (orphans.length) banner.appendChild(orphanRepair(m, orphans));
     };
     paintBanner();
 

--- a/apps/web/src/portal/panels/responsibility.ts
+++ b/apps/web/src/portal/panels/responsibility.ts
@@ -1,5 +1,5 @@
 import type { ResponsibilityMatrix, RespRow } from "../../api/client";
-import { orphanedRoles, validateMatrix } from "./raciValidation";
+import { MAX_ROLES, orphanedRoles, validateMatrix } from "./raciValidation";
 import { escapeHtml as esc, toast } from "../../ui/feedback";
 import { confirmModal, promptModal } from "../../ui/modal";
 import { noProjectHtml } from "../../ui/empty";
@@ -171,7 +171,19 @@ export async function renderResponsibility(ctx: PanelContext) {
       const restore = el("button", "tool-btn") as HTMLButtonElement;
       restore.textContent = `↩ Restore ${orphans.length} column(s)`;
       restore.title = `Add ${orphans.join(", ")} back as columns so their assignments show again`;
+      // REFUSE RATHER THAN OVERFLOW. `set_config` TRUNCATES a longer list and returns 200, and the
+      // visible roles go first — so an over-long restore drops the orphans off the tail, reloads
+      // clean, and leaves the assignments exactly as stranded as before. That is this whole item's
+      // defect arriving through its own repair button; the server-side merge in `apply_template`
+      // refuses for the same reason. Raised in review.
+      const fits = m.roles.length + orphans.length <= MAX_ROLES;
+      restore.disabled = !fits;
+      restore.title = fits
+        ? `Add ${orphans.join(", ")} back as columns so their assignments show again`
+        : `Restoring ${orphans.length} column(s) would need ${m.roles.length + orphans.length} of a `
+          + `${MAX_ROLES}-column limit — remove unused columns first, or clear these assignments.`;
       restore.onclick = async () => {
+        if (!fits) return;
         restore.disabled = true;
         try { await api.setResponsibilityConfig(pid, [...m.roles, ...orphans], m.mode); void load(); }
         catch { toast("Couldn't restore those columns", "error"); restore.disabled = false; }
@@ -193,7 +205,14 @@ export async function renderResponsibility(ctx: PanelContext) {
             }
           }
           void load();
-        } catch { toast("Couldn't clear those assignments", "error"); clear.disabled = false; }
+        } catch {
+          // Each row is its own PATCH, so a failure part-way leaves earlier rows cleared. Re-read
+          // rather than leaving the panel showing in-memory state the server never accepted: the
+          // banner then reports what is actually still stranded, and clearing again is idempotent.
+          // Raised in review — see the reply for why this is not a transactional bulk endpoint.
+          toast("Couldn't clear all of those — reloading to show what remains", "error");
+          void load();
+        }
       };
       row.append(restore, clear);
       return row;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -352,6 +352,80 @@ Seven of eleven engines once shipped with no route. The R32 filing-spine entries
 band are all closed and recorded in [`roadmap-completed.md`](roadmap-completed.md). The current
 instances:
 
+- ◧ **DEAD-FIELD — a route with no caller is caught by a gate; a PAYLOAD with no reader is caught by
+  nobody** *(one instance CLOSED in this change; the sweep is NOT done)*
+
+  `test_route_reachability` asks whether a route is called. Nothing asks whether the answer it
+  returns is *read*. PROP-OVERRIDE was found by hand: the route and the client method each had a
+  caller, so every reachability check passed, and the single caller discarded the fields that
+  mattered. The population was then derived rather than guessed — every field of every
+  `export interface` under `apps/web/src/api/`, against every reference anywhere in
+  `apps/web/src`, minus the declaring file:
+
+  | | |
+  |---|---|
+  | declared response fields with **no reader** in the web tree | **43** |
+  | ├ **live defect** — a wrong answer rather than a gap | **4** *(closed here)* |
+  | ├ finding-shaped — silence degrades an answer without inverting it | ~8 |
+  | └ detail — legitimately not displayed | ~31 |
+
+  **The four were `ResponsibilityMatrix.validation.*`, and they were the load-bearing kind: the
+  panel asserted the OPPOSITE of the truth.** See RESP-ORPHAN below.
+
+  **The ~8 share a signature worth naming: each is the CAVEAT on a number that IS shown.**
+  `ReviewCycles.rounds_undated` sits beside a days-split computed only over dated rounds — and
+  `apps/web/src/portal/panels/design.ts` handles the sibling `rounds_open` with exactly the right
+  care (*"counted but not scored"*) and misses this one. `MakeReady.window_days` is the denominator
+  of a ready/blocked pair. `BidLevelingDetail.recommendation.responsiveness` is the caveat on an
+  apparent-low recommendation. `PrequalScores.not_in_pool` names who was excluded from a pool whose
+  size is displayed. `PreflightSummary.blocking_checks` names what a HOLD override just bypassed.
+
+  **Deliberately NOT gated yet, and that is a judgement rather than an omission.** A gate over this
+  axis needs an allowlist of the ~31 legitimate cases, and an allowlist nobody has triaged is a
+  freeze list that rots — the exact failure the `KNOWN_UNCALLED` heading recorded when four of its
+  entries turned out to have callers. Triage the ~8 first; the allowlist is only honest once the
+  remainder has been read. **The 43 is reproducible, not remembered:** it is a field-vs-reference
+  scan over `apps/web/src`, and re-deriving it is cheaper than trusting this number.
+
+- ✅ **RESP-ORPHAN — the RACI banner said "complete" over a grid with nothing in it** *(S — Lane C;
+  **CLOSED**, fix in this change)*
+
+  The first DEAD-FIELD instance found by derivation rather than by reading, and the worst kind: not
+  a missing detail but an inverted verdict.
+
+  `apply_template` appends rows and **replaced** the role columns, and the ISO-19650 template ships
+  its own. Load a second template into a matrix that already has rows and every earlier assignment
+  is keyed to a column that no longer exists. The grid iterates the current roles, so those rows
+  render as blank lines — while `_validate` counted `assignments.values()` entire, so the banner
+  reported *"Every activity has exactly one Accountable and at least one Responsible."* The panel's
+  own confirm dialog promises *"Existing rows are kept."* **The rows were kept; their content was
+  not.**
+
+  `unknown_role` — computed since the engine was written, read by nobody — is the finding that
+  explains the blank row, and was the only place that explanation existed. `accountable_load` was
+  worse than unread: it *credited* roles that are not columns, overstating a real person's
+  ownership.
+
+  Fixed at three levels, because one was not enough. Validity is counted over visible columns
+  (server and client). The columns are merged rather than replaced when rows exist — and the merge
+  **refuses before mutating** when the union would exceed the sixteen-column cap, since
+  `set_config` truncates and the union puts the template's new columns last, so a silent truncation
+  would orphan exactly the rows the call was creating. The banner names the stranded columns and
+  offers to restore them (nothing was deleted) or clear them.
+
+  **Two lessons, both about fixtures rather than checks.** `services/api/test_responsibility.py`
+  already *created* the orphaned state — it swaps role columns on a project that has rows — and
+  never re-asserted validation afterwards; *a fixture can cross the path and look away.* And the
+  panel's first DOM test could not express its own subject: every letter in its fixture was
+  orphaned, so `clean` was already false and the banner's orphan guard was never the branch under
+  test — **mutating that guard away left all four tests green.** A third fixture, clean on visible
+  cells and still carrying one orphan, is what reaches it.
+
+  The rule now exists in two languages that cannot be deduplicated, so parity is asserted instead:
+  `apps/web/src/portal/panels/raciValidationCases.json` is read by **both**
+  `apps/web/src/portal/panels/raciValidation.test.ts` and `services/api/test_responsibility.py`. A
+  divergence only that loop covers — folding orphans into `clean` — was mutation-checked and caught.
+
 - ✅ **PORTAL-SHOWMODEL — the public 3D viewer shipped, and nothing could mint a token that reached
   it** *(S — Lane C; **CLOSED**, fix in this change)*
 
@@ -1366,7 +1440,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R43-MASSINGBILL-CORE · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* *(**UX-3 left this cell 2026-09-06: all five of its items now ship** — see its entry. The cell had pointed at `apps/web/src/viewer/tools/authoringSection.ts`, which is a real file and the WRONG one: every one of the five landed under `apps/web/src/viewer/draft/`. Lanes are assigned by directory, so a pointer that resolves is not the same as a pointer that is right — a tracked-path gate cannot catch this, and did not)* |

--- a/services/api/src/aec_api/responsibility.py
+++ b/services/api/src/aec_api/responsibility.py
@@ -31,6 +31,9 @@ DEFAULT_ROLES = ["Owner", "Architect/EOR", "GC / PM", "Superintendent",
                  "Subcontractor", "Consultant", "Cx Agent"]
 
 
+MAX_ROLES = 16          # role columns a matrix may carry; `set_config` truncates at it
+
+
 def _rows_and_config(db: Session, pid: str) -> tuple[list[dict], dict]:
     recs = mod.list_records(db, KEY, pid, limit=1000)
     config = None
@@ -56,7 +59,7 @@ def config(db: Session, pid: str) -> dict:
 def set_config(db: Session, pid: str, roles: list[str], mode: str, actor: str) -> dict:
     """Upsert the single config row (role columns + mode)."""
     mode = mode if mode in MODES else "RACI"
-    roles = [str(r).strip() for r in roles if str(r).strip()][:16] or DEFAULT_ROLES
+    roles = [str(r).strip() for r in roles if str(r).strip()][:MAX_ROLES] or DEFAULT_ROLES
     _, cfg = _rows_and_config(db, pid)
     data = {"kind": "config", "activity": "· matrix settings", "roles": roles, "mode": mode}
     if cfg:
@@ -67,14 +70,26 @@ def set_config(db: Session, pid: str, roles: list[str], mode: str, actor: str) -
 
 
 def _validate(rows: list[dict], roles: set[str], mode: str) -> dict:
-    """Per-row rule checks + role load. Exactly one Accountable, at least one doer (R/D)."""
+    """Per-row rule checks + role load. Exactly one Accountable, at least one doer (R/D).
+
+    **Counted over the CURRENT columns only, and that is the whole point.** An assignment keyed by
+    a role that is not a column is invisible: the grid renders `roles`, so the cell has nowhere to
+    appear. Counting it toward "exactly one Accountable" reported a row as complete while the user
+    looked at an empty line — and `apply_template` produces exactly that state, because it appends
+    rows and *replaces* the role columns, so a second template orphans every earlier row.
+
+    The orphans are not discarded, they are reported: `unknown_role` is what explains a blank row,
+    and it is the only place that explanation exists. `accountable_load` is likewise a load across
+    the columns that exist — crediting a role nobody can see overstates a real person's ownership.
+    """
     doer = DOER[mode]
     missing_accountable, no_responsible, unknown_role = [], [], []
     a_load: dict[str, int] = {}
     for r in rows:
         a = r["assignments"]
-        n_acc = sum(1 for v in a.values() if v == "A")
-        n_doer = sum(1 for v in a.values() if v == doer)
+        visible = {k: v for k, v in a.items() if k in roles}
+        n_acc = sum(1 for v in visible.values() if v == "A")
+        n_doer = sum(1 for v in visible.values() if v == doer)
         if n_acc != 1:
             missing_accountable.append({"ref": r["ref"], "activity": r["activity"], "count": n_acc})
         if n_doer < 1:
@@ -82,7 +97,7 @@ def _validate(rows: list[dict], roles: set[str], mode: str) -> dict:
         for role, v in a.items():
             if role not in roles:
                 unknown_role.append({"ref": r["ref"], "role": role})
-            if v == "A":
+            elif v == "A":
                 a_load[role] = a_load.get(role, 0) + 1
     return {
         "missing_accountable": missing_accountable,
@@ -217,14 +232,43 @@ def templates() -> list[dict]:
 
 
 def apply_template(db: Session, pid: str, key: str, mode: str, actor: str) -> dict:
-    """Create matrix rows from a starter template; also (re)sets the config to the default roles."""
+    """Append a starter template's rows, and give it the columns its cells are keyed by.
+
+    **The columns are MERGED into the existing set, not swapped for it, whenever rows already
+    exist.** This function appends rows and the panel's own dialog promises *"Existing rows are
+    kept"* — but it used to replace the role columns outright, and `bim_iso19650` ships its own.
+    Loading a second template therefore kept every earlier row and orphaned all of its assignments
+    onto columns that no longer existed: the rows rendered blank, and the assignments survived only
+    in `_validate`'s `unknown_role`. Keeping the rows and discarding what they say is not keeping
+    them.
+
+    On an empty matrix there is nothing to orphan, so the template's roles are adopted as-is and a
+    fresh project still gets exactly the columns its template describes.
+    """
     tpl = TEMPLATES.get(key)
     if not tpl:
         return {"error": f"unknown template {key!r}", "created": 0}
     mode = mode if mode in MODES else "RACI"
     # DACI reuses the same cell letters except the doer: R→D.
     remap = (lambda v: "D" if v == "R" else v) if mode == "DACI" else (lambda v: v)
-    set_config(db, pid, tpl.get("roles") or DEFAULT_ROLES, mode, actor)
+    tpl_roles = list(tpl.get("roles") or DEFAULT_ROLES)
+    existing_rows, _ = _rows_and_config(db, pid)
+    if existing_rows:
+        # union, existing columns first so the grid the user knows does not reshuffle under them
+        have = config(db, pid)["roles"]
+        roles = have + [r for r in tpl_roles if r not in have]
+        if len(roles) > MAX_ROLES:
+            # REFUSE BEFORE MUTATING. `set_config` truncates at the cap, and the union puts the
+            # TEMPLATE's new columns last — so a silent truncation would orphan the very rows this
+            # call is about to create, which is the defect this merge exists to prevent, arriving
+            # by a second door. Nothing is written.
+            return {"error": f"this matrix already has {len(have)} role columns and the "
+                             f"{key!r} template needs {len(roles) - len(have)} more, over the "
+                             f"{MAX_ROLES}-column limit — remove unused columns first. "
+                             "Nothing was changed.", "created": 0}
+    else:
+        roles = tpl_roles
+    set_config(db, pid, roles, mode, actor)
     created = 0
     for r in tpl["rows"]:
         data = {

--- a/services/api/test_responsibility.py
+++ b/services/api/test_responsibility.py
@@ -1,6 +1,7 @@
 """Responsibility matrix (RACI / DACI) — the grid assembly, validation rules (exactly one
 Accountable, at least one Responsible), role-column config, starter templates, and the DACI remap.
 Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_responsibility.py"""
+import json
 import os
 
 os.environ["DATABASE_URL"] = "sqlite:///./test_responsibility.db"
@@ -12,6 +13,7 @@ for _f in ("./test_responsibility.db",):
 
 from fastapi.testclient import TestClient  # noqa: E402
 
+from aec_api import responsibility  # noqa: E402
 from aec_api.main import app  # noqa: E402
 
 
@@ -93,5 +95,88 @@ with TestClient(app) as c:
     # unknown template -> 400
     assert c.post(f"/projects/{pid}/responsibility/apply-template", json={"key": "nope"}).status_code == 400
 
+    # --- RESP-ORPHAN: an assignment on a column that is GONE must not count as an assignment -----
+    # The defect: `_validate` counted every value in `assignments`, but the grid renders only the
+    # CURRENT `roles`. A row whose letters all sit on removed columns therefore rendered as a blank
+    # line while the matrix reported itself complete. `unknown_role` — computed since day one and
+    # read by nobody — is the finding that explains the blank row.
+    #
+    # This state is reachable two ways and BOTH are exercised: a config swap (the block at the top
+    # of this file already produced it and never looked), and `apply-template`, which appends rows
+    # and used to replace the columns.
+    pid4 = c.post("/projects", json={"name": "Orphan Tower"}).json()["id"]
+    mk(c, pid4, "responsibility", {"activity": "Author models",
+                                   "assignments": {"Architect/EOR": "A", "GC / PM": "R"}})
+    m4 = c.get(f"/projects/{pid4}/responsibility").json()
+    assert m4["validation"]["clean"] is True, "baseline row is well-formed"
+
+    # swap the columns out from under it
+    c.put(f"/projects/{pid4}/responsibility/config",
+          json={"roles": ["Client", "Task Team"], "mode": "RACI"})
+    m4 = c.get(f"/projects/{pid4}/responsibility").json()
+    v4 = m4["validation"]
+    assert v4["clean"] is False, "a row whose every letter is on a removed column is NOT clean"
+    assert [x["activity"] for x in v4["missing_accountable"]] == ["Author models"], v4
+    assert v4["missing_accountable"][0]["count"] == 0, v4["missing_accountable"]
+    assert [x["activity"] for x in v4["no_responsible"]] == ["Author models"], v4
+    assert sorted(x["role"] for x in v4["unknown_role"]) == ["Architect/EOR", "GC / PM"], v4
+    # and the load must not credit a role that is not a column — that overstates a real person
+    assert v4["accountable_load"] == {}, v4["accountable_load"]
+
+    # --- RESP-ORPHAN: a second template MERGES its columns instead of replacing them -------------
+    # The panel's dialog promises "Existing rows are kept". Keeping the rows and discarding what
+    # they say is not keeping them.
+    pid5 = c.post("/projects", json={"name": "Two Templates"}).json()["id"]
+    c.post(f"/projects/{pid5}/responsibility/apply-template", json={"key": "construction"})
+    before = c.get(f"/projects/{pid5}/responsibility").json()
+    assert before["validation"]["clean"] is True, before["validation"]
+    c.post(f"/projects/{pid5}/responsibility/apply-template", json={"key": "bim_iso19650"})
+    after = c.get(f"/projects/{pid5}/responsibility").json()
+    assert after["count"] == 5 + 9, after["count"]
+    # the construction columns survive, the BIM personas are added after them
+    assert after["roles"][:len(before["roles"])] == before["roles"], after["roles"]
+    assert "Appointing Party" in after["roles"] and "Architect/EOR" in after["roles"], after["roles"]
+    assert after["validation"]["unknown_role"] == [], after["validation"]["unknown_role"]
+    assert after["validation"]["clean"] is True, after["validation"]
+
+    # --- RESP-ORPHAN: the merge REFUSES rather than truncating past the column cap ---------------
+    # `set_config` truncates at MAX_ROLES and the union puts the template's NEW columns last, so a
+    # silent truncation would orphan exactly the rows the call is creating. Refuse before mutating.
+    pid6 = c.post("/projects", json={"name": "Full House"}).json()["id"]
+    c.post(f"/projects/{pid6}/responsibility/apply-template", json={"key": "construction"})
+    wide = [f"Role {i}" for i in range(14)]      # 14 + the 6 BIM personas > MAX_ROLES
+    c.put(f"/projects/{pid6}/responsibility/config", json={"roles": wide, "mode": "RACI"})
+    r6 = c.post(f"/projects/{pid6}/responsibility/apply-template", json={"key": "bim_iso19650"})
+    assert r6.status_code == 400, (r6.status_code, r6.text[:200])
+    assert "Nothing was changed" in r6.json()["detail"], r6.json()
+    m6 = c.get(f"/projects/{pid6}/responsibility").json()
+    assert m6["count"] == 5 and m6["roles"] == wide, (m6["count"], m6["roles"])
+
+    # --- RESP-ORPHAN: the rule agrees with the web implementation, case for case ----------------
+    # The rule exists twice and cannot be deduplicated across the language boundary: the panel needs
+    # it locally so a cell edit repaints the banner without a round-trip. Two copies of one rule is
+    # what produced this defect — the client counted every assignment while the grid renders only
+    # the current columns. `raciValidationCases.json` is the shared ground, and it is only shared if
+    # BOTH sides read it, so this walks the same file `raciValidation.test.ts` walks.
+    cases_path = os.path.join(os.path.dirname(__file__),
+                              "../../apps/web/src/portal/panels/raciValidationCases.json")
+    with open(cases_path, encoding="utf-8") as fh:
+        cases = json.load(fh)["cases"]
+    assert len(cases) >= 5, f"parity fixture has only {len(cases)} cases"
+    for case in cases:
+        rows = [{"ref": r["ref"], "activity": r["activity"], "assignments": r["assignments"]}
+                for r in case["rows"]]
+        mode = "DACI" if case["doer"] == "D" else "RACI"
+        got = responsibility._validate(rows, set(case["roles"]), mode)
+        want = case["expect"]
+        assert got["clean"] is want["clean"], (case["name"], got)
+        assert got["missing_accountable"] == want["missing"], (case["name"], got["missing_accountable"])
+        assert got["no_responsible"] == want["noR"], (case["name"], got["no_responsible"])
+        assert sorted({u["role"] for u in got["unknown_role"]}) == sorted(want["unknown"]), \
+            (case["name"], got["unknown_role"])
+        assert got["accountable_load"] == want["load"], (case["name"], got["accountable_load"])
+
 print("RESPONSIBILITY OK - grid assembly, single-A / >=1-R validation, role config, RACI<->DACI, templates + "
-      "remap, and the ROLES-BIM ISO 19650 template (own BIM-org persona columns, 9 info-mgmt duties, clean)")
+      "remap, the ROLES-BIM ISO 19650 template (own BIM-org persona columns, 9 info-mgmt duties, clean), and "
+      "RESP-ORPHAN: validity is counted over VISIBLE columns, unknown_role explains a blank row, a second "
+      "template merges its columns, and the merge refuses past the cap instead of truncating")

--- a/services/api/test_responsibility.py
+++ b/services/api/test_responsibility.py
@@ -3,6 +3,7 @@ Accountable, at least one Responsible), role-column config, starter templates, a
 Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_responsibility.py"""
 import json
 import os
+import re
 
 os.environ["DATABASE_URL"] = "sqlite:///./test_responsibility.db"
 os.environ["STORAGE_DIR"] = "./test_storage_responsibility"
@@ -175,6 +176,20 @@ with TestClient(app) as c:
         assert sorted({u["role"] for u in got["unknown_role"]}) == sorted(want["unknown"]), \
             (case["name"], got["unknown_role"])
         assert got["accountable_load"] == want["load"], (case["name"], got["accountable_load"])
+
+    # --- RESP-ORPHAN: the client's copy of the column cap matches this one --------------------
+    # The panel disables Restore when the union would overflow, because `set_config` TRUNCATES
+    # rather than refusing and the orphans sit at the tail. A client guard set to the wrong number
+    # is worse than none: it would refuse valid restores AND still let the real overflow through.
+    # Raised in review; gated here because a constant duplicated across a language boundary drifts.
+    raci_ts = os.path.join(os.path.dirname(__file__),
+                           "../../apps/web/src/portal/panels/raciValidation.ts")
+    with open(raci_ts, encoding="utf-8") as fh:
+        ts_src = fh.read()
+    m_cap = re.search(r"export const MAX_ROLES = (\d+);", ts_src)
+    assert m_cap, "raciValidation.ts no longer declares MAX_ROLES — the guard or this gate moved"
+    assert int(m_cap.group(1)) == responsibility.MAX_ROLES, \
+        (int(m_cap.group(1)), responsibility.MAX_ROLES)
 
 print("RESPONSIBILITY OK - grid assembly, single-A / >=1-R validation, role config, RACI<->DACI, templates + "
       "remap, the ROLES-BIM ISO 19650 template (own BIM-org persona columns, 9 info-mgmt duties, clean), and "


### PR DESCRIPTION
# What & why

Load a second starter template into a responsibility matrix that already has rows and the role columns change under them. The earlier rows survive — the dialog promises they will — but every letter on them is now keyed to a column that no longer exists, so those rows render as blank lines. And the banner still says **"Every activity has exactly one Accountable and at least one Responsible"**, because `_validate` counted assignments the grid has no cell to draw.

**The panel's own confirm dialog promises *"Existing rows are kept."* The rows were kept; their content was not.**

Found by deriving the population behind the axis PROP-OVERRIDE (#478) exposed: *a route with no caller is caught by a gate; a **payload with no reader** is caught by nobody.* Every field of every exported interface under `apps/web/src/api/`, against every reference in `apps/web/src`, minus the declaring file:

| | |
|---|---|
| declared response fields with **no reader** | **43** |
| ├ **live defect** — a wrong answer rather than a gap | **4** *(closed here)* |
| ├ finding-shaped — silence degrades an answer without inverting it | ~8 |
| └ detail — legitimately not displayed | ~31 |

The four are `ResponsibilityMatrix.validation.*`. `unknown_role` — computed since the engine was written, read by nobody — is the finding that explains the blank row, and was the only place that explanation existed. `accountable_load` was worse than unread: it *credited* roles that are not columns, overstating a real person's ownership.

Proven rather than reasoned, before any fix:

```
clean          : True
unknown_role   : [{'ref': 'R-001', 'role': 'Architect/EOR'}, {'ref': 'R-001', 'role': 'Sub'}]
accountable_ld : {'Architect/EOR': 1}
```

## Fixed at three levels, because one was not enough

1. **Validity is counted over visible columns**, server and client. The row above now reads as what it is: no Accountable, no Responsible, with `unknown_role` saying why.
2. **`apply_template` merges the template's columns after yours** when rows already exist, rather than replacing them — and **refuses before mutating** when the union would exceed the 16-column cap. That second guard is load-bearing: `set_config` truncates, and the union puts the template's *new* columns last, so a silent truncation would orphan exactly the rows the call is creating. The unguarded path returns `200, created 9`.
3. **The banner names the stranded columns** and offers to *restore* them (nothing was deleted, so they become visible again) or *clear* them.

## Two fixture lessons, both recorded next to the checks

**`test_responsibility.py` already created the orphaned state** — it swaps role columns on a project that has rows — and never re-asserted validation afterwards. *A fixture can cross the path and look away.*

**The panel's first DOM test could not express its own subject.** Every letter in its fixture was orphaned, so `clean` was already false and the banner's orphan guard was never the branch under test — **mutating that guard away left all four tests green**. A third fixture, clean on visible cells and still carrying one orphan, is what reaches it.

## Review findings (`fa10636`) — the first is the sharpest thing on this PR

**① Restore reintroduced the defect it repairs.** `orphanRepair` sent `[...m.roles, ...orphans]` to `setResponsibilityConfig`, and `set_config` **truncates** a longer list and returns 200 with the visible roles first — so the orphans fall off the tail, `load()` reloads clean, and the assignments stay exactly as stranded. This item exists because a silent truncation strands assignments; I gave `apply_template` a refuse-before-mutating guard for precisely that reason, then let the client path overflow. **A repair that silently fails to repair is worse than no repair button**, because the warning disappears and the user believes it worked. Restore is now computed against the cap, disabled with an explanatory title when it will not fit, and returns early rather than trusting `disabled`.

`MAX_ROLES` is a named constant on both sides and `test_responsibility.py` asserts they agree — a constant duplicated across a language boundary drifts, and a client guard set to the *wrong* number would refuse valid restores while still letting the real overflow through.

**② Partial clear left the panel ahead of the server.** Each row is its own PATCH; the `catch` toasted and stopped, leaving rendered the in-memory assignments the server had rejected — under-reporting what was still stranded, which on this item is exactly the failure mode. It now re-reads. The transactional bulk endpoint the finding proposes is a new API surface beyond this diff and is answered on the thread with its shape and reasoning; the `rename` and `remove column` handlers in this file have the same per-row structure, and a partial **rename** is the materially worse one, so the right scope is all three at once as its own change.

## Parity, since the rule now exists in two languages

`apps/web/src/portal/panels/raciValidationCases.json` is read by **both** `apps/web/src/portal/panels/raciValidation.test.ts` and `services/api/test_responsibility.py`. A divergence only that loop covers (folding orphans into `clean`) was mutation-checked and caught.

**11 mutations, 10 caught on the first pass**; the one survivor is the fixture gap analysed above, now closed.

## Deliberately not gated yet

A gate over the DEAD-FIELD axis needs an allowlist of the ~31 legitimate cases, and an allowlist nobody has triaged is a freeze list that rots — the exact failure `KNOWN_UNCALLED` recorded when four of its entries turned out to have callers. The ~8 finding-shaped ones are recorded in the roadmap under Lane B.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree)
- [x] Backend: **full suite 680/680 suites passed** (1712 s wall, 3 parallel). Precisely: that run covers the tree as of `ab4de720`; `fa10636` touched only `test_responsibility.py` on the Python side, which was run directly against the new tree and passes. CI's API test gate covers the current head in full.
- [x] Web: typecheck, lint and build clean; **2287/2287 across 221 files** (was 2272/219)
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; roadmap updated (new DEAD-FIELD item assigned to Lane B — the lane gate caught it unassigned)
- [ ] Version bump — not a release PR
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA