### PR TITLE
R39-DECOMP-VIEWER ⑱: lift snap picking out of app.ts, and give it the tests it never had

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,8 @@ plan calls the only risk that can end the project.
 
 **And its `ready: true` measures the wrong half.** The ledger's own test asserts every `covered` entry is
 reachable through the facade's type — which proves each *claim is backed*, not that the *claims cover the
-ground*. Its 24 entries are a dissection of this viewer as it stood around 2026-08-06. This viewer is **129 TS
-files / 16,408 non-test lines / 53 test files** today, and the list names none of: the plan/sheets/specs canvas
+ground*. Its 24 entries are a dissection of this viewer as it stood around 2026-08-06. This viewer is **155 TS
+files / 19,159 non-test lines / 65 test files** today (re-measured 2026-09-10), and the list names none of: the plan/sheets/specs canvas
 modes, collaborative peer cursors, dimensional locks, viewer load timings, reference point clouds, GIS context,
 or the model-bounds allowlist. *Derive the population AND the reach — a completeness verdict computed over a
 self-authored list is confident and unfounded.*
@@ -259,9 +259,9 @@ bump. So: the *factual* blocker is corrected here because it was false; the *dec
 untouched and still open. Keep shipping viewer work in the meantime — that guidance below is unchanged and was
 never contingent on the npm question.
 
-**What an agent working in `apps/web/src/viewer` should know.** **Sixty-seven** commits have touched that
+**What an agent working in `apps/web/src/viewer` should know.** **Seventy-nine** commits have touched that
 directory since extraction began on 2026-08-06, and `apps/web/src/viewer/app.ts` has gone from 5,064 lines to
-**2,508** — largely R39-DECOMP-VIEWER, which is the same decomposition the extraction plan asks for and is being
+**2,442** — largely R39-DECOMP-VIEWER, which is the same decomposition the extraction plan asks for and is being
 done here first. That is good and it is also divergence: every one of those commits is a change the swap will
 have to reconcile. So:
 

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -10,10 +10,9 @@ import { installCollabPresence } from "./collabPresence";
 import { installKeysDyn } from "./keysDyn";
 import { installEnvTools } from "./envTools";
 import { inferDirection } from "./inference";
-import { applyDynamicInput, polarConstrain, resolveSnap } from "./snapEngine";
-import {
-  OVERRIDE_LABEL, createSnapOverride, overrideCandidates, type OverrideKind,
-} from "./snapOverride";
+import { applyDynamicInput, polarConstrain } from "./snapEngine";
+import { OVERRIDE_LABEL, createSnapOverride } from "./snapOverride";
+import { snapByOverride, snapPoint, snapToGeometry, type SnapHit } from "./snapPick";
 import { canAcceptDraftDrag, dropCompletion, readDraftDragKey } from "./railDrag";
 import { parseDynConstraint } from "./dynInput";
 import { mountCadBar } from "./cadBar";
@@ -541,7 +540,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     // UX-2 snap-as-you-place: the picked point snaps to the element's nearest vertex / edge midpoint /
     // corner, so every lastPoint consumer (notes · dimensions · revision clouds · tags · fittings)
     // anchors exactly on geometry instead of the raw raycast point.
-    const snapped = await snapToGeometry(hit.point, hit);
+    const snapped = await snapToGeometry(hit.point, hit, loader.fragments);
     lastPoint = (snapped ?? hit.point).clone();
     if (snapped) flashSnapGlyph(e, "◻ snap");
     showCoords(lastPoint);
@@ -1001,74 +1000,8 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     console.warn("[toolbar] not described by toolbarLayout:", toolbarView.unlaid());
   }
 
-  /** Round a point's plan coords (x,z) to the grid-snap increment; leave height (y). */
-  function snapPoint(p: THREE.Vector3): THREE.Vector3 {
-    const inc = ctx.getSettings().snap;
-    if (!inc) return p;
-    return new THREE.Vector3(Math.round(p.x / inc) * inc, p.y, Math.round(p.z / inc) * inc);
-  }
-
-  type Hit = { point: THREE.Vector3; fragments: { modelId: string }; localId: number };
-  /** Snap to the hit element's nearest mesh vertex within ~0.4 m (true endpoint snap), then to its
-   *  bounding-box corners / edge midpoints / center (the classic osnap set), then to grid snap. */
-  async function snapToGeometry(raw: THREE.Vector3, hit: Hit | null): Promise<THREE.Vector3 | null> {
-    if (!hit) return null;
-    const nearest = (pts: THREE.Vector3[]) => {
-      let best: THREE.Vector3 | null = null, bd = 0.4;
-      for (const v of pts) { const d = raw.distanceTo(v); if (d < bd) { bd = d; best = v; } }
-      return best ? best.clone() : null;
-    };
-    try {
-      const model = loader.fragments.list.get(hit.fragments.modelId);
-      const verts = model ? await model.getPositions([hit.localId]) : null;
-      if (verts?.length) { const v = nearest(verts); if (v) return v; }
-    } catch { /* fall back to bbox candidates */ }
-    try {
-      const boxes = await loader.fragments.getBBoxes({ [hit.fragments.modelId]: new Set([hit.localId]) });
-      if (!boxes.length) return null;
-      const bx = boxes[0]!; // safe: boxes.length checked above
-      const xs = [bx.min.x, bx.max.x], ys = [bx.min.y, bx.max.y], zs = [bx.min.z, bx.max.z];
-      const corners = xs.flatMap((x) => ys.flatMap((y) => zs.map((z) => new THREE.Vector3(x, y, z))));
-      // UX-2: edge midpoints (each axis at its midpoint × the other two axes' extremes) + the center —
-      // the midpoint/center osnaps annotation placement expects.
-      const mx = (bx.min.x + bx.max.x) / 2, my = (bx.min.y + bx.max.y) / 2, mz = (bx.min.z + bx.max.z) / 2;
-      const mids = [
-        ...ys.flatMap((y) => zs.map((z) => new THREE.Vector3(mx, y, z))),
-        ...xs.flatMap((x) => zs.map((z) => new THREE.Vector3(x, my, z))),
-        ...xs.flatMap((x) => ys.map((y) => new THREE.Vector3(x, y, mz))),
-        new THREE.Vector3(mx, my, mz),
-      ];
-      return nearest([...corners, ...mids]);
-    } catch { return null; }
-  }
-
-  /** AUTH-SNAP-OVERRIDE — resolve ONE named snap kind against the picked element's plan footprint.
-   *
-   *  Null when the model has nothing of that kind to offer; the caller then keeps the raw cursor and
-   *  says so on the glyph. It deliberately does **not** fall back to another kind — the drafter named
-   *  one, and a point silently placed on a midpoint while the HUD said "perpendicular" carries a
-   *  GlobalId into the schedules.
-   *
-   *  No aperture. The automatic path uses a 0.4 m tolerance because it is guessing which of six kinds
-   *  the drafter meant; here the kind is stated and the candidates are the ≤4 points of the element
-   *  the drafter explicitly picked, so a distance cut would only make a stated intent fail. */
-  async function snapByOverride(raw: THREE.Vector3, hit: Hit | null, kind: OverrideKind,
-                                from: THREE.Vector3 | null): Promise<THREE.Vector3 | null> {
-    if (kind === "none" || !hit) return null;
-    try {
-      const boxes = await loader.fragments.getBBoxes({ [hit.fragments.modelId]: new Set([hit.localId]) });
-      const bx = boxes[0];
-      if (!bx) return null;
-      const cur = { x: raw.x, z: raw.z };
-      const cands = overrideCandidates(kind, { minX: bx.min.x, maxX: bx.max.x, minZ: bx.min.z, maxZ: bx.max.z },
-                                       cur, from ? { x: from.x, z: from.z } : null);
-      const r = resolveSnap(cur, cands, Number.POSITIVE_INFINITY, kind);
-      return r ? new THREE.Vector3(r.x, raw.y, r.z) : null;
-    } catch { return null; }
-  }
-
   // --- P0 Draft placement: parameter-driven (params baked into `armed.build`), no prompt() --------
