### PR TITLE
PARCEL-SHAPE: size the building on the real parcel — and TM-UNIT-CLAIM, a pricing report that contradicted its own total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ The massing engine had always accepted a `lot_polygon` and offset it inward for 
 footprint, and nothing could reach it: the request type had no such field. And the parcel reader
 itself had no caller on any screen.
 
-Now: paste a boundary (or load a `.geojson` / `.wkt` file) on the feasibility tab. It reports the
+Now: paste a boundary (or load a `.geojson` / `.wkt` file) on the feasibility tab — one outer ring,
+so a WKT `MULTIPOLYGON` is refused by name rather than sent to an endpoint that would reject it. It reports the
 parcel's area, the rectangle it replaces, and the percentage between them, and the width/depth boxes
 become the parcel's own bounding extents, disabled — so it is clear which figure the building is
 being sized on. The result summary says the same thing again beside the GFA. Nothing is substituted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,29 @@ while a control on that very tab had been sending it all along. Two false positi
 direction its own docstring calls the expensive one. Assignments now count; comparisons and arrow
 parameters still do not, and a self-test pins the distinction.
 
+### T&M pricing: an unpriced line that was in the total after all
+
+A follow-up review found the pricing report contradicting the figure printed beside it. An equipment
+line with a rate the user typed, a blank amount, and a register rate quoted per Day/Week/Month was
+listed as unpriced — *"8 hours are NOT in the figures above"* — directly beneath the $800 the engine
+had just added to that line.
+
+Both halves were doing something defensible. The register genuinely cannot price the line: converting
+a weekly rate against hours needs a working day nobody stated. But `equipment_lines.rate` is declared
+in `$/hr`, so when a rate is typed, `rate × hours` is the **line's own** arithmetic and is computed
+like any other line — the register's unit is a fact about the register, not about the line, and
+refusing the sum would drop a line the superintendent priced out of the ticket total.
+
+So the sum was right and the sentence was wrong. A pricing run now says which of the two happened:
+a quantity nothing could price still reads "NOT in the figures above", while one the line priced
+itself reads "in the figures above at the rate you entered, not the register's". Overtime and idle
+hours are unchanged — nothing multiplies those, here or anywhere, because a 1.5× premium is a
+contract term rather than a default.
+
+The fixture that missed it gave the line no rate of its own, so the old sentence was true by
+accident. That is the fourth time in this item that the case distinguishing two behaviours was the
+case nobody wrote.
+
 ### T&M pricing: five corrections to the first cut
 
 Review of the merged TM-RATES change found the pricing engine wrong in five ways. All are fixed, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Feasibility sizes the building on the real parcel, not on its bounding rectangle
+
+The "Generate from zoning" tab could describe a lot only as **lot width × lot depth**. For any parcel
+that is not a rectangle — a corner lot, a flag lot, anything with a cut corner — that describes a box
+*around* the lot, and a box's area is always larger. The error is not cosmetic: lot area sets max
+GFA, which sets floors, which sets the unit count, which sets rent and the acquisition proforma's
+IRR. Every one of those came out optimistic and none of them said so. On an L-shaped 1,600 m² lot
+inside a 50 × 50 m box, the rectangle yields **5,000 m² of buildable GFA against the parcel's true
+3,200** — 56% more building, on the number a deal gets priced from.
+
+Three pieces existed and had never been connected. The parcel reader parsed a real GeoJSON/WKT
+boundary and projected it to metres — then returned the area and threw the projected outline away.
+The massing engine had always accepted a `lot_polygon` and offset it inward for a true buildable
+footprint, and nothing could reach it: the request type had no such field. And the parcel reader
+itself had no caller on any screen.
+
+Now: paste a boundary (or load a `.geojson` / `.wkt` file) on the feasibility tab. It reports the
+parcel's area, the rectangle it replaces, and the percentage between them, and the width/depth boxes
+become the parcel's own bounding extents, disabled — so it is clear which figure the building is
+being sized on. The result summary says the same thing again beside the GFA. Nothing is substituted
+silently; a user who prefers the rectangle can clear the boundary and still have it.
+
+**A gate was wrong in the same direction.** `test_body_param_reach.py` decides whether the web app
+sends a given request field by looking for it in the source — and only recognised object-literal
+syntax (`key:`). A body assembled field by field (`p.dome_radius = …`, which is how this tab has
+always sent its optionals) was invisible to it, so `dome_radius` sat on the "nothing sends this" list
+while a control on that very tab had been sending it all along. Two false positives out of 27, in the
+direction its own docstring calls the expensive one. Assignments now count; comparisons and arrow
+parameters still do not, and a self-test pins the distinction.
+
 ### T&M pricing: five corrections to the first cut
 
 Review of the merged TM-RATES change found the pricing engine wrong in five ways. All are fixed, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,28 @@ while a control on that very tab had been sending it all along. Two false positi
 direction its own docstring calls the expensive one. Assignments now count; comparisons and arrow
 parameters still do not, and a self-test pins the distinction.
 
+### Parcel boundaries and T&M reports: four corrections from review
+
+- **A line with no rate but an amount already entered was reported as excluded.** Only a line with a
+  *typed rate* was counted as being in the ticket total, but an amount entered directly never reaches
+  the rate-extension step at all — it survives untouched and is summed into the total regardless. The
+  same contradiction the previous entry fixed, one path over, and the fixture there could not see it
+  because it had a rate.
+- **A parcel boundary with a repeated point produced a wrong buildable footprint.** Stripping the
+  duplicated closing point is not enough; an interior repeat survives it. The setback offset divides
+  by each edge's length and guards against division by zero, so a zero-length edge does not fail —
+  it leaves that corner un-inset while its neighbours move, and returns a plausible polygon with the
+  wrong area. Repeated points are now removed before anything is measured, and a boundary with fewer
+  than three distinct points is refused.
+- **Clearing a parcel while it was still loading could bring it back.** Press "Use this parcel", then
+  Clear before the response arrives, and the late response republished the parcel just dismissed —
+  after which "Generate IFC model + apply" would save a model and a proforma for a lot the panel no
+  longer showed.
+- **A WKT `MULTIPOLYGON` was accepted by the panel and rejected by the server.** Refused locally now,
+  by name, with the export that works. Supporting it properly is a design question rather than a
+  cleanup: the buildable footprint comes from offsetting one outer ring, and a lot split by a
+  right-of-way has no single ring to offset.
+
 ### T&M pricing: an unpriced line that was in the total after all
 
 A follow-up review found the pricing report contradicting the figure printed beside it. An equipment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ footprint, and nothing could reach it: the request type had no such field. And t
 itself had no caller on any screen.
 
 Now: paste a boundary (or load a `.geojson` / `.wkt` file) on the feasibility tab — one outer ring,
-so a WKT `MULTIPOLYGON` is refused by name rather than sent to an endpoint that would reject it. It reports the
+so a WKT `MULTIPOLYGON` is refused by name rather than sent to an endpoint that would reject it, and
+a ring that encloses no area (repeated or collinear points) is refused with the reason rather than
+priced as a lot of zero square metres. It reports the
 parcel's area, the rectangle it replaces, and the percentage between them, and the width/depth boxes
 become the parcel's own bounding extents, disabled — so it is clear which figure the building is
 being sized on. The result summary says the same thing again beside the GFA. Nothing is substituted

--- a/apps/web/src/api/authoring.ts
+++ b/apps/web/src/api/authoring.ts
@@ -471,6 +471,11 @@ export interface ComputeGraph {
 export interface MassingParams {
   name?: string; use_type?: "residential" | "commercial";
   lot_width?: number | null; lot_depth?: number | null; lot_area?: number | null;
+  /** The real parcel ring, [[x,y],…] in metres and OPEN (no repeated closing vertex) — as
+   *  `parcelAnalyze` returns it in `ring_m`. When present the server offsets this polygon
+   *  inward for the true buildable footprint and ignores `lot_width`/`lot_depth`, whose
+   *  bounding rectangle always overstates the lot. */
+  lot_polygon?: number[][] | null;
   far?: number; coverage_max?: number; front_setback?: number; rear_setback?: number;
   side_setback?: number; height_limit?: number | null; floor_to_floor?: number;
   efficiency?: number; avg_unit_m2?: number;

--- a/apps/web/src/api/clientCallers.test.ts
+++ b/apps/web/src/api/clientCallers.test.ts
@@ -306,7 +306,7 @@ const UNCALLED: readonly string[] = [
   "importFamilyPack", "layoutVerify", "listMacros", "listingReso",
   "liveStream", "loanCovenants", "massingOptionRecipes", "mcpTools",
   "mep", "modelAdjacency", "moduleCalc", "myWork",
-  "netEffectiveRent", "normalizeT12", "parcelAnalyze", "parcelsDataStatus",
+  "netEffectiveRent", "normalizeT12", "parcelsDataStatus",
   "pdfInfo", "permitsTimeline", "preconSnapshot",
   "proformaRenovation", "proformaRollover", "progressActuals",
   "progressCaptureDiff", "progressRollup", "raisePlan", "recordDistribution",

--- a/apps/web/src/api/cost.ts
+++ b/apps/web/src/api/cost.ts
@@ -38,10 +38,18 @@ export interface TmPricingReport {
   /** Rows no register has a usable entry for. Left exactly as they are. */
   unmatched: { table: string; name: string; register: string }[];
   /**
-   * A real quantity nothing could price, with the reason. Overtime and idle hours (no OT or idle
-   * rate exists), and a register rate quoted per Day/Week/Month against a line measured in hours.
+   * A real quantity the RATE REGISTER could not price, with the reason. Overtime and idle hours (no
+   * OT or idle rate exists), and a register rate quoted per Day/Week/Month against a line measured
+   * in hours.
+   *
+   * `in_totals` says whether the LINE priced itself anyway, from a rate the user typed. Overtime
+   * and idle hours never do — nothing multiplies them — but a line whose register rate is quoted
+   * per Day/Week does, because its own `rate` column is `$/hr`. The panel must branch on it: this
+   * used to read "a real quantity NOTHING could price", which was true of one case and false of the
+   * other, and the panel printed the false sentence directly above the amount the engine had added.
    */
-  unpriced: { table: string; name: string; column: string; quantity: number; reason: string }[];
+  unpriced: { table: string; name: string; column: string; quantity: number; reason: string;
+              in_totals: boolean }[];
   /** How many rows this run actually changed. */
   priced: number;
   totals: { labor_total: number; material_total: number; equipment_total: number;

--- a/apps/web/src/api/entitlements.ts
+++ b/apps/web/src/api/entitlements.ts
@@ -147,6 +147,12 @@ export function withEntitlements<TBase extends Ctor<HttpCore>>(Base: TBase) {
       parcel_id: string | null; vertices: number; coordinates_were_lonlat: boolean;
       area_m2: number; area_acres: number; perimeter_m: number;
       centroid: { x: number; y: number }; bbox: { minx: number; miny: number; maxx: number; maxy: number };
+      /** The boundary in metres, origin-shifted to its own bounding box and OPEN — feed it
+       *  straight to `previewMassing`/`generateMassing` as `lot_polygon`. */
+      ring_m: number[][];
+      /** The bounding rectangle a user would otherwise have typed, and its area — always
+       *  ≥ `area_m2`, which is the whole reason the ring is worth sending. */
+      lot_width_m: number; lot_depth_m: number; bounding_rect_m2: number;
       compliance?: { checks: Check[]; ok: boolean | null; violations: string[] }; note: string;
     }>(`/parcels/analyze`, { method: "POST", body: JSON.stringify(body) });
   }

--- a/apps/web/src/portal/register/tmPricing.test.ts
+++ b/apps/web/src/portal/register/tmPricing.test.ts
@@ -33,7 +33,10 @@ const FULL: TmPricingReport = {
              { table: "labor_lines", name: "Foreman", field: "amount", typed: 1045, register: 760 }],
   unmatched: [{ table: "labor_lines", name: "Glazier", register: "labor_rate" }],
   unpriced: [{ table: "labor_lines", name: "Electrician", column: "ot_hours", quantity: 2,
-               reason: "the rate register holds no rate for these" }],
+               reason: "the rate register holds no rate for these", in_totals: false },
+             { table: "equipment_lines", name: "Tower crane", column: "hours", quantity: 8,
+               reason: "the register quotes this per week, so it could not check the rate you"
+                 + " entered", in_totals: true }],
   priced: 2,
   totals: { labor_total: 760, material_total: 425, equipment_total: 0, grand_total: 1185 },
 };
@@ -83,6 +86,14 @@ describe("the T&M pricing control", () => {
     expect(text, "hours nothing could price").toContain("ot hours");
     expect(text, "...and the REASON, since 'unpriced' now covers a per-week rate too")
       .toContain("holds no rate for these");
+    // Two different findings share the `unpriced` list and printing them identically was a lie in
+    // one direction: a line whose register rate is quoted per week still prices itself from the
+    // $/hr rate the user typed, so "are NOT in the figures above" appeared directly beneath the
+    // amount the engine had just added. What the register could not do and what the TOTAL contains
+    // are separate questions.
+    expect(text, "an excluded quantity says so").toMatch(/2 ot hours are NOT in the figures above/);
+    expect(text, "...and one the line priced itself must NOT deny the amount above it")
+      .toMatch(/8 hours are in the figures above at the rate you entered/);
     expect(text).toContain("$1,185");
   });
 

--- a/apps/web/src/portal/register/tmPricing.test.ts
+++ b/apps/web/src/portal/register/tmPricing.test.ts
@@ -38,7 +38,11 @@ const FULL: TmPricingReport = {
                reason: "the register quotes this per week, so it could not check the rate you"
                  + " entered", in_totals: true }],
   priced: 2,
