### PR TITLE
ROUND-UNDATED: the review-cycles card scored 2 of 5 rounds and said "2 round(s)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### the review-cycles card says how many rounds it could not measure
+
+"Whose court did the time sit in" is the question that card exists to settle, and it was answering
+over fewer rounds than the register holds. A review round with no submitted date cannot start a
+clock, so it is left out of the split entirely — correctly — but the round count printed beside the
+days was the *scored* count, with nothing saying so. Two dated rounds out of five recorded read as a
+complete answer.
+
+It now says it: **"3 more round(s) carry no submitted date and are NOT in the figures above — the
+split covers 2 of 5 recorded rounds"**, with a nudge to add the dates. The card already handled the
+sibling case, rounds still open, with exactly this care; this is the harder one, because an undated
+round is not counted at all.
+
+The days figures also now name their basis — **calendar days**, because a statutory review clock
+does not pause for a weekend, while durations elsewhere in this system are working days. The engine
+had always returned that axis and nothing printed it.
+
 ### the responsibility matrix stops telling you it is complete when it is not
 
 Load a second starter template into a RACI matrix that already has rows and the columns changed

--- a/apps/web/src/portal/panels/design.test.ts
+++ b/apps/web/src/portal/panels/design.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PanelContext } from "../panelContext";
+import { renderDiligence } from "./design";
+
+/**
+ * DEAD-FIELD — the rounds that are NOT in the number the card prints.
+ *
+ * `approval_cycles.cycles()` drops any round with no submitted date: it cannot start a clock, so it
+ * `continue`s out of the list entirely. `rounds` is therefore a count of the DATED rounds, and the
+ * days split and the agency share are computed over that smaller set — while the register holds
+ * more. "2 round(s) · 50d with the agency · 78.1% agency time" over a five-round application reads
+ * as a complete answer to the one question this card exists to settle.
+ *
+ * The engine computes `rounds_undated` to say exactly that, and no consumer read it. Its sibling
+ * `rounds_open` is handled a few lines above with precisely the right care — *"counted but not
+ * scored"* — which is what makes the omission worth fixing rather than merely noting: the author
+ * knew the shape of the problem and covered one of its two cases.
+ *
+ * Found by deriving the "declared response field with no reader" population after PROP-OVERRIDE
+ * (#478) and RESP-ORPHAN (#479). Of the four caveat-shaped candidates checked, this is the one that
+ * survived triage — `MakeReady.window_days` is the client's own request parameter echoed back,
+ * `PrequalScores.not_in_pool` is already visible as a per-row `rejected` flag, and
+ * `PreflightSummary.blocking_checks` is rendered in full immediately above the override button.
+ * **A field with no reader is a candidate, not a defect.**
+ */
+
+const el = () => document.createElement("div");
+
+const READINESS = {
+  go: false,
+  due_diligence: { total: 2, cleared: 1, flagged: 0, by_category: {}, high_risk: [] },
+  entitlements: { total: 1, by_state: {}, approved: 0, pending: 1, denied: 0,
+    expiring_within_180d: [] },
+};
+
+/** Two dated rounds scored; three more in the register that no clock can measure. */
+const CYCLES_WITH_UNDATED = {
+  available: true, status: "ok", reason: undefined,
+  rounds: 2, rounds_closed: 2, rounds_open: 0, rounds_undated: 3,
+  open_detail: [],
+  days_with_agency: 50, days_with_applicant: 14, agency_share_pct: 78.1,
+  mean_agency_turnaround_days: 25, mean_applicant_turnaround_days: 7,
+  total_comments: 12, rounds_out_of_order: [], days_basis: "calendar",
+};
+
+const CYCLES_ALL_DATED = { ...CYCLES_WITH_UNDATED, rounds_undated: 0 };
+
+const flush = async () => { for (let i = 0; i < 8; i++) await Promise.resolve(); };
+
+function ctx(cycles: unknown) {
+  const api = {
+    diligenceReadiness: vi.fn().mockResolvedValue(structuredClone(READINESS)),
+    entitlementReviewCycles: vi.fn().mockImplementation(() => Promise.resolve(structuredClone(cycles))),
+    entitlementConditions: vi.fn().mockResolvedValue({ entitlements: [], unrecorded: [], note: "" }),
+    entitlementConditionChecks: vi.fn().mockResolvedValue({ checks: [], note: "" }),
+    dealAuthority: vi.fn().mockResolvedValue({ decisions: [], note: "" }),
+  };
+  const c = {
+    root: el(),
+    host: { projectId: () => "p1", api } as unknown as PanelContext["host"],
+    mods: [], activeKey: "diligence",
+    bar: (title: string) => { const b = el(); b.textContent = title; return b; },
+    buildNav: () => undefined, renderHome: async () => undefined, openModule: async () => undefined,
+    navigate: () => undefined, hasDest: () => true,
+  } as unknown as PanelContext;
+  return { c, api };
+}
+
+describe("the review-cycles card answers for the rounds it could not measure", () => {
+  it("says how many rounds are NOT in the split", async () => {
+    const { c } = ctx(CYCLES_WITH_UNDATED);
+    await renderDiligence(c); await flush();
+    const text = c.root.textContent ?? "";
+    expect(text, "the card printed a split without saying what it excludes")
+      .toMatch(/3 more round\(s\) carry no submitted date/);
+    // the honest total, not just the scored one
+    expect(text).toContain("2 of 5 recorded rounds");
+  });
+
+  it("says nothing when every round is dated", async () => {
+    // Without this the test above passes for the wrong reason: a card that always warns would
+    // satisfy it, and a permanent caveat is noise rather than an answer.
+    const { c } = ctx(CYCLES_ALL_DATED);
+    await renderDiligence(c); await flush();
+    expect(c.root.textContent ?? "").not.toMatch(/carry no submitted date/);
+  });
+
+  it("states the day basis, because the rest of this system counts working days", async () => {
+    const { c } = ctx(CYCLES_ALL_DATED);
+    await renderDiligence(c); await flush();
+    expect(c.root.textContent ?? "").toContain("(calendar days)");
+  });
+});

