### PR TITLE
DEAD-FIELD: the sweep was blocked on the wrong thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### The dead-field sweep was asking a question its method cannot answer
+
+An internal audit axis checks whether every field the API declares is actually *read* by the web
+app — a field with no reader is a candidate for "a caveat that never reaches the screen", which is
+how a number gets shown without the warning that qualifies it. The roadmap recorded that axis as
+blocked on reading ~35 remaining fields one by one.
+
+Re-deriving it found a different blocker. **The scan matches a bare identifier, not a type.** So
+`SpatialNode.elevation` — referenced in dozens of files and by none of them as a `SpatialNode`,
+because storeys, drawing grids and GIS overlays all happen to name a field `elevation` — is counted
+as read while nothing renders it. Across the tree, **256 of the 719 fields counted as read, 35%, have
+no reader that even names the declaring interface.** It fails hardest on `name`, `key`, `id`,
+`title`, `status` and `count`, each referenced in 200+ files — which are the names most likely to be
+displayed. A freeze list built on this would be guaranteed wrong rather than merely unverified.
+
+The population is now re-run by a test rather than remembered, with the collision pinned as a fact:
+identifier readers present, typed readers zero. Making the scan sound needs a type-aware pass over
+the TypeScript symbol table, and that is now what the entry says. Two bugs in the derivation itself
+turned up on the way — matching only top-level fields cannot see a *nested* one, and this axis's one
+real defect was nested; and including the generated OpenAPI types reports 730 instead of 32.
+
+Seven more fields were read while doing it and none was a defect, which is consistent with the
+earlier rate. One is worth naming: a cost-variance figure that looked unread turns out to be a
+documented refusal — comparing a realised overrun against an entered contingency is a claim about
+what an underwriting asserts, not a unit conversion.
+
 ### Renaming a responsibility column moves its cells with it, or moves nothing
 
 The RACI/DACI matrix stores two halves of one fact in two places: the **role columns** in a config