-  totals: { labor_total: 760, material_total: 425, equipment_total: 0, grand_total: 1185 },
+  // The crane below carries `in_totals: true`, so the totals must CONTAIN its $800. They said
+  // equipment $0 / grand $1,185 — a fixture reproducing the exact contradiction the assertions
+  // beneath it exist to forbid, which is how a report and its own total come to disagree in
+  // the first place. Raised in review.
+  totals: { labor_total: 760, material_total: 425, equipment_total: 800, grand_total: 1985 },
 };
 
 function host(rep: TmPricingReport | Error) {
@@ -94,7 +98,7 @@ describe("the T&M pricing control", () => {
     expect(text, "an excluded quantity says so").toMatch(/2 ot hours are NOT in the figures above/);
     expect(text, "...and one the line priced itself must NOT deny the amount above it")
       .toMatch(/8 hours are in the figures above at the rate you entered/);
-    expect(text).toContain("$1,185");
+    expect(text).toContain("$1,985");
   });
 
   it("says so when a run changes nothing, instead of looking like a failure", async () => {

--- a/apps/web/src/portal/register/tmPricing.ts
+++ b/apps/web/src/portal/register/tmPricing.ts
@@ -91,8 +91,15 @@ export function renderTmReport(box: HTMLElement, rep: TmPricingReport): void {
       + " to price this line", "var(--status-warn)"));
   }
   for (const u of rep.unpriced) {
+    // Two different findings share this list, and printing them identically was a lie in one
+    // direction: a line whose register rate is quoted per week still prices itself from the $/hr
+    // rate the user typed, so "are NOT in the figures above" appeared directly beneath the amount
+    // the engine had just added. What the register could not do and what the TOTAL contains are
+    // separate questions; only the second one belongs in that sentence.
     box.appendChild(line(
-      `⏱ ${u.name}: ${u.quantity} ${u.column.replace("_", " ")} are NOT in the figures above — `
+      `⏱ ${u.name}: ${u.quantity} ${u.column.replace("_", " ")} `
+      + (u.in_totals ? "are in the figures above at the rate you entered, not the register's — "
+                     : "are NOT in the figures above — ")
       + u.reason, "var(--status-warn)"));
   }
 }

--- a/apps/web/src/proforma/massingTab.ts
+++ b/apps/web/src/proforma/massingTab.ts
@@ -5,6 +5,7 @@ import type { ApiClient, MassingParams, MassingResult } from "../api/client";
 import { escapeHtml } from "../ui/feedback";
 
 import { money, pct } from "./format";