-  async function captureDraftPoint(e: MouseEvent, hit: Hit | null) {
+  async function captureDraftPoint(e: MouseEvent, hit: SnapHit | null) {
     const spec = armed;
     if (!spec) return;
     const raw = hit?.point ?? screenToGround(e);
@@ -1080,9 +1013,10 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     const ovr = snapOverride.consume();
     const ovrFrom = armPts.length >= 1 ? armPts[armPts.length - 1]! : null;
     const geoSnap = raw
-      ? (ovr ? await snapByOverride(raw, hit, ovr, ovrFrom) : await snapToGeometry(raw, hit))
+      ? (ovr ? await snapByOverride(raw, hit, ovr, ovrFrom, loader.fragments)
+         : await snapToGeometry(raw, hit, loader.fragments))
       : null;                                                      // hard endpoint/edge/vertex snap
-    let p = raw ? (geoSnap ?? (ovr ? raw.clone() : snapPoint(raw))) : null;
+    let p = raw ? (geoSnap ?? (ovr ? raw.clone() : snapPoint(raw, ctx.getSettings().snap))) : null;
     if (ovr === "none") flashSnapGlyph(e, "⊾ no snap");
     else if (ovr) flashSnapGlyph(e, geoSnap ? `⊾ ${OVERRIDE_LABEL[ovr]}` : `⊾ no ${OVERRIDE_LABEL[ovr]} here`);
     else if (geoSnap) flashSnapGlyph(e, "◻ snap");

--- a/apps/web/src/viewer/snapPick.test.ts
+++ b/apps/web/src/viewer/snapPick.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+
+import { snapByOverride, snapPoint, snapToGeometry, type SnapFragments, type SnapHit } from "./snapPick";
+
+/** Why this file exists.
+ *
+ *  These three functions were closures inside `initViewerApp` and had **no tests at all** — grep for
+ *  `snapToGeometry` before the extraction found exactly one file, `app.ts` itself. That is the
+ *  argument for lifting them rather than a line count: snapping is where a click becomes a
+ *  coordinate, and a wall placed on the wrong vertex is written into the IFC under a GlobalId and
+ *  travels to everyone downstream. The extraction is only worth its diff if the behaviour is now
+ *  pinned, so every assertion below was mutation-checked against the code it describes.
+ */
+
+/** The smallest thing that satisfies `SnapFragments`. `positions` is what the picked element's mesh
+ *  reports; `boxes` is what `getBBoxes` returns. Either can be made to throw, because both `try`
+ *  blocks in `snapToGeometry` are load-bearing and a fragments loader really does reject. */
+function fakeFrags(opts: {
+  positions?: THREE.Vector3[] | null;
+  positionsThrow?: boolean;
+  boxes?: { min: THREE.Vector3; max: THREE.Vector3 }[];
+  boxesThrow?: boolean;
+  noModel?: boolean;
+} = {}): SnapFragments & { bboxCalls: number } {
+  const frags = {
+    bboxCalls: 0,
+    list: {
+      get: (_id: string) => opts.noModel ? undefined : {
+        getPositions: async (_ids: number[]) => {
+          if (opts.positionsThrow) throw new Error("fragment read failed");
+          return opts.positions ?? null;
+        },
+      },
+    },
+    getBBoxes: async (_sel: Record<string, Set<number>>) => {
+      frags.bboxCalls += 1;
+      if (opts.boxesThrow) throw new Error("bbox read failed");
+      return opts.boxes ?? [];
+    },
+  };
+  return frags;
+}
+
+const HIT: SnapHit = { point: new THREE.Vector3(), fragments: { modelId: "m1" }, localId: 7 };
+
+/** A 4 × 3 × 2 box at the origin, so every candidate class lands on a distinct round number:
+ *  corners at 0/4 · 0/3 · 0/2, edge midpoints at 2 / 1.5 / 1, centre at (2, 1.5, 1). */
+const BOX = [{ min: new THREE.Vector3(0, 0, 0), max: new THREE.Vector3(4, 3, 2) }];
+
+describe("snapPoint", () => {
+  it("rounds the plan coords to the increment and leaves height alone", () => {
+    const p = snapPoint(new THREE.Vector3(1.2, 7.9, -3.4), 0.5);
+    expect([p.x, p.y, p.z]).toEqual([1, 7.9, -3.5]);
+  });
+
+  it("returns the point untouched when the increment is zero", () => {
+    // Not merely equal — the SAME object. `snapPoint` is called on the raw cursor point on every
+    // armed pick, and a copy here would be a per-pick allocation for nothing.
+    const raw = new THREE.Vector3(1.234, 5, 6.789);
+    expect(snapPoint(raw, 0)).toBe(raw);
+  });
+});
+
+describe("snapToGeometry", () => {
+  it("is null with no hit — a click on empty space snaps to nothing", async () => {
+    expect(await snapToGeometry(new THREE.Vector3(1, 0, 1), null, fakeFrags({ boxes: BOX }))).toBeNull();
+  });
+
+  it("prefers a mesh vertex inside the aperture over any bbox candidate", async () => {
+    const vertex = new THREE.Vector3(0.9, 0, 0.9);
+    const out = await snapToGeometry(new THREE.Vector3(1, 0, 1), HIT,
+                                     fakeFrags({ positions: [vertex], boxes: BOX }));
+    expect([out!.x, out!.y, out!.z]).toEqual([0.9, 0, 0.9]);
+  });
+
+  it("returns a CLONE of the vertex, so the caller cannot mutate the model's positions", async () => {
+    // `lastPoint = (snapped ?? hit.point).clone()` at the call site clones again, but the override
+    // path and every future caller do not have to know that. Aliasing a fragment's position array
+    // into a draft point would corrupt the geometry of the element that was snapped TO.
+    const vertex = new THREE.Vector3(1, 0, 1);
+    const out = await snapToGeometry(new THREE.Vector3(1, 0, 1), HIT,
+                                     fakeFrags({ positions: [vertex], boxes: BOX }));
+    expect(out).not.toBe(vertex);
+    out!.set(99, 99, 99);
+    expect([vertex.x, vertex.y, vertex.z]).toEqual([1, 0, 1]);
+  });
+
+  it("ignores a vertex outside the 0.4 m aperture and falls through to the bbox corners", async () => {
+    // The vertex is 0.5 m away — real, but not what the drafter was pointing at. The nearest corner
+    // (0,0,0) is 0.3 m away and wins.
+    const out = await snapToGeometry(new THREE.Vector3(0.3, 0, 0), HIT,
+                                     fakeFrags({ positions: [new THREE.Vector3(0.8, 0, 0)], boxes: BOX }));
+    expect([out!.x, out!.y, out!.z]).toEqual([0, 0, 0]);
+  });
+
+  it("snaps to an edge midpoint rather than a corner when the midpoint is nearer", async () => {
+    // (2, 0, 0) is the midpoint of the near bottom edge; the nearest corner is 2 m away.
+    const out = await snapToGeometry(new THREE.Vector3(2, 0, 0.1), HIT, fakeFrags({ boxes: BOX }));
+    expect([out!.x, out!.y, out!.z]).toEqual([2, 0, 0]);
+  });
+
+  it("snaps to the box centre when the cursor is nearest to it", async () => {
+    const out = await snapToGeometry(new THREE.Vector3(2, 1.5, 1.1), HIT, fakeFrags({ boxes: BOX }));
+    expect([out!.x, out!.y, out!.z]).toEqual([2, 1.5, 1]);
+  });
+
+  it("applies the SAME 0.4 m aperture to the bbox candidates — far from everything is no snap",
+     async () => {
+       // This is the "◻ snap" glyph not appearing. Without the aperture on this path the pick would
+       // be yanked metres across the model to the nearest corner of whatever the ray happened to
+       // graze, which is worse than not snapping.
+       const out = await snapToGeometry(new THREE.Vector3(2, 0.8, 0.4), HIT, fakeFrags({ boxes: BOX }));
+       expect(out).toBeNull();
+     });
+
+  it("falls back to bbox candidates when reading the mesh throws", async () => {
+    const out = await snapToGeometry(new THREE.Vector3(0.1, 0, 0), HIT,
+                                     fakeFrags({ positionsThrow: true, boxes: BOX }));
+    expect([out!.x, out!.y, out!.z]).toEqual([0, 0, 0]);
+  });
+
+  it("falls back to bbox candidates when the model is not in the fragments list", async () => {
+    const out = await snapToGeometry(new THREE.Vector3(0.1, 0, 0), HIT,
+                                     fakeFrags({ noModel: true, boxes: BOX }));
+    expect([out!.x, out!.y, out!.z]).toEqual([0, 0, 0]);
+  });
+
+  it("is null when there is no bbox to fall back to", async () => {
+    expect(await snapToGeometry(new THREE.Vector3(0.1, 0, 0), HIT, fakeFrags({ boxes: [] }))).toBeNull();
+  });
+
+  it("is null when the bbox read throws", async () => {
+    expect(await snapToGeometry(new THREE.Vector3(0.1, 0, 0), HIT,
+                                fakeFrags({ boxesThrow: true }))).toBeNull();
+  });
+});
+
+describe("snapByOverride", () => {
+  const from = new THREE.Vector3(-10, 0, 1);
+
+  it("answers `none` from the drafter's statement, without ever reading the element", async () => {
+    // The `toBeNull()` half of this ALONE could not fail: `overrideCandidates("none")` returns no
+    // candidates, so the resolver answers null too and deleting the early return changes nothing
+    // observable. Measured — the mutation passed all 21 tests. What the early return actually buys
+    // is that "no snap" is decided by what the drafter SAID, not by what the model happens to
+    // contain, and the way to state that is that the loader is never asked. If a `none` producer
+    // were ever added to `overrideCandidates`, this refusal would still hold; the vacuous version
+    // would have silently started snapping.
+    const frags = fakeFrags({ boxes: BOX });
+    expect(await snapByOverride(new THREE.Vector3(0.1, 0, 0), HIT, "none", from, frags)).toBeNull();
+    expect(frags.bboxCalls).toBe(0);
+  });
+
+  it("is null with no hit", async () => {
+    expect(await snapByOverride(new THREE.Vector3(0.1, 0, 0), null, "endpoint", from,
+                                fakeFrags({ boxes: BOX }))).toBeNull();
+  });
+
+  it("resolves an endpoint at ANY distance — a stated kind has no aperture", async () => {
+    // The deliberate difference from `snapToGeometry`. The automatic path guesses which of six kinds
+    // was meant and needs a tolerance to stay honest; here the drafter named the kind AND picked the
+    // element, so a distance cut could only make a stated intent fail silently.
+    const out = await snapByOverride(new THREE.Vector3(50, 0, 50), HIT, "endpoint", from,
+                                     fakeFrags({ boxes: BOX }));
+    expect([out!.x, out!.z]).toEqual([4, 2]);
+  });
+
+  it("keeps the raw height — an override is a PLAN snap", async () => {
+    const out = await snapByOverride(new THREE.Vector3(0.1, 7.25, 0.1), HIT, "center", from,
+                                     fakeFrags({ boxes: BOX }));
+    expect([out!.x, out!.y, out!.z]).toEqual([2, 7.25, 1]);
+  });
+
+  it("refuses a perpendicular with no previous point instead of falling back to another kind",
+     async () => {
+       // There is no perpendicular to something from nowhere. Returning an endpoint here would place
+       // a point the HUD then labels "perpendicular", and that label travels into the schedules.
+       expect(await snapByOverride(new THREE.Vector3(1, 0, 1), HIT, "perpendicular", null,
+                                   fakeFrags({ boxes: BOX }))).toBeNull();
+     });
+
+  it("resolves a perpendicular once there IS a previous point", async () => {
+    // `from` sits due west of the footprint at z = 1, so the foot on the minX edge is (0, ., 1).
+    const out = await snapByOverride(new THREE.Vector3(0.2, 0, 1), HIT, "perpendicular", from,
+                                     fakeFrags({ boxes: BOX }));
+    expect([out!.x, out!.z]).toEqual([0, 1]);
+  });
+
+  it("is null when the element has nothing of the named kind", async () => {
+    // No box → no candidates of any kind. The caller keeps the raw cursor and the glyph says
+    // "no midpoint here", which is the honest answer.
+    expect(await snapByOverride(new THREE.Vector3(1, 0, 1), HIT, "midpoint", from,
+                                fakeFrags({ boxes: [] }))).toBeNull();
+  });
+
+  it("is null when the bbox read throws", async () => {
+    expect(await snapByOverride(new THREE.Vector3(1, 0, 1), HIT, "endpoint", from,
+                                fakeFrags({ boxesThrow: true }))).toBeNull();
+  });
+});

--- a/apps/web/src/viewer/snapPick.ts
+++ b/apps/web/src/viewer/snapPick.ts
@@ -1,0 +1,92 @@
+import * as THREE from "three";
+
+import { resolveSnap } from "./snapEngine";
+import { overrideCandidates, type OverrideKind } from "./snapOverride";
+
+/** What a pick gives us: where the ray landed, and which element it landed on. */
+export type SnapHit = { point: THREE.Vector3; fragments: { modelId: string }; localId: number };
+
+/** The slice of the fragments loader these need, and nothing more.
+ *
+ *  **This is the whole reason the three functions below could leave `app.ts`.** They were closures
+ *  inside a 2,380-line `initViewerApp`, and the measurement that chose them counted what each one
+ *  closes over: `buildToolsPanel` (696 lines) closes over 51 of the 143 outer bindings, so lifting it
+ *  would mean inventing a 51-parameter callback bag — coupling added in the name of removing it, the
+ *  same reject that kept `renderDesignHome` in `portal.ts`. These three close over `loader` and the
+ *  grid increment. One structural parameter, declared here rather than importing `ModelLoader`, so a
+ *  test can hand them a plain object and the module never learns what a viewer is. */
+export interface SnapFragments {
+  list: { get(modelId: string): { getPositions(localIds: number[]): Promise<THREE.Vector3[] | null | undefined> } | undefined };
+  getBBoxes(selection: Record<string, Set<number>>): Promise<{ min: THREE.Vector3; max: THREE.Vector3 }[]>;
+}
+
+/** Round a point's plan coords (x,z) to the grid-snap increment; leave height (y).
+ *
+ *  `inc` is passed rather than read from settings: the caller owns the setting, and a pure function
+ *  of (point, increment) is one a test can state an expectation about. */
+export function snapPoint(p: THREE.Vector3, inc: number): THREE.Vector3 {
+  if (!inc) return p;
+  return new THREE.Vector3(Math.round(p.x / inc) * inc, p.y, Math.round(p.z / inc) * inc);
+}
+
+/** Snap to the hit element's nearest mesh vertex within ~0.4 m (true endpoint snap), then to its
+ *  bounding-box corners / edge midpoints / center (the classic osnap set), then to grid snap. */
+export async function snapToGeometry(
+  raw: THREE.Vector3, hit: SnapHit | null, frags: SnapFragments,
+): Promise<THREE.Vector3 | null> {
+  if (!hit) return null;
+  const nearest = (pts: THREE.Vector3[]) => {
+    let best: THREE.Vector3 | null = null, bd = 0.4;
+    for (const v of pts) { const d = raw.distanceTo(v); if (d < bd) { bd = d; best = v; } }
+    return best ? best.clone() : null;
+  };
+  try {
+    const model = frags.list.get(hit.fragments.modelId);
+    const verts = model ? await model.getPositions([hit.localId]) : null;
+    if (verts?.length) { const v = nearest(verts); if (v) return v; }
+  } catch { /* fall back to bbox candidates */ }
+  try {
+    const boxes = await frags.getBBoxes({ [hit.fragments.modelId]: new Set([hit.localId]) });
+    if (!boxes.length) return null;
+    const bx = boxes[0]!; // safe: boxes.length checked above
+    const xs = [bx.min.x, bx.max.x], ys = [bx.min.y, bx.max.y], zs = [bx.min.z, bx.max.z];
+    const corners = xs.flatMap((x) => ys.flatMap((y) => zs.map((z) => new THREE.Vector3(x, y, z))));
+    // UX-2: edge midpoints (each axis at its midpoint × the other two axes' extremes) + the center —
+    // the midpoint/center osnaps annotation placement expects.
+    const mx = (bx.min.x + bx.max.x) / 2, my = (bx.min.y + bx.max.y) / 2, mz = (bx.min.z + bx.max.z) / 2;
+    const mids = [
+      ...ys.flatMap((y) => zs.map((z) => new THREE.Vector3(mx, y, z))),
+      ...xs.flatMap((x) => zs.map((z) => new THREE.Vector3(x, my, z))),
+      ...xs.flatMap((x) => ys.map((y) => new THREE.Vector3(x, y, mz))),
+      new THREE.Vector3(mx, my, mz),
+    ];
+    return nearest([...corners, ...mids]);
+  } catch { return null; }
+}
+
+/** AUTH-SNAP-OVERRIDE — resolve ONE named snap kind against the picked element's plan footprint.
+ *
+ *  Null when the model has nothing of that kind to offer; the caller then keeps the raw cursor and
+ *  says so on the glyph. It deliberately does **not** fall back to another kind — the drafter named
+ *  one, and a point silently placed on a midpoint while the HUD said "perpendicular" carries a
+ *  GlobalId into the schedules.
+ *
+ *  No aperture. The automatic path uses a 0.4 m tolerance because it is guessing which of six kinds
+ *  the drafter meant; here the kind is stated and the candidates are the ≤4 points of the element
+ *  the drafter explicitly picked, so a distance cut would only make a stated intent fail. */
+export async function snapByOverride(
+  raw: THREE.Vector3, hit: SnapHit | null, kind: OverrideKind,
+  from: THREE.Vector3 | null, frags: SnapFragments,
+): Promise<THREE.Vector3 | null> {
+  if (kind === "none" || !hit) return null;
+  try {
+    const boxes = await frags.getBBoxes({ [hit.fragments.modelId]: new Set([hit.localId]) });
+    const bx = boxes[0];
+    if (!bx) return null;
+    const cur = { x: raw.x, z: raw.z };
+    const cands = overrideCandidates(kind, { minX: bx.min.x, maxX: bx.max.x, minZ: bx.min.z, maxZ: bx.max.z },
+                                     cur, from ? { x: from.x, z: from.z } : null);
+    const r = resolveSnap(cur, cands, Number.POSITIVE_INFINITY, kind);
+    return r ? new THREE.Vector3(r.x, raw.y, r.z) : null;
+  } catch { return null; }
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1877,7 +1877,7 @@ four phantom entries — one of them a bare `SCALE-SEAM` with its `㉘` silently
 exact failure `roadmapLanes.test.ts` documents in its `MARKS` note. The gates caught all four.)*
 
 * **Not R39-DECOMP-VIEWER ③.** It ranked second last time on a size-ceiling argument that had
-  already gone false. `app.ts` is decomposing steadily (5,064 → 2,508, slices still landing), the ratchet
+  already gone false. `app.ts` is decomposing steadily (5,064 → 2,442, slices still landing), the ratchet
   is pinned, and it moves on its own whenever a feature pushes it. It does not need a sprint; it
   needs to keep being interleaved. **Re-measure the ceiling before ever promoting it again** — that
   is the specific error row 2 made.
@@ -3884,7 +3884,7 @@ re-open): the converter build stage moved to the supported Node LTS with a pinne
 refusal (`services/api/src/aec_api/main.py`), and full-history checkout for the secret-scan job.
 
 
-- 🟡 **R39-DECOMP-VIEWER ③** *(L, Lane E — **`app.ts` is 5,064 → 2,508, a 50% cut. The `builders`
+- 🟡 **R39-DECOMP-VIEWER ③** *(L, Lane E — **`app.ts` is 5,064 → 2,442, a 52% cut. The `builders`
   map is entirely gone.** Slice count deliberately not restated here: `services/api/test_file_sizes.py`
   is the record, and a count repeated in prose is a copy that drifts — this header said "seven slices"
   while the list immediately below it named eleven. The paragraph below saying the extraction "is NOT begun"
@@ -3899,7 +3899,7 @@ refusal (`services/api/src/aec_api/main.py`), and full-history checkout for the 
   ⑤ project-browser panel (216) · ⑥ `loadProjectModel` (37) · ⑦ **drawings & sheets (142, v0.3.978)** ·
   ⑨ **fabrication detail (65)** · ⑩ **MEP / fire / life safety (169)** — both v0.3.981 ·
   ⑫ **envelope & free-form geometry (75, v0.3.982)** · ⑬ **model federation & version compare
-  (88, v0.3.1043)**. `app.ts` 5,064 → **2,508**, a **50% cut**.
+  (88, v0.3.1043)**. `app.ts` 5,064 → **2,442**, a **52% cut**.
   Each ratcheted `services/api/test_file_sizes.py` down, never reset. `services/api/test_file_sizes.py`
   carries the per-slice history; that comment, not this list, is the record.
 
@@ -4427,7 +4427,10 @@ removed. Remaining, in priority order:
   "click optional" pattern would have turned a button press into a server error. *And it went into
   `apps/web/src/viewer/tools/envelopeSection.ts`, not `apps/web/src/viewer/app.ts`* — the ratchet in
   `services/api/test_file_sizes.py` only moves one way, so a new tool in `app.ts` would have been paid
-  for by unwinding an extraction; `app.ts` stays at exactly 2,508.
+  for by unwinding an extraction; `app.ts` did not move — it stood at 2,508 when this item shipped.
+  *(Phrased as a measurement with a date rather than "stays at exactly 2,508", which is a present-tense
+  claim about a number this item does not own. Slice ⑱ later took it to 2,442, which would have made
+  the original wording false without anyone touching this item.)*
 
   **The gate it produced outlives the item.**
   `apps/web/src/viewer/tools/sectionButtonsWired.test.ts` asserts every member of every `*Buttons`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6031,6 +6031,23 @@ Scores for the record: defect risk 7.3/10, maintainability 8.5/10, static perfor
 
 - ◧ **REL-4 leaves** *(M)* — `portal.ts` next leaf + `viewer/app.ts` leaves.
 
+  **This item's two halves live in DIFFERENT lanes, and the lane table cannot say so.** REL-4 sits in
+  Lane A, whose owned paths are `shell/`, `account/`, `portal/portal.ts`, `portal/homes/` and
+  `main.ts` — `apps/web/src/viewer/` belongs to Lane E. So the `viewer/app.ts` half of this item is
+  not executable inside its own lane, and every app.ts slice since ⑭ has in practice shipped as
+  R39-DECOMP-VIEWER. Noted 2026-09-10 rather than re-cut, because which lane owns an item is the
+  table's call, not a slice's. `roadmapLanes.test.ts` asserts the rows are DISJOINT and that every
+  code appears in exactly one — neither of which is violated here, because the overlap is between an
+  item's PROSE and its row's paths, and nothing reads the prose.
+
+  **And the `portal.ts` half has no slice worth taking right now** (measured 2026-09-10, not recalled):
+  of 73 methods, exactly **3 call no sibling at all** and the largest of those is 20 lines (`barChart`).
+  Every candidate above 36 lines calls siblings — `renderHome` 405 lines / 16 distinct `this.*`,
+  `buildRoomRail` 148 / 9, `renderDesignHome` 94 / 9, `buildNav` 80 / 12 — so each would need the
+  callback bag this entry's own table refused for `renderDesignHome`. The next `portal.ts` leaf is not
+  waiting to be found; it has to be *made* by breaking `renderHome` up first, which is a different and
+  larger piece of work than "take the next leaf".
+
   **First `portal.ts` leaf out in v0.3.1082: `renderDeveloperHome` → `apps/web/src/portal/homes/developerHome.ts`**
   (1,473 → 1,400). Small on purpose. The `this.` references of every candidate were grepped *before*
   naming the slice, and the result changed the plan:

--- a/services/api/test_file_sizes.py
+++ b/services/api/test_file_sizes.py
@@ -124,7 +124,7 @@ PER_FILE = {
     #: construction, and the three slices' friction was spent silently. Pinned at 2_570, the file's
     #: EXACT measured size — ⑯ set 2_571 against a file that already measured 2,570, which is the
     #: off-by-one MAX_SLACK is deliberately loose enough to tolerate.
-    "apps/web/src/viewer/app.ts": 2_508,   # R39-DECOMP-VIEWER (17): field verification -> tools/verifySection.ts (2_571 -> 2_508). The chain starts at 2_571 and the file measured 2_570 when this slice began: ONE line left with no slice recording it, which is the drift this row's roadmap cell already documents from an unrelated lane committing to the same shared file. This slice removed 62 of the 63; the 63rd is that stray, absorbed here rather than hidden by starting the entry at a number nobody can reproduce. The gate is what refused the discontinuity. app.ts is ONE 2,445-line function, so REL-4's "grep the this. refs first" rule has no this. to grep; the equivalent is how many SIBLING closures a candidate captures, and of fourteen candidates >=25 lines exactly ONE captured zero. buildToolsPanel captures 14, handleKey 12, selectByGuids 6 — every other move would have been a callback bag. Four of renderVerify's five free variables already travelled on the typed ViewerCtx, so the deps object is that context narrowed, not one invented to make the move possible.   # detailing -> tools/detailingSection.ts (2_630 -> 2_571).   # content + family library -> tools/contentLibrarySection.ts (2_757 -> 2_630).   # interactive annotation -> tools/annotationSection.ts (2_865 -> 2_757). The file was AT this pin with zero headroom, which is why the roadmap row calling it "97%, ~136 lines" was corrected in the same pass.   # CAD command line -> cadBar.ts, which also gained the R29 prompt loop (2_885 -> 2_865). The 39-line inline block became a 10-line mount call; the ratchet is why the interactive mode went into a new module instead of on top of app.ts.   # clash rail -> tools/clashPanel.ts (2_944 -> 2_885)
+    "apps/web/src/viewer/app.ts": 2_442,   # R39-DECOMP-VIEWER (18): snap picking -> snapPick.ts (2_508 -> 2_442). THE MEASUREMENT CAME FIRST AND REJECTED THE OBVIOUS CANDIDATE. Same rule as (17) - app.ts is one function, so the sibling-closure count stands in for REL-4's "grep the this. refs" - and buildToolsPanel, the largest closure at 696 lines, captures 51 of the 143 outer bindings. Lifting it would mean a 51-entry callback bag: coupling ADDED in the name of removing it. The three snap functions capture `loader` and one settings read between them, so the seam is ONE structural parameter, declared as a local `SnapFragments` interface rather than importing ModelLoader, and the module never learns what a viewer is. THE ARGUMENT IS NOT THE LINE COUNT: grep found snapToGeometry, snapByOverride and snapPoint referenced in exactly one file, app.ts itself - snapping had NO tests at all, and it is where a click becomes the coordinate that gets written into the IFC under a GlobalId. snapPick.test.ts pins 21 behaviours, each mutation-checked. ONE OF THEM COULD NOT FAIL ON FIRST WRITING: asserting that an override of kind "none" returns null passed with the `kind == "none"` early return DELETED, because overrideCandidates("none") returns no candidates and the resolver answers null anyway. The assertion was true and measured nothing. What the early return actually buys is that "no snap" is decided by what the drafter SAID rather than by what the model contains, so the test now asserts the loader is never READ - and that mutation fails. Run the mutation AND check that the assertion you care about is the one that fires.   # R39-DECOMP-VIEWER (17): field verification -> tools/verifySection.ts (2_571 -> 2_508). The chain starts at 2_571 and the file measured 2_570 when this slice began: ONE line left with no slice recording it, which is the drift this row's roadmap cell already documents from an unrelated lane committing to the same shared file. This slice removed 62 of the 63; the 63rd is that stray, absorbed here rather than hidden by starting the entry at a number nobody can reproduce. The gate is what refused the discontinuity. app.ts is ONE 2,445-line function, so REL-4's "grep the this. refs first" rule has no this. to grep; the equivalent is how many SIBLING closures a candidate captures, and of fourteen candidates >=25 lines exactly ONE captured zero. buildToolsPanel captures 14, handleKey 12, selectByGuids 6 — every other move would have been a callback bag. Four of renderVerify's five free variables already travelled on the typed ViewerCtx, so the deps object is that context narrowed, not one invented to make the move possible.   # detailing -> tools/detailingSection.ts (2_630 -> 2_571).   # content + family library -> tools/contentLibrarySection.ts (2_757 -> 2_630).   # interactive annotation -> tools/annotationSection.ts (2_865 -> 2_757). The file was AT this pin with zero headroom, which is why the roadmap row calling it "97%, ~136 lines" was corrected in the same pass.   # CAD command line -> cadBar.ts, which also gained the R29 prompt loop (2_885 -> 2_865). The 39-line inline block became a 10-line mount call; the ratchet is why the interactive mode went into a new module instead of on top of app.ts.   # clash rail -> tools/clashPanel.ts (2_944 -> 2_885)
     # Pinned at its EXACT measured size, not above it. qaSection.ts became the file every reach fix
     # lands in and reached 1,373 lines while unpinned - the same accumulation app.ts and client.ts
     # already have entries for. Pinned before it needs splitting rather than after: a ratchet added
@@ -331,15 +331,20 @@ def _history_pairs(comment):
     return out
 
 
-#: One file's newest history entry legitimately disagrees with its cap. `viewer/app.ts` records
-#: "(2_630 -> 2_571)", which is what slices ⑭⑮⑯ measured on 2026-08-27; the pin was RESTORED to
-#: 2_570 on 2026-08-29, and this file's own comment above already calls that off-by-one deliberate
-#: and tolerated. Editing the history to 2_570 would make the check pass by falsifying what a slice
-#: measured - the mirror image of adjusting a check until it passes. Exempt it and say why.
-_CAP_AGREEMENT_EXEMPT = {
-    "apps/web/src/viewer/app.ts":
-        "pin restored to 2_570 on 2026-08-29 after the ⑭⑮⑯ history was written at 2_571",
-}
+#: A file's newest history entry can legitimately disagree with its cap, and one did: `viewer/app.ts`
+#: recorded "(2_630 -> 2_571)" for what slices ⑭⑮⑯ measured on 2026-08-27 while the pin was RESTORED
+#: to 2_570 on 2026-08-29. Editing the history to 2_570 would have made the check pass by falsifying
+#: what a slice measured - the mirror image of adjusting a check until it passes - so it was exempted
+#: instead, with the reason written down.
+#:
+#: **RETIRED 2026-09-10, and left empty on purpose.** Slice ⑰ wrote "(2_571 -> 2_508)" and slice ⑱
+#: "(2_508 -> 2_442)", whose result IS the cap, so the newest entry and the pin agree again and the
+#: exemption stopped excusing anything. An exemption that no longer excuses anything is
+#: indistinguishable from one that does, right up until it silently covers the next REAL
+#: disagreement - the same shape as the undated-exemption rule in `scripts/audit_npm_gate.py`. The
+#: map stays so the next legitimate case has somewhere to go, and this note stays so the retirement
+#: is a record rather than a deletion.
+_CAP_AGREEMENT_EXEMPT: dict[str, str] = {}
 
 
 _SRC_LINES = open(__file__, encoding="utf-8").read().split("\n")


### PR DESCRIPTION
# What & why

`apps/web/src/viewer/app.ts` **2,508 → 2,442**. `snapPoint`, `snapToGeometry` and `snapByOverride`
move to `apps/web/src/viewer/snapPick.ts` behind a one-parameter `SnapFragments` seam, and get
`apps/web/src/viewer/snapPick.test.ts` — **21 behaviours that did not exist before**. Roadmap item:
R39-DECOMP-VIEWER ③ (Lane E). Second commit is a roadmap-truth correction to REL-4.

## The measurement came first, and it rejected the obvious candidate

`app.ts` is one 2,380-line function, so REL-4's *"grep the `this.` refs before choosing a slice"* has
no `this.` to grep; the equivalent is how many **sibling bindings** a candidate captures.

| candidate | lines | captures |
|---|---|---|
| `buildToolsPanel` | 696 | **51 of the 143 outer bindings** — a 51-entry callback bag |
| `snapToGeometry` + `snapByOverride` + `snapPoint` | ~66 | `loader`, and one settings read |

Lifting `buildToolsPanel` would be coupling **added** in the name of removing it — the same reject
that kept `renderDesignHome` in `portal.ts`. The three snap functions go behind one structural
parameter, declared as a local interface rather than importing `ModelLoader`, so the module never
learns what a viewer is. **Typecheck passing is the proof that `loader.fragments` actually satisfies
that interface** — the seam is not asserted, it is checked.

## The argument is not the line count

`grep` finds all three referenced in exactly one file, `app.ts` itself. **Snapping had no tests at
all** — and it is where a click becomes the coordinate written into the IFC under a GlobalId. A wall
snapped to the wrong vertex travels to everyone downstream.

`snapPick.test.ts` pins the 0.4 m aperture on **both** the vertex and the bbox path, the vertex
clone (a caller must not be able to mutate the model's own positions), midpoint/centre candidates,
both `catch` fallbacks — and on the override path, that a *stated* kind has **no** aperture, keeps
the raw height, and refuses a perpendicular with no previous point rather than falling back to
another kind.

## One assertion could not fail when first written

Asserting that an override of kind `"none"` returns `null` **passed with the `kind === "none"` early
return deleted** — because `overrideCandidates("none")` returns no candidates and the resolver
answers `null` anyway. The assertion was true and measured nothing.

What the early return actually buys is that *"no snap" is decided by what the drafter said, rather
than by what the model contains*. The test now asserts **the loader is never read**, and that
mutation fails. Eight further mutations each fired the specific assertion they should:

| mutation | assertion that fired |
|---|---|
| `snapPoint` clones when `inc = 0` | the identity assertion, alone |
| vertex aperture → `Infinity` | both aperture tests |
| return the vertex, not a clone | the aliasing test |
| drop midpoint/centre candidates | midpoint + centre |
| override gains a 0.4 aperture | "any distance" + plan-height |
| drop the `"none"` early return | *(nothing — the reason this section exists)* |
| override overwrites height | the plan-height test |
| perpendicular falls back to origin | the refusal test |

## Ratchet and prose moved in the SAME edit, not the same commit

- `services/api/test_file_sizes.py` pin `2_508 → 2_442`, history entry `(2_508 -> 2_442)`.
  Mutation-checked at `2_441`: red twice, on growth *and* on history-vs-cap.
- **`_CAP_AGREEMENT_EXEMPT` retired and left empty.** Its entry existed because the ⑭⑮⑯ history
  ended at `2_571` while the pin was restored to `2_570`; ⑰ and ⑱ have since written entries ending
  exactly at the cap, so it stopped excusing anything. An exemption that excuses nothing is
  indistinguishable from one that does, right up until it silently covers the next real disagreement.
- `CLAUDE.md` and `docs/roadmap.md` figures `2,508 → 2,442` (and 50% → 52%). Mutation-checked:
  leaving the `CLAUDE.md` prose stale reds `services/api/test_claude_md_gates.py`.

## Three other CLAUDE.md numbers were stale again

Re-measured 2026-09-10, not recalled: **67 → 79** commits in the viewer since extraction began, and
**129 TS files / 16,408 non-test lines / 53 test files → 155 / 19,159 / 65**. That paragraph's own
warning — *a number that decays toward the conclusion it supports is the hardest kind to notice* —
had come true a second time, in the paragraph written to diagnose it.

## Second commit: REL-4's two halves are in different lanes

REL-4 is **Lane A**, whose paths are `shell/`, `account/`, `portal/portal.ts`, `portal/homes/`,
`main.ts`. Its own text names `viewer/app.ts`, which is **Lane E's** directory — so half the item is
not executable inside its own lane, and every app.ts slice since ⑭ has in practice shipped as
R39-DECOMP-VIEWER. `apps/web/src/shell/roadmapLanes.test.ts` cannot catch this: it asserts the
**rows** are disjoint and that every code appears in exactly one, and the overlap here is between an
item's *prose* and its row's paths. **Noted rather than re-cut** — which lane owns an item is the
table's call, not a slice's.

The `portal.ts` half is separately empty, measured rather than recalled: of **73 methods, exactly 3
call no sibling**, and the largest of those is 20 lines (`barChart`). Every candidate above 36 lines
calls siblings — `renderHome` 405/16, `buildRoomRail` 148/9, `renderDesignHome` 94/9, `buildNav`
80/12. The next leaf is not waiting to be found; it has to be **made** by breaking `renderHome` up
first, which is larger work than "take the next leaf".

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `python -m ruff check ../..` over the WHOLE tree — `All checks passed!`
- [x] Backend: **689/689 suites pass, 0 failures** (`run_tests.py`, 1079s wall)
- [x] Web: `npm run typecheck && npm run lint && npm run build` all clean
- [x] No import cycles introduced
- [ ] `CHANGELOG.md` entry — **deliberately none.** No behaviour change: snap resolution is
      byte-identical, the extraction is a move plus two parameter additions
- [ ] Version bumped in both manifests — not a release PR
- [x] No secrets, no competitor names in shipped docs

## Verification

* `npx vitest run src/viewer` — **65 files, 739 tests, all pass**
* `snapPick.test.ts` — 21 tests, **9 mutations run individually**, each checked for *which*
  assertion fired, not merely that something failed
* `test_file_sizes.py` and `test_claude_md_gates.py` both pass, and both were mutated to confirm
  they can fail on this change

**Stated verification limit.** The tests drive `snapPick` through a hand-written `SnapFragments`
fake, so they prove the snap *logic*, not that the real `FragmentsModels` returns what the fake
returns. What covers that gap is the typecheck: `loader.fragments` must structurally satisfy the
declared interface or the build fails. Nothing here exercises a real fragment model, and no test in
this repository did before either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved snapping behavior for viewer interactions, including grid, geometry, and override snapping.
  - Added safer fallback handling when geometry or model data is unavailable.

- **Bug Fixes**
  - Corrected snapping edge cases involving bounding boxes, missing geometry, loader errors, and perpendicular snapping.

- **Tests**
  - Added comprehensive coverage for snapping and fallback behavior.

- **Documentation**
  - Updated viewer size metrics, extraction progress figures, and roadmap details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->