### PR TITLE
TM-RATES: five review findings on the merged pricing engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ none of them was reachable from the original tests:
   needs a working day nobody stated.
 - **A closed (superseded) rate beat its live replacement** and was snapshotted onto the line.
 
+Review of those fixes found three more, also fixed here: an unpriced line labelled its quantity with
+the rate column (*"8 rate are NOT in the figures above"*), the rate comparison still rounded
+half-even while the amount beside it rounded half-up — which can report a rate variance over a
+figure that agrees to the cent — and one test sequenced its setup so a fixture failure would have
+skipped the pricing rather than failing.
+
 ### T&M tickets price themselves from the project rate registers
 
 **TM-RATES.** The eTicket register carries three line tables — labour, material, equipment — and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### T&M pricing: five corrections to the first cut
+
+Review of the merged TM-RATES change found the pricing engine wrong in five ways. All are fixed, and
+none of them was reachable from the original tests:
+
+- **Material never priced.** The line table's item name lives in `description`; the code looked for a
+  `material` column, which `material_lines` does not have. Labour and equipment happened to use the
+  same name on both sides, so one conflated field looked right in two cases out of three.
+- **A hand-entered amount was overwritten.** 8 hours plus 2 overtime written up at $1,045 became
+  $760, and a lump-sum line with no hours became $0. A typed amount is evidence for the same reason
+  a typed rate is — it may carry a premium or an allowance both parties agreed. It is now reported
+  when it disagrees with rate × quantity, never replaced.
+- **A register row with no rate priced the line at $0** and reported it as a success.
+- **A rate quoted per Day or Week was extended against hours** — a $1,200/week crane read as $9,600
+  for an eight-hour day. It is now reported unpriced, for the same reason overtime is: converting
+  needs a working day nobody stated.
+- **A closed (superseded) rate beat its live replacement** and was snapshotted onto the line.
+
 ### T&M tickets price themselves from the project rate registers
 
 **TM-RATES.** The eTicket register carries three line tables — labour, material, equipment — and the