+import { type LoadedParcel, parcelBoundaryControl } from "./parcelBoundary";
 
 export interface MassingTabCtx {
   api: ApiClient;
@@ -45,6 +46,27 @@ export function renderMassingTab(root: HTMLElement, ctx: MassingTabCtx): void {
     inputs[key] = inp; wrap.appendChild(inp); grid.appendChild(wrap);
   }
   host.appendChild(grid);
+
+  // PARCEL-SHAPE — the lot's real outline, when the user has one. The two numeric inputs above can
+  // only describe a rectangle, and `compute_massing` has always been able to offset a true polygon
+  // inward; nothing could reach it. While a parcel is loaded, width/depth are shown as the parcel's
+  // own bounding box and disabled, so it is clear which figure the building is being sized on.
+  let parcel: LoadedParcel | null = null;
+  const boundary = parcelBoundaryControl({ api: ctx.api }, (p) => {
+    parcel = p;
+    for (const key of ["lot_width", "lot_depth"] as const) {
+      const inp = inputs[key];
+      if (!inp) continue;
+      inp.disabled = !!p;
+      inp.title = p ? "superseded by the parcel boundary below — the building is sized on the real"
+        + " outline, and this is only its bounding box" : "";
+    }
+    if (p) {
+      if (inputs.lot_width) inputs.lot_width.value = String(p.widthM);
+      if (inputs.lot_depth) inputs.lot_depth.value = String(p.depthM);
+    }
+  });
+  host.appendChild(boundary.el);
 
   // shape: box (zoning massing) or a monolithic / earth dome (hemisphere by radius)
   const domeWrap = document.createElement("label");
@@ -103,6 +125,10 @@ export function renderMassingTab(root: HTMLElement, ctx: MassingTabCtx): void {
     if (corrChk.checked) { p.units = true; p.unit_layout = "corridor"; }
     const pk = parseInt(pkInput.value, 10); if (pk > 0) p.parking = pk;
     if (domeChk.checked) { p.shape = "dome"; p.dome_radius = parseFloat(domeR.value) || 8; }
+    // The ring wins over the rectangle. Both are sent: the server prefers `lot_polygon` when it has
+    // one, and leaving width/depth in keeps the request self-describing rather than making the
+    // rectangle vanish from the record of what was asked for.
+    if (parcel) p.lot_polygon = parcel.ring;
     return p;
   };
   const out = document.createElement("div"); out.style.marginTop = "6px";
@@ -112,6 +138,12 @@ export function renderMassingTab(root: HTMLElement, ctx: MassingTabCtx): void {
       `<div class="meta" style="margin-bottom:4px"><b>${m.floors} floors</b> · ${Math.round(m.building_height_m)} m · ` +
       `<b>${m.buildable_gfa_sf.toLocaleString()} sf</b> GFA · ${m.units} units · ${m.footprint_m2.toLocaleString()} m² plate ` +
       `<span class="meta">(bound by ${m.binding_constraint}, ${m.far_achieved} FAR)</span></div>` +
+      // Say which lot the figures above were computed on. A GFA sized on a real 1,600 m² parcel and
+      // one sized on its 2,500 m² bounding box look identical on screen, and differ by 56%.
+      (parcel
+        ? `<div class="meta">on the real parcel — ${Math.round(parcel.areaM2).toLocaleString()} m²,`
+          + ` not the ${Math.round(parcel.rectM2).toLocaleString()} m² bounding rectangle</div>`
+        : "") +
       (su ? `<div class="meta">Total cost ${money(su.total_uses ?? 0)} · equity ${money(su.equity ?? 0)} · ` +
             `IRR <b>${pct(ret?.equity_irr ?? null)}</b> · ${ret?.equity_multiple ?? "—"}× EM</div>` : "") +
       (r.proforma.solve_error ? `<div class="meta" style="color:var(--status-crit)">proforma: ${r.proforma.solve_error}</div>` : "") +

--- a/apps/web/src/proforma/parcelBoundary.test.ts
+++ b/apps/web/src/proforma/parcelBoundary.test.ts
@@ -136,6 +136,27 @@ describe("the parcel boundary control", () => {
     expect(c.parcel()).toBeNull();
   });
 
+  it("a read that lands after Clear does NOT resurrect the parcel", async () => {
+    // Press Use, press Clear before the request settles, and the late response used to publish the
+    // parcel the user had just dismissed — after which "Generate IFC model + apply" would save a
+    // model and a proforma for a lot the panel no longer showed. Raised in review.
+    let release: ((v: unknown) => void) | undefined;
+    const h = {
+      api: { parcelAnalyze: vi.fn().mockImplementation(() => new Promise((r) => { release = r; })) },
+    } as unknown as ParcelBoundaryHost;
+    const seen: (LoadedParcel | null)[] = [];
+    const c = parcelBoundaryControl(h, (p) => seen.push(p));
+    (c.el.querySelector("textarea") as HTMLTextAreaElement).value = '{"type":"Polygon"}';
+    (c.el.querySelector("button") as HTMLButtonElement).click();
+    const clear = [...c.el.querySelectorAll("button")]
+      .find((b) => (b.textContent ?? "") === "Clear") as HTMLButtonElement;
+    clear.click();
+    release?.(ELL);
+    await flush();
+    expect(c.parcel(), "the cleared parcel must stay cleared").toBeNull();
+    expect(seen.filter(Boolean), "and nothing may publish it after the fact").toEqual([]);
+  });
+
   it("can be cleared back to the rectangle", async () => {
     const seen: (LoadedParcel | null)[] = [];
     const c = parcelBoundaryControl(host(ELL), (p) => seen.push(p));

--- a/apps/web/src/proforma/parcelBoundary.test.ts
+++ b/apps/web/src/proforma/parcelBoundary.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { overstatement, parseBoundary, parcelBoundaryControl } from "./parcelBoundary";
+import type { LoadedParcel, ParcelBoundaryHost } from "./parcelBoundary";
+
+/**
+ * PARCEL-SHAPE — the claim about the CONTROL.
+ *
+ * `services/api/test_parcel_geometry.py` proves the server returns a metric ring and that the ring
+ * sizes a smaller building than its bounding box. That is a claim about an ENGINE. The defect this
+ * item exists to end is a UI one: a feasibility tab that could describe a lot only as `width ×
+ * depth`, and so quietly underwrote every irregular parcel as its bounding rectangle.
+ *
+ * So the assertions here are about what the user is told, not only about what is sent. A control
+ * that adopted the ring and said nothing would fix the arithmetic and leave the reader unable to
+ * tell which lot a number came from — and a GFA sized on 1,600 m² looks exactly like one sized on
+ * 2,500 m².
+ */
+
+// The L-shaped corner lot from the server test: 1,600 m² inside a 50 × 50 m box.
+const ELL = {
+  ring_m: [[0, 0], [50, 0], [50, 20], [20, 20], [20, 50], [0, 50]],
+  area_m2: 1600, area_acres: 0.395, bounding_rect_m2: 2500,
+  lot_width_m: 50, lot_depth_m: 50, vertices: 6, coordinates_were_lonlat: false,
+};
+
+const LOADED: LoadedParcel = {
+  ring: ELL.ring_m, areaM2: 1600, areaAcres: 0.395, rectM2: 2500,
+  widthM: 50, depthM: 50, vertices: 6, wasLonLat: false,
+};
+
+function host(res: unknown | Error) {
+  return {
+    api: {
+      parcelAnalyze: vi.fn().mockImplementation(() =>
+        res instanceof Error ? Promise.reject(res) : Promise.resolve(res)),
+    },
+  } as unknown as ParcelBoundaryHost & { api: { parcelAnalyze: ReturnType<typeof vi.fn> } };
+}
+
+const flush = async () => { for (let i = 0; i < 6; i++) await Promise.resolve(); };
+
+describe("reading a parcel boundary", () => {
+  it("tells GeoJSON from WKT by shape, and refuses anything else by name", () => {
+    expect(parseBoundary('{"type":"Polygon","coordinates":[]}')).toEqual({
+      geojson: { type: "Polygon", coordinates: [] } });
+    expect(parseBoundary("POLYGON ((0 0, 1 0, 1 1, 0 0))")).toEqual({
+      wkt: "POLYGON ((0 0, 1 0, 1 1, 0 0))" });
+    expect(parseBoundary("polygon ((0 0, 1 0, 1 1, 0 0))").wkt, "WKT keywords are case-insensitive")
+      .toBeTruthy();
+    // A parse error must name the problem. "could not read that" sends the user to re-export a
+    // file that was fine, when a trailing comma is the whole story.
+    expect(() => parseBoundary("{oops")).toThrow(/not valid JSON/);
+    expect(() => parseBoundary("LINESTRING (0 0, 1 1)")).toThrow(/GeoJSON.*or WKT/);
+    expect(() => parseBoundary("   ")).toThrow(/paste a parcel boundary/);
+  });
+});
+
+describe("what the panel says about a parcel", () => {
+  it("states BOTH areas and how much the rectangle overstates the lot", () => {
+    const s = overstatement(LOADED);
+    expect(s).toContain("1,600 m²");
+    expect(s, "the rectangle it replaces, or the reader cannot judge the difference")
+      .toContain("2,500 m²");
+    // 2500/1600 - 1 = 56.25% → 56. Of the PARCEL, not of the box: this is the number that maps
+    // onto the GFA error, and (2500-1600)/2500 = 36% answers a question nobody asked.
+    expect(s).toMatch(/56% larger/);
+  });
+
+  it("says when the boundary was read as longitude/latitude", () => {
+    // The projection is decided by a magnitude heuristic, and a parcel drawn in local metres near
+    // the origin satisfies it. The two readings differ ~111,000x, so naming the decision is the
+    // difference between a user catching it in a glance and generating a 1 m building.
+    expect(overstatement({ ...LOADED, wasLonLat: true })).toContain("read as longitude/latitude");
+    expect(overstatement(LOADED), "...and silence when it was already in metres")
+      .not.toContain("longitude");
+  });
+
+  it("does not invent a difference on a rectangular parcel", () => {
+    // Without this the sentence above passes for the wrong reason — a control that always prints a
+    // percentage would report "0% larger" on a plain rectangular lot and send the reader hunting.
+    const sq: LoadedParcel = { ...LOADED, areaM2: 2500, rectM2: 2500 };
+    expect(overstatement(sq)).toMatch(/rectangular parcel, so nothing changes/);
+    expect(overstatement(sq)).not.toMatch(/larger/);
+  });
+});
+
+describe("the parcel boundary control", () => {
+  it("holds no parcel until one is read, and then holds the RING", async () => {
+    const h = host(ELL);
+    const seen: (LoadedParcel | null)[] = [];
+    const c = parcelBoundaryControl(h, (p) => seen.push(p));
+    expect(c.parcel()).toBeNull();
+    (c.el.querySelector("textarea") as HTMLTextAreaElement).value =
+      '{"type":"Polygon","coordinates":[[[0,0]]]}';
+    (c.el.querySelector("button") as HTMLButtonElement).click();
+    await flush();
+    expect(c.parcel()?.ring, "the ring is what `lot_polygon` needs; area alone changes nothing")
+      .toEqual(ELL.ring_m);
+    expect(seen).toEqual([c.parcel()]);
+    expect(c.el.textContent ?? "").toMatch(/56% larger/);
+  });
+
+  it("keeps the parcel it had when a later read fails", async () => {
+    // A half-read boundary silently replacing a good one is worse than a rejected paste: the panel
+    // would go on reporting "on the real parcel" for a parcel it no longer has.
+    const h = host(ELL);
+    const c = parcelBoundaryControl(h, () => undefined);
+    const ta = c.el.querySelector("textarea") as HTMLTextAreaElement;
+    const use = c.el.querySelector("button") as HTMLButtonElement;
+    ta.value = '{"type":"Polygon","coordinates":[[[0,0]]]}';
+    use.click();
+    await flush();
+    expect(c.parcel()).not.toBeNull();
+    ta.value = "not a boundary at all";
+    use.click();
+    await flush();
+    expect(c.parcel()?.ring, "the good parcel survives a bad paste").toEqual(ELL.ring_m);
+    expect(c.el.textContent ?? "").toMatch(/GeoJSON.*or WKT/);
+    expect(use.disabled, "a failed read must not lock the control").toBe(false);
+  });
+
+  it("reports a server refusal rather than adopting nothing silently", async () => {
+    const c = parcelBoundaryControl(host(new Error("422 could not parse the parcel boundary")),
+      () => undefined);
+    (c.el.querySelector("textarea") as HTMLTextAreaElement).value = "POLYGON ((0 0))";
+    (c.el.querySelector("button") as HTMLButtonElement).click();
+    await flush();
+    expect(c.el.textContent ?? "").toContain("could not parse the parcel boundary");
+    expect(c.parcel()).toBeNull();
+  });
+
+  it("can be cleared back to the rectangle", async () => {
+    const seen: (LoadedParcel | null)[] = [];
+    const c = parcelBoundaryControl(host(ELL), (p) => seen.push(p));
+    (c.el.querySelector("textarea") as HTMLTextAreaElement).value = '{"type":"Polygon"}';
+    (c.el.querySelector("button") as HTMLButtonElement).click();
+    await flush();
+    const clear = [...c.el.querySelectorAll("button")]
+      .find((b) => (b.textContent ?? "") === "Clear") as HTMLButtonElement;
+    expect(clear.hidden, "nothing to clear before a parcel is loaded").toBe(false);
+    clear.click();
+    expect(c.parcel(), "the rectangle above is live again").toBeNull();
+    expect(seen[seen.length - 1]).toBeNull();
+  });
+});

--- a/apps/web/src/proforma/parcelBoundary.test.ts
+++ b/apps/web/src/proforma/parcelBoundary.test.ts
@@ -52,6 +52,12 @@ describe("reading a parcel boundary", () => {
     // file that was fine, when a trailing comma is the whole story.
     expect(() => parseBoundary("{oops")).toThrow(/not valid JSON/);
     expect(() => parseBoundary("LINESTRING (0 0, 1 1)")).toThrow(/GeoJSON.*or WKT/);
+    // MULTIPOLYGON was accepted here while the server takes POLYGON only, so the control shipped it
+    // and the user got a round trip and a generic 422. Refused locally, by name, with the reason —
+    // and asserted, because "the client accepts what the server accepts" is exactly the kind of
+    // claim that holds until someone widens one side. Raised in review.
+    expect(() => parseBoundary("MULTIPOLYGON (((0 0, 1 0, 1 1, 0 0)))"))
+      .toThrow(/MULTIPOLYGON is not supported/);
     expect(() => parseBoundary("   ")).toThrow(/paste a parcel boundary/);
   });
 });

--- a/apps/web/src/proforma/parcelBoundary.ts
+++ b/apps/web/src/proforma/parcelBoundary.ts
@@ -1,0 +1,185 @@
+import type { ApiClient } from "../api/client";
+
+/**
+ * PARCEL-SHAPE — size the building on the parcel's real outline, not on its bounding rectangle.
+ *
+ * ## What was missing
+ *
+ * Three halves that never met. `parcel_geometry.analyze` parses a cadastral boundary (GeoJSON or
+ * WKT), projects it to metres — and returned only area / perimeter / centroid / bbox, **discarding
+ * the projected ring it had just computed**. `massing.compute_massing` accepts `lot_polygon` and
+ * does a true inward polygon offset for the buildable footprint, which no client could reach:
+ * `MassingParams` had no such field, so the feasibility tab could only ever send
+ * `lot_width × lot_depth`. And `parcelAnalyze` had no caller on any screen at all.
+ *
+ * ## Why it is worth a control
+ *
+ * A bounding rectangle's area is **always ≥ the parcel's**, and the error is not cosmetic — it
+ * runs the whole way down the underwriting: lot area → max GFA → floors → unit count → rent →
+ * the acquisition proforma's IRR. Every one of those is biased optimistic, and none of them says
+ * so. On an ordinary L-shaped corner lot (1,600 m² inside a 50 × 50 m box) the rectangle yields
+ * 5,000 m² of buildable GFA against the parcel's true 3,200 — **56% too much building**, on a
+ * number a deal gets priced from.
+ *
+ * So the control does not silently substitute one for the other. It states both: the parcel's
+ * area, the rectangle it replaces, and the percentage between them. A user who then chooses the
+ * rectangle has chosen it.
+ */
+
+/** What the control needs, so a test can drive it without standing up a client. */
+export interface ParcelBoundaryHost {
+  api: { parcelAnalyze: ApiClient["parcelAnalyze"] };
+}
+
+/** A loaded parcel: the ring the massing engine wants, plus what it is worth saying about it. */
+export interface LoadedParcel {
+  ring: number[][];
+  areaM2: number;
+  areaAcres: number;
+  rectM2: number;
+  widthM: number;
+  depthM: number;
+  vertices: number;
+  /** The server read the ring as longitude/latitude and projected it. Reported, because the rule
+   *  that decides is a HEURISTIC on coordinate magnitude — every |x| ≤ 180 and |y| ≤ 90 — and a
+   *  parcel sketched in local metres near the origin fits that description exactly. The two
+   *  readings differ by a factor of about 111,000, so the mistake is never subtle once named, and
+   *  invisible until it is. */
+  wasLonLat: boolean;
+}
+
+export interface ParcelBoundaryControl {
+  el: HTMLElement;
+  /** The ring to send as `lot_polygon`, or null while no parcel is loaded. */
+  parcel: () => LoadedParcel | null;
+}
+
+/**
+ * Split from the DOM so the branch that matters can be asserted directly. Returns the sentence the
+ * panel shows once a parcel is loaded — both areas and the overstatement between them.
+ *
+ * The percentage is of the PARCEL, not of the rectangle: "the box is 56% bigger than the lot" is
+ * the number that maps onto the GFA error. Expressing it the other way round ("the lot is 36% of
+ * the box") is arithmetically fine and answers a question nobody asked.
+ */
+export function overstatement(p: LoadedParcel): string {
+  const n = (v: number) => Math.round(v).toLocaleString();
+  const head = `Parcel ${n(p.areaM2)} m² (${p.areaAcres.toFixed(3)} ac) · ${p.vertices} vertices`
+    + (p.wasLonLat ? " · read as longitude/latitude and projected to metres" : "");
+  if (p.rectM2 <= p.areaM2) {
+    // A rectangular parcel: the two agree, and saying "0% larger" invites the reader to hunt for a
+    // difference that is not there. Rounding can also put rectM2 a hair under areaM2.
+    return `${head} · its ${p.widthM} × ${p.depthM} m bounding box is the same lot — a rectangular`
+      + " parcel, so nothing changes.";
+  }
+  const over = Math.round(((p.rectM2 - p.areaM2) / p.areaM2) * 100);
+  return `${head} · the ${p.widthM} × ${p.depthM} m rectangle you would otherwise type is`
+    + ` ${n(p.rectM2)} m² — ${over}% larger. Sizing on the rectangle overstates GFA, units and IRR`
+    + " by about that much.";
+}
+
+/**
+ * GeoJSON or WKT, decided by the first character rather than by a guess at the content. Throws with
+ * a message worth showing when the text is neither.
+ */
+export function parseBoundary(text: string): { geojson?: unknown; wkt?: string } {
+  const t = text.trim();
+  if (!t) throw new Error("paste a parcel boundary first");
+  if (t.startsWith("{") || t.startsWith("[")) {
+    try {
+      return { geojson: JSON.parse(t) };
+    } catch (e) {
+      throw new Error(`that is not valid JSON: ${(e as Error).message}`, { cause: e });
+    }
+  }
+  if (/^(POLYGON|MULTIPOLYGON)/i.test(t)) return { wkt: t };
+  throw new Error("expected GeoJSON (starting with '{') or WKT (starting with 'POLYGON')");
+}
+
+function row(): HTMLElement {
+  const d = document.createElement("div");
+  d.style.cssText = "display:flex;gap:6px;align-items:center;margin-top:4px;flex-wrap:wrap";
+  return d;
+}
+
+export function parcelBoundaryControl(
+  host: ParcelBoundaryHost, onChange: (p: LoadedParcel | null) => void,
+): ParcelBoundaryControl {
+  let loaded: LoadedParcel | null = null;
+
+  const wrap = document.createElement("div");
+  wrap.style.cssText = "margin:6px 0;padding:6px 8px;border:1px solid var(--line);border-radius:6px";
+  const title = document.createElement("div");
+  title.className = "meta";
+  title.textContent = "📐 Real parcel boundary (optional) — paste GeoJSON or WKT, or load a file."
+    + " Without one the lot is the width × depth rectangle above.";
+  wrap.appendChild(title);
+
+  const ta = document.createElement("textarea");
+  ta.rows = 2;
+  ta.placeholder = '{"type":"Polygon","coordinates":[[[x,y],…]]}  or  POLYGON ((x y, x y, …))';
+  ta.style.cssText = "width:100%;margin-top:4px;font-family:var(--mono,monospace);font-size:11px";
+  wrap.appendChild(ta);
+
+  const file = document.createElement("input");
+  file.type = "file";
+  file.accept = ".geojson,.json,.wkt,.txt,application/geo+json,application/json,text/plain";
+  file.style.cssText = "font-size:11px";
+  file.onchange = async () => {
+    const f = file.files?.[0];
+    if (!f) return;
+    ta.value = await f.text();
+  };
+
+  const useBtn = document.createElement("button");
+  useBtn.className = "tool-btn";
+  useBtn.textContent = "Use this parcel";
+  const clearBtn = document.createElement("button");
+  clearBtn.className = "tool-btn";
+  clearBtn.textContent = "Clear";
+  clearBtn.hidden = true;
+
+  const out = document.createElement("div");
+  out.className = "meta";
+  out.style.marginTop = "4px";
+
+  const say = (text: string, tone?: string) => {
+    out.textContent = text;
+    out.style.color = tone ?? "";
+  };
+
+  useBtn.onclick = async () => {
+    useBtn.disabled = true;
+    try {
+      const body = parseBoundary(ta.value);
+      say("reading the boundary…");
+      const r = await host.api.parcelAnalyze(body);
+      loaded = {
+        ring: r.ring_m, areaM2: r.area_m2, areaAcres: r.area_acres,
+        rectM2: r.bounding_rect_m2, widthM: r.lot_width_m, depthM: r.lot_depth_m,
+        vertices: r.vertices, wasLonLat: r.coordinates_were_lonlat,
+      };
+      say(overstatement(loaded), "var(--accent)");
+      clearBtn.hidden = false;
+      onChange(loaded);
+    } catch (e) {
+      // The parcel is NOT adopted on a failure, and any previously loaded one is left alone — a
+      // half-read boundary silently replacing a good one is worse than a rejected paste.
+      say((e as Error).message, "var(--status-crit)");
+    } finally {
+      useBtn.disabled = false;
+    }
+  };
+
+  clearBtn.onclick = () => {
+    loaded = null;
+    clearBtn.hidden = true;
+    say("back to the width × depth rectangle.");
+    onChange(null);
+  };
+
+  const controls = row();
+  controls.append(file, useBtn, clearBtn);
+  wrap.append(controls, out);
+  return { el: wrap, parcel: () => loaded };
+}

--- a/apps/web/src/proforma/parcelBoundary.ts
+++ b/apps/web/src/proforma/parcelBoundary.ts
@@ -128,6 +128,11 @@ export function parcelBoundaryControl(
   host: ParcelBoundaryHost, onChange: (p: LoadedParcel | null) => void,
 ): ParcelBoundaryControl {
   let loaded: LoadedParcel | null = null;
+  // Every read carries a sequence number, and only the newest may publish. Clear bumps it too.
+  // Without this a user can start a read, press Clear before it settles, and have the LATE
+  // response resurrect the parcel they just dismissed — after which "Generate IFC model" saves
+  // a model and a proforma for a lot the panel no longer shows. Raised in review.
+  let reads = 0;
 
   const wrap = document.createElement("div");
   wrap.style.cssText = "margin:6px 0;padding:6px 8px;border:1px solid var(--line);border-radius:6px";
@@ -172,10 +177,12 @@ export function parcelBoundaryControl(
 
   useBtn.onclick = async () => {
     useBtn.disabled = true;
+    const seq = ++reads;
     try {
       const body = parseBoundary(ta.value);
       say("reading the boundary…");
       const r = await host.api.parcelAnalyze(body);
+      if (seq !== reads) return;               // superseded or cleared while this was in flight
       loaded = {
         ring: r.ring_m, areaM2: r.area_m2, areaAcres: r.area_acres,
         rectM2: r.bounding_rect_m2, widthM: r.lot_width_m, depthM: r.lot_depth_m,
@@ -187,13 +194,14 @@ export function parcelBoundaryControl(
     } catch (e) {
       // The parcel is NOT adopted on a failure, and any previously loaded one is left alone — a
       // half-read boundary silently replacing a good one is worse than a rejected paste.
-      say((e as Error).message, "var(--status-crit)");
+      if (seq === reads) say((e as Error).message, "var(--status-crit)");
     } finally {
       useBtn.disabled = false;
     }
   };
 
   clearBtn.onclick = () => {
+    reads++;                                   // invalidate anything still in flight
     loaded = null;
     clearBtn.hidden = true;
     say("back to the width × depth rectangle.");

--- a/apps/web/src/proforma/parcelBoundary.ts
+++ b/apps/web/src/proforma/parcelBoundary.ts
@@ -92,7 +92,18 @@ export function parseBoundary(text: string): { geojson?: unknown; wkt?: string }
       throw new Error(`that is not valid JSON: ${(e as Error).message}`, { cause: e });
     }
   }
-  if (/^(POLYGON|MULTIPOLYGON)/i.test(t)) return { wkt: t };
+  // MULTIPOLYGON is named so the refusal is specific, and it is refused here rather than sent: the
+  // server's `parse_boundary` takes POLYGON only, so accepting it locally bought a round trip and a
+  // generic 422 that never said why. The first draft of this function listed it as accepted syntax
+  // — a client advertising support the server does not have, which is the same drift in miniature
+  // that this whole item is about. Supporting it is a PRODUCT question, not a cleanup: the buildable
+  // footprint comes from offsetting ONE outer ring inward, and a lot split by a right-of-way has no
+  // single ring to offset, so which part is "the parcel" is somebody's decision to make.
+  if (/^MULTIPOLYGON/i.test(t)) {
+    throw new Error("MULTIPOLYGON is not supported — a parcel boundary is one outer ring. Export the"
+      + " lot on its own as POLYGON ((x y, x y, ...)).");
+  }
+  if (/^POLYGON/i.test(t)) return { wkt: t };
   throw new Error("expected GeoJSON (starting with '{') or WKT (starting with 'POLYGON')");
 }
 

--- a/apps/web/src/proforma/parcelBoundary.ts
+++ b/apps/web/src/proforma/parcelBoundary.ts
@@ -107,12 +107,23 @@ export function parseBoundary(text: string): { geojson?: unknown; wkt?: string }
   throw new Error("expected GeoJSON (starting with '{') or WKT (starting with 'POLYGON')");
 }
 
+/** A flex row for the control strip — wrapping, so the file picker and buttons stay reachable
+ *  in the proforma panel's narrow column rather than overflowing it. */
 function row(): HTMLElement {
   const d = document.createElement("div");
   d.style.cssText = "display:flex;gap:6px;align-items:center;margin-top:4px;flex-wrap:wrap";
   return d;
 }
 
+/**
+ * The control. `onChange` fires with the loaded parcel, or `null` when it is cleared, so the
+ * caller can both send the ring and say which lot its figures came from — the massing tab uses
+ * it for exactly that, and for disabling the width/depth inputs the parcel supersedes.
+ *
+ * A failed read leaves any parcel already loaded ALONE. Half-replacing one is worse than
+ * refusing the paste: the panel would go on captioning its numbers "on the real parcel" for a
+ * parcel it no longer had.
+ */
 export function parcelBoundaryControl(
   host: ParcelBoundaryHost, onChange: (p: LoadedParcel | null) => void,
 ): ParcelBoundaryControl {

--- a/apps/web/src/proforma/proforma.render.test.ts
+++ b/apps/web/src/proforma/proforma.render.test.ts
@@ -82,6 +82,55 @@ describe("renderMassing (characterization)", () => {
     expect(out).toContain("18.2%");                          // equity IRR formatted
   });
 
+  // PARCEL-SHAPE — the wiring claim, end to end through the real tab. `parcelBoundary.test.ts`
+  // proves the control; this proves the tab SENDS what the control holds. Deleting
+  // `if (parcel) p.lot_polygon = parcel.ring` leaves every assertion in this file green but one.
+  it("estimate with a parcel loaded: sends the RING, and says which lot the figures are on", async () => {
+    const previewMassing = vi.fn().mockResolvedValue(RESULT);
+    const parcelAnalyze = vi.fn().mockResolvedValue({
+      ring_m: [[0, 0], [50, 0], [50, 20], [20, 20], [20, 50], [0, 50]],
+      area_m2: 1600, area_acres: 0.395, bounding_rect_m2: 2500,
+      lot_width_m: 50, lot_depth_m: 50, vertices: 6, coordinates_were_lonlat: false,
+    });
+    const { root, ui } = mount({ previewMassing, parcelAnalyze });
+    ui.renderMassing();
+    const host = root.querySelector("#pf-massing") as HTMLElement;
+    (host.querySelector("textarea") as HTMLTextAreaElement).value =
+      '{"type":"Polygon","coordinates":[[[1000,2000],[1050,2000],[1050,2020],[1020,2020],[1020,2050],[1000,2050]]]}';
+    btn(host, "Use this parcel").click();
+    await flush();
+    expect(parcelAnalyze).toHaveBeenCalledTimes(1);
+    // The two rectangle inputs are superseded, not silently left showing a stale 50 x 40.
+    const nums = [...host.querySelectorAll(".pf-form input[type=number]")] as HTMLInputElement[];
+    expect(nums[0]?.value).toBe("50");
+    expect(nums[1]?.value, "lot depth becomes the parcel's own bbox extent").toBe("50");
+    expect(nums[0]?.disabled && nums[1]?.disabled, "and neither can be edited past the parcel")
+      .toBe(true);
+
+    btn(host, "Estimate yield").click();
+    await flush();
+    const sent = previewMassing.mock.calls[0]?.[0];
+    expect(sent.lot_polygon, "the ring is what makes the server offset a real parcel")
+      .toEqual([[0, 0], [50, 0], [50, 20], [20, 20], [20, 50], [0, 50]]);
+    const out = host.textContent ?? "";
+    expect(out, "a GFA on 1,600 m2 and one on 2,500 m2 look identical unless the panel says")
+      .toContain("on the real parcel");
+    expect(out).toContain("1,600 m²");
+    expect(out).toContain("2,500 m²");
+  });
+
+  it("estimate with NO parcel: no lot_polygon key at all, and no claim about a parcel", async () => {
+    // Without this the case above passes for the wrong reason: a tab that always sent some polygon
+    // would satisfy it, and would then overrule the rectangle the user actually typed.
+    const previewMassing = vi.fn().mockResolvedValue(RESULT);
+    const { root, ui } = mount({ previewMassing });
+    ui.renderMassing();
+    btn(root, "Estimate yield").click();
+    await flush();
+    expect(previewMassing.mock.calls[0]?.[0].lot_polygon).toBeUndefined();
+    expect(root.querySelector("#pf-massing")?.textContent ?? "").not.toContain("on the real parcel");
+  });
+
   it("generate without a project: guard message, api never called", async () => {
     const generateMassing = vi.fn();
     const { root, ui } = mount({ generateMassing }, null);

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -646,7 +646,7 @@ describe("the roadmap lane table", () => {
     // the assignment: drop `portal/register/` from Lane B and the directory has no owner, which
     // every session may then edit — the state the carve-out check above exists to forbid. So the
     // claim is named. Two paths, not a general coverage rule, because the lanes do NOT cover the
-    // tree today (`drawings/`, `proforma/`, `studio/` and others are unowned) and a rule that fails
+    // tree today (`studio/`, `tools/`, `pins/` and others are unowned) and a rule that fails
     // for reasons nobody has decided yet is a rule people turn off.
     const ownerOf = (path: string) =>
       LANES.filter((l) => l.paths.some((p) => p === path || p.endsWith(path))).map((l) => l.name);
@@ -715,7 +715,11 @@ const NOT_A_LANE = (rel: string) =>
 //: taken from a different reader is a threshold for a different question. `surface.test.ts` records
 //: being bitten by precisely this (698 from a probe vs 696 from the gate), so the number is read back
 //: out of the assertion that enforces it.
-const UNOWNED_CEILING = 39;  // 53 → 48: Lane J claimed `apps/web/src/tooling/` (v0.3.1017).
+const UNOWNED_CEILING = 34;  // 53 → 48: Lane J claimed `apps/web/src/tooling/` (v0.3.1017).
+//: 39 → 34 (2026-09-09): Lane B claimed `apps/web/src/proforma/`. PARCEL-SHAPE added two files
+//: to that directory, this ratchet went red, and the remedy it names — a row, not a bigger
+//: number — took SEVEN files out of the unowned set rather than the two that tripped it. The
+//: gate found an unowned directory by being stepped on, which is the only way it can.
 //                             48 → 39: Lane E claimed `apps/web/src/tree/` (v0.3.1055), and the
 //                             ceiling is re-seated to the MEASURED number rather than lowered by
 //                             the size of that directory — 48 had slack in it that nobody had
@@ -760,8 +764,13 @@ describe("the lane table covers the tree it governs", () => {
     // The paired control. A matcher that is too loose returns zero unowned for any table at all,
     // which is indistinguishable from full coverage. `vendor/` is excluded by name above, so use a
     // real unclaimed source path: this must be found, and it must stop being found once a row lands.
-    expect(unowned.some((f) => f.startsWith("apps/web/src/proforma/")),
-      "proforma/ is unclaimed today — if this fails, either a row was added (update this test) " +
+    // Was `proforma/` until 2026-09-09, when PARCEL-SHAPE added a file there, the ratchet above
+    // went red, and Lane B claimed the directory — which is this whole mechanism working, and is
+    // why the control has to be re-pointed rather than relaxed. Note what it costs: the exemplar
+    // must be a path SOMEBODY has not yet decided about, so it decays by design, and the day the
+    // table covers the tree this assertion has to be deleted rather than repaired.
+    expect(unowned.some((f) => f.startsWith("apps/web/src/studio/")),
+      "studio/ is unclaimed today — if this fails, either a row was added (update this test) " +
       "or the matcher stopped working").toBe(true);
   });
 });

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -352,6 +352,42 @@ Seven of eleven engines once shipped with no route. The R32 filing-spine entries
 band are all closed and recorded in [`roadmap-completed.md`](roadmap-completed.md). The current
 instances:
 
+- ✅ **PARCEL-SHAPE — the feasibility tab can only describe a lot as a rectangle** *(M — Lane C for
+  the reader, D for the massing engine it feeds, B for the control; **CLOSED**, fix in this change)*
+
+  The second finding from REQUEST-GAP's optional list, and the one that gate's own note named as its
+  worked example of *"a real capability the client cannot reach"*: `lot_polygon` on
+  `POST /generate/massing`. Three pieces, none connected to the next.
+
+  | | |
+  |---|---|
+  | `services/api/src/aec_api/parcel_geometry.py` | parsed a GeoJSON/WKT boundary and projected it to metres — then returned area/perimeter/centroid/bbox and **threw the projected ring away** |
+  | `services/data/src/aec_data/massing.py` | accepted `lot_polygon` and did a **true inward polygon offset** for the buildable footprint — unreachable, because `MassingParams` had no such field |
+  | `apps/web/src/proforma/massingTab.ts` | built its request from numeric inputs only, so it could send `lot_width × lot_depth` and nothing else |
+
+  **The bias is one-directional and it compounds.** A bounding rectangle's area is always ≥ the
+  parcel's, and lot area sets max GFA → floors → units → rent → the acquisition proforma's IRR. On an
+  L-shaped 1,600 m² lot inside a 50 × 50 m box: **5,000 m² of buildable GFA on the rectangle against
+  3,200 on the parcel** — 56% more building, on the number a deal is priced from, with nothing on
+  screen to say which lot it came from. That number is asserted in `services/api/test_parcel_geometry.py`
+  by running both engines, not stated in prose here.
+
+  `analyze` now returns `ring_m` (metres, open, origin-shifted to its own bbox so the model renders
+  near the scene origin while `bbox`/`centroid` keep the real coordinates for export) plus the
+  bounding rectangle it replaces. `apps/web/src/proforma/parcelBoundary.ts` is the control: paste or
+  load a boundary, and it reports both areas and the percentage between them. Nothing is substituted
+  silently — the rectangle is one button away.
+
+  **A gate was wrong in the same direction, and this is the part worth carrying.**
+  `services/api/test_body_param_reach.py` decided "does the client send this key?" by matching
+  object-literal syntax only (`key:`). A body assembled field by field — `p.dome_radius = …`, which
+  is how this very tab has always sent its optionals — was invisible to it. So `dome_radius` sat on
+  the unsent list while a control on that tab had been sending it since it shipped: **two false
+  positives out of 27, in the direction the rule's own docstring calls the expensive one.** The rule
+  had been written from the shape of the code that happened to be in front of it. Assignments now
+  count; `==` and `=>` still do not, and a self-test pins that distinction because both counts are
+  printed rather than frozen, so a silent regression would show up only as a number nobody watches.
+
 - ✅ **TM-RATES / REQUEST-GAP — the mirror axis: a request parameter nothing SENDS** *(M — Lane C
   primary, with its own route in G, its control in B and its client method in I, which is the lane
   table's stated pattern rather than an exception; **CLOSED**, fix in this change)*
@@ -1577,7 +1613,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts` | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · R22-PIPELINE *(Lane C remainder is the resourcing engine only)* · PERF-WORKERS ① · R43-MASSINGBILL-CORE · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* *(**UX-3 left this cell 2026-09-06: all five of its items now ship** — see its entry. The cell had pointed at `apps/web/src/viewer/tools/authoringSection.ts`, which is a real file and the WRONG one: every one of the five landed under `apps/web/src/viewer/draft/`. Lanes are assigned by directory, so a pointer that resolves is not the same as a pointer that is right — a tracked-path gate cannot catch this, and did not)* |

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -413,10 +413,25 @@ def price_ticket_lines(db: Session, pid: str, data: dict) -> tuple[dict[str, Any
                 # `{quantity} {column}` rendering. It said `rate_col` here, which rendered as
                 # "8 rate are NOT in the figures above" — the label disagreeing with the number
                 # beside it. Raised in review.
+                #
+                # `in_totals` — what this means for the LINE depends entirely on whether the line
+                # carries a rate of its own. `equipment_lines.rate` is declared `"unit": "$/hr"` in
+                # module.json, so when one is typed, `rate x quantity` is the line's OWN arithmetic
+                # and is extended below like any other line: the register's unit is a fact about the
+                # REGISTER, not about the line, and refusing the sum would drop a line the user
+                # priced out of the ticket total.
+                #
+                # So the entry is about what the REGISTER could not do, and the report has to say
+                # which of the two happened. It did not: it claimed the quantity was excluded in
+                # both cases, so a line the engine had just priced at 8 x $100 was reported as
+                # "8 hours are NOT in the figures above" directly beneath the $800 it had added —
+                # the report contradicting the total beside it. Raised in review on #483, after
+                # that PR had merged.
                 unpriced.append({"table": field, "name": name, "column": qty_col,
-                                 "quantity": _n(row.get(qty_col)),
-                                 "reason": f"the register quotes this per {entry[1]}, and the line "
-                                           f"is in hours"})
+                                 "quantity": _n(row.get(qty_col)), "in_totals": bool(typed),
+                                 "reason": f"the register quotes this per {entry[1]}, "
+                                           + ("so it could not check the rate you entered"
+                                              if typed else "and the line is in hours")})
             elif not typed:
                 row[rate_col] = entry[0]
                 filled.append({"table": field, "name": name, "rate": entry[0]})
@@ -438,8 +453,11 @@ def price_ticket_lines(db: Session, pid: str, data: dict) -> tuple[dict[str, Any
                     variance.append({"table": field, "name": name, "field": "amount",
                                      "typed": money.q2(current), "register": extended})
             if extra_col and _n(row.get(extra_col)):
+                # Overtime / idle hours: genuinely excluded. Nothing multiplies `extra_col`, here or
+                # anywhere — a 1.5x premium is a contract term, not a default. `in_totals` is stated
+                # rather than left absent so every entry answers the same question.
                 unpriced.append({"table": field, "name": name, "column": extra_col,
-                                 "quantity": _n(row.get(extra_col)),
+                                 "quantity": _n(row.get(extra_col)), "in_totals": False,
                                  "reason": "the rate register holds no rate for these"})
             if row != before:
                 moved += 1

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -428,7 +428,15 @@ def price_ticket_lines(db: Session, pid: str, data: dict) -> tuple[dict[str, Any
                 # the report contradicting the total beside it. Raised in review on #483, after
                 # that PR had merged.
                 unpriced.append({"table": field, "name": name, "column": qty_col,
-                                 "quantity": _n(row.get(qty_col)), "in_totals": bool(typed),
+                                 "quantity": _n(row.get(qty_col)),
+                                 # `typed OR a retained amount`. A line with no rate of its own but
+                                 # an amount already entered never reaches the extension block (that
+                                 # needs a rate), so the amount survives untouched — and
+                                 # `apply_table_totals` sums the amount column into the ticket
+                                 # total regardless. `bool(typed)` alone called that excluded while
+                                 # it was in the figures: the same contradiction this field was
+                                 # added to end, one path over. Raised in review.
+                                 "in_totals": bool(typed or _n(row.get("amount"))),
                                  "reason": f"the register quotes this per {entry[1]}, "
                                            + ("so it could not check the rate you entered"
                                               if typed else "and the line is in hours")})

--- a/services/api/src/aec_api/parcel_geometry.py
+++ b/services/api/src/aec_api/parcel_geometry.py
@@ -77,6 +77,14 @@ def analyze(geojson: Any = None, wkt: str | None = None, parcel_id: str | None =
     ring = parse_boundary(geojson, wkt)
     if ring[0] == ring[-1]:
         ring = ring[:-1]
+    # Drop CONSECUTIVE duplicates, including the wrap-around pair. Stripping the closing point is not
+    # enough: an interior repeat survives it, and `offset_polygon` divides by each edge's length, so
+    # a zero-length edge does not raise — `ln or 1e-9` makes the normal ~1e9 and the vertex is left
+    # UNMOVED while its neighbours inset. The result is a plausible-looking polygon with a wrong
+    # area, which is worse than a refusal: it becomes a buildable footprint nobody can see is wrong.
+    # This function's own comment already claimed the ring was safe for that reason, which was true
+    # of the closing vertex and false of every other one. Raised in review.
+    ring = [p for i, p in enumerate(ring) if p != ring[i - 1]] or ring[:1]
     if len(ring) < 3:
         raise ValueError("a parcel boundary needs at least 3 distinct points")
     m, was_lonlat = _to_metres(ring)

--- a/services/api/src/aec_api/parcel_geometry.py
+++ b/services/api/src/aec_api/parcel_geometry.py
@@ -98,6 +98,13 @@ def analyze(geojson: Any = None, wkt: str | None = None, parcel_id: str | None =
         area2 += x1 * y2 - x2 * y1
         perim += math.hypot(x2 - x1, y2 - y1)
     area = abs(area2) / 2.0
+    # Distinct is not the same as ENCLOSING. Three collinear points survive the dedupe above and the
+    # >= 3 check, and shoelace them to exactly zero — while their bounding box is positive, so the
+    # panel would divide by zero and print "Infinity% larger" over a lot with no area at all, and
+    # `compute_massing` would then 422 on a boundary the control had already accepted. Refuse it
+    # here, where the reason can be stated, rather than downstream where it cannot. Raised in review.
+    if area <= 0:
+        raise ValueError("a parcel boundary must enclose an area — these points are collinear")
     cx = sum(p[0] for p in ring) / len(ring)
     cy = sum(p[1] for p in ring) / len(ring)
 

--- a/services/api/src/aec_api/parcel_geometry.py
+++ b/services/api/src/aec_api/parcel_geometry.py
@@ -93,6 +93,18 @@ def analyze(geojson: Any = None, wkt: str | None = None, parcel_id: str | None =
     cx = sum(p[0] for p in ring) / len(ring)
     cy = sum(p[1] for p in ring) / len(ring)
 
+    # PARCEL-SHAPE — the projected ring itself, which this function computed and then threw away.
+    # `massing.compute_massing` takes `lot_polygon` in metres and offsets it inward for the real
+    # buildable footprint; without the ring every caller had to fall back to lot_width × lot_depth,
+    # and a bounding rectangle's area is ALWAYS ≥ the parcel's. That bias runs the whole way down:
+    # lot area → max GFA → unit count → the acquisition proforma's IRR, optimistic at every step.
+    # Origin-shifted to its own bbox minimum so the polygon sits near (0,0) — the real coordinates
+    # stay in `bbox`/`centroid` for export, and the model renders near the scene origin.
+    # OPEN (no repeated closing vertex): `offset_polygon` divides by each edge's length, and a
+    # zero-length closing edge would hand it a meaningless normal.
+    ox, oy = min(q[0] for q in m), min(q[1] for q in m)
+    bw, bd = max(q[0] for q in m) - ox, max(q[1] for q in m) - oy
+
     out: dict[str, Any] = {
         "parcel_id": parcel_id,
         "vertices": len(ring), "coordinates_were_lonlat": was_lonlat,
@@ -101,8 +113,14 @@ def analyze(geojson: Any = None, wkt: str | None = None, parcel_id: str | None =
         "centroid": {"x": round(cx, 6), "y": round(cy, 6)},
         "bbox": {"minx": min(p[0] for p in ring), "miny": min(p[1] for p in ring),
                  "maxx": max(p[0] for p in ring), "maxy": max(p[1] for p in ring)},
+        "ring_m": [[round(x - ox, 3), round(y - oy, 3)] for x, y in m],
+        "lot_width_m": round(bw, 2), "lot_depth_m": round(bd, 2),
+        "bounding_rect_m2": round(bw * bd, 1),
         "note": "Parcel metrics from the uploaded boundary (GeoJSON/WKT — no government scraping). Lon/lat "
-                "rings are projected equirectangularly at the centroid latitude (~0.1% at parcel scale).",
+                "rings are projected equirectangularly at the centroid latitude (~0.1% at parcel scale). "
+                "`ring_m` is that boundary in metres, origin-shifted to its own bounding box — send it "
+                "to /generate/massing as `lot_polygon` to size a building on the real parcel rather than "
+                "on `lot_width_m` × `lot_depth_m`, which overstates the lot by `bounding_rect_m2` − `area_m2`.",
     }
 
     if zoning or proposal:

--- a/services/api/test_body_param_reach.py
+++ b/services/api/test_body_param_reach.py
@@ -120,13 +120,25 @@ def body_params(spec: dict) -> list[tuple[str, str, str, bool]]:
 
 
 def names_key(code: str, key: str) -> bool:
-    """Does the web source name this wire key — as a JSON property, or as ES shorthand?
+    """Does the web source name this wire key — as a JSON property, ES shorthand, or an ASSIGNMENT?
 
     Deliberately coarse in the LENIENT direction, exactly like the leaf rule it mirrors: a key named
     anywhere counts as sent. Over-matching can only make this gate miss a gap; under-matching would
     invent work for somebody, which is the expensive mistake.
+
+    **And it made exactly that mistake from the day it shipped.** The first draft accepted only
+    `key:` / `key,` / `key}` — object-literal syntax. A request body assembled INCREMENTALLY is not
+    written that way: `massingTab.params()` builds `p` field by field (`p.dome_radius = ...`,
+    `p.parking = ...`) and stringifies it, which is an ordinary way to send an optional only when it
+    applies. So `dome_radius` sat on the unsent list while a control on the feasibility tab had been
+    sending it all along, and PARCEL-SHAPE's `lot_polygon` joined it the day it was wired. Two false
+    positives out of 27, in the direction the paragraph above calls expensive — because the rule was
+    written from the shape of the code that happened to be in front of it.
+
+    `=` is admitted, but not `==` / `===` (a comparison is a read, not a send) and not `=>` (an
+    arrow parameter that happens to be named for the key is not a send either).
     """
-    return re.search(rf'["\']?\b{re.escape(key)}\b["\']?\s*[:,}}]', code) is not None
+    return re.search(rf'["\']?\b{re.escape(key)}\b["\']?\s*(?:[:,}}]|=(?![=>]))', code) is not None
 
 
 def unsent(params, code: str, *, required: bool) -> list[tuple[str, str, str]]:
@@ -138,6 +150,17 @@ def unsent(params, code: str, *, required: bool) -> list[tuple[str, str, str]]:
     """
     return sorted((p, m, k) for p, m, k, r in params if r is required and not names_key(code, k))
 
+
+# --- the matcher's own blind spot, pinned ---------------------------------------------------------
+# Reverting `names_key` to object-literal syntax alone reds this. That matters because the fix is
+# invisible to every check below: both counts are printed and neither is frozen, so a silent
+# regression would show up as a number nobody was watching. A comparison and an arrow parameter must
+# NOT count — they are reads, not sends.
+_M = "const p = {}; p.lot_polygon = ring; if (x.foo === 1) {} const f = (bar) => bar;"
+assert names_key(_M, "lot_polygon"), "an incrementally assembled body is a SEND"
+assert names_key('{"lot_polygon": r}', "lot_polygon"), "...and so is an object literal"
+assert not names_key(_M, "foo"), "`foo === 1` is a comparison, not a send"
+assert not names_key(_M, "bar"), "`(bar) => bar` is an arrow parameter, not a send"
 
 SPEC = app.openapi()
 CODE = strip_comments(_web_source())
@@ -217,8 +240,11 @@ for p, m, k in MISSING_REQUIRED:
 print(f"  optional and unsent: {len(MISSING_OPTIONAL)} — an engine on a default nobody chose."
       "\n    UNTRIAGED, deliberately not frozen. Read one before calling it a defect: "
       "`/design/options/generate`'s\n    `far_steps` default (60/80/100% of base FAR) is right, "
-      "and `/generate/massing`'s `lot_polygon` is a\n    real capability the client cannot reach. "
-      "Same shape, opposite verdicts.")
+      "and `/generate/massing`'s `lot_area` is a\n    real capability the client cannot reach — it "
+      "is how you state a lot whose DIMENSIONS are unknown, and the tab\n    offers only width x depth "
+      "or a boundary. Same shape, opposite verdicts. (`lot_polygon` was\n    this line's example until "
+      "PARCEL-SHAPE wired it — an exemplar that gets FIXED is the good\n    outcome, and leaving it here "
+      "would have made this note a lie.)")
 
 print()
 if FAILED:

--- a/services/api/test_parcel_geometry.py
+++ b/services/api/test_parcel_geometry.py
@@ -58,6 +58,31 @@ try:
 except ValueError as e:
     assert "too large" in str(e)
 
+# --- PARCEL-SHAPE: a repeated vertex must not reach offset_polygon ---------------------------------
+# Stripping the CLOSING duplicate is not enough — an interior repeat survives it. `offset_polygon`
+# divides by each edge's length and guards with `ln or 1e-9`, so a zero-length edge does not raise:
+# the normal becomes ~1e9 and that vertex is left UNMOVED while its neighbours inset. The result is
+# a plausible polygon with the wrong area, which is worse than a refusal because nothing looks
+# broken. Raised in review, and asserted through the real offset rather than on the ring alone.
+import sys as _sys0  # noqa: E402
+
+_sys0.path.insert(0, os.path.join("..", "data", "src"))
+from aec_data.massing import offset_polygon as _offset  # noqa: E402
+
+dup = {"type": "Polygon", "coordinates": [[[1000, 2000], [1000, 2000], [1050, 2000], [1050, 2050],
+                                           [1000, 2050], [1000, 2000]]]}
+d = pg.analyze(geojson=dup)
+assert d["ring_m"] == [[0.0, 0.0], [50.0, 0.0], [50.0, 50.0], [0.0, 50.0]], d["ring_m"]
+assert d["vertices"] == 4 and d["area_m2"] == 2500.0, d
+assert _offset(d["ring_m"], 5) == [[5.0, 5.0], [45.0, 5.0], [45.0, 45.0], [5.0, 45.0]], _offset(d["ring_m"], 5)
+# ...and a boundary that is only repeats is refused rather than emitted as a 1-point ring.
+for degenerate in ([[0, 0], [0, 0], [0, 0]], [[5, 5], [5, 5]]):
+    try:
+        pg.analyze(geojson={"type": "Polygon", "coordinates": [degenerate]})
+        raise AssertionError(f"expected ValueError for {degenerate!r}")
+    except ValueError:
+        pass
+
 # --- PARCEL-SHAPE: the projected ring comes BACK, and it sizes a smaller building ------------------
 # `analyze` computed the metric ring and threw it away, so the only lot a client could describe was
 # `lot_width × lot_depth` — a bounding rectangle, whose area is ALWAYS ≥ the parcel's. The bias runs

--- a/services/api/test_parcel_geometry.py
+++ b/services/api/test_parcel_geometry.py
@@ -83,6 +83,20 @@ for degenerate in ([[0, 0], [0, 0], [0, 0]], [[5, 5], [5, 5]]):
     except ValueError:
         pass
 
+# A ring can be three DISTINCT points and still enclose nothing. Collinear vertices shoelace to
+# exactly zero while their bounding box stays positive, so `overstatement` in the web control divided
+# (rect - area) by area and rendered "Infinity% larger" over a lot with no area — and the massing
+# call behind it would then 422 on a boundary the control had already accepted. Distinct is not
+# enclosing; the >= 3 check above cannot tell the difference. Raised in review.
+for flat in ([[1000, 2000], [1010, 2010], [1020, 2020]],          # diagonal, positive bbox
+             [[0, 0], [10, 0], [20, 0]],                          # horizontal
+             [[0, 0], [0, 10], [0, 20], [0, 30]]):                # vertical, four points
+    try:
+        pg.analyze(geojson={"type": "Polygon", "coordinates": [flat]})
+        raise AssertionError(f"expected ValueError for collinear {flat!r}")
+    except ValueError as e:
+        assert "collinear" in str(e), e
+
 # --- PARCEL-SHAPE: the projected ring comes BACK, and it sizes a smaller building ------------------
 # `analyze` computed the metric ring and threw it away, so the only lot a client could describe was
 # `lot_width × lot_depth` — a bounding rectangle, whose area is ALWAYS ≥ the parcel's. The bias runs

--- a/services/api/test_parcel_geometry.py
+++ b/services/api/test_parcel_geometry.py
@@ -58,6 +58,60 @@ try:
 except ValueError as e:
     assert "too large" in str(e)
 
+# --- PARCEL-SHAPE: the projected ring comes BACK, and it sizes a smaller building ------------------
+# `analyze` computed the metric ring and threw it away, so the only lot a client could describe was
+# `lot_width × lot_depth` — a bounding rectangle, whose area is ALWAYS ≥ the parcel's. The bias runs
+# lot area → max GFA → floors → units → the acquisition proforma's IRR, optimistic at every step and
+# silent about it.
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, os.path.join("..", "data", "src"))
+from aec_data import massing as _massing  # noqa: E402
+
+# An L-shaped corner lot in projected metres: 1,600 m² inside a 50 × 50 m box.
+ell = {"type": "Polygon", "coordinates": [[[1000, 2000], [1050, 2000], [1050, 2020], [1020, 2020],
+                                           [1020, 2050], [1000, 2050], [1000, 2000]]]}
+e = pg.analyze(geojson=ell)
+assert e["area_m2"] == 1600.0 and e["bounding_rect_m2"] == 2500.0, e
+assert e["lot_width_m"] == 50.0 and e["lot_depth_m"] == 50.0, e
+# Origin-shifted to its own bbox min: real coordinates stay in `bbox`/`centroid` for export, and the
+# generated model renders near the scene origin instead of 1 km out.
+assert e["ring_m"] == [[0.0, 0.0], [50.0, 0.0], [50.0, 20.0], [20.0, 20.0], [20.0, 50.0], [0.0, 50.0]], e["ring_m"]
+assert e["bbox"]["minx"] == 1000, e["bbox"]
+# OPEN, no repeated closing vertex — `offset_polygon` divides by each edge's length, and a
+# zero-length closing edge hands it a meaningless normal.
+assert e["ring_m"][0] != e["ring_m"][-1], e["ring_m"]
+assert len(e["ring_m"]) == e["vertices"] == 6, e
+
+# The claim the whole item exists for, measured rather than asserted in prose: the same lot, same
+# zoning, sized on the ring vs on the bounding rectangle the two numeric inputs could describe.
+sb = {"far": 2.0, "side_setback": 5, "front_setback": 5, "rear_setback": 5}
+poly_run = _massing.compute_massing({"lot_polygon": e["ring_m"], **sb})
+rect_run = _massing.compute_massing({"lot_width": e["lot_width_m"], "lot_depth": e["lot_depth_m"], **sb})
+assert poly_run["lot_area_m2"] == 1600.0 and rect_run["lot_area_m2"] == 2500.0, (poly_run, rect_run)
+assert poly_run["buildable_gfa_m2"] == 3200.0, poly_run["buildable_gfa_m2"]
+assert rect_run["buildable_gfa_m2"] == 5000.0, rect_run["buildable_gfa_m2"]
+# 5000/3200 - 1 = 56%. Not a rounding difference — 56% more building on a number a deal is priced
+# from. The direction is the invariant: the rectangle can never understate.
+assert rect_run["buildable_gfa_m2"] > poly_run["buildable_gfa_m2"], (rect_run, poly_run)
+# ...and the ring really is offset inward, not merely used for its area: the buildable footprint is
+# a polygon, and it is smaller than the parcel.
+assert poly_run["buildable_polygon"] and len(poly_run["buildable_polygon"]) == 6, poly_run["buildable_polygon"]
+assert poly_run["footprint_m2"] < e["area_m2"], poly_run["footprint_m2"]
+
+# A rectangular parcel is the degenerate case: ring and bounding box agree, so nothing changes and
+# the panel must not claim an overstatement. Without this the assertions above would also pass for
+# an `analyze` that returned the BBOX corners as the ring.
+sq = pg.analyze(geojson=rect)
+assert sq["bounding_rect_m2"] == sq["area_m2"] == 5000.0, sq
+assert sq["lot_width_m"] == 100.0 and sq["lot_depth_m"] == 50.0, sq
+
+# A lon/lat ring returns `ring_m` in METRES, not degrees — the field is what `lot_polygon` consumes,
+# and a degree-valued ring would silently generate a 1 m building.
+lm = pg.analyze(geojson=ll)["ring_m"]
+assert 111.0 < max(x for x, _ in lm) < 112.0, lm            # ~111.19 m per 0.001 degree
+assert lm[0] == [0.0, 0.0], lm
+
 # --- bad input raises ------------------------------------------------------------------------------
 for bad in ({"type": "Point", "coordinates": [0, 0]}, "not json {", None):
     try:
@@ -75,6 +129,25 @@ from aec_api.main import app  # noqa: E402
 
 with TestClient(app) as c:
     assert c.post("/parcels/analyze", json={"geojson": {"type": "Point", "coordinates": [0, 0]}}).status_code == 422
+    # PARCEL-SHAPE end to end, over HTTP. The section above proves the two ENGINES disagree; this
+    # proves the ring survives the wire — `MassingIn.lot_polygon` accepts the exact shape
+    # `/parcels/analyze` emits. Calling `compute_massing` directly skips that validation entirely,
+    # which is the half a schema change would break silently.
+    ar = c.post("/parcels/analyze", json={"geojson": ell})
+    assert ar.status_code == 200, ar.text
+    aj = ar.json()
+    env = {"far": 2.0, "side_setback": 5, "front_setback": 5, "rear_setback": 5}
+    pv = c.post("/generate/massing/preview", json={**env, "lot_polygon": aj["ring_m"]})
+    rc = c.post("/generate/massing/preview",
+                json={**env, "lot_width": aj["lot_width_m"], "lot_depth": aj["lot_depth_m"]})
+    assert pv.status_code == 200 and rc.status_code == 200, (pv.text, rc.text)
+    pm, rm = pv.json()["metrics"], rc.json()["metrics"]
+    assert pm["lot_area_m2"] == 1600.0 and rm["lot_area_m2"] == 2500.0, (pm, rm)
+    assert pm["buildable_gfa_m2"] == 3200.0 and rm["buildable_gfa_m2"] == 5000.0, (pm, rm)
+    # And the proforma seeded from each carries the bias forward, which is the point of the item:
+    # the rectangle's deal is underwritten on a building that does not fit on the lot.
+    assert pv.json()["proforma"] != rc.json()["proforma"], "the two runs must not seed the same deal"
+
     rr = c.post("/parcels/analyze", json={"geojson": rect, "zoning": {"max_far": 2.0},
                                           "proposal": {"gfa_m2": 12_000}})
     assert rr.status_code == 200, rr.text
@@ -84,4 +157,7 @@ print("PARCEL-IMPORT OK - a 100x50 m parcel parses from GeoJSON/Feature/WKT to e
       "300 m perimeter); a lon/lat ring projects equirectangularly to within 1% of the analytic area; against "
       "a max-FAR 2.0 / coverage 0.6 / height 30 m envelope a 12,000 m² GFA proposal is FAR 2.4 (violation, "
       "max buildable 10,000 m²) while coverage 0.4 and height-at-limit pass; missing limits report ok=None; "
-      "the /parcels/analyze route 422s on a Point and returns the compliance read otherwise.")
+      "the /parcels/analyze route 422s on a Point and returns the compliance read otherwise. "
+      "PARCEL-SHAPE: `ring_m` comes back in metres, open and origin-shifted, and an L-shaped 1,600 m² "
+      "lot inside a 50x50 m box yields 3,200 m² GFA through `lot_polygon` against 5,000 m² through the "
+      "bounding rectangle - 56% more building on the number a deal is priced from.")

--- a/services/api/test_tm_rates.py
+++ b/services/api/test_tm_rates.py
@@ -244,6 +244,35 @@ with TestClient(app) as c:
     check("...and `column` names the quantity the panel prints beside it",
           [(u["column"], u["quantity"]) for u in rep["unpriced"]] == [("hours", 8.0)],
           rep["unpriced"])
+    check("...and the entry says the quantity is NOT in the totals, because it is not",
+          [u["in_totals"] for u in rep["unpriced"]] == [False], rep["unpriced"])
+
+    # (iv-c) THE SAME LINE, WITH A RATE THE USER TYPED. The fixture above gives the line no rate of
+    # its own, so the engine had nothing to extend and the report's "these hours are NOT in the
+    # figures above" was true by accident. Add one and the two halves contradict each other: the
+    # register cannot price the line, but `equipment_lines.rate` is declared `"unit": "$/hr"` in
+    # module.json, so `rate x hours` is the LINE's own arithmetic and is computed — and the panel
+    # printed "8 hours are NOT in the figures above" directly beneath the $800 it had just added.
+    #
+    # The fix is to the CLAIM, not the sum. Refusing to extend a rate the user typed would drop a
+    # line they priced out of the ticket total, which is worse than the wrong sentence. Raised in
+    # review on #483 and missed before that PR merged.
+    #
+    # FOURTH time in this item that a fixture was narrower than the rule it covered, and the same
+    # shape every time: the case that distinguishes two behaviours was the case nobody wrote.
+    typed_tid = ticket(equipment_lines=[{"equipment": "Tower crane", "hours": 8, "rate": 100}])
+    typed_rep = price(typed_tid)
+    typed_row = rows(typed_tid, "equipment_lines")[0]
+    check("a rate the USER typed still extends against hours — the register's unit is a fact about "
+          "the register, not the line",
+          typed_row.get("amount") == 800.0, typed_row)
+    check("...and the report says the hours ARE in the totals, instead of denying the amount above",
+          [u["in_totals"] for u in typed_rep["unpriced"]] == [True], typed_rep["unpriced"])
+    check("...with a reason about what the REGISTER could not do",
+          all("could not check the rate you entered" in (u.get("reason") or "")
+              for u in typed_rep["unpriced"]), typed_rep["unpriced"])
+    check("...and no rate variance, because $100/hr and $1,200/week are not comparable numbers",
+          not typed_rep["variance"], typed_rep["variance"])
     # Sequenced plainly rather than crammed into one expression: the walrus-and-tuple version put
     # `price()` inside a short-circuit `and`, so a None from `stored()` would have SKIPPED the
     # pricing rather than failing the check, and it carried no detail. Raised in review.

--- a/services/api/test_tm_rates.py
+++ b/services/api/test_tm_rates.py
@@ -273,6 +273,22 @@ with TestClient(app) as c:
               for u in typed_rep["unpriced"]), typed_rep["unpriced"])
     check("...and no rate variance, because $100/hr and $1,200/week are not comparable numbers",
           not typed_rep["variance"], typed_rep["variance"])
+
+    # (iv-d) NO typed rate, but an amount already on the line. This never reaches the extension
+    # block — that needs a rate — so the amount survives untouched, and `apply_table_totals` sums the
+    # amount column into the ticket total regardless. `in_totals: bool(typed)` called it excluded
+    # while it sat in the figures: the same contradiction (iv-c) fixed, one path over, and the
+    # fixture there could not see it because it had a rate. Raised in review.
+    kept_tid = ticket(equipment_lines=[{"equipment": "Tower crane", "hours": 8, "amount": 800}])
+    kept_rep = price(kept_tid)
+    assert rows(kept_tid, "equipment_lines")[0].get("amount") == 800, rows(kept_tid, "equipment_lines")[0]
+    check("an amount already on the line counts as IN the totals, rate or no rate",
+          [u["in_totals"] for u in kept_rep["unpriced"]] == [True], kept_rep["unpriced"])
+    # The negative case, so the check above cannot pass by always answering True.
+    bare_tid = ticket(equipment_lines=[{"equipment": "Tower crane", "hours": 8}])
+    bare_rep = price(bare_tid)
+    check("...and neither rate nor amount really is excluded",
+          [u["in_totals"] for u in bare_rep["unpriced"]] == [False], bare_rep["unpriced"])
     # Sequenced plainly rather than crammed into one expression: the walrus-and-tuple version put
     # `price()` inside a short-circuit `and`, so a None from `stored()` would have SKIPPED the
     # pricing rather than failing the check, and it carried no detail. Raised in review.


### PR DESCRIPTION
# What & why

Two independent changes plus three rounds of review fixes. They share a branch, not a subject — **read §2 even if the first is not your area**, because it corrects a money-affecting defect that was on `main`.

---

## 1 · PARCEL-SHAPE — feasibility sizes the building on the real parcel

Roadmap: **PARCEL-SHAPE**, Band 2 (built but unreachable). The second finding from REQUEST-GAP's optional list, and the one `test_body_param_reach.py`'s own note named as its worked example of *"a real capability the client cannot reach"* — `lot_polygon` on `POST /generate/massing`.

The "Generate from zoning" tab could describe a lot only as **lot width × lot depth**. For any parcel that is not a rectangle — a corner lot, a flag lot, anything with a cut corner — that describes a box *around* the lot, and a box's area is always larger. The error is not cosmetic: lot area sets max GFA → floors → unit count → rent → the acquisition proforma's IRR. Every one came out optimistic and none of them said so.

Three pieces existed and had never been connected:

| | |
|---|---|
| `services/api/src/aec_api/parcel_geometry.py` | parsed a GeoJSON/WKT boundary and projected it to metres — then returned area/perimeter/centroid/bbox and **threw the projected ring away** |
| `services/data/src/aec_data/massing.py` | accepted `lot_polygon` and did a **true inward polygon offset** for the buildable footprint — unreachable, because `MassingParams` had no such field |
| `apps/web/src/proforma/massingTab.ts` | built its request from numeric inputs only, so it could send `lot_width × lot_depth` and nothing else |

`analyze` now returns `ring_m` — metres, **open**, duplicate-free, enclosing a real area, origin-shifted to its own bbox so the model renders near the scene origin while `bbox`/`centroid` keep the real coordinates for export — plus `lot_width_m` / `lot_depth_m` / `bounding_rect_m2`, the rectangle it replaces.

`apps/web/src/proforma/parcelBoundary.ts` is the control: paste or load a boundary, and it reports both areas, the percentage between them, and whether the ring was read as longitude/latitude. That last one is deliberate — the projection is decided by a magnitude heuristic (`|x| ≤ 180 and |y| ≤ 90`), and a parcel sketched in local metres near the origin fits it exactly. The two readings differ by ~111,000×, so the mistake is never subtle once named and invisible until it is. Nothing is substituted silently; the rectangle is one button away.

**The number:** an L-shaped **1,600 m²** lot inside a 50 × 50 m box yields **3,200 m² GFA through `lot_polygon` against 5,000 through the rectangle — 56% more building**, on the figure a deal is priced from. Asserted twice: engine-to-engine, and end-to-end over HTTP through `MassingIn`'s validation, so a schema change cannot break the wire silently.

### Two gates were wrong in the same direction

- **`test_body_param_reach.py`'s matcher recognised only object-literal syntax** (`key:`). A body assembled field by field — `p.dome_radius = …`, which is how this tab has always sent its optionals — was invisible to it. So `dome_radius` sat on the "nothing sends this" list while a control on that very tab had been sending it since it shipped. **Two false positives out of 27, in the direction the rule's own docstring calls the expensive one**, because the rule was written from the shape of the code that happened to be in front of it. Assignments now count; `==` and `=>` still do not, and a self-test pins that. 27 → 23.
- **No lane owned `apps/web/src/proforma/`.** Adding a file there reddened the unowned ratchet; the remedy it names is a lane row, not a bigger number, so Lane B claimed the directory — which took **seven** files out of the unowned set rather than the two that tripped it. Ceiling 39 → 34. That gate's paired control used `proforma/` as its example of an unclaimed path, so it moves to `studio/`.

`parcelAnalyze` leaves `clientCallers`' `UNCALLED` list, which is what makes the wiring claim checkable rather than asserted.

---

## 2 · TM-UNIT-CLAIM — an unpriced line that was in the total after all

**This fixes a defect that reached `main`.** A CodeRabbit finding landed on #483 at 05:36Z; I merged at 05:59Z without re-reading that PR's review threads. Checking CI is not checking the PR, and the review bot's clock is independent of CI's — that is the process failure, and it is mine.

An equipment line with a rate the user typed, a blank amount, and a register rate quoted per Day/Week/Month takes the unit-mismatch branch, is appended to `unpriced`, and then **falls through** to the extension block. The panel printed *"8 hours are NOT in the figures above"* directly beneath the $800 the engine had just added to that line — the report contradicting the total beside it. Reproduced before anything was changed.

**The arithmetic is right and the sentence was wrong**, which is the opposite of the fix the review proposed. `eticket/module.json` declares `equipment_lines.rate` with `"unit": "$/hr"`, so when a rate is typed, `rate × hours` is the **line's own** arithmetic. Skipping the extension — the prescribed remedy — would drop a line the superintendent priced out of the ticket total. That is asserted rather than argued: **one mutation applies the prescribed fix verbatim and reds the new test.** *(CodeRabbit re-reviewed and withdrew the recommendation: "My prior recommendation to skip the extension was incorrect.")*

So `unpriced` entries carry `in_totals` and the panel branches on it. Two things worth carrying:

- The fixture that let this reach `main` gave the line **no rate of its own**, so the old sentence was true by accident. **Fourth time in this item** that the case distinguishing two behaviours was the case nobody wrote.
- **DOC-STRAND caught a second issue on the way**: the new field comment was stacked above the old one, whose text (*"a real quantity nothing could price"*) is the exact false claim being corrected. Merged into one.

---

## 3 · Review round 1 — the boundary control accepted WKT the server rejects

`parseBoundary` listed `MULTIPOLYGON` as accepted syntax; `parse_boundary` does `w.upper().startswith("POLYGON")`, which a `MULTIPOLYGON` fails. The control shipped text the endpoint would reject and the user paid a round trip for a generic 422 that never said why. Fixed on the **client**, to match the contract rather than widen it.

---

## 4 · Review round 2 — four more, each reproduced before it was touched

| | |
|---|---|
| **`cost.py` — a retained amount read as excluded** | `in_totals` was `bool(typed)`. A line with no typed rate but an `amount` already entered never reaches the extension block (that needs a rate), so the amount survives untouched and `apply_table_totals` sums it into the ticket total anyway. The same contradiction §2 fixed, one path over — and §2's fixture could not see it, because it had a rate. Now `bool(typed or amount)`. |
| **`parcel_geometry.py` — duplicate vertices** | **Worse than reported.** `offset_polygon` guards with `ln or 1e-9`, so a zero-length edge does not raise: the normal becomes ~1e9 and that vertex stays put while its neighbours inset. A 50 × 50 lot offset by 5 returned `[[0,0],[0,5],[45,5],[45,45],[5,45]]` — a plausible polygon with a wrong area, which is worse than a refusal. This function's own comment claimed the ring was safe for exactly that reason: true of the closing vertex, false of every other one. |
| **`parcelBoundary.ts` — a cleared parcel resurrected** | Use, then Clear before the read settles, and the late response republished the dismissed parcel; "Generate IFC model + apply" would then save a model and proforma for a lot the panel no longer showed. Reads now carry a sequence number and Clear bumps it. |
| **`tmPricing.test.ts` — a self-contradictory fixture** | The crane was `in_totals: true` while the totals said equipment $0 — a fixture reproducing the exact contradiction the assertions beneath it forbid. |

**One mutation survived on the first pass, and the cause is recorded in the commit.** The fixture fix had silently no-op'd: I used a bare `.replace()` for that edit instead of the `assert … in s` pattern used everywhere else, so an edit matching nothing reported success. The mutation is the only reason it was caught. **An edit that can silently match nothing is an unverified claim**, and belongs under an assert like any other.

---

## 5 · Review round 3 — a boundary that encloses nothing

Found only because the PR left draft, which is what makes CodeRabbit review at all. Three **collinear** points pass the distinct-vertex check added in round 2: `area_m2` comes back `0.0` with `bounding_rect_m2` `400.0`, so `overstatement` divides by zero and renders **"Infinity% larger"** over a lot with no area — and `compute_massing` then 422s on a boundary the control had already accepted.

`analyze` refuses non-positive area, naming collinearity. Tested across three shapes — diagonal, horizontal, and a **four-point** vertical, so the check cannot pass on vertex count alone.

**It is the round-2 mistake one turn deeper.** The dedupe fix guarantees no zero-length *edges*; I treated that as guaranteeing a usable *polygon*. **Distinct is not enclosing**, and `len(ring) >= 3` cannot tell the difference. Had this PR merged twenty minutes earlier — on eleven green checks and zero open threads, exactly the evidence used for #483 — it would be on `main`.

---

## Deliberately not done

**Backend `MULTIPOLYGON` support** — a deferral, not an oversight. The buildable footprint comes from offsetting *one* outer ring inward, and a lot split by a right-of-way has no single ring. Largest by area, the one containing the address point, or all summed with no offset — that is a product decision for the maintainer. *(CodeRabbit, independently: "A multi-part parcel needs an explicit product rule before the system can select one buildable ring.")*

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (the WHOLE tree)
- [x] Backend: affected `test_*.py` pass — **682/682 suites**, run separately on every Python-touching commit: `f35d058c`, `06803b24`, `8523c4cb`, `ba314e5a`
- [x] Web: typecheck, lint and build clean — **2310/2310 tests**
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entries added (newest at top); roadmap item updated
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

**Mutations: 18, all red.** PARCEL-SHAPE 9 · TM-UNIT-CLAIM 3 · round 1: 1 · round 2: 4 · round 3: 1 (zero-area boundaries accepted again).

All eleven checks green on `ba314e5a`, API test gate included. CodeRabbit's pass on that head: *"No actionable comments were generated"*, Merge Risk ⚪ Minimal, *"No current merge-blocking risk remains."* Five inline threads resolved; the collinear finding arrived outside the diff range and is answered in a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA