### PR TITLE
AGENT-TRAIL: the governance console said "nothing ran" while runs existed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,15 +59,33 @@ jobs:
           # Drop the runner image's preinstalled Google Chrome apt source before updating. On
           # 2026-09-09 it served a Packages.gz whose hash disagreed with a Release file Google had
           # just republished; `apt-get update` exits 100 on a hash mismatch, so this job died
-          # before running anything. Twice, byte-identically, which is what ruled out a blip.
-          # Nothing here installs from that source, and removing the LIST only stops apt fetching
-          # its index — an already-installed Chrome is untouched. A third-party repository we do
-          # not use must not be able to fail our build.
+          # before running anything — three times, byte-identically, which is what ruled out a
+          # blip. Nothing here installs from that source, and removing the source FILE only stops
+          # apt fetching its index; an already-installed Chrome is untouched. A third-party
+          # repository we do not use must not be able to fail our build.
           #
-          # Only this one source: the runner carries others (Microsoft's, for instance) and the
-          # same hazard applies to them in principle, but nothing has been measured failing there
-          # and removing them would be fixing a hypothesis.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first attempt at this fix removed
+          # `google-chrome.list` by name and changed nothing, because Ubuntu 24.04 images may
+          # define the same repository as deb822 `.sources` instead — a guessed path that silently
+          # matches nothing looks exactly like a working fix. Grep decides which files go.
+          #
+          # Only Google's: the runner carries other third-party sources and the same hazard applies
+          # to them in principle, but nothing has been measured failing there and removing them
+          # would be fixing a hypothesis.
+          # `|| true` because grep exits 1 when it matches nothing, which would sink the
+          # whole pipeline on an image that carries no Google source at all. Whether the
+          # source was there is the assertion's question, not the removal's.
+          { sudo grep -rlZ 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null || true; } \
+            | sudo xargs -0 -r rm -f
+          # Prove the removal took, rather than assuming it did as the first attempt had to.
+          # Written as an `if`, NOT as `! grep ...`: bash's `set -e` explicitly exempts a
+          # command whose status is inverted with `!`, so the negated form would print
+          # nothing and carry on with the source still in place — a second check that
+          # cannot fail, which is the same defect as the guessed filename it is here to catch.
+          if sudo grep -rq 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null; then
+            echo "::error::Google apt source survived removal; apt-get update is unguarded"
+            exit 1
+          fi
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libgl1 libglib2.0-0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,21 @@ jobs:
 
       # system libs the scientific wheels expect (mirrors services/api/Dockerfile)
       - name: System deps
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libgl1 libglib2.0-0
+        run: |
+          # Drop the runner image's preinstalled Google Chrome apt source before updating. On
+          # 2026-09-09 it served a Packages.gz whose hash disagreed with a Release file Google had
+          # just republished; `apt-get update` exits 100 on a hash mismatch, so this job died
+          # before running anything. Twice, byte-identically, which is what ruled out a blip.
+          # Nothing here installs from that source, and removing the LIST only stops apt fetching
+          # its index — an already-installed Chrome is untouched. A third-party repository we do
+          # not use must not be able to fail our build.
+          #
+          # Only this one source: the runner carries others (Microsoft's, for instance) and the
+          # same hazard applies to them in principle, but nothing has been measured failing there
+          # and removing them would be fixing a hypothesis.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libgl1 libglib2.0-0
 
       - name: Python deps
         run: |

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -59,15 +59,33 @@ jobs:
           # Drop the runner image's preinstalled Google Chrome apt source before updating. On
           # 2026-09-09 it served a Packages.gz whose hash disagreed with a Release file Google had
           # just republished; `apt-get update` exits 100 on a hash mismatch, so this job died
-          # before running anything. Twice, byte-identically, which is what ruled out a blip.
-          # Nothing here installs from that source, and removing the LIST only stops apt fetching
-          # its index — an already-installed Chrome is untouched. A third-party repository we do
-          # not use must not be able to fail our build.
+          # before running anything — three times, byte-identically, which is what ruled out a
+          # blip. Nothing here installs from that source, and removing the source FILE only stops
+          # apt fetching its index; an already-installed Chrome is untouched. A third-party
+          # repository we do not use must not be able to fail our build.
           #
-          # Only this one source: the runner carries others (Microsoft's, for instance) and the
-          # same hazard applies to them in principle, but nothing has been measured failing there
-          # and removing them would be fixing a hypothesis.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first attempt at this fix removed
+          # `google-chrome.list` by name and changed nothing, because Ubuntu 24.04 images may
+          # define the same repository as deb822 `.sources` instead — a guessed path that silently
+          # matches nothing looks exactly like a working fix. Grep decides which files go.
+          #
+          # Only Google's: the runner carries other third-party sources and the same hazard applies
+          # to them in principle, but nothing has been measured failing there and removing them
+          # would be fixing a hypothesis.
+          # `|| true` because grep exits 1 when it matches nothing, which would sink the
+          # whole pipeline on an image that carries no Google source at all. Whether the
+          # source was there is the assertion's question, not the removal's.
+          { sudo grep -rlZ 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null || true; } \
+            | sudo xargs -0 -r rm -f
+          # Prove the removal took, rather than assuming it did as the first attempt had to.
+          # Written as an `if`, NOT as `! grep ...`: bash's `set -e` explicitly exempts a
+          # command whose status is inverted with `!`, so the negated form would print
+          # nothing and carry on with the source still in place — a second check that
+          # cannot fail, which is the same defect as the guessed filename it is here to catch.
+          if sudo grep -rq 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null; then
+            echo "::error::Google apt source survived removal; apt-get update is unguarded"
+            exit 1
+          fi
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libgl1 libglib2.0-0 postgresql-client
 

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -55,7 +55,21 @@ jobs:
           cache: pip
 
       - name: System deps
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libgl1 libglib2.0-0 postgresql-client
+        run: |
+          # Drop the runner image's preinstalled Google Chrome apt source before updating. On
+          # 2026-09-09 it served a Packages.gz whose hash disagreed with a Release file Google had
+          # just republished; `apt-get update` exits 100 on a hash mismatch, so this job died
+          # before running anything. Twice, byte-identically, which is what ruled out a blip.
+          # Nothing here installs from that source, and removing the LIST only stops apt fetching
+          # its index — an already-installed Chrome is untouched. A third-party repository we do
+          # not use must not be able to fail our build.
+          #
+          # Only this one source: the runner carries others (Microsoft's, for instance) and the
+          # same hazard applies to them in principle, but nothing has been measured failing there
+          # and removing them would be fixing a hypothesis.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libgl1 libglib2.0-0 postgresql-client
 
       - name: Python deps
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,10 @@ exactly the claim someone acts on. The narrowing now happens in the query, and a
 how many runs there are in total beside how many it is showing.
 
 **Settings ▸ Diagnostics ▸ Agent runs** is new: every agent run across every project, who ran it,