--- a/apps/web/src/api/cost.ts
+++ b/apps/web/src/api/cost.ts
@@ -29,12 +29,19 @@ type Ctor<T> = new (...args: any[]) => T;
 export interface TmPricingReport {
   /** Rows whose blank rate the register supplied. */
   filled: { table: string; name: string; rate: number }[];
-  /** Rows whose typed rate disagrees with the register. Kept as typed — reported, not corrected. */
-  variance: { table: string; name: string; typed: number; register: number }[];
-  /** Rows no register has an entry for. Left exactly as they are. */
+  /**
+   * A cell whose typed value disagrees with what the register implies. Kept as typed — reported,
+   * never corrected. `field` says WHICH cell: the rate column, or `amount` when a hand-entered
+   * extension differs from rate x quantity (an overtime premium, a negotiated allowance).
+   */
+  variance: { table: string; name: string; field: string; typed: number; register: number }[];
+  /** Rows no register has a usable entry for. Left exactly as they are. */
   unmatched: { table: string; name: string; register: string }[];
-  /** Overtime / idle hours: real quantities with no rate anywhere to price them at. */
-  unpriced: { table: string; name: string; column: string; quantity: number }[];
+  /**
+   * A real quantity nothing could price, with the reason. Overtime and idle hours (no OT or idle
+   * rate exists), and a register rate quoted per Day/Week/Month against a line measured in hours.
+   */
+  unpriced: { table: string; name: string; column: string; quantity: number; reason: string }[];
   /** How many rows this run actually changed. */
   priced: number;
   totals: { labor_total: number; material_total: number; equipment_total: number;

--- a/apps/web/src/portal/register/tmPricing.test.ts
+++ b/apps/web/src/portal/register/tmPricing.test.ts
@@ -29,9 +29,11 @@ const EMPTY: TmPricingReport = {
 
 const FULL: TmPricingReport = {
   filled: [{ table: "labor_lines", name: "Electrician", rate: 95 }],
-  variance: [{ table: "labor_lines", name: "Plumber", typed: 110, register: 95 }],
+  variance: [{ table: "labor_lines", name: "Plumber", field: "rate", typed: 110, register: 95 },
+             { table: "labor_lines", name: "Foreman", field: "amount", typed: 1045, register: 760 }],
   unmatched: [{ table: "labor_lines", name: "Glazier", register: "labor_rate" }],
-  unpriced: [{ table: "labor_lines", name: "Electrician", column: "ot_hours", quantity: 2 }],
+  unpriced: [{ table: "labor_lines", name: "Electrician", column: "ot_hours", quantity: 2,
+               reason: "the rate register holds no rate for these" }],
   priced: 2,
   totals: { labor_total: 760, material_total: 425, equipment_total: 0, grand_total: 1185 },
 };
@@ -71,9 +73,16 @@ describe("the T&M pricing control", () => {
     const text = el.textContent ?? "";
     expect(text, "the rate the register supplied").toContain("Electrician");
     expect(text, "a typed rate that disagrees with the register must be VISIBLE")
-      .toMatch(/\$110.*\$95|110.*register says.*95/);
+      .toMatch(/110.*register says.*95/);
+    // The amount variance reads differently on purpose: it is not the register disagreeing, it is
+    // the line's own arithmetic — an overtime premium the engine must report and not recompute away.
+    expect(text, "a typed AMOUNT that disagrees with rate x quantity must be visible, and must not "
+      + "be described as the register disagreeing")
+      .toMatch(/amount is \$1,045 and rate × quantity is \$760/);
     expect(text, "a trade the register does not know").toContain("Glazier");
     expect(text, "hours nothing could price").toContain("ot hours");
+    expect(text, "...and the REASON, since 'unpriced' now covers a per-week rate too")
+      .toContain("holds no rate for these");
     expect(text).toContain("$1,185");
   });
 

--- a/apps/web/src/portal/register/tmPricing.ts
+++ b/apps/web/src/portal/register/tmPricing.ts
@@ -76,9 +76,14 @@ export function renderTmReport(box: HTMLElement, rep: TmPricingReport): void {
   // A disagreement with the rate table is the finding this control exists to surface, so it is
   // stated in full — both numbers — and never quietly resolved in either direction.
   for (const v of rep.variance) {
-    box.appendChild(line(
-      `⚠ ${v.name}: this line is at ${rateFmt(v.typed)} and the register says ${rateFmt(v.register)}`
-      + " — left as entered", "var(--status-warn)"));
+    // `field` distinguishes the two: a rate that disagrees with the register, and an AMOUNT that
+    // disagrees with rate x quantity — which is usually an overtime premium or a negotiated
+    // allowance, and is exactly the figure that must not be silently recomputed away.
+    box.appendChild(line(v.field === "amount"
+      ? `⚠ ${v.name}: this line's amount is ${rateFmt(v.typed)} and rate × quantity is `
+        + `${rateFmt(v.register)} — left as entered`
+      : `⚠ ${v.name}: this line is at ${rateFmt(v.typed)} and the register says `
+        + `${rateFmt(v.register)} — left as entered`, "var(--status-warn)"));
   }
   for (const u of rep.unmatched) {
     box.appendChild(line(
@@ -87,8 +92,8 @@ export function renderTmReport(box: HTMLElement, rep: TmPricingReport): void {
   }
   for (const u of rep.unpriced) {
     box.appendChild(line(
-      `⏱ ${u.name}: ${u.quantity} ${u.column.replace("_", " ")} are NOT in the figures above —`
-      + " the rate register holds no rate for them", "var(--status-warn)"));
+      `⏱ ${u.name}: ${u.quantity} ${u.column.replace("_", " ")} are NOT in the figures above — `
+      + u.reason, "var(--status-warn)"));
   }
 }
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -405,6 +405,29 @@ instances:
   outside that directory. *Narrowing a search to remove noise removes evidence of a call, and absent
   evidence reads as absence.*
 
+  **FIVE MORE FINDINGS ON THE MERGED CODE, and the first one is this item's own lesson turned on
+  itself.** A review of `c6ccc435` found the pricing engine wrong in five ways, all in
+  `services/api/src/aec_api/cost.py`, all confirmed and fixed in the follow-up:
+
+  | | |
+  |---|---|
+  | **the material name column** | `TM_TABLES` used ONE field for both the register's name column and the LINE's. `material_lines` has columns `description/qty/unit/unit_price/amount` — **no `material` column at all** — so every material line a user could create read as name `""` and material never priced. Labour and equipment coincide (`trade`, `equipment` on both sides), which is exactly how a conflated field survives |
+  | **a typed amount was overwritten** | `amount` was recomputed unconditionally, so 8h + 2h OT written up at $1,045 became $760 and a lump-sum line with no hours became $0. The item's own rule — a typed rate is evidence — was applied to the rate and not to the amount. That was an inconsistency, not a design |
+  | **a blank register rate priced at $0** | `rate` is optional on all three registers, so a half-filled row gave `0.0`, which is not `None`; the line matched, took zero, was reported as **successfully priced**, and kept a stale amount because the recompute is guarded on a truthy rate |
+  | **the register's `unit` was dropped** | `equipment_rate` offers Hour/Day/Week/Month and the line's quantity is hours, so a $1,200/week crane extended against an 8-hour day read as **$9,600**, reported as an ordinary success |
+  | **a CLOSED rate won the lookup** | both registers carry open/closed and `list_records` is oldest-first, so a superseded rate beat its replacement and was then SNAPSHOTTED onto the line permanently — the REFUSAL-READERS class, in a register whose whole purpose is to be superseded |
+
+  **The first one passed a mutation sweep because the fixture put a `material` key on the row** — a
+  key the schema does not declare. *An assertion cannot be stronger than the world its fixture can
+  describe* is the sentence in this item's own test docstring, written about `test_cost.py`, and the
+  fixture one paragraph below it had the same defect. Writing the lesson down is not the same as
+  applying it, and a fixture that invents a column is the strongest form of the failure: it makes
+  the product look like the test's idea of it.
+
+  The follow-up prices only what it can defend — fill a blank, report a disagreement, overwrite
+  nothing — and each of the five is pinned by a fixture built from `module.json`'s real columns,
+  with the reverting mutation red on all five.
+
   **A review finding widened the money spine, and named a gap in its gate.** The first draft extended
   a line as `round(rate * qty, 2)` — binary multiply, then HALF-EVEN — so a rate of `2.675` at
   quantity 1 extends to `2.67`, a cent short on the number a contractor is paid. This is exactly the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -428,6 +428,17 @@ instances:
   nothing — and each of the five is pinned by a fixture built from `module.json`'s real columns,
   with the reverting mutation red on all five.
 
+  **Review of the follow-up then found three more, and one of them is the same fixture failure a
+  THIRD time.** `column` on an unpriced entry carried the RATE column while its `quantity` came from
+  the quantity column, so the panel rendered *"8 rate are NOT in the figures above"* — and the test
+  asserted only the `reason` string, so it sailed through. The rate comparison also still used
+  `round()` while the amount beside it used `money.q2`; **that mutation initially SURVIVED**, which
+  is the more useful result — a consistency claim nothing can falsify is not true, it is untested.
+  The separating case is a line typed at `2.675` against a register at `2.68`: they agree to the
+  cent under `q2` and disagree under `round()`, so the screen whose only job is to flag a real
+  disagreement would have reported one over nothing. *Fixing a rounding inconsistency without a
+  fixture that distinguishes the two roundings leaves the same hole one layer along.*
+
   **A review finding widened the money spine, and named a gap in its gate.** The first draft extended
   a line as `round(rate * qty, 2)` — binary multiply, then HALF-EVEN — so a rate of `2.675` at
   quantity 1 extends to `2.67`, a cent short on the number a contractor is paid. This is exactly the

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -409,16 +409,24 @@ def price_ticket_lines(db: Session, pid: str, data: dict) -> tuple[dict[str, Any
             elif hours_based and entry[1] not in _HOURLY_UNITS:
                 # A per-Day/Week/Month rate against a quantity in hours. Converting needs a working
                 # day this system was never told, so it is named rather than guessed.
-                unpriced.append({"table": field, "name": name, "column": rate_col,
+                # `column` names the QUANTITY, matching the other producer below and the panel's
+                # `{quantity} {column}` rendering. It said `rate_col` here, which rendered as
+                # "8 rate are NOT in the figures above" — the label disagreeing with the number
+                # beside it. Raised in review.
+                unpriced.append({"table": field, "name": name, "column": qty_col,
                                  "quantity": _n(row.get(qty_col)),
                                  "reason": f"the register quotes this per {entry[1]}, and the line "
                                            f"is in hours"})
             elif not typed:
                 row[rate_col] = entry[0]
                 filled.append({"table": field, "name": name, "rate": entry[0]})
-            elif round(typed, 2) != round(entry[0], 2):
+            elif money.q2(typed) != money.q2(entry[0]):
+                # money.q2, not round(): a rate carries cents, and round() is HALF-EVEN while money
+                # is HALF-UP. The amount comparison below already used q2, so mixing the two here
+                # could report a rate variance that is only a rounding disagreement, or miss a real
+                # one at the half-cent. Raised in review — the same defect this PR's own subject is.
                 variance.append({"table": field, "name": name, "field": rate_col,
-                                 "typed": round(typed, 2), "register": round(entry[0], 2)})
+                                 "typed": money.q2(typed), "register": money.q2(entry[0])})
             rate = _n(row.get(rate_col))
             if rate:
                 extended = money.mul(rate, _n(row.get(qty_col)))

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -291,30 +291,63 @@ def lien_waiver(db: Session, pid: str, kind: str = "conditional_progress", app_n
 
 #: The three T&M line tables an eTicket carries, and how each one prices.
 #:
-#: `(lines field, rate module, name column, quantity column, rate column, unpriceable column)`
+#: `(lines field, rate module, REGISTER name column, LINE name column, quantity column, rate column,
+#: unpriceable column)`
 #:
-#: The rate column differs across the three — labour and equipment are `$/hr` on `rate`, material is
-#: a `unit_price` — which is why this is a table rather than a naming convention. The last entry
-#: names a quantity the rate register **cannot** price: `labor_rate` has no overtime rate and
-#: `equipment_rate` no idle rate, anywhere. Those hours are therefore reported as unpriced rather
-#: than multiplied by an assumed factor — a 1.5x nobody agreed to is a contract term, not a default,
-#: and this is the number a contractor gets paid.
-TM_TABLES: tuple[tuple[str, str, str, str, str, str | None], ...] = (
-    ("labor_lines", "labor_rate", "trade", "hours", "rate", "ot_hours"),
-    ("material_lines", "material_rate", "material", "qty", "unit_price", None),
-    ("equipment_lines", "equipment_rate", "equipment", "hours", "rate", "idle_hours"),
+#: **The register's name column and the LINE's name column are different questions, and conflating
+#: them shipped a HIGH defect.** The first version carried one column for both. Labour and equipment
+#: happen to agree (`trade`, `equipment` on each side) — material does not: the register keys on
+#: `material`, the eTicket line names the thing in `description`, and `material_lines` has no
+#: `material` column at all. So every material line a user could actually create read as name `""`
+#: and material never priced. It passed review and a mutation sweep because the test fixture put a
+#: `material` key on the row — *a fixture describing a world the schema does not have*, which is the
+#: failure `test_tm_rates.py`'s own docstring names one line up. Two of three coinciding is exactly
+#: how a conflated field survives.
+#:
+#: The rate column also differs across the three — labour and equipment are `$/hr` on `rate`,
+#: material is a `unit_price`. The last entry names a quantity the register **cannot** price:
+#: `labor_rate` has no overtime rate and `equipment_rate` no idle rate. Those hours are reported
+#: unpriced rather than multiplied by an assumed factor — a 1.5x nobody agreed to is a contract
+#: term, not a default, and this is the number a contractor gets paid.
+TM_TABLES: tuple[tuple[str, str, str, str, str, str, str | None], ...] = (
+    ("labor_lines", "labor_rate", "trade", "trade", "hours", "rate", "ot_hours"),
+    ("material_lines", "material_rate", "material", "description", "qty", "unit_price", None),
+    ("equipment_lines", "equipment_rate", "equipment", "equipment", "hours", "rate", "idle_hours"),
 )
 
+#: Register `unit` values whose rate multiplies out against HOURS. `labor_rate` offers Hour|Day and
+#: `equipment_rate` Hour|Day|Week|Month, and the line's quantity is hours either way — so a Day or
+#: Week rate extended by hours is wrong by the length of a working day, a number this system is not
+#: entitled to assume. Blank counts as hourly: the field is optional and both columns are labelled
+#: `$/hr`. Anything else is reported and NOT priced, for the same reason overtime is not.
+_HOURLY_UNITS = {"", "hour", "hourly", "hr", "/hr", "$/hr"}
 
-def _rate_index(db: Session, pid: str, mod: str, name_field: str) -> dict[str, float]:
-    """`{lowercased name: rate}` for one rate register. One query, not one per line."""
+
+def _rate_index(db: Session, pid: str, mod: str, name_field: str) -> dict[str, tuple[float, str]]:
+    """`{lowercased name: (rate, unit)}` for one rate register. One query, not one per line.
+
+    Two exclusions, both of which the first version got wrong:
+
+    - **A row with no rate is not an entry.** `rate` is optional on all three registers, so a
+      half-filled row yielded `0.0` — which is not `None`, so the line matched, took a rate of zero,
+      was reported as successfully priced, and kept a stale amount because the recompute is guarded
+      on a truthy rate. A fabricated "the register says $0" is worse than saying nothing.
+    - **A `closed` row is a retired rate.** Both registers carry an open/closed workflow, and
+      `list_records` orders oldest-first, so a superseded rate won the lookup and was then
+      SNAPSHOTTED onto the line permanently. That is the REFUSAL-READERS class, in a register whose
+      whole purpose is to be superseded.
+    """
     if mod not in me.TABLES:
         return {}
-    out: dict[str, float] = {}
+    out: dict[str, tuple[float, str]] = {}
     for r in _records(db, mod, pid):
-        name = str((r["data"] or {}).get(name_field, "")).strip().lower()
-        if name and name not in out:
-            out[name] = _n((r["data"] or {}).get("rate"))
+        if r.get("workflow_state") == "closed":
+            continue
+        d = r["data"] or {}
+        name = str(d.get(name_field, "")).strip().lower()
+        rate = _n(d.get("rate"))
+        if name and rate > 0 and name not in out:
+            out[name] = (rate, str(d.get("unit", "")).strip().lower())
     return out
 
 
@@ -333,15 +366,18 @@ def price_ticket_lines(db: Session, pid: str, data: dict) -> tuple[dict[str, Any
     with the right number in its body. **The lines are the evidence and the total is the summary**,
     which `apply_table_totals` says in as many words; pricing therefore belongs in the evidence.
 
-    ## What it will and will not overwrite
+    ## One rule, applied to every cell: FILL a blank, REPORT a disagreement, overwrite nothing
 
-    - A row with **no rate** takes the register's — that is the whole feature.
-    - A row whose typed rate **differs** from the register keeps the typed one, and the difference
-      is reported. A T&M rate that disagrees with the rate table is the thing a GC wants to see
-      before signing, not something to correct behind their back.
-    - A row the register has **no entry for** is left exactly as it is, and named.
-    - `amount` IS recomputed wherever a rate is known, because amount is arithmetic over the rate
-      and the quantity, not a negotiated figure.
+    - a row with **no rate** takes the register's — that is the whole feature;
+    - a row whose typed rate **differs** from the register keeps the typed one, reported;
+    - a row whose typed **amount** differs from rate x quantity keeps the typed one, reported. The
+      first version recomputed `amount` unconditionally, which silently replaced a figure a human
+      had entered: 8h + 2h OT at $95 written up as $1,045 became $760, and a lump-sum line with no
+      hours became $0. **A typed amount is evidence for exactly the reason a typed rate is** — it
+      may carry a premium, a negotiated allowance, or a rounding both parties signed. Applying the
+      principle to the rate and not to the amount was an inconsistency, not a design;
+    - a row the register has **no usable entry** for is left exactly as it is, and named;
+    - a register rate quoted per Day/Week/Month is **not** extended against hours, and says so.
 
     The rate is copied into the row, never referenced: updating the register later must not change
     what is owed for work already done. `test_eticket_tm.py` pins that, and this respects it.
@@ -352,11 +388,12 @@ def price_ticket_lines(db: Session, pid: str, data: dict) -> tuple[dict[str, Any
     unmatched: list[dict] = []
     unpriced: list[dict] = []
     priced = 0
-    for field, mod, name_col, qty_col, rate_col, extra_col in TM_TABLES:
+    for field, mod, reg_col, line_col, qty_col, rate_col, extra_col in TM_TABLES:
         rows = data.get(field)
         if not isinstance(rows, list):
             continue                      # never filled in, or legacy free text
-        index = _rate_index(db, pid, mod, name_col)
+        index = _rate_index(db, pid, mod, reg_col)
+        hours_based = qty_col == "hours"
         out: list[Any] = []
         moved = 0
         for row in rows:
@@ -364,29 +401,38 @@ def price_ticket_lines(db: Session, pid: str, data: dict) -> tuple[dict[str, Any
                 out.append(row)
                 continue
             row, before = dict(row), row
-            name = str(row.get(name_col, "")).strip()
+            name = str(row.get(line_col, "")).strip()
             typed = _n(row.get(rate_col))
-            listed = index.get(name.lower())
-            if listed is None:
+            entry = index.get(name.lower())
+            if entry is None:
                 unmatched.append({"table": field, "name": name, "register": mod})
+            elif hours_based and entry[1] not in _HOURLY_UNITS:
+                # A per-Day/Week/Month rate against a quantity in hours. Converting needs a working
+                # day this system was never told, so it is named rather than guessed.
+                unpriced.append({"table": field, "name": name, "column": rate_col,
+                                 "quantity": _n(row.get(qty_col)),
+                                 "reason": f"the register quotes this per {entry[1]}, and the line "
+                                           f"is in hours"})
             elif not typed:
-                row[rate_col] = listed
-                filled.append({"table": field, "name": name, "rate": listed})
-            elif round(typed, 2) != round(listed, 2):
-                variance.append({"table": field, "name": name, "typed": round(typed, 2),
-                                 "register": round(listed, 2)})
+                row[rate_col] = entry[0]
+                filled.append({"table": field, "name": name, "rate": entry[0]})
+            elif round(typed, 2) != round(entry[0], 2):
+                variance.append({"table": field, "name": name, "field": rate_col,
+                                 "typed": round(typed, 2), "register": round(entry[0], 2)})
             rate = _n(row.get(rate_col))
             if rate:
-                # money.mul, not round(rate * qty, 2): the latter rounds HALF-EVEN over a binary
-                # product, so 2.675 at qty 1 extends to 2.67. This is the line a contractor is paid
-                # on. Raised in review — and it is a shape `test_money_spine.py` cannot see, since
-                # its scan requires a division by 100 that a percentage has and a product does not.
-                amount = money.mul(rate, _n(row.get(qty_col)))
-                if money.q2(_n(row.get("amount"))) != amount:
-                    row["amount"] = amount
+                extended = money.mul(rate, _n(row.get(qty_col)))
+                current = _n(row.get("amount"))
+                if not current:
+                    row["amount"] = extended
+                elif money.q2(current) != extended:
+                    # Reported, NOT corrected — see the rule above.
+                    variance.append({"table": field, "name": name, "field": "amount",
+                                     "typed": money.q2(current), "register": extended})
             if extra_col and _n(row.get(extra_col)):
                 unpriced.append({"table": field, "name": name, "column": extra_col,
-                                 "quantity": _n(row.get(extra_col))})
+                                 "quantity": _n(row.get(extra_col)),
+                                 "reason": "the rate register holds no rate for these"})
             if row != before:
                 moved += 1
             out.append(row)

--- a/services/api/test_tm_rates.py
+++ b/services/api/test_tm_rates.py
@@ -165,7 +165,7 @@ with TestClient(app) as c:
     # requires the expression to divide by 100, which a percentage does and a product does not.
     c.post(f"/projects/{pid}/modules/material_rate", headers=H,
            json={"data": {"material": "Half-cent widget", "rate": 2.675}})
-    tid = ticket(material_lines=[{"description": "w", "material": "Half-cent widget", "qty": 1}])
+    tid = ticket(material_lines=[{"description": "Half-cent widget", "qty": 1}])
     price(tid)
     check("an extended amount rounds half-UP at the half-cent, not half-even",
           rows(tid, "material_lines")[0].get("amount") == 2.68,
@@ -174,10 +174,93 @@ with TestClient(app) as c:
     check("...and the derived total carries the same cent", stored(tid).get("material_total") == 2.68,
           stored(tid).get("material_total"))
 
+    # ---- 4c. FIVE REVIEW FINDINGS, each a fixture the first version could not express ------------
+    # Every one of these passed the original suite. They are grouped because they share a cause: the
+    # fixtures described a world simpler than the schema, so the assertions could not reach the bug.
+
+    # (i) THE MATERIAL NAME COLUMN. `material_lines` has columns description/qty/unit/unit_price/
+    # amount — there is NO `material` column. The first TM_TABLES used one field for both the
+    # REGISTER's name column and the LINE's, which is right for labour and equipment by coincidence
+    # and wrong for material, so every material line a user could create priced as unmatched. The
+    # original test passed only because its fixture put a `material` key on the row.
+    # Its own fixture, deliberately: the first draft of THIS check read a `tid` left over from the
+    # section above and asserted 4.25 against a different ticket. Same error one layer up — an
+    # assertion whose subject is not the thing it names.
+    tid = ticket(material_lines=[{"description": "EMT 3/4", "qty": 10}])
+    price(tid)
+    check("a material line names its item in `description`, the column the schema actually has",
+          rows(tid, "material_lines")[0].get("unit_price") == 4.25,
+          rows(tid, "material_lines")[0])
+    check("...and it extends", rows(tid, "material_lines")[0].get("amount") == 42.5,
+          rows(tid, "material_lines")[0])
+    tid = ticket(material_lines=[{"description": "EMT 3/4", "qty": 10, "material": "nonsense"}])
+    price(tid)
+    check("...while a stray non-schema key on the row changes nothing",
+          rows(tid, "material_lines")[0].get("amount") == 42.5,
+          rows(tid, "material_lines")[0])
+
+    # (ii) A TYPED AMOUNT IS EVIDENCE, exactly as a typed rate is. 8h + 2h OT written up at $1,045
+    # must not become $760 because straight time is all this engine can derive.
+    tid = ticket(labor_lines=[{"worker": "A", "trade": "Electrician", "hours": 8, "ot_hours": 2,
+                               "rate": 95, "amount": 1045}])
+    rep = price(tid)
+    check("a typed amount is NOT overwritten by rate x quantity",
+          rows(tid, "labor_lines")[0].get("amount") == 1045, rows(tid, "labor_lines")[0])
+    check("...and the difference from straight time is reported instead",
+          [(v["field"], v["typed"], v["register"]) for v in rep["variance"]]
+          == [("amount", 1045.0, 760.0)], rep["variance"])
+    # A lump-sum line with no hours must not be zeroed either.
+    tid = ticket(labor_lines=[{"worker": "B", "trade": "Electrician", "amount": 500}])
+    price(tid)
+    check("a lump-sum line with no quantity keeps its amount",
+          rows(tid, "labor_lines")[0].get("amount") == 500, rows(tid, "labor_lines")[0])
+
+    # (iii) A REGISTER ROW WITH NO RATE IS NOT AN ENTRY. `rate` is optional, so a half-filled row
+    # gave 0.0 — not None — and the line took a rate of zero, was reported as priced, and kept a
+    # stale amount because the recompute is guarded on a truthy rate.
+    c.post(f"/projects/{pid}/modules/labor_rate", headers=H, json={"data": {"trade": "Rigger"}})
+    tid = ticket(labor_lines=[{"worker": "C", "trade": "Rigger", "hours": 6}])
+    rep = price(tid)
+    check("a register row with no rate reads as NO entry, not as $0",
+          [u["name"] for u in rep["unmatched"]] == ["Rigger"] and not rep["filled"], rep)
+    check("...so the line is left alone rather than priced at zero",
+          "rate" not in rows(tid, "labor_lines")[0], rows(tid, "labor_lines")[0])
+
+    # (iv) THE REGISTER'S UNIT. equipment_rate offers Hour|Day|Week|Month and the line's quantity is
+    # hours, so a $1,200/Week lift extended against an 8-hour day reads as $9,600 — reported as an
+    # ordinary success. Converting needs a working day nobody stated, so it is named, not guessed.
+    c.post(f"/projects/{pid}/modules/equipment_rate", headers=H,
+           json={"data": {"equipment": "Tower crane", "rate": 1200, "unit": "Week"}})
+    tid = ticket(equipment_lines=[{"equipment": "Tower crane", "hours": 8}])
+    rep = price(tid)
+    check("a per-week rate is NOT extended against hours",
+          "rate" not in rows(tid, "equipment_lines")[0], rows(tid, "equipment_lines")[0])
+    check("...and the reason names the register's unit",
+          any("per week" in (u.get("reason") or "") for u in rep["unpriced"]), rep["unpriced"])
+    check("...while an explicitly hourly rate still prices",
+          stored(ticket_priced_hourly := ticket(
+              equipment_lines=[{"equipment": "Scissor lift", "hours": 6}])) is not None
+          and (price(ticket_priced_hourly),
+               rows(ticket_priced_hourly, "equipment_lines")[0].get("amount"))[1] == 180.0)
+
+    # (v) A CLOSED RATE IS RETIRED. Both registers carry open/closed and list_records is oldest
+    # first, so a superseded rate won the lookup and was SNAPSHOTTED onto the line permanently.
+    lr = c.get(f"/projects/{pid}/modules/labor_rate", headers=H, params={"limit": 100}).json()
+    lr = lr["records"] if isinstance(lr, dict) else lr
+    old = next(r for r in lr if r["data"]["trade"] == "Electrician")
+    c.post(f"/projects/{pid}/modules/labor_rate/{old['id']}/transition", headers=H,
+           json={"action": "close"})
+    c.post(f"/projects/{pid}/modules/labor_rate", headers=H,
+           json={"data": {"trade": "Electrician", "rate": 130}})
+    tid = ticket(labor_lines=[{"worker": "D", "trade": "Electrician", "hours": 2}])
+    price(tid)
+    check("a CLOSED register row does not win the lookup over its live replacement",
+          rows(tid, "labor_lines")[0].get("rate") == 130, rows(tid, "labor_lines")[0])
+
     # ---- 5. material prices off `unit_price`, not `rate` -----------------------------------------
     # The three tables do not share a rate column, which is why the mapping is a table and not a
     # naming convention: a loop assuming `rate` would silently price no material at all.
-    tid = ticket(material_lines=[{"description": "conduit", "material": "EMT 3/4", "qty": 100}])
+    tid = ticket(material_lines=[{"description": "EMT 3/4", "qty": 100}])
     price(tid)
     d = stored(tid)
     check("material takes the register's rate into unit_price",

--- a/services/api/test_tm_rates.py
+++ b/services/api/test_tm_rates.py
@@ -237,11 +237,36 @@ with TestClient(app) as c:
           "rate" not in rows(tid, "equipment_lines")[0], rows(tid, "equipment_lines")[0])
     check("...and the reason names the register's unit",
           any("per week" in (u.get("reason") or "") for u in rep["unpriced"]), rep["unpriced"])
+    # `column` must name the QUANTITY, not the rate: the panel renders it as
+    # "{quantity} {column} are NOT in the figures above", so `rate_col` here read as "8 rate".
+    # Asserting only the reason text missed it — raised in review, and the THIRD time in this item
+    # that a fixture checked less than the thing it was about.
+    check("...and `column` names the quantity the panel prints beside it",
+          [(u["column"], u["quantity"]) for u in rep["unpriced"]] == [("hours", 8.0)],
+          rep["unpriced"])
+    # Sequenced plainly rather than crammed into one expression: the walrus-and-tuple version put
+    # `price()` inside a short-circuit `and`, so a None from `stored()` would have SKIPPED the
+    # pricing rather than failing the check, and it carried no detail. Raised in review.
+    hourly_tid = ticket(equipment_lines=[{"equipment": "Scissor lift", "hours": 6}])
+    hourly_before = stored(hourly_tid)
+    price(hourly_tid)
+    hourly_row = rows(hourly_tid, "equipment_lines")[0]
     check("...while an explicitly hourly rate still prices",
-          stored(ticket_priced_hourly := ticket(
-              equipment_lines=[{"equipment": "Scissor lift", "hours": 6}])) is not None
-          and (price(ticket_priced_hourly),
-               rows(ticket_priced_hourly, "equipment_lines")[0].get("amount"))[1] == 180.0)
+          hourly_before is not None and hourly_row.get("amount") == 180.0,
+          {"before": hourly_before, "row": hourly_row})
+
+    # (iv-b) THE RATE COMPARISON ROUNDS LIKE MONEY. `round()` is HALF-EVEN and `money.q2` HALF-UP,
+    # so a line typed at 2.675 against a register at 2.68 AGREES to the cent under q2 and DISAGREES
+    # under round() — a variance reported over nothing, on the screen whose whole job is to flag a
+    # real disagreement. Raised in review; added here because reverting to round() left every other
+    # assertion green, which makes a consistency claim untestable rather than true.
+    c.post(f"/projects/{pid}/modules/material_rate", headers=H,
+           json={"data": {"material": "Half-cent stock", "rate": 2.68}})
+    tid = ticket(material_lines=[{"description": "Half-cent stock", "qty": 4, "unit_price": 2.675}])
+    rep = price(tid)
+    check("a typed rate that agrees with the register TO THE CENT reports no variance",
+          [v for v in rep["variance"] if v["field"] == "unit_price"] == [],
+          f"round() would call 2.675 vs 2.68 a disagreement; money.q2 makes both 2.68 — {rep['variance']}")
 
     # (v) A CLOSED RATE IS RETIRED. Both registers carry open/closed and list_records is oldest
     # first, so a superseded rate won the lookup and was SNAPSHOTTED onto the line permanently.


### PR DESCRIPTION
Follow-up to #482 (`c6ccc435`). A review of the merged pricing engine found it wrong in five ways. Every one reproduces, every fix is pinned by a fixture built from `module.json`'s **real** columns, and the reverting mutation reds each.

## The five

| | defect | mutation output |
|---|---|---|
| 1 | **Material never priced.** `TM_TABLES` used one field for both the register's name column and the **line's**. `material_lines` has `description/qty/unit/unit_price/amount` — there is **no `material` column** — so every material line a user could create read as name `""` and fell through to `unmatched` | `{'description': 'EMT 3/4', 'qty': 10}` — untouched |
| 2 | **A typed `amount` was overwritten.** 8h + 2h OT written up at $1,045 became straight time; a lump-sum line with no hours became $0 | `amount: 1045` → `760.0`; lump sum → `0.0` |
| 3 | **A blank register rate priced at $0.** `rate` is optional, so a half-filled row gave `0.0` — not `None` — and the line matched, took zero, and was reported as **successfully priced** with a stale amount | `filled: [{name: 'Rigger', rate: 0.0}], priced: 1` |
| 4 | **The register's `unit` was dropped.** `equipment_rate` offers Hour/Day/Week/Month and the line's quantity is hours | `$1,200/week crane, hours: 8 → amount: 9600.0` |
| 5 | **A `closed` rate won the lookup** and was snapshotted onto the line permanently — the REFUSAL-READERS class, in a register whose whole purpose is to be superseded | `rate: 95.0` (retired) instead of `130` |

## Why #1 survived a mutation sweep

The fixture wrote `{"description": "conduit", "material": "EMT 3/4", …}` — **a key the schema does not declare.** *"An assertion cannot be stronger than the world its fixture can describe"* is the sentence in that same test's docstring, written about `test_cost.py`, and the fixture one paragraph below it had the same defect.

A fixture that invents a column is the strongest form of that failure: the product ends up looking like the test's idea of the product. Labour and equipment coincide (`trade`, `equipment` on both sides), so one conflated field was right in two cases out of three — which is exactly how it survives.

It recurred while fixing it: my first replacement assertion read a `tid` left over from the section above and checked the wrong ticket. That's noted in the test, beside the fix.

## The rule change #2 forced

The original preserved a typed **rate** as evidence and recomputed the **amount** unconditionally. Those are the same question. One rule now, on every cell: **fill a blank, report a disagreement, overwrite nothing.** An amount carrying an OT premium or a negotiated allowance survives and is reported against rate × quantity.

#4 follows the same principle as the overtime decision: a Day/Week/Month rate is **not** converted against hours, because that needs a working day nobody stated. Reported unpriced, with the reason.

The report gains `field` on a variance (rate vs amount) and `reason` on an unpriced quantity; the panel renders both, and an amount variance reads as the line's own arithmetic rather than as the register disagreeing.

## Deliberately not included

`apps/web/src/api/schema.d.ts` still declares the `lines` body field this route no longer takes. Regenerating it churns **38,231 lines** — `openapi.json` was broadly stale, not stale only here. Real cleanup, separate change; bundling it would swamp this diff. Harmless at runtime (FastAPI ignores the extra key) and it is a generated file with no CI freshness gate.

## Verification

- **682/682** backend suites · **2299/2299** web tests
- `tsc --noEmit`, `eslint`, `ruff check ../..` clean
- **5 mutations, one per finding, all red** — each reproducing the defect's own number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Material entries are now priced correctly.
  - Hand-entered amounts are preserved, with discrepancies reported clearly.
  - Entries without valid rates are no longer incorrectly priced at $0.
  - Daily, weekly, and monthly rates are no longer applied to hourly quantities.
  - Active rates are selected over closed or superseded rates.
  - Pricing comparisons now use consistent currency rounding.
  - Recalculating pricing preserves consistent results.

- **Improvements**
  - Pricing reports identify the differing field and explain why entries remain unpriced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->