--- a/apps/web/src/api/deadFieldScope.test.ts
+++ b/apps/web/src/api/deadFieldScope.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * DEAD-FIELD — the SCOPE of the derivation, not the fields it returns.
+ *
+ * The roadmap's DEAD-FIELD axis is derived by matching every field of every `export interface` under
+ * `apps/web/src/api/` against every reference in `apps/web/src`, minus the declaring file. That
+ * derivation is **identifier-based, not type-aware**, and this file exists to keep that limitation a
+ * measured fact rather than a footnote — because the entry's stated blocker ("read the remaining
+ * ~35 detail fields, then gate") is the wrong one if the method cannot support a gate at all.
+ *
+ * ### The worked example, asserted below
+ *
+ * `SpatialNode.elevation` is referenced in dozens of files and by **none of them as a SpatialNode** —
+ * they are storeys, drawing grids, GIS overlays, draft gizmos, all different types that happen to
+ * name a field `elevation`. Nothing renders `SpatialNode.elevation`. The derivation calls it read.
+ * Its companion `elevationUnit` — which the declaring comment says travels with the number precisely
+ * because the unit varies per model — is correctly reported unread, so the pair lands in two
+ * different buckets for no reason a reader could act on.
+ *
+ * ### Why this blocks a gate rather than delaying one
+ *
+ * A freeze-list built on this would inherit the blind spot, and it falls hardest on exactly the
+ * fields most likely to be displayed: the common names. `name`, `key`, `id`, `title`, `status` and
+ * `count` are each referenced in 200+ files, so any interface declaring one has that field marked
+ * read no matter what the product does with it. `KNOWN_UNCALLED` recorded the cost of a freeze list
+ * nobody had checked; this would be the same list with a mechanical reason to be wrong.
+ *
+ * Making it sound needs a **type-aware** pass (the TypeScript compiler API or language service,
+ * resolving each property access to its declaring symbol). That is the unblocking step, and it is
+ * not what the roadmap currently says it is.
+ *
+ * This test therefore pins the SHAPE of the measurement, not a defect list: the counts are a band so
+ * ordinary work does not fail the build, and the collision case is asserted exactly, so a future
+ * type-aware derivation makes this test fail and demand rewriting — which is the point.
+ */
+
+// process.cwd() is apps/web under vitest — the same convention `roadmapLanes.test.ts` records.
+const API = resolve(process.cwd(), "src/api");
+const WEB = resolve(process.cwd(), "src");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
+  }
+  return out;
+}
+
+/** (interface, field) -> declaring file, for hand-written api/ interfaces. */
+function declaredFields(): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const f of walk(API)) {
+    // schema.d.ts is GENERATED from OpenAPI and deliberately not regenerated (doing so churned
+    // 38,231 lines). Its `components` blob declares more fields than the rest of api/ combined —
+    // including it reports 730 "unread" and buries the axis entirely.
+    if (f.endsWith(".test.ts") || f.endsWith("schema.d.ts")) continue;
+    const src = readFileSync(f, "utf-8");
+    for (const m of src.matchAll(/export interface (\w+)\s*\{/g)) {
+      let i = m.index! + m[0].length - 1;
+      let depth = 0;
+      for (; i < src.length; i++) {
+        if (src[i] === "{") depth++;
+        else if (src[i] === "}" && --depth === 0) break;
+      }
+      const body = src.slice(m.index! + m[0].length, i);
+      // ANY indent, not just the top level: a derivation anchored on two spaces cannot see a NESTED
+      // field, and this axis's one load-bearing defect (`ResponsibilityMatrix.validation.*`) was
+      // nested. A predicate that decides what to LOOK at hides its own misses.
+      for (const fm of body.matchAll(/^[ \t]+(?:readonly\s+)?([A-Za-z_]\w*)\??\s*:/gm)) {
+        const k = `${m[1]}.${fm[1]}`;
+        if (!out.has(k)) out.set(k, f);
+      }
+    }
+  }
+  return out;
+}
+
+const files = walk(WEB);
+const tokens = new Map<string, Set<string>>();
+for (const f of files) {
+  tokens.set(f, new Set(readFileSync(f, "utf-8").match(/[A-Za-z_]\w*/g) ?? []));
+}
+const decls = declaredFields();
+
+function readersOf(field: string, declaring: string): string[] {
+  return files.filter((f) => f !== declaring && tokens.get(f)!.has(field));
+}
+
+describe("DEAD-FIELD: what the derivation can and cannot see", () => {
+  it("derives a population of the expected order — the roadmap's number is not read, it is re-run", () => {
+    // A band, not a pin: this must not fail because someone added an interface. It fails if the
+    // derivation itself breaks (regex stops matching, directory moves), which is the real risk —
+    // a silently-empty population would report a clean axis.
+    expect(decls.size).toBeGreaterThan(600);
+    const unread = [...decls].filter(([k, f]) => readersOf(k.split(".")[1]!, f).length === 0);
+    expect(unread.length).toBeGreaterThan(10);
+    expect(unread.length).toBeLessThan(80);
+  });
+
+  it("SpatialNode.elevation has readers by NAME and none by TYPE — the collision, exactly", () => {
+    // The whole argument in one case. If this ever fails because the derivation became type-aware,
+    // rewrite this file rather than relaxing the assertion: the limitation would be gone.
+    const decl = decls.get("SpatialNode.elevation");
+    expect(decl, "SpatialNode.elevation is no longer declared — re-derive before trusting this")
+      .toBeTruthy();
+    const readers = readersOf("elevation", decl!);
+    expect(readers.length,
+      "the identifier is referenced widely, which is what makes the field look read")
+      .toBeGreaterThan(10);
+    // ...and not one of those files names the interface, i.e. none of them is handling a SpatialNode.
+    const typed = readers.filter((f) => tokens.get(f)!.has("SpatialNode") && !f.endsWith(".test.ts"));
+    expect(typed,
+      "a production file now handles SpatialNode — check whether it renders `elevation`, and "
+      + "whether it renders `elevationUnit` beside it (the unit varies per model, often mm)")
+      .toEqual([]);
+  });
+
+  it("the common field names are unusable as evidence, and that is the blocker", () => {
+    // Not a defect list — a statement about the METHOD. Each of these is referenced so widely that
+    // declaring one guarantees a "read" verdict regardless of what the product does with it.
+    for (const name of ["name", "key", "id", "title", "status", "count"]) {
+      const n = files.filter((f) => tokens.get(f)!.has(name)).length;
+      expect(n, `'${name}' should be referenced in enough files to be evidence-free`)
+        .toBeGreaterThan(100);
+    }
+  });
+});

--- a/apps/web/src/api/deadFieldScope.test.ts
+++ b/apps/web/src/api/deadFieldScope.test.ts
@@ -81,7 +81,16 @@ function declaredFields(): Map<string, string> {
   return out;
 }
 