-which pack it came through, and which failed — instead of opening each project's console in turn
-and adding them up. It is admin-only, because these are audit records and the audit log already is;
-a run nobody could attribute is listed as unattributed rather than hidden, since those are the ones
-worth looking at.
+which pack it came through, and which failed — instead of opening each project's console in turn and
+adding them up. It is admin-only because these are audit records, and the audit log is already
+restricted to administrators. A run nobody could attribute is listed as unattributed rather than
+hidden, since those are the ones worth looking at.
 
 ### Resourcing "by department" — the axis your firm defines, not one we invent
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### The agent trail said "nothing ran here" while runs existed
+
+Every AI agent run against a project is recorded — which tool, through which named pack, by whom,
+and whether it failed. That trail is the thing an organisation checks before letting an agent near
+its projects, and the thing it reads first after something goes wrong.
+
+It was quietly dropping runs. The console asked the database for the most recent activity and only
+*then* narrowed it to the project you were looking at — so on a deployment where one project is
+busier than the rest, a quieter project's console could report **no agent activity at all while
+activity existed**. Measured: one run on a quiet project, a few hundred newer runs elsewhere, and
+the quiet project's console showed nothing. The busy project lost older rows the same way, without
+saying so.
+
+For this screen that is not a blank, it is a wrong answer — "no agent touched this project" is
+exactly the claim someone acts on. The narrowing now happens in the query, and a capped view says
+how many runs there are in total beside how many it is showing.
+
+**Settings ▸ Diagnostics ▸ Agent runs** is new: every agent run across every project, who ran it,
+which pack it came through, and which failed — instead of opening each project's console in turn
+and adding them up. It is admin-only, because these are audit records and the audit log already is;
+a run nobody could attribute is listed as unattributed rather than hidden, since those are the ones
+worth looking at.
+
 ### Resourcing "by department" — the axis your firm defines, not one we invent
 
 Portfolio resourcing already showed weekly demand per trade summed across every project, which is

