### PR TITLE
PINS-SHEET: a printed plan sheet says when its pin list was capped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### A printed plan sheet now says when its pin list was capped
+
+The pin overlay was fixed to report a cap; the **printed sheet stayed silent**. A superintendent
+walks the building with paper, so the half that reaches the person at risk was the half still
+missing — a capped sheet printed a confident subset and looked complete.
+
+A capped sheet now carries a note: *"Pin list capped at 2000 of ~2400 project pins — this sheet may
+not show every issue on this level."* It is deliberately **qualitative about the sheet and
+quantitative only about the project**. The cap is spent before pins are filtered to a storey, so how
+many of the dropped pins belonged to *this* level cannot be known at either end, and printing a
+per-sheet number would repeat the original defect in a new place. The `~` marks the total as an
+upper bound while legacy records with empty-but-not-null pin fields still exist.
+
+A sheet with **no** pins left after a cap still warns — that case is the blank overlay reaching
+paper, and it is exactly when "this level looks clean" is most wrong.
+
+The blocker recorded for this in the roadmap was false: it said the drawing engine takes positions
+and labels, not notes, when the engine had been printing *"N pin(s) not located on this sheet"* all
+along. Nobody had checked the claim against the code.
+
 ### The pin overlay went blank on busy projects, and nothing said so
 
 Pins are how an issue gets a place in the building — an RFI on *that* wall, a punch item at *that*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -432,10 +432,34 @@ concurrency record names the specific thing to watch, a fourth sign-in path.
 > prefix. *An assertion whose failure message describes a scenario it does not actually test is
 > worse than no assertion, because it reads as coverage.*
 >
-> **Still open, named rather than half-fixed:** a plan sheet cannot yet PRINT that its pins were
-> capped — the drawing engine takes positions and labels, not notes — so a capped project still
-> under-reports on paper. And two write sites can persist `{}` / `[]` into `anchor` /
-> `element_guids`, which is the sole reason the capped total is an upper bound rather than exact.
+> **PINS-SHEET — the paper half shipped, and THE BLOCKER RECORDED HERE WAS FALSE.** This said the
+> sheet could not print the cap because *"the drawing engine takes positions and labels, not
+> notes"*. The engine had been printing `"N pin(s) not located on this sheet"` since pins were
+> added — a note, from a count, in exactly the place the cap note now goes. The real work was one
+> optional argument threaded through two signatures, and `_plan_pins` throwing the envelope away.
+> *A blocker is a claim about the code, and this one was never checked against it — which is how a
+> one-line change stays open behind a sentence that sounds like an architecture problem.* The same
+> failure the Node and Python floors above record, in a third form: **the expensive part is not
+> being wrong, it is being wrong in a way that stops anyone from looking.**
+>
+> What the note says is deliberately asymmetric: **qualitative about the sheet, quantitative only
+> about the project** — *"Pin list capped at 2000 of ~2400 project pins — this sheet may not show
+> every issue on this level."* The cap is spent before the storey filter, so how many of the
+> dropped pins belonged to *this* level is genuinely unknowable at either end, and printing a
+> per-sheet number would be the original lie in a new place. `~` marks the total as the upper bound
+> it is while legacy `{}`/`[]` rows exist.
+>
+> Three links, three mutation checks, because two of them individually stay green while the sheet
+> goes silent: `_plan_pins` returns the envelope, `_pin_layer` renders it, and the route passes it.
+> The last is asserted structurally (AST over the `plan_svg` call) — deleting one keyword argument
+> is exactly the edit that survives a green suite. A capped sheet with **no** pins left still warns:
+> that is the blank overlay from PINS-CAP reaching paper, and it is when the reader most needs it.
+>
+> **Still open, named rather than half-fixed:** two write sites can persist `{}` / `[]` into
+> `anchor` / `element_guids`, which is the sole reason the capped total is an upper bound rather
+> than exact — new rows are normalised, legacy rows need a backfill. And the `count(*) OVER ()`
+> concurrency fix still has **no assertion**: mutate it back to two statements and every test here
+> passes. It needs a two-session controlled test, not another paragraph.
 >
 > **The original note, kept because it is the derivation:** undisclosed truncation, a different class found while walking
 > this one: a cap that reports its slice as the whole. `topic_lifecycle.timeline` returns