-const files = walk(WEB);
+// THIS FILE IS NOT PART OF THE CORPUS, and leaving it in was a live defect caught in review.
+// The scan matches a bare identifier in raw text — comments and strings included — so the prose
+// below naming `elevation`, `elevationUnit` and `SpatialNode` counted as *readers* of those fields.
+// Measured: unread was 31 with this file in the corpus and 32 without, and the single field it
+// moved was `SpatialNode.elevationUnit` — precisely the one the roadmap holds up as the correctly
+// reported-unread half of the pair. **The file falsified its own worked example by existing**, and
+// the reported population would then drift with documentation edits rather than with product usage.
+// A measurement whose corpus contains the measurement is the same shape as the flaw it records.
+const AUDIT = resolve(API, "deadFieldScope.test.ts");
+const files = walk(WEB).filter((f) => f !== AUDIT);
 const tokens = new Map<string, Set<string>>();
 for (const f of files) {
   tokens.set(f, new Set(readFileSync(f, "utf-8").match(/[A-Za-z_]\w*/g) ?? []));
@@ -121,6 +130,19 @@ describe("DEAD-FIELD: what the derivation can and cannot see", () => {
     expect(typed,
       "a production file now handles SpatialNode — check whether it renders `elevation`, and "
       + "whether it renders `elevationUnit` beside it (the unit varies per model, often mm)")
+      .toEqual([]);
+  });
+
+  it("this file's own prose is not a reader — the exclusion above, asserted", () => {
+    // Pins the fix rather than trusting it: `elevationUnit` is named several times in the comments
+    // here, so it is unread ONLY while this file is out of the corpus. Delete the filter and this
+    // fails, which is the point — the roadmap's 32 and the number this test computes must agree.
+    const decl = decls.get("SpatialNode.elevationUnit");
+    expect(decl, "SpatialNode.elevationUnit is no longer declared — re-derive before trusting this")
+      .toBeTruthy();
+    expect(readersOf("elevationUnit", decl!),
+      "something now reads elevationUnit — if it is this audit file, the corpus filter has been "
+      + "removed and the population is drifting with prose rather than with product usage")
       .toEqual([]);
   });
 

--- a/apps/web/src/api/deadFieldScope.test.ts
+++ b/apps/web/src/api/deadFieldScope.test.ts
@@ -42,6 +42,7 @@ import { describe, expect, it } from "vitest";
 const API = resolve(process.cwd(), "src/api");
 const WEB = resolve(process.cwd(), "src");
 
+/** Every `.ts`/`.tsx` under `dir`, recursively — the file set both halves of the scan run over. */
 function walk(dir: string, out: string[] = []): string[] {
   for (const e of readdirSync(dir)) {
     const p = join(dir, e);
@@ -87,6 +88,9 @@ for (const f of files) {
 }
 const decls = declaredFields();
 
+/** Files mentioning `field` as a bare identifier, excluding the one that declares it.
+ *  This is the derivation's whole notion of "read", and the reason it cannot be trusted: the match
+ *  is on the NAME, so a file handling an unrelated type with a same-named field counts as a reader. */
 function readersOf(field: string, declaring: string): string[] {
   return files.filter((f) => f !== declaring && tokens.get(f)!.has(field));
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -611,18 +611,60 @@ instances:
   over-claim.* The substantive result stands: *this codebase is more careful than the raw derivation
   suggested*, and **a field with no reader is a candidate, not a defect.**
 
-  **The axis is still NOT gateable, and the reason is worth being exact about.** The 8 above were
-  read individually. The remaining **~35** were bucketed as "detail" in a single pass and have
-  **not** been verified one by one — so an allowlist built from them today would be a freeze list
-  whose contents nobody has checked, which is the failure `KNOWN_UNCALLED` recorded when four of its
-  entries turned out to have callers. Gating waits on that reading, not on a decision.
+  **THE STATED BLOCKER WAS WRONG, and re-deriving the population found the real one (2026-09-09).**
+  This said the axis was ungateable until the remaining ~35 "detail" fields were read one by one.
+  They are not the obstacle. **The derivation is identifier-based, not type-aware**, and that is a
+  systematic flaw a gate would inherit rather than a backlog a gate is waiting on.
 
-  **Deliberately NOT gated yet, and that is a judgement rather than an omission.** A gate over this
-  axis needs an allowlist of the ~31 legitimate cases, and an allowlist nobody has triaged is a
-  freeze list that rots — the exact failure the `KNOWN_UNCALLED` heading recorded when four of its
-  entries turned out to have callers. Triage the ~8 first; the allowlist is only honest once the
-  remainder has been read. **The 43 is reproducible, not remembered:** it is a field-vs-reference
-  scan over `apps/web/src`, and re-deriving it is cheaper than trusting this number.
+  | | |
+  |---|---|
+  | declared fields (hand-written `api/` interfaces, excluding generated `schema.d.ts`) | **751** |
+  | no reader anywhere | **32** |
+  | read only by a test | **14** |
+  | counted as read, but **no reader file even names the declaring interface** | **256 — 35% of the "read" bucket** |
+
+  **The worked case is `SpatialNode.elevation`.** It is referenced in dozens of files and by none of
+  them as a `SpatialNode` — they are storeys, drawing grids, GIS overlays, draft gizmos, all
+  different types that happen to name a field `elevation`. Nothing renders it. The derivation calls
+  it read. Meanwhile its companion `elevationUnit` — which the declaring comment says travels with
+  the number *precisely because the unit varies per model, often millimetres* — is correctly
+  reported unread. One pair, two buckets, for a reason no reader could act on.
+
+  **It fails hardest exactly where it matters most.** `name`, `key`, `id`, `title`, `status` and
+  `count` are each referenced in 200+ files, so any interface declaring one has that field marked
+  read whatever the product does with it — and those are the names most likely to be *displayed*. A
+  freeze list built on this would be `KNOWN_UNCALLED`'s failure with a mechanical guarantee of being
+  wrong, rather than the chance of it.
+
+  **So the unblocking step is a TYPE-AWARE pass** — the TypeScript compiler API or language service,
+  resolving each property access to its declaring symbol — not more reading. Until then the "unread"
+  bucket is a **lower bound** and the "read" bucket is not evidence.
+
+  *Two bugs in the derivation itself were found on the way, both the same shape as the axis's own
+  lesson.* Anchoring field matching at two-space indent cannot see a **nested** field — and this
+  axis's one load-bearing defect, `ResponsibilityMatrix.validation.*`, was nested. Including the
+  generated `schema.d.ts` reports **730** unread, burying the axis in OpenAPI scaffolding. *A
+  predicate that decides what to LOOK at hides its own misses, which is the third time this
+  repository has paid for that specific mistake.*
+
+  **The numbers above are checked, not written:** `apps/web/src/api/deadFieldScope.test.ts` re-runs
+  the derivation, asserts the population is of the expected order (a band, so ordinary work does not
+  fail the build), and pins the `SpatialNode.elevation` collision exactly — identifier readers
+  present, typed readers zero. If a future type-aware derivation makes that assertion fail, the file
+  is to be rewritten rather than relaxed: the limitation would be gone, which is the goal.
+
+  **Triage since: 7 more read, 0 defects**, consistent with the earlier 8-read/1-real rate.
+  `MassingMetrics.lot_area_m2` (the engine recomputes it by shoelace from the same ring the panel's
+  caption derives from — they agree by construction) · `net_sellable_m2` (read server-side, shown as
+  `net_sellable_sf`) · `structure.slenderness` (folded into a `flags` string that IS read) ·
+  `EvmEarnedSchedule.ieac_t_periods` (`forecast_finish` and `days_late` are rendered; this is the
+  same forecast in rawer units) · `FinancialStatements.suspended_loss_at_sale` (the after-tax IRR
+  incorporates it; the by-year table is scoped to operations by its own title) ·
+  `SpatialNode.{elevation, elevationUnit}` (neither is rendered). **`DealMemoryProject.cost_variance_pct`
+  is the one worth naming separately: it is not an oversight but a documented refusal** —
+  `routers/operations.py` states that comparing a realised overrun to an entered contingency is a
+  claim about what an underwriting asserts, not a unit conversion, and it waits on the same domain
+  call `/schedule/eot` does.
 
 - ✅ **RESP-ORPHAN — the RACI banner said "complete" over a grid with nothing in it** *(S — Lane C;
   **CLOSED**, fix in this change)*


### PR DESCRIPTION
# What & why

The DEAD-FIELD axis checks whether every field the API declares is actually **read** by the web app —
an unread field is a candidate for *"a caveat that never reaches the screen"*, which is how a number
gets displayed without the warning that qualifies it. `docs/roadmap.md` recorded the axis as
ungateable until the remaining **~35** fields bucketed as "detail" were read one by one.

**They are not the obstacle.** Re-deriving the population — rather than trusting the written number —
found that the derivation is **identifier-based, not type-aware**, and that is a systematic flaw a
gate would inherit rather than a backlog a gate is waiting on.

### The worked case

`SpatialNode.elevation` is referenced in dozens of files and by **none of them as a `SpatialNode`** —
they are storeys, drawing grids, GIS overlays and draft gizmos, all different types that happen to
name a field `elevation`. Nothing renders it. The scan calls it read.

Its companion `elevationUnit` — which the declaring comment says travels with the number *precisely
because the unit varies per model, very often millimetres* — **is** correctly reported unread. One
pair, two buckets, for a reason no reader could act on.

### Measured

| | |
|---|---|
| declared fields (hand-written `api/` interfaces, excluding generated `schema.d.ts`) | **751** |
| no reader anywhere | **32** |
| read only by a test | **14** |
| counted as read, but **no reader file even names the declaring interface** | **256 — 35%** |

It fails hardest exactly where it matters most: `name`, `key`, `id`, `title`, `status` and `count`
are each referenced in 200+ files, so any interface declaring one is marked read whatever the product
does with it — and those are the names most likely to be *displayed*. A freeze list built on this
would be `KNOWN_UNCALLED`'s failure with a mechanical guarantee of being wrong, rather than the chance
of it. **The unblocking step is a type-aware pass** over the TypeScript symbol table, not more reading.

### Two bugs in the derivation itself, both the axis's own lesson

- Anchoring field matching at two-space indent **cannot see a nested field** — and this axis's one
  load-bearing defect, `ResponsibilityMatrix.validation.*`, was nested.
- Including the generated `schema.d.ts` reports **730** unread instead of 32, burying the axis in
  OpenAPI scaffolding.

*A predicate that decides what to LOOK at hides its own misses — the third time this repository has
paid for that specific mistake.*

### The numbers are now checked, not written

`apps/web/src/api/deadFieldScope.test.ts` re-runs the derivation, asserts the population is of the
expected order (a **band**, so ordinary work does not fail the build — it fails if the derivation
itself breaks and silently reports an empty population), and pins the collision exactly: identifier
readers present, typed readers zero. If a future type-aware derivation makes that assertion fail, the
file is to be **rewritten rather than relaxed** — the limitation would be gone, which is the goal.

### Triage while doing it: 7 read, 0 defects

Consistent with the earlier 8-read/1-real rate. `MassingMetrics.lot_area_m2` (the engine recomputes
it by shoelace from the same ring the panel's caption derives from — they agree by construction) ·
`net_sellable_m2` (read server-side, shown as `net_sellable_sf`) · `structure.slenderness` (folded
into a `flags` string that is read) · `EvmEarnedSchedule.ieac_t_periods` (`forecast_finish` and
`days_late` are rendered) · `FinancialStatements.suspended_loss_at_sale` (the after-tax IRR
incorporates it) · `SpatialNode.{elevation, elevationUnit}` (neither rendered).
**`DealMemoryProject.cost_variance_pct` is worth naming separately: not an oversight but a documented
refusal** — `routers/operations.py` states that comparing a realised overrun to an entered
contingency is a claim about what an underwriting asserts, not a unit conversion.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean — **All checks passed!**
- [x] Backend: no Python source changed; `test_claude_md_gates.py` (which reads `docs/roadmap.md`) passes
- [x] Web: typecheck, lint and the full suite clean — vitest **2316/2316** across 225 files
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; the DEAD-FIELD roadmap entry corrected
- [ ] Version bump — not a release PR
- [x] No secrets, no competitor names in shipped docs

Additionally: **3 informative mutations on the new test, all red** — a broken field regex (the
population guard catches a silently-empty derivation), re-including `schema.d.ts`, and breaking the
type filter so identifier readers count as typed ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the roadmap and changelog with revised API field-usage audit results.
  - Clarified how field references are evaluated and documented known limitations, including name collisions and nested fields.
  - Identified type-aware analysis as the next step for improving audit accuracy.

- **Tests**
  - Added automated checks to validate audit coverage, population counts, collision cases, and commonly reused field names.
  - Recorded additional field reviews with no defects identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->