--- a/apps/web/src/account/accountUI.ts
+++ b/apps/web/src/account/accountUI.ts
@@ -348,6 +348,7 @@ async function openProfile(platformAdmin: boolean, tier: string, initial = "prof
     actions: {
       manageUsers: adminModal,
       auditLog: auditModal,
+      agentRuns: agentRunsModal,
       errorLog: errorsModal,
       dataConnections: () => void import("../connections/connectionsUI")
         .then((m) => m.openConnectionsModal(D.api, D.getProjectId)),
@@ -563,6 +564,44 @@ function auditModal() {
   fAction.onkeydown = fActor.onkeydown = (e) => { if (e.key === "Enter") void render(); };
   card.append(filters, table, msg);
   void render().finally(ready);
+}
+
+function agentRunsModal() {
+  const { card, msg, ready } = modalShell("Agent runs", 700);
+  msg.style.color = "var(--err)";
+  const api = D.api;
+  const summary = document.createElement("div"); summary.className = "meta";
+  const table = document.createElement("div"); table.style.cssText = "max-height:55vh;overflow:auto;margin-top:8px";
+
+  void api.agentPackRuns(200).then((r) => {
+    // "Nothing ran" is an ANSWER here, so the header states the scope it is an answer about:
+    // how many runs exist, not merely how many this window holds.
+    const actors = Object.entries(r.by_actor).sort((a, b) => b[1] - a[1]);
+    summary.textContent = `${r.run_total} run(s) across the estate`
+      + (r.truncated ? ` · showing the newest ${r.run_count}` : "")
+      + (r.failure_count ? ` · ${r.failure_count} failed` : "")
+      + (actors.length ? ` · ${actors.map(([who, n]) => `${who} ${n}`).join(", ")}` : "");
+    if (!r.runs.length) { table.innerHTML = '<div class="meta">no agent has run yet</div>'; return; }
+    const cell = (x: string, extra = "") =>
+      `<td style="padding:4px 8px;border-bottom:1px solid var(--line);white-space:nowrap;${extra}">${x}</td>`;
+    table.innerHTML = `<table class="sens-table" style="width:100%;font-size:12px"><tr>`
+      + `<th style="text-align:left">When</th><th style="text-align:left">Who</th>`
+      + `<th style="text-align:left">Project</th><th style="text-align:left">Pack</th>`
+      + `<th style="text-align:left">Tool</th><th style="text-align:left">Result</th></tr>`
+      + r.runs.map((x) => `<tr>`
+        + cell(x.ts ? new Date(x.ts).toLocaleString() : "—")
+        // An unattributed run is shown as such rather than blank: the transport refuses to invent a
+        // name, and a blank cell reads as a rendering gap instead of the fact it is.
+        + cell(escapeHtml(x.actor || "(unattributed)"), x.actor ? "" : "color:var(--muted)")
+        + cell(escapeHtml(x.project_id ?? "—")) + cell(escapeHtml(x.pack ?? "—"))
+        + cell(escapeHtml(x.tool ?? "—"))
+        + cell(x.ok === false ? "failed" : x.ok === true ? "ok" : "—",
+               x.ok === false ? "color:var(--err)" : "")
+        + `</tr>`).join("") + `</table>`;
+  }).catch(() => { msg.textContent = "could not load agent runs (admin only)"; })
+    .finally(ready);
+
+  card.append(summary, table, msg);
 }
 
 function errorsModal() {

--- a/apps/web/src/account/accountUI.ts
+++ b/apps/web/src/account/accountUI.ts
@@ -566,6 +566,11 @@ function auditModal() {
   void render().finally(ready);
 }
 
+/** Settings ▸ Diagnostics ▸ **Agent runs** — every agent run across the estate.
+ *
+ *  Sits beside the audit-log modal deliberately: it reads the same rows, and the route behind it is
+ *  admin-only for that reason. The header states the TOTAL rather than what this window holds,
+ *  because on this screen "nothing ran" is an answer someone acts on, not a blank. */
 function agentRunsModal() {
   const { card, msg, ready } = modalShell("Agent runs", 700);
   msg.style.color = "var(--err)";

--- a/apps/web/src/account/profileSettings.test.ts
+++ b/apps/web/src/account/profileSettings.test.ts
@@ -18,7 +18,7 @@ import type { CloudStatus } from "../api/cloud";
  */
 function actions(): ProfileActions {
   return {
-    manageUsers: vi.fn(), auditLog: vi.fn(), errorLog: vi.fn(), dataConnections: vi.fn(),
+    manageUsers: vi.fn(), auditLog: vi.fn(), agentRuns: vi.fn(), errorLog: vi.fn(), dataConnections: vi.fn(),
     projectMembers: null, changePassword: vi.fn(), twoFactor: vi.fn(), appSettings: vi.fn(),
     signOutEverywhere: vi.fn(), signOut: vi.fn(), connectCloud: vi.fn(),
     refreshCloud: vi.fn(async () => ({} as CloudStatus)), disconnectCloud: vi.fn(async () => {}),

--- a/apps/web/src/account/profileSettings.ts
+++ b/apps/web/src/account/profileSettings.ts
@@ -24,6 +24,7 @@ import type { CloudStatus } from "../api/cloud";
 export interface ProfileActions {
   manageUsers: () => void;
   auditLog: () => void;
+  agentRuns: () => void;
   errorLog: () => void;
   dataConnections: () => void;
   projectMembers: (() => void) | null;   // null when there is no project / not a project admin
@@ -261,5 +262,6 @@ function buildAdmin(body: HTMLElement, deps: ProfileDeps): void {
   server.append(row("Server settings", "Licence, integrations and API keys.", "Open…", a.appSettings));
   const logs = group(body, "Diagnostics");
   logs.append(row("Audit log", "Who did what, newest first.", "View…", a.auditLog));
+  logs.append(row("Agent runs", "Whose agent ran what, across every project.", "View…", a.agentRuns));
   logs.append(row("Errors", "Recent server-side errors.", "View…", a.errorLog));
 }

--- a/apps/web/src/api/ai.test.ts
+++ b/apps/web/src/api/ai.test.ts
@@ -7,7 +7,7 @@ const api = new ApiClient("http://localhost:0");
 describe("the ai client", () => {
   it("exposes risk summary, ask, triage, estimate, author, and draft-rfi", () => {
     for (const k of ["riskSummary", "aiAsk", "triageRfi", "aiEstimate", "aiAuthor", "draftRfi",
-                     "agentPacks"]) {
+                     "agentPacks", "agentPackRuns"]) {
       expect(typeof (api as unknown as Record<string, unknown>)[k], k).toBe("function");
     }
   });

--- a/apps/web/src/api/ai.ts
+++ b/apps/web/src/api/ai.ts
@@ -63,8 +63,26 @@ export function withAi<TBase extends Ctor<HttpCore>>(Base: TBase) {
         writes: boolean; write_tools: string[] }[];
       pack_count: number; read_only_count: number;
       runs: { ts: string | null; actor: string; tool: string | null; pack: string | null; ok: boolean | null }[];
-      run_count: number; failure_count: number;
+      run_count: number; run_total: number; truncated: boolean; failure_count: number;
+      by_tool: Record<string, number>; by_actor: Record<string, number>;
     }>(`/projects/${pid}/agent-packs`);
+  }
+  /** Every agent run across the estate — whose agent ran what, on which project.
+   *
+   *  The per-project call above answers "what ran here", which is the wrong altitude for the
+   *  question asked before granting an agent access or after an incident. **Admin only**, because
+   *  these rows come from the audit log and `/audit` is admin-only: a non-admin estate-wide view
+   *  would be a way to read audit rows without being an admin. */
+  agentPackRuns(limit = 200) {
+    return this.json<{
+      packs: { key: string; label: string; purpose: string; tool_count: number;
+        writes: boolean; write_tools: string[] }[];
+      pack_count: number; read_only_count: number;
+      runs: { ts: string | null; actor: string; tool: string | null; pack: string | null;
+        ok: boolean | null; project_id: string | null }[];
+      run_count: number; run_total: number; truncated: boolean; failure_count: number;
+      by_tool: Record<string, number>; by_actor: Record<string, number>; note: string;
+    }>(`/agent-packs/runs?limit=${limit}`);
   }
 
   /** askModel — a plain-English question about the model, grounded in the property-index snapshot. */

--- a/apps/web/src/api/surface.test.ts
+++ b/apps/web/src/api/surface.test.ts
@@ -181,7 +181,7 @@ describe("the API client's public surface", () => {
       "goldenThread", "k1Pack", "capTable", "waterfallScenario", "capitalCall", "ffeBom", "specLinks", "authoringMatrix",
       "equipmentBudgetLines", "lodCensus", "exportQa", "qualityTurnoverReadiness",
       "costDatasets", "costVintage", "unitRates", "costSummary", "gmpBudget", "payAppPdf", "elementCosts5d", "gaebX83Url",
-      "codeAmendments", "agentPacks", "modelHistory", "fileModel", "spacePack",
+      "codeAmendments", "agentPacks", "agentPackRuns", "modelHistory", "fileModel", "spacePack",
       "compiledPdfUrl", "projectPackagePdfUrl",
       "bep", "cdeStatus", "infoRequirementsRegister", "cdeExchangeAcceptance",
       "drawingSchedulesCsvUrl", "permitsGeojsonUrl", "moduleLogPdfUrl", "viewTemplateGraphics",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1718,7 +1718,7 @@ two rows share a path, so two agents in different rows cannot collide.
 
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
-| **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* · R22-AGENT-PACKS *(moved from C 2026-08-16 — what remains is the governance CONSOLE, which is shell work. Its own entry said Lane A/E and the cell had not followed. The item stays ◧: the console is real work and this cell does not claim otherwise)* |
+| **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* |
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · PERF-WORKERS ① · R43-MASSINGBILL-CORE · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
@@ -2729,7 +2729,7 @@ stakes we are missing.
   never noticing `approval_risk.py`, which the eventual build should probably feed. Third
   collision found on 2026-07-31, after `report_builders/` (five hardcoded builders, not the no-code
   builder R22-REPORT-BUILDER describes).
-- ◧ **R22-AGENT-PACKS** *(M — **Lane C part COMPLETE**: `agent_packs.py` shipped, audit half CLOSED
+- ✅ **R22-AGENT-PACKS** *(M — CLOSED 2026-09-09; **Lane C part COMPLETE**: `agent_packs.py` shipped, audit half CLOSED
   2026-08-06, attribution fixed at the call site. **Dropped from the Lane C cell 2026-08-16** —
   its own text already said the remainder is the governance console, which is Lane A/E. Leaving a
   code in a lane that cannot finish it makes the lane look busier than it is)* — **named agent packs + org "Skills" + a governance console** over the
@@ -2750,7 +2750,36 @@ stakes we are missing.
   rather than recording them silently, and refuses to invent a person-shaped default (an unverified
   name in an audit trail is worse than an honest "the transport ran this").
   `services/api/test_mcp_attribution.py` asserts the **call site** forwards all three, mutation-checked
-  against the original defect. **What remains is the governance console itself — Lane A/E, not C.**
+  against the original defect.
+
+  ✅ **THE CONSOLE SHIPPED 2026-09-09 — and building it found the trail lying.** `run_log` applied
+  `limit` **before** the project filter: the filter was a Python `continue` running over rows the
+  database had already truncated to the newest 200 across *every* project. So a quiet project on a
+  busy install reported **zero runs while runs existed** — measured at the size that exposes it, one
+  run on project A and 250 newer on project B, and A's console answered "nothing ran". Busy projects
+  lost rows too (B returned 200 of its 250, silently).
+
+  **For a governance console that is not a blank, it is a wrong answer.** "No agent touched this
+  project" is precisely the claim someone relies on before granting access and after an incident,
+  and it degraded without an error. The filter now runs in SQL
+  (`detail["project_id"].as_string()`, one expression across SQLite and Postgres), and the window
+  reports `run_total` beside `run_count` so a capped view says so rather than presenting its slice
+  as the whole — the same partial-answer-in-a-complete-answer's-costume, one layer down.
+
+  **`GET /agent-packs/runs` is the estate-wide console**, and it is **admin-only because that
+  follows from an existing fact**: these rows come out of `audit_log` and `GET /audit` is already
+  admin-only, so a non-admin estate-wide view would be a way to read audit rows without being an
+  admin — a privilege-escalation surface wearing the name of a governance feature. The per-project
+  route stays at project `viewer`, where the rows are already in scope. `by_actor` is the axis that
+  only earns its place across projects: within one, the useful tally is which tools ran; across the
+  estate the question is *who*, and an unattributed run is counted under an explicit
+  "(unattributed)" rather than dropped, since the transport refuses to invent a name and those are
+  exactly the rows a reviewer needs. Reachable from Settings ▸ Diagnostics ▸ **Agent runs**.
+  `services/api/test_agent_runs_route.py` asserts the refusal against a **real non-admin session**
+  rather than by reading the dependency's name — `Depends(current_user)` identifies and reads like a
+  gate, which this repository's own SEC-GLOBAL-AUTHZ note records as how such a hole survives review.
+
+  **R22-AGENT-PACKS is now closed.**
 
 **Tier 2 — evidence, provenance and procurement**
 

--- a/services/api/run_tests.py
+++ b/services/api/run_tests.py
@@ -67,7 +67,7 @@ TESTS = ["test_provenance_report", "test_provenance_estimate_leg", "test_answers
          # Tier-2/3 competitive upgrades:
          # REFUSAL-READERS — the behavioural gate for the refusal-state reader class:
          "test_refusal_readers",
-         "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approval_conditions", "test_agent_packs", "test_mcp_attribution", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
+         "test_prequal", "test_vendor_memory", "test_payapp", "test_accounting", "test_carbon", "test_codecheck", "test_code_analysis", "test_codes", "test_approval_conditions", "test_agent_packs", "test_agent_runs_route", "test_mcp_attribution", "test_approvability", "test_rfi_readiness", "test_readiness_bcf", "test_productivity", "test_ebc", "test_element_connections", "test_scene", "test_pricing", "test_cost_db",
          "test_ids_authoring", "test_procurement", "test_conceptual", "test_parcels", "test_net",
          "test_design_phase", "test_family_library", "test_change_instruments", "test_turnover",
          "test_prod_hardening", "test_diligence", "test_deal_funnel", "test_deal_memory", "test_deal_memory_beside", "test_energy_star_bridge", "test_operations", "test_reserves_cam", "test_esg",

--- a/services/api/src/aec_api/agent_packs.py
+++ b/services/api/src/aec_api/agent_packs.py
@@ -158,23 +158,49 @@ def run_log(db, project_id: str | None = None, limit: int = 200) -> dict[str, An
 
     q = db.query(AuditLog).filter(AuditLog.method == "MCP")
     if project_id:
-        q = q.filter(AuditLog.detail.isnot(None))
+        # THE PROJECT FILTER MUST RUN IN SQL, BEFORE THE LIMIT. It used to be a Python `continue`
+        # after `.limit(limit)` had already truncated to the newest rows across EVERY project, so a
+        # quiet project on a busy install reported **zero runs while runs existed** — measured: one
+        # run on project A, 250 newer runs on project B, and A's console answered "nothing ran".
+        # For a governance console that is not a blank, it is a wrong answer: "no agent touched this
+        # project" is exactly the claim someone relies on before granting access or after an
+        # incident. Busy projects lost rows too (B returned 200 of its 250).
+        #
+        # `detail["project_id"].as_string()` compiles to json_extract on SQLite and ->> on
+        # Postgres, so one expression covers the test dialect and the production one. A row whose
+        # detail carries no project_id yields NULL and is excluded, which is what the old Python
+        # comparison against "" did — the semantics are unchanged, only the stage they run at.
+        q = q.filter(AuditLog.detail["project_id"].as_string() == project_id)
+    # How many runs there ARE, before the window. A console that caps at `limit` and says nothing
+    # reports "these are the runs" when it means "these are the newest N" — the same
+    # partial-answer-wearing-a-complete-answer's-costume the fix above is about, one layer down.
+    total = q.count()
     rows = q.order_by(AuditLog.ts.desc()).limit(limit).all()
     runs = []
     for r in rows:
         d = r.detail or {}
-        if project_id and str(d.get("project_id") or "") != project_id:
-            continue
         runs.append({"ts": getattr(r.ts, "isoformat", lambda: None)(), "actor": r.actor,
                      "action": r.action, "tool": d.get("tool"), "pack": d.get("pack"),
                      "ok": d.get("ok"), "project_id": d.get("project_id")})
     by_tool: dict[str, int] = {}
+    # `by_actor` is the axis that only matters once the log spans projects: across an estate the
+    # governance question is *who ran an agent*, and a tally of tools cannot answer it. An
+    # unattributed run is counted under an explicit "(unattributed)" rather than dropped — the
+    # transport refuses to invent a person-shaped default, so those rows exist and hiding them
+    # would understate exactly the runs a reviewer most needs to see.
+    by_actor: dict[str, int] = {}
     for x in runs:
         if x.get("tool"):
             by_tool[x["tool"]] = by_tool.get(x["tool"], 0) + 1
+        who = x.get("actor") or "(unattributed)"
+        by_actor[who] = by_actor.get(who, 0) + 1
     failures = [x for x in runs if x.get("ok") is False]
-    return {"runs": runs, "run_count": len(runs), "by_tool": by_tool,
+    return {"runs": runs, "run_count": len(runs), "by_tool": by_tool, "by_actor": by_actor,
             "failure_count": len(failures),
+            # `run_total` counts every matching run; `run_count` is what this window holds. They
+            # differ only when `truncated`, and a caller that shows one while meaning the other is
+            # the reason both are here rather than just the list's length.
+            "run_total": total, "truncated": total > len(runs),
             "note": ("failures are included deliberately — a tool history that lists only successes "
                      "cannot answer what an agent attempted, which is the question asked after an "
                      "incident rather than before one."),

--- a/services/api/src/aec_api/main.py
+++ b/services/api/src/aec_api/main.py
@@ -646,7 +646,15 @@ _CSP = "frame-ancestors 'none'" if not _CSP_ENV else (_CSP_STRICT if _CSP_ENV ==
 # that lacks its own require_role dependency still can't be reached anonymously. Public auth / health /
 # capability / catalog / stateless-compute paths stay open.
 _PROTECTED_PREFIXES = ("/projects", "/proforma", "/connections", "/settings", "/audit", "/auth/users",
-                       "/convert", "/interop", "/pipeline", "/routines", "/cloud")
+                       "/convert", "/interop", "/pipeline", "/routines", "/cloud", "/agent-packs")
+# `/agent-packs` (AGENT-TRAIL) is here for the same reason `/audit` is: the estate-wide agent console
+# reads `audit_log` rows spanning every project, which is tenant state at its most sensitive. It is
+# read-only, so `test_global_mutating_authz` would never have looked at it — the prefix gate is what
+# caught it, on exactly the shape its own note predicts ("adding a new prefix silently opts out of
+# the safety net and nothing fails"). As with `/cloud`, this is defence in depth and NOT the gate:
+# the route carries `require_admin_user` itself, because an armed middleware makes a guarded and an
+# unguarded route look identical from outside, and then nothing is testing the route's own guard.
+# `/projects/{pid}/agent-packs` is unaffected — it sits under `/projects`.
 # `/cloud` (CLOUD-LIBRARY) is here because every route under it reads one user's massing.cloud vault
 # — tenant state by definition. Note `/auth/cloud/*` is deliberately NOT covered: sign-in has to be
 # reachable by someone who is not signed in yet, which is the whole point of it. Those routes carry

--- a/services/api/src/aec_api/routers/assistant.py
+++ b/services/api/src/aec_api/routers/assistant.py
@@ -9,6 +9,7 @@ from .. import agent_packs, assistant, routines
 from ..db import get_db
 from ..models import Project
 from ..rbac import require_identified, require_role
+from .auth import require_admin_user
 
 router = APIRouter()
 
@@ -132,3 +133,28 @@ def project_agent_packs(pid: str, db: Session = Depends(get_db),
     if not db.get(Project, pid):
         raise HTTPException(404, "project not found")
     return {**agent_packs.catalog(), **agent_packs.run_log(db, project_id=pid)}
+
+
+@router.get("/agent-packs/runs")
+def agent_pack_runs(limit: int = 200, db: Session = Depends(get_db),
+                    _: object = Depends(require_admin_user)):
+    """R22-AGENT-PACKS — the governance console **across the estate**: every agent run, whoever ran
+    it and whichever project it touched.
+
+    The per-project route above answers "what ran here". That is the wrong altitude for the question
+    an enterprise actually asks before granting an agent access, and after an incident: *whose agent
+    ran what, anywhere.* A reviewer who has to open twenty project consoles and add them up is not
+    being governed by a console; and a run against a project they forgot to check is invisible.
+
+    **Admin-only, and that follows from an existing fact rather than from taste.** These rows come
+    from `audit_log`, and `GET /audit` is already admin-only — so a non-admin org-wide view here
+    would be a way to read audit rows without being an admin, which is a privilege-escalation
+    surface wearing the name of a governance feature. (The per-project route stays at project
+    `viewer`, because there the rows are scoped to a project the caller already has access to.)
+
+    `by_actor` is the axis that only earns its place here: within one project the interesting
+    tally is which tools ran, but across the estate the question is *who ran an agent*, and a tool
+    tally cannot answer it. An unattributed run is counted, not dropped.
+    """
+    return {**agent_packs.catalog(),
+            **agent_packs.run_log(db, project_id=None, limit=max(1, min(int(limit), 1000)))}

--- a/services/api/test_agent_packs.py
+++ b/services/api/test_agent_packs.py
@@ -122,6 +122,56 @@ with SessionLocal() as db:
     check("  and surfacing the failures", log["failure_count"] >= 1, log["failure_count"])
     check("  saying why failures are included", "after an incident" in log["note"])
 
+    # --- AGENT-TRAIL: "nothing ran here" is an ANSWER, not a blank -------------------------------
+    # The project filter used to be a Python `continue` AFTER `.limit(limit)` had already truncated
+    # to the newest rows across every project, so a quiet project on a busy install reported zero
+    # runs while runs existed. Reproduced at the size that exposes it — one run on the quiet
+    # project, `limit`-worth of newer runs elsewhere — because at any smaller size the defect and
+    # the fix are indistinguishable, which is why nothing caught it for a release.
+    from datetime import datetime, timedelta, timezone  # noqa: PLC0415
+    t0 = datetime.now(timezone.utc)
+    db.add(AuditLog(ts=t0 - timedelta(hours=5), actor="alice", action="mcp.run", method="MCP",
+                    detail={"tool": "standards_check", "pack": "Submittal Review", "ok": True,
+                            "project_id": "QUIET"}))
+    for i in range(250):
+        db.add(AuditLog(ts=t0 - timedelta(minutes=250 - i), actor="bob", action="mcp.run",
+                        method="MCP", detail={"tool": "clash", "ok": True, "project_id": "BUSY"}))
+    db.commit()
+
+    quiet = ap.run_log(db, project_id="QUIET")
+    check("A QUIET PROJECT STILL REPORTS ITS RUN when a busier one fills the window",
+          quiet["run_count"] == 1, quiet["run_count"])
+    check("  and it is the right run, not merely a non-zero count",
+          quiet["runs"][0]["actor"] == "alice" and quiet["runs"][0]["project_id"] == "QUIET",
+          quiet["runs"][:1])
+    check("  a project with no runs at all still reports none",
+          ap.run_log(db, project_id="NOBODY")["run_count"] == 0)
+
+    # A capped window says so. Reporting 200 as though it were all of them is the same
+    # partial-answer-in-a-complete-answer's-costume one layer down.
+    busy = ap.run_log(db, project_id="BUSY", limit=200)
+    check("a capped window reports the TOTAL beside what it holds",
+          busy["run_count"] == 200 and busy["run_total"] == 250 and busy["truncated"] is True,
+          (busy["run_count"], busy["run_total"], busy["truncated"]))
+    check("  and an uncapped one is not marked truncated",
+          ap.run_log(db, project_id="QUIET")["truncated"] is False)
+
+    # ORG-WIDE: the axis a per-project console cannot have. `by_actor` counts WHO, and an
+    # unattributed run is counted rather than dropped — the transport refuses to invent a name, so
+    # those rows exist and are exactly the ones a reviewer needs to see.
+    db.add(AuditLog(ts=t0, actor=None, action="mcp.run", method="MCP",
+                    detail={"tool": "clash", "ok": True, "project_id": "BUSY"}))
+    db.commit()
+    org = ap.run_log(db, project_id=None, limit=1000)
+    check("the estate-wide log spans projects a per-project view would separate",
+          {r["project_id"] for r in org["runs"]} >= {"QUIET", "BUSY"},
+          sorted({r["project_id"] for r in org["runs"] if r["project_id"]}))
+    check("  counting runs per ACTOR, which is the estate-wide question",
+          org["by_actor"].get("alice") == 1 and org["by_actor"].get("bob", 0) >= 250,
+          org["by_actor"])
+    check("  an unattributed run is counted, never dropped",
+          org["by_actor"].get("(unattributed)") == 1, org["by_actor"])
+
 engine.dispose()
 for _f in ("./test_agent_packs.db",):
     if os.path.exists(_f):

--- a/services/api/test_agent_runs_route.py
+++ b/services/api/test_agent_runs_route.py
@@ -44,6 +44,11 @@ FAILED: list[str] = []
 
 
 def check(name: str, ok: bool, detail: object = "") -> None:
+    """Record one assertion, printing the measured value beside a failure.
+
+    `detail` carries what was actually seen, not a restatement of the expectation — a failure that
+    prints only its own name tells the next reader nothing they did not already have.
+    """
     print(("PASS  " if ok else "FAIL  ") + name + (f"   {detail}" if detail else ""))
     if not ok:
         FAILED.append(name)

--- a/services/api/test_agent_runs_route.py
+++ b/services/api/test_agent_runs_route.py
@@ -1,0 +1,126 @@
+"""AGENT-TRAIL — `GET /agent-packs/runs`, the estate-wide agent governance console.
+
+Two claims are asserted here, and the second is the one that matters.
+
+**It answers across projects.** The per-project console answers "what ran here", which is the wrong
+altitude for the question an enterprise asks before granting an agent access and after an incident:
+*whose agent ran what, anywhere.* A reviewer who must open twenty consoles and add them up is not
+being governed by one.
+
+**IT IS ADMIN-ONLY, AND THAT FOLLOWS FROM AN EXISTING FACT RATHER THAN FROM TASTE.** These rows come
+out of `audit_log`, and `GET /audit` is already admin-only. So a non-admin estate-wide view here
+would be a way to read audit rows without being an admin — a privilege-escalation surface wearing
+the name of a governance feature. Asserted with a real non-admin session rather than by reading the
+dependency's name, because `Depends(current_user)` *identifies* and reads exactly like a gate; the
+repository's own SEC-GLOBAL-AUTHZ note records that being how such a hole survives review.
+
+Run: PYTHONPATH=src:../data/src ./.venv/bin/python test_agent_runs_route.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ["DATABASE_URL"] = "sqlite:///./test_agent_runs_route.db"
+os.environ["STORAGE_DIR"] = "./test_storage_agent_runs_route"
+os.environ["AEC_RBAC"] = "1"
+os.environ.pop("AEC_TRUST_XUSER", None)
+os.environ.pop("AEC_ADMIN_EMAILS", None)
+for _f in ("./test_agent_runs_route.db",):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from aec_api.db import Base, SessionLocal, engine  # noqa: E402
+from aec_api.main import app  # noqa: E402
+from aec_api.models import AuditLog  # noqa: E402
+
+Base.metadata.create_all(bind=engine)
+
+FAILED: list[str] = []
+
+
+def check(name: str, ok: bool, detail: object = "") -> None:
+    print(("PASS  " if ok else "FAIL  ") + name + (f"   {detail}" if detail else ""))
+    if not ok:
+        FAILED.append(name)
+
+
+c = TestClient(app)
+
+# The first registration on an empty user table bootstraps the platform admin (AEC_ADMIN_EMAILS is
+# unset here, which is the single-operator case R43-ORG-OWNERSHIP leaves granting "admin").
+def _login(username: str, password: str) -> str:
+    """A bearer token for `username`. Registration returns the account, not a session."""
+    r = c.post("/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200, r.text[:200]
+    return r.json()["token"]
+
+
+r = c.post("/auth/register", json={"username": "boss@x.test", "password": "correct-horse-1"})
+assert r.status_code in (200, 201), r.text[:200]
+assert r.json()["role"] == "admin", r.json()
+admin_tok = _login("boss@x.test", "correct-horse-1")
+r = c.post("/auth/register", json={"username": "worker@x.test", "password": "correct-horse-2"},
+           headers={"Authorization": f"Bearer {admin_tok}"})
+assert r.status_code in (200, 201), r.text[:200]
+# The worker must NOT be an admin, or the refusal below would pass for the wrong reason — the
+# whole assertion is that a signed-in non-admin is turned away.
+assert r.json().get("role") != "admin", r.json()
+worker_tok = _login("worker@x.test", "correct-horse-2")
+AH = {"Authorization": f"Bearer {admin_tok}"}
+WH = {"Authorization": f"Bearer {worker_tok}"}
+
+t0 = datetime.now(timezone.utc)
+with SessionLocal() as db:
+    db.add(AuditLog(ts=t0 - timedelta(hours=2), actor="alice", action="mcp.run", method="MCP",
+                    detail={"tool": "standards_check", "pack": "Submittal Review", "ok": True,
+                            "project_id": "P-ONE"}))
+    db.add(AuditLog(ts=t0 - timedelta(hours=1), actor="bob", action="mcp.run", method="MCP",
+                    detail={"tool": "clash", "pack": "QA", "ok": False, "project_id": "P-TWO"}))
+    db.commit()
+
+# --- the gate, asserted against a live non-admin session -----------------------------------------
+r = c.get("/agent-packs/runs", headers=WH)
+check("A NON-ADMIN IS REFUSED — these are audit rows, and /audit is admin-only",
+      r.status_code in (401, 403), r.status_code)
+r = c.get("/agent-packs/runs")
+check("  and so is an anonymous caller", r.status_code in (401, 403), r.status_code)
+
+# --- what an admin actually gets ------------------------------------------------------------------
+r = c.get("/agent-packs/runs", headers=AH)
+check("an admin gets the console", r.status_code == 200, r.status_code)
+body = r.json()
+check("  spanning projects a per-project view would separate",
+      {x["project_id"] for x in body["runs"]} >= {"P-ONE", "P-TWO"},
+      sorted({x["project_id"] for x in body["runs"] if x["project_id"]}))
+check("  counting runs per ACTOR — the estate-wide question a tool tally cannot answer",
+      body["by_actor"].get("alice") == 1 and body["by_actor"].get("bob") == 1, body["by_actor"])
+check("  carrying the pack each run came through", {x["pack"] for x in body["runs"]}
+      >= {"Submittal Review", "QA"}, [x["pack"] for x in body["runs"]])
+check("  and the failure, because 'what did it try' is the post-incident question",
+      body["failure_count"] == 1, body["failure_count"])
+check("  the catalog rides along, so the console can say what each pack is",
+      body["pack_count"] >= 1 and isinstance(body["packs"], list), body.get("pack_count"))
+check("  a full window is not reported as truncated",
+      body["truncated"] is False and body["run_total"] == body["run_count"],
+      (body["run_total"], body["run_count"]))
+
+# The window is clamped, not trusted -- and a clamped window still tells the truth about the total.
+one = c.get("/agent-packs/runs?limit=1", headers=AH).json()
+check("a narrowed window says so rather than reporting its slice as the whole",
+      one["run_count"] == 1 and one["run_total"] == 2 and one["truncated"] is True,
+      (one["run_count"], one["run_total"], one["truncated"]))
+check("  limit is clamped rather than trusted",
+      c.get("/agent-packs/runs?limit=0", headers=AH).json()["run_count"] == 1)
+
+print()
+if FAILED:
+    print(f"agent runs route: {len(FAILED)} FAILED — {FAILED}")
+    sys.exit(1)
+print('agent runs route OK - the estate-wide agent console spans projects and counts by actor, and '
+      'it is admin-only because its rows are audit rows: asserted with a real non-admin session, '
+      'not by reading the dependency\'s name')


### PR DESCRIPTION
## The defect

R22-AGENT-PACKS' remaining item was the governance console. Building it found the trail underneath
already lying.

`run_log` applied `limit` **before** the project filter — the filter was a Python `continue` running
over rows the database had already truncated to the newest 200 across *every* project. Measured at
the size that exposes it:

| | | |
|---|---|---|
| project A | 1 run | console reported **0** |
| project B | 250 runs (newer) | console reported 200, silently |

**For a governance console that is not a blank, it is a wrong answer.** "No agent touched this
project" is precisely the claim someone relies on before granting an agent access and after an
incident, and it degraded with no error — which is why nothing caught it.

## The fix

* The filter runs in SQL, before the limit: `detail["project_id"].as_string()` compiles to
  `json_extract` on SQLite and `->>` on Postgres, so one expression covers the test dialect and the
  production one. A row with no `project_id` yields NULL and is excluded, which is what the old
  Python comparison against `""` did — the semantics are unchanged, only the stage they run at.
* `run_total` rides beside `run_count` with `truncated`, so a capped window stops reporting its
  slice as the whole. Same partial-answer-in-a-complete-answer's-costume, one layer down.

## The console

`GET /agent-packs/runs` is the estate-wide view the entry asked for. The per-project route answers
"what ran here", which is the wrong altitude for the question an enterprise asks: *whose agent ran
what, anywhere.* Reachable from **Settings ▸ Diagnostics ▸ Agent runs**.

**Admin-only, and that follows from an existing fact rather than taste.** These rows come out of
`audit_log` and `GET /audit` is already admin-only, so a non-admin estate-wide view would be a way
to read audit rows without being an admin — a privilege-escalation surface wearing the name of a
governance feature. The per-project route stays at project `viewer`, where the rows are already in
scope.

`by_actor` is the axis that only earns its place across projects: within one, the useful tally is
which tools ran; across the estate the question is *who*. An unattributed run is counted under an
explicit `(unattributed)` rather than dropped — the transport refuses to invent a person-shaped
default, so those rows exist and are exactly the ones a reviewer needs to see.

## What the repo's own gate caught, and what it says about the others

The full suite failed on `test_protected_prefix_coverage`: `/agent-packs` was a new top-level prefix
outside `main._PROTECTED_PREFIXES` and unclassified. That is the exact shape SEC-GLOBAL-AUTHZ's note
predicts — *"adding a new prefix silently opts out of the safety net and nothing fails."* Which gates
could see it is the interesting part:

| gate | verdict | why |
|---|---|---|
| `test_global_mutating_authz` | never looked | the route is a GET |
| `test_global_authz` | satisfied | the route really does carry `require_admin_user` |
| `test_protected_prefix_coverage` | **caught it** | the only one asking whether the new namespace is in the net |

Registered rather than exempted, for the same reason `/audit` is: the console reads audit rows
spanning every project. As with `/cloud` this is defence in depth and **not** the gate — the route
keeps its own `require_admin_user`, because an armed middleware makes a guarded and an unguarded
route look identical from outside, and then nothing is testing the route's own guard.

## Verification

**Nine mutations killed**, including one that restores the original defect (it fails on exactly the
assertion written for it) and one that downgrades the gate to `require_identified`. The refusal is
asserted against a **real non-admin session** rather than by reading the dependency's name:
`Depends(current_user)` identifies and reads like a gate, which this repository's own note records
as how such a hole survives review.

* Web: **2321 tests / 226 files**, `tsc --noEmit`, `eslint src`, `vite build` — clean
* `ruff check ../..` clean; `test_claude_md_gates`, `roadmapLanes`, `docStranded` pass
* Full backend suite re-running on this head; the prefix gate, the new route test, `test_global_authz`,
  `test_route_reachability` and `test_agent_packs` all pass individually

The one thing local runs cannot check is the `->>` compilation on Postgres — that is what the
runtime-parity job here is for.

Closes R22-AGENT-PACKS; marker and Lane A cell updated together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an administrator-only Agent Runs diagnostics view in Settings.
  - Displays cross-project runs, actor attribution, packs, failures, totals, and truncation status.
  - Unattributed runs remain visible and clearly identified.

- **Bug Fixes**
  - Corrected project-level filtering so activity counts accurately reflect matching runs.
  - Added total-versus-capped result reporting and actor summaries.
  - Restricted estate-wide Agent Runs access to authenticated administrators.

- **Documentation**
  - Updated the roadmap and changelog with Agent Packs governance and diagnostics details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->