--- a/services/api/src/aec_api/routers/drawings.py
+++ b/services/api/src/aec_api/routers/drawings.py
@@ -736,10 +736,12 @@ def plan(pid: str, elevation: float = 0.0, cut_height: float = 1.2, title: str =
             have = [str(lvl.get("name") or "") for lvl in drawings.storey_elevations(_m)]
             raise HTTPException(404, f"no storey named {storey!r}; levels: {have}")
         elevation = resolved
+    # Resolved only when asked for: this is a DB round trip over every register, and a sheet
+    # printed without pins should not pay for it.
+    _pins = _plan_pins(db, pid, elevation, cut_height, _m) if pins else (None, None)
     svg = drawings.plan_svg(_m, elevation, cut_height, title,
                             rooms=rooms, callouts=callouts, view_depth=view_depth,
-                            by_discipline=by_discipline,
-                            pins=_plan_pins(db, pid, elevation, cut_height, _m) if pins else None)
+                            by_discipline=by_discipline, pins=_pins[0], pin_cap=_pins[1])
     return _svg(svg)
 
 
@@ -748,8 +750,9 @@ def plan(pid: str, elevation: float = 0.0, cut_height: float = 1.2, title: str =
 _PIN_BAND_M = 2.0
 
 
-def _plan_pins(db: Session, pid: str, elevation: float, cut_height: float, model=None) -> list[dict]:
-    """Pins for this plan, as plain dicts for the drawing engine.
+def _plan_pins(db: Session, pid: str, elevation: float, cut_height: float,
+               model=None) -> tuple[list[dict], dict]:
+    """Pins for this plan, as plain dicts for the drawing engine, plus the resolver's cap envelope.
 
     The engine never learns what a Topic or a record is — `aec_data` may not import `aec_api`, and a
     drawing module has no business knowing about the issue tracker. It receives positions and labels.
@@ -762,11 +765,8 @@ def _plan_pins(db: Session, pid: str, elevation: float, cut_height: float, model
     counts it in a note rather than letting the sheet under-report.
     """
     from .. import pins as pin_engine
-    # `["pins"]`: the engine returns an envelope now. The sheet cannot yet PRINT that it was
-    # capped — the drawing engine takes positions and labels, not notes — so a capped project
-    # still under-reports on paper. Named in the roadmap rather than half-fixed here; what this
-    # change buys the sheet is that the cap is no longer spent on rows that are not pins at all.
-    rows = pin_engine.resolve_pins(db, pid, model=model)["pins"]
+    env = pin_engine.resolve_pins(db, pid, model=model)
+    rows = env["pins"]
     lo, hi = elevation - _PIN_BAND_M, elevation + cut_height + _PIN_BAND_M
     out: list[dict] = []
     for p in rows:
@@ -775,7 +775,13 @@ def _plan_pins(db: Session, pid: str, elevation: float, cut_height: float, model
             continue
         out.append({"x": p.get("x"), "y": p.get("y"), "kind": p.get("kind"),
                     "label": p.get("label") or "", "guid": p.get("guid")})
-    return out
+    # `shown` is the PROJECT-wide resolved count, deliberately not `len(out)`. The cap is spent
+    # before this storey filter runs, so "how many of the dropped pins were on this level" is not a
+    # question either side can answer — see `_pin_layer`, which is why the printed note is
+    # qualitative about the sheet and quantitative only about the project.
+    cap = {"truncated": bool(env["truncated"]), "shown": len(rows),
+           "total": env["pin_total"], "approx": bool(env["total_counts_candidates"])}
+    return out, cap
 
 
 #: How many rekey rows the dry-run preview returns inline. Over this the response says it capped

--- a/services/api/test_pin_cap.py
+++ b/services/api/test_pin_cap.py
@@ -252,6 +252,97 @@ check("...and the assertion can fail: a bare desc() does not satisfy it",
       "NULLS LAST" not in _bare.upper(),
       f"a plain desc() already compiled to NULLS LAST, so the check above proves nothing: {_bare!r}")
 
+# --- PINS-SHEET: the envelope has to reach PAPER, not just the API -------------------------------
+# `resolve_pins` was honest from the day PINS-CAP landed and the plan sheet still printed a
+# confident subset, because `_plan_pins` read `["pins"]` and dropped the rest of the envelope on the
+# floor. The API being right does not help someone holding a printout — and the printout is what a
+# superintendent walks the building with.
+#
+# This is the WIRING half. `test_plan_pins.py` proves the engine renders the note; without this, a
+# deleted `pin_cap=` at the call site would leave every engine assertion green and the sheet silent
+# again. That is the tested-but-unwired shape this repo already has a gate for.
+from aec_api.routers import drawings as _dr  # noqa: E402
+
+_real2 = pin_engine._MAX_PINS
+SPID = "p-sheet-capped"
+try:
+    pin_engine._MAX_PINS = 5
+    with SessionLocal() as db:
+        # Self-contained: the block above deletes its rows on the way out, so seed our own rather
+        # than inheriting a project that may or may not still exist.
+        db.query(Topic).filter(Topic.project_id == SPID).delete()
+        # Alternating Z **on purpose**: odd pins sit on a far-away storey, so the sheet's Z band
+        # drops some of what the cap already returned. Without that the sheet row count and the
+        # project count coincide at the cap and the `shown` assertion below cannot fail — an
+        # assertion whose failure message describes a scenario it does not test reads as coverage
+        # and is worse than no assertion.
+        for i in range(8):
+            db.add(Topic(id=f"t-sheet-{i}", project_id=SPID, guid=f"G-sheet-{i}", type="rfi",
+                         title=f"Placed {i}", status="open",
+                         anchor={"x": float(i), "y": 0.0, "z": 0.5 if i % 2 == 0 else 50.0},
+                         created_at=__import__("datetime").datetime(2026, 8, 9, 0, i)))
+        db.commit()
+        rows, cap = _dr._plan_pins(db, SPID, 0.0, 1.2)
+        check("_plan_pins returns the cap envelope, not just positions",
+              isinstance(cap, dict) and set(cap) == {"truncated", "shown", "total", "approx"},
+              f"got {cap!r} — the sheet cannot warn about a cap it was never told about")
+        check("a capped project reaches the sheet marked as capped",
+              cap["truncated"] is True and cap["total"] == 8,
+              f"{cap!r} — 8 pins exist and 5 fit, so the note must print with the project total")
+        # `shown` is the PROJECT-wide resolved count, deliberately NOT len(rows): the cap is spent
+        # before the storey filter, so len(rows) would understate by however many pins the Z band
+        # excluded and would read as a per-sheet number the code cannot actually compute.
+        check("the fixture actually exercises the storey filter",
+              len(rows) < cap["shown"],
+              f"rows_on_sheet={len(rows)} shown={cap['shown']} — if the Z band drops nothing, the "
+              f"next assertion holds under the very mutation it exists to catch")
+        check("`shown` is the project count, not this storey's row count",
+              cap["shown"] == pin_engine._MAX_PINS,
+              f"shown={cap['shown']} rows_on_sheet={len(rows)} cap={pin_engine._MAX_PINS} — "
+              f"binding `shown` to the filtered list invents a per-sheet shortfall")
+
+        db.query(Topic).filter(Topic.project_id == SPID).delete()
+        db.commit()
+
+    # The honest negative, on a project small enough that nothing is capped.
+    with SessionLocal() as db:
+        db.query(Topic).filter(Topic.project_id == "p-sheet-whole").delete()
+        db.add(Topic(id="t-whole", project_id="p-sheet-whole", guid="G-whole", type="rfi",
+                     title="Only one", status="open", anchor={"x": 1.0, "y": 1.0, "z": 0.0},
+                     created_at=__import__("datetime").datetime(2026, 6, 1)))
+        db.commit()
+        _, cap_ok = _dr._plan_pins(db, "p-sheet-whole", 0.0, 1.2)
+        check("an UNCAPPED project reaches the sheet unmarked",
+              cap_ok["truncated"] is False,
+              f"{cap_ok!r} — a note that prints on every sheet is one nobody reads")
+        db.query(Topic).filter(Topic.project_id == "p-sheet-whole").delete()
+        db.commit()
+finally:
+    pin_engine._MAX_PINS = _real2
+check("the cap constant was restored after the sheet block", pin_engine._MAX_PINS == _real2,
+      f"{pin_engine._MAX_PINS} != {_real2}")
+
+# The last link, asserted structurally because the two behavioural halves above cannot see it.
+# `_plan_pins` returns the envelope (tested) and `_pin_layer` renders it (tested in
+# `test_plan_pins.py`) — but if the router stops PASSING it, both stay green and the sheet goes
+# silent. Deleting one keyword argument is exactly the kind of edit that survives a green suite.
+import ast as _ast  # noqa: E402
+import pathlib as _pathlib  # noqa: E402
+
+_src = _pathlib.Path("src/aec_api/routers/drawings.py").read_text(encoding="utf-8")
+_calls = [n for n in _ast.walk(_ast.parse(_src))
+          if isinstance(n, _ast.Call) and isinstance(n.func, _ast.Attribute)
+          and n.func.attr == "plan_svg"]
+check("the plan route still calls the drawing engine",
+      len(_calls) == 1,
+      f"found {len(_calls)} plan_svg call(s) — this check assumes exactly one and must be "
+      f"revisited, not silently widened, if the route grows another")
+_kw = {k.arg for c in _calls for k in c.keywords}
+check("the route passes the cap envelope through to the sheet",
+      "pin_cap" in _kw and "pins" in _kw,
+      f"plan_svg called with {sorted(_kw)} — without `pin_cap` the engine renders no note and "
+      f"every other assertion in this file and in test_plan_pins.py still passes")
+
 if FAILED:
     print("FAIL test_pin_cap")
     for f in FAILED:

--- a/services/api/test_plan_pins.py
+++ b/services/api/test_plan_pins.py
@@ -115,6 +115,14 @@ empty = _pin_layer([], T, MN, MX, CAP)
 check("A CAPPED SHEET WITH NO PINS LEFT STILL WARNS", "Pin list capped" in empty,
       "no pins + no note reads as 'this level is clean', which is the original defect on paper")
 
+# BOTH empty representations, because the guard above distinguishes them and the loop must not.
+# Found in review: `[]` fell out of the loop and `None` raised TypeError, so the warning-only layer
+# — the one case that reaches the loop with no pins at all — crashed on half its legal inputs.
+# `pins` is typed `list[dict] | None`; testing one spelling of "empty" tested half the contract.
+none_capped = _pin_layer(None, T, MN, MX, CAP)
+check("...and does so for pins=None, not just []", "Pin list capped" in none_capped,
+      "a parameter typed `list[dict] | None` has two empty forms and the loop saw only one")
+
 print()
 if FAILED:
     print("FAILED:", ", ".join(FAILED))

--- a/services/api/test_plan_pins.py
+++ b/services/api/test_plan_pins.py
@@ -70,6 +70,51 @@ check("a label cannot break out of the SVG", "<script>" not in xss and "&lt;scri
 amp = _pin_layer([{"x": 1.0, "y": 1.0, "kind": "rfi", "label": "M&E coordination"}], T, MN, MX)
 check("a bare & does not corrupt the document", "&amp;" in amp and "M&E" not in amp)
 
+# --- the cap note: a sheet whose pin list was capped upstream must SAY SO -------------------------
+# PINS-CAP shipped an honest API and left the paper silent: `resolve_pins` reported `truncated`,
+# `_plan_pins` dropped the envelope on the floor, and the sheet printed a confident subset. A
+# superintendent works off the printed sheet, so this is the half that reaches the person at risk.
+#
+# The blocker recorded in the roadmap for this was FALSE — "the drawing engine takes positions and
+# labels, not notes" — and the engine had been printing "N pin(s) not located on this sheet" the
+# whole time. A blocker nobody re-checked is how a one-line fix stays open.
+CAP = {"truncated": True, "shown": 2000, "total": 2400, "approx": False}
+capped = _pin_layer([{"x": 1.0, "y": 1.0, "kind": "rfi", "label": "A"}], T, MN, MX, CAP)
+check("a capped sheet says the pin list was capped", "Pin list capped at 2000 of 2400" in capped)
+check("  ...and warns about THIS sheet without inventing a per-sheet number",
+      "may not show every issue on this level" in capped,
+      "the cap is spent before the storey filter, so the per-sheet shortfall is unknowable")
+
+# THE MUTATION: a note that prints unconditionally is worse than no note, because it teaches the
+# reader to ignore it. An uncapped sheet must be silent.
+whole = _pin_layer([{"x": 1.0, "y": 1.0, "kind": "rfi", "label": "A"}], T, MN, MX,
+                   {"truncated": False, "shown": 3, "total": 3, "approx": False})
+check("an UNCAPPED sheet says nothing about caps", "Pin list capped" not in whole,
+      "the honest negative — otherwise the warning is decoration, not information")
+check("no cap envelope at all is also silent",
+      "Pin list capped" not in _pin_layer([{"x": 1.0, "y": 1.0, "kind": "rfi"}], T, MN, MX))
+
+# An upper-bound total is marked as one. `total_counts_candidates` means legacy `{}`/`[]` rows the
+# SQL predicate cannot exclude may be counted, so the number is a ceiling, not a count.
+approx = _pin_layer([{"x": 1.0, "y": 1.0, "kind": "rfi"}], T, MN, MX,
+                    {"truncated": True, "shown": 2000, "total": 2400, "approx": True})
+check("an upper-bound total prints as approximate", "of ~2400 project pins" in approx)
+
+# Both notes at once must not overlay each other — and the cap note is the one that must survive.
+both = _pin_layer([{"x": None, "y": None, "kind": "rfi", "label": "Nowhere"}], T, MN, MX, CAP)
+check("two notes stack rather than overprinting",
+      'y="16"' in both and 'y="29"' in both,
+      "one y for both is one unreadable note, and the cap warning is the one that matters")
+check("  ...and both are actually present", "not located on this sheet" in both
+      and "Pin list capped" in both)
+
+# A cap that empties this storey entirely still prints the warning. This is the blank-overlay case
+# from PINS-CAP reaching paper: zero pins on the sheet is exactly when the reader most needs to know
+# the list was cut, and `if not pins: return ""` used to swallow it.
+empty = _pin_layer([], T, MN, MX, CAP)
+check("A CAPPED SHEET WITH NO PINS LEFT STILL WARNS", "Pin list capped" in empty,
+      "no pins + no note reads as 'this level is clean', which is the original defect on paper")
+
 print()
 if FAILED:
     print("FAILED:", ", ".join(FAILED))

--- a/services/data/src/aec_data/drawings.py
+++ b/services/data/src/aec_data/drawings.py
@@ -570,7 +570,7 @@ def plan_drawing_svg(meshes, elevation: float, cut_height: float, title: str,
                      grid: dict | None = None, dims: bool = True, width: int = 1200,
                      tags: list[dict] | None = None, callouts: list[dict] | None = None,
                      below: list[np.ndarray] | None = None, by_discipline: bool = False,
-                     pins: list[dict] | None = None) -> str:
+                     pins: list[dict] | None = None, pin_cap: dict | None = None) -> str:
     # R38-SYNC-SELECT: the cut is always the GUIDED one now, so every polyline can carry the
     # GlobalId of the element it draws. `by_discipline` only decides colour + legend, not identity —
     # a plan whose linework forgets its elements in one rendering mode would make selection sync a
@@ -752,7 +752,7 @@ def plan_drawing_svg(meshes, elevation: float, cut_height: float, title: str,
                    f'stroke-width="0.8" stroke-dasharray="5 3"/>'
                    f'<text x="{pad+28}" y="{ly:.0f}" font-family="sans-serif" font-size="10" '
                    f'fill="#777">below cut (view depth)</text>')
-    out.append(_pin_layer(pins, T, mn, mx))
+    out.append(_pin_layer(pins, T, mn, mx, pin_cap))
     # R43-PLAN-EMPTY-AT-CUT, the human half. `data-plan-cut-loops` tells a program the cut was
     # empty; it does nothing for someone holding a printed sheet. A plan with a full titleblock, a
     # scale bar and a grid — and no building — reads as "this storey is empty", which is a different
@@ -797,7 +797,7 @@ def plan_drawing_svg(meshes, elevation: float, cut_height: float, title: str,
 _PIN_FILL = {"rfi": "#b45309", "punch": "#b91c1c", "clash": "#7c3aed", "info": "#1d4ed8"}
 
 
-def _pin_layer(pins, T, mn, mx) -> str:
+def _pin_layer(pins, T, mn, mx, pin_cap: dict | None = None) -> str:
     """Draw issue pins on the plan — the thing that makes a coordination sheet worth printing.
 
     A pin is a real position in the building, so it is drawn at that position: the same world→sheet
@@ -811,8 +811,18 @@ def _pin_layer(pins, T, mn, mx) -> str:
       see is one nobody closes. The caret says "this is off-sheet" rather than lying about where it is.
     - **A pin with no usable position is not invented.** It is skipped and counted in the legend, so
       the sheet says "2 pins not located" instead of quietly showing fewer pins than exist.
+
+    And a third, `pin_cap`: **a sheet whose pin list was capped upstream says so.** The resolver caps
+    the project's pins before anything is filtered to a storey, so a cap that bites can empty one
+    level's sheet while another prints normally — and neither sheet can tell which happened to it.
+    That is why the note is *qualitative about this sheet* ("may not show every issue on this level")
+    and *quantitative only about the project*: the per-sheet shortfall is genuinely unknowable here,
+    and inventing a number for it would be the same lie in a new place.
+
+    `pin_cap` is a plain dict — `{"shown", "total", "approx"}` — because `aec_data` may not import
+    `aec_api`. `approx` marks a total the resolver could only bound from above, and prints as `~`.
     """
-    if not pins:
+    if not pins and not (pin_cap or {}).get("truncated"):
         return ""
     parts: list[str] = ['<g id="pins">']
     unlocated = 0
@@ -840,9 +850,21 @@ def _pin_layer(pins, T, mn, mx) -> str:
         if label:
             parts.append(f'<text x="{cx + 12:.1f}" y="{cy - 13:.1f}" font-family="sans-serif" '
                          f'font-size="9" fill="#333">{label}</text>')
+    notes: list[str] = []
     if unlocated:
-        parts.append(f'<text x="12" y="16" font-family="sans-serif" font-size="10" fill="#b45309">'
-                     f'{unlocated} pin(s) not located on this sheet</text>')
+        notes.append(f"{unlocated} pin(s) not located on this sheet")
+    cap = pin_cap or {}
+    if cap.get("truncated"):
+        total = cap.get("total")
+        shown = cap.get("shown")
+        approx = "~" if cap.get("approx") else ""
+        notes.append(f"Pin list capped at {shown} of {approx}{total} project pins — "
+                     f"this sheet may not show every issue on this level")
+    # Stacked, not overlaid. Two notes at the same y is one unreadable note, and the cap warning is
+    # the one a reader most needs — so it must not be the one that gets painted over.
+    for i, note in enumerate(notes):
+        parts.append(f'<text x="12" y="{16 + i * 13}" font-family="sans-serif" font-size="10" '
+                     f'fill="#b45309">{_esc(note)}</text>')
     parts.append("</g>")
     return "".join(parts)
 
@@ -1125,7 +1147,7 @@ def plan_svg(model: ifcopenshell.file, elevation: float, cut_height: float = 1.2
              title: str = "PLAN", grid: bool = True, dims: bool = True,
              rooms: bool = True, callouts: bool | list[str] = False,
              view_depth: float | None = None, by_discipline: bool = False,
-             pins: list[dict] | None = None) -> str:
+             pins: list[dict] | None = None, pin_cap: dict | None = None) -> str:
     meshes = bake(model)
     cut_z = elevation + cut_height                 # the horizontal cut plane — tags/callouts filter to it
     g = grid_from_meshes(meshes) if grid else {"x": [], "y": []}
@@ -1141,7 +1163,7 @@ def plan_svg(model: ifcopenshell.file, elevation: float, cut_height: float = 1.2
         below = below_footprint_baked(meshes, cut_z, cut_z - float(view_depth))
     return plan_drawing_svg(meshes, elevation, cut_height, title, g, dims,
                             tags=tags, callouts=co, below=below, by_discipline=by_discipline,
-                            pins=pins)
+                            pins=pins, pin_cap=pin_cap)
 
 
 # --- elevations (orthographic outline projections) --------------------------

--- a/services/data/src/aec_data/drawings.py
+++ b/services/data/src/aec_data/drawings.py
@@ -827,7 +827,11 @@ def _pin_layer(pins, T, mn, mx, pin_cap: dict | None = None) -> str:
     parts: list[str] = ['<g id="pins">']
     unlocated = 0
     n = 0
-    for p in pins:
+    # `pins or []`: widening the guard above to let a truncated cap through with no pins made the
+    # two empty representations behave differently — `[]` fell out of the loop, `None` raised. Both
+    # are legal for a parameter typed `list[dict] | None`, and the warning-only layer is exactly the
+    # case that reaches this loop with neither.
+    for p in pins or []:
         x, y = p.get("x"), p.get("y")
         if x is None or y is None:
             unlocated += 1


### PR DESCRIPTION
# What & why

PINS-CAP (#492) made the pin API honest about being capped and left the **printed sheet silent**.
`_plan_pins` read `["pins"]` off the envelope and dropped the rest on the floor, so a capped project
printed a plan that looked complete. A superintendent walks the building with paper — this is the
half that reaches the person actually at risk.

Second of the three follow-ons `docs/roadmap.md` recorded from #492.

## 🔴 The blocker recorded for this was false

The roadmap said — and my own #492 body and a code comment repeated — that the sheet could not print
the cap because *"the drawing engine takes positions and labels, not notes"*.

The engine has been printing this since pins were added:

```python
if unlocated:
    parts.append(f'<text ...>{unlocated} pin(s) not located on this sheet</text>')
```

A note, derived from a count, in the exact place the cap note now goes. The real work was one
optional argument threaded through two signatures.

> **A blocker is a claim about the code, and this one was never checked against it.** That is how a
> one-line change stays open behind a sentence that sounds like an architecture problem — the same
> shape as the Node and Python floor drifts in `CLAUDE.md`: the expensive part is not being wrong,
> it is being wrong in a way that stops anyone from looking.

## What the sheet says, and what it deliberately does not

```
Pin list capped at 2000 of ~2400 project pins — this sheet may not show every issue on this level
```

**Qualitative about the sheet, quantitative only about the project** — on purpose. The cap is spent
*before* pins are filtered to a storey, so how many dropped pins belonged to *this* level is
unknowable at both ends. A confident per-sheet number would be the original defect in a new place.
`~` marks the total as the upper bound it is while legacy `{}`/`[]` rows exist.

Notes stack rather than overprint: two `<text>` at one `y` is one unreadable note, and the cap
warning must not be the one painted over.

**A capped sheet with zero pins left still warns.** That is the blank overlay from #492 reaching
paper, and `if not pins: return ""` swallowed it — precisely when "this level looks clean" is most
wrong.

## Three links, three mutations

Two of the three stay green individually while the sheet goes silent, so each was mutated against
the shipped code:

| Link | Mutation | Caught by |
|---|---|---|
| `_plan_pins` returns the envelope | bind `shown` to the filtered list | `shown` is the project count |
| `_pin_layer` renders it | restore `if not pins: return ""` | capped sheet with no pins still warns |
| `_pin_layer` renders it | make the note unconditional | an uncapped sheet says nothing |
| the route passes it | delete `pin_cap=` | structural AST assertion over the `plan_svg` call |

The last is structural because it has to be: deleting one keyword argument leaves every behavioural
assertion in both test files green.

## ⚠️ One of my own, caught before review this time

**The `shown` assertion could not fail as first written.** With every fixture pin on the storey,
`len(out)` equalled the cap anyway, so the mutation it exists to catch passed. The fixture now
alternates Z so the storey filter genuinely bites, and a guard assertion checks that it does before
the real assertion runs.

Same trap as the shared-budget claim in #492 — *an assertion whose failure message describes a
scenario it does not test reads as coverage* — found by re-deriving it rather than by a reviewer.

## Deliberately out of scope, and named

- Legacy rows holding `{}` / `[]` in `anchor` / `element_guids` still need a **backfill** before a
  capped total is exact rather than an upper bound. New rows are normalised (#492); old ones are not.
- The `count(*) OVER ()` concurrency fix from #492 still has **no assertion** — mutate it back to two
  statements and everything here passes. It needs a two-session controlled test.

Both stay in `docs/roadmap.md` rather than half-done.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree)
- [x] Backend: affected `test_*.py` pass — `test_plan_pins.py`, `test_pin_cap.py` (both already in `run_tests.py` TESTS)
- [x] Web: unchanged by this PR (no web files touched)
- [x] No import cycles introduced — `aec_data` still does not import `aec_api`; the envelope crosses as a plain dict
- [x] `CHANGELOG.md` entry added (newest at top); `docs/roadmap.md` corrected
- [ ] Version bumped in both manifests — not a release PR
- [x] No secrets, no competitor names in shipped docs

## Review round: 1 finding, real, mine

**`pins=None` with a truncated `pin_cap` raised `TypeError`.** Widening the guard so a capped sheet
renders its warning with no pins made that path reachable, but the loop below still read
`for p in pins:`. Fixed in `d9fd0282` with `pins or []`.

Reproduced before changing anything, and reverting the fix reproduces it again — so the added
assertion is known to be capable of failing rather than merely passing.

**The test gap is the part worth recording.** Four mutations ran against this code before it was
pushed, covering `[]` **with** a cap and `None` **without** one — never `None` **with** one, which is
exactly the combination the widened guard newly admits. `pins` is typed `list[dict] | None`, so
"empty" has two spellings, and testing one of them tested half the contract.

Not reachable from the plan route today (it passes `(None, None)` together, so an absent pin list
always arrives with an absent cap), but `plan_svg` and `plan_drawing_svg` declare both parameters
independently optional. Latent rather than theoretical, which is why it is fixed rather than noted.

## Verification

* **Full backend suite: 687/687**, runner exit 0, zero failures, 0 test databases unaccounted for —
  re-run against the current head `d9fd0282`, after the review fix above. (It also passed 687/687
  at `049c0fbc`; the number is unchanged because the fix added one assertion to an existing suite.)
* `ruff check ../..` clean over the whole tree.
* Four mutations run against the shipped code, each caught by the intended assertion and no other
  (table above). Restored and re-verified after each.
* Doc gates pass: `test_claude_md_gates`, `test_changelog_current`, `test_file_sizes`,
  `test_doc_substance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Printed plan sheets now warn when the project’s pin list has been capped.
  - Warnings include the number of displayed pins and an approximate project-wide total.
  - Cap warnings remain visible when no pins appear on the sheet and can appear alongside off-sheet pin notices.
  - Pin totals account for the project-wide list before sheet-specific filtering.

- **Documentation**
  - Updated the changelog and roadmap to document pin-cap warnings and clarify drawing-engine capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
_Generated by [Claude Code](https://claude.ai/code)_