--- a/apps/web/src/portal/panels/design.ts
+++ b/apps/web/src/portal/panels/design.ts
@@ -193,14 +193,33 @@ export async function renderDiligence(ctx: PanelContext) {
         const share = rc.agency_share_pct === null
           ? "share unavailable — a round is still open, and a share of an unknown total is not a share"
           : `${rc.agency_share_pct}% of the measured time was agency time`;
+        // `days_basis` is stated rather than assumed: durations elsewhere in this system are
+        // WORKING days, and a statutory review clock does not pause for a weekend. The engine
+        // returns the axis for that reason; printing "50d" without it invites the wrong reading.
+        const basis = rc.days_basis ? ` (${rc.days_basis} days)` : "";
         line.textContent = `${rc.rounds} round(s) · ${rc.days_with_agency ?? "—"}d with the agency · `
-          + `${rc.days_with_applicant ?? "—"}d with us · ${share}`;
+          + `${rc.days_with_applicant ?? "—"}d with us${basis} · ${share}`;
         if (rc.rounds_open) {
           const open = el("div", "meta");
           open.textContent = `${rc.rounds_open} round(s) still open, counted but not scored: `
             + rc.open_detail.map((o) => `#${o.round ?? "?"} with the `
               + `${o.held_by === "with_agency" ? "agency" : "applicant"} since ${o.since}`).join(" · ");
           card.appendChild(open);
+        }
+        // DEAD-FIELD — the rounds that are NOT in the number above. A round with no submitted date
+        // cannot start a clock, so `cycles()` drops it from `rounds` entirely; the split and the
+        // share are then computed over a smaller set than the register holds, and "2 round(s)" over
+        // a five-round application reads as a complete answer. `rounds_undated` is computed to say
+        // exactly this and was read by nobody. The sibling `rounds_open` above already gets this
+        // treatment — *"counted but not scored"* — and this is the harder case, because an undated
+        // round is not counted either.
+        if (rc.rounds_undated) {
+          const und = el("div", "meta"); und.style.color = "var(--status-warn)";
+          und.textContent = `${rc.rounds_undated} more round(s) carry no submitted date and are `
+            + `NOT in the figures above — the split covers ${rc.rounds} of `
+            + `${(rc.rounds ?? 0) + rc.rounds_undated} recorded rounds. Add the submitted dates to `
+            + `bring them into the clock.`;
+          card.appendChild(und);
         }
         if (rc.rounds_out_of_order.length) {
           const ooo = el("div", "meta"); ooo.style.color = "var(--status-warn)";

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -372,13 +372,24 @@ instances:
   **The four were `ResponsibilityMatrix.validation.*`, and they were the load-bearing kind: the
   panel asserted the OPPOSITE of the truth.** See RESP-ORPHAN below.
 
-  **The ~8 share a signature worth naming: each is the CAVEAT on a number that IS shown.**
-  `ReviewCycles.rounds_undated` sits beside a days-split computed only over dated rounds — and
-  `apps/web/src/portal/panels/design.ts` handles the sibling `rounds_open` with exactly the right
-  care (*"counted but not scored"*) and misses this one. `MakeReady.window_days` is the denominator
-  of a ready/blocked pair. `BidLevelingDetail.recommendation.responsiveness` is the caveat on an
-  apparent-low recommendation. `PrequalScores.not_in_pool` names who was excluded from a pool whose
-  size is displayed. `PreflightSummary.blocking_checks` names what a HOLD override just bypassed.
+  **The candidates share a signature: each is the CAVEAT on a number that IS shown.** The estimate
+  first written here was "~8 finding-shaped"; **four have since been triaged and only ONE was real**,
+  so the shape is a candidate filter rather than a defect count, and the honest figure is unknown
+  until the rest are read:
+
+  | field | verdict |
+  |---|---|
+  | `ReviewCycles.rounds_undated` | **REAL — fixed.** The days-split covers only dated rounds and the count printed beside it was the scored one. Two of five read as complete. `design.ts` handles the sibling `rounds_open` with exactly the right care (*"counted but not scored"*) and missed this. |
+  | `MakeReady.window_days` | **Not a defect.** The server echoes back the client's own request parameter, which the panel already prints. |
+  | `PrequalScores.not_in_pool` | **Not a defect.** A rejected sub carries a `rejected` flag on its row and the table renders `flags`, so the exclusion is on screen. |
+  | `PreflightSummary.blocking_checks` | **Not a defect.** `reportCenter.ts` renders the full failing checklist immediately above the override button, at the moment of the decision. |
+
+  **A field with no reader is a candidate, not a defect** — 1 of 4 survived, and writing "~8
+  finding-shaped" as though the filter were the finding is the same over-claim this file has had to
+  correct elsewhere. Still unread and untriaged: `ReviewCycles.{total_comments,
+  mean_agency_turnaround_days}`, `BidLevelingDetail.recommendation.responsiveness`,
+  `OptionRecord.axis_status`, `SpecSubmittalLog.withdrawn_excluded[].would_require`,
+  `EntitlementConditions.{entitlement_count, discharged_count}`.
 
   **Deliberately NOT gated yet, and that is a judgement rather than an omission.** A gate over this
   axis needs an allowlist of the ~31 legitimate cases, and an allowlist nobody has triaged is a


### PR DESCRIPTION
# What & why

*"Whose court did the review time sit in"* is the question the review-cycles card exists to settle, and it was answering over fewer rounds than the register holds.

`approval_cycles.cycles()` drops any round with no submitted date — it cannot start a clock, so it `continue`s out of the list. **That part is right.** But `rounds` is then the count of *dated* rounds, and the panel printed it beside the days split with nothing saying so. Proven by running the engine before touching anything — five recorded rounds, three undated:

```
rounds          : 2   <- what the panel prints
rounds_undated  : 3   <- computed, read by nobody
PANEL LINE: 2 round(s) · 50d with the agency · 14d with us · 78.1% of the measured time was agency time
REGISTER HOLDS: 5 rounds
```

The card already handles the sibling case — rounds still open — as *"counted but not scored"*. **This is the harder one, because an undated round is not counted at all.** It now says so, and nudges toward the fix: *"3 more round(s) carry no submitted date and are NOT in the figures above — the split covers 2 of 5 recorded rounds. Add the submitted dates to bring them into the clock."*

Also surfaced **`days_basis`**. The engine returns `"calendar"` and explains why at length: a statutory review clock does not pause for a weekend, while durations elsewhere in this system are *working* days. Printing "50d" without the axis invites the wrong reading of the one number the card is there to support.

## The three candidates that were NOT defects

This is the first triage pass over the DEAD-FIELD population recorded in #479 — **one real defect out of four checked**, and the ratio is the more useful result:

| field | verdict |
|---|---|
| `ReviewCycles.rounds_undated` | **REAL — fixed here.** |
| `MakeReady.window_days` | Not a defect. The server echoes back the client's own request parameter, which the panel already prints. |
| `PrequalScores.not_in_pool` | Not a defect. A rejected sub carries a `rejected` flag on its row and the table renders `flags`. |
| `PreflightSummary.blocking_checks` | Not a defect. `reportCenter.ts` renders the full failing checklist immediately above the override button, at the moment of decision. |

So the roadmap's *"~8 finding-shaped"* is replaced with this table. **A field with no reader is a candidate, not a defect**, and writing the filter as though it were the finding is the same over-claim this repo has had to correct elsewhere. The remaining untriaged names are listed rather than counted.

## An un-run mutation looks exactly like a surviving one

New `apps/web/src/portal/panels/design.test.ts` — 3 tests, 3 mutations, 3 caught. Worth recording that **the first M3 attempt "survived"**: my `sed` had the wrong indentation and never applied, so the test passed over unmutated code. Re-run with an exact match it reds immediately. The negative case (`says nothing when every round is dated`) is there because a card that always warns would satisfy the positive test while being a different defect.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `ruff check ../..` clean (whole tree). No Python changed in this PR.
- [x] Backend: citation, size and lane gates pass (`test_claude_md_gates`, `test_file_sizes`, `roadmapLanes`)
- [x] Web: typecheck, lint and build clean; **2290/2290 across 222 files** (was 2287/221)
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; roadmap's DEAD-FIELD estimate corrected with measured verdicts
- [ ] Version bump — not a release PR
- [x] No secrets, no competitor names in shipped docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review-cycle summaries now show how many recorded rounds lack a submission date and are excluded from the figures.
  - Summaries now identify day counts as calendar days.
  - Total recorded rounds are reported more clearly, including when some rounds lack dates.

- **Documentation**
  - Updated the roadmap to reflect the review-cycle reporting correction and clarify remaining investigation items.

- **Tests**
  - Added coverage for dated and undated review rounds, total-round reporting, and calendar-day labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->