### PR TITLE
SCREEN-VS-REPORT: the valuation screen was less honest than its own PDF, and the type-aware pass that found it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### A valuation that could not be computed no longer reads as a valuation of zero
+
+When a project has no proforma and no comparables, none of the three appraisal approaches produces a
+value. The valuation screen used to print **$0** as the opinion of value, in the same large type it
+uses for a real one — so a property that could not be appraised looked like a property worth nothing.
+It now shows a dash and says what is missing and what to add.
+
+The same screen was quietly showing less than the valuation report built from the identical data. It
+now names which of the three approaches reconciled into the value and says when the others were
+excluded, shows the implied cap rate the comparables carry, shows the median that matches the basis in
+force (a per-unit valuation used to display an empty "$/SF" row), shows the depreciation percentage
+beside the amount deducted, and shows a missing cap rate as absent rather than as 0.00%.
+
+It also names comparables the appraiser excluded. The server has been reporting those for some time,
+precisely so a valuation whose sample shrank reads as a decision somebody made rather than as a
+thinner market — but the web app had no field for them at all, so no one ever saw it.
+
 ### The pin count and the pins it describes are proven to come from one read
 
 The pin overlay fetches a page of pins and the project-wide total in a single database read, so the

--- a/apps/web/src/api/deadFieldTyped.test.ts
+++ b/apps/web/src/api/deadFieldTyped.test.ts
@@ -25,7 +25,11 @@ import { describe, expect, it } from "vitest";
  * | typed-unread that the identifier method called "read" | ~556 — pure name collisions |
  * | of those, leaf name present as a STRING LITERAL outside `api/` | ~308 |
  *
- * That last row is the typed pass's OWN blind spot, in the opposite direction: this codebase reads
+ * There is a THIRD limit that no checker can remove: a field read through `Object.entries(resp)` or
+ * a spread never has its name appear at all. That residual is measured below rather than described,
+ * because a caveat held only in prose is the thing this repository keeps paying for.
+ *
+ * That first row is the typed pass's OWN blind spot, in the opposite direction: this codebase reads
  * plenty of fields through string keys in column configs, and no checker can see those. So the honest
  * output is a PARTITION, not a number — and the sound candidate set is the intersection: no typed
  * reader AND no string-literal reader. Reporting the typed count alone would have been the same
@@ -137,8 +141,32 @@ function stringLiterals(): Set<string> {
   return out;
 }
 
+/** Interfaces named in a file that ALSO reads objects dynamically — `Object.keys/entries/values` or
+ *  a spread. No static analysis can clear a field consumed that way: the property name never appears.
+ *  This is the derivation's SECOND blind spot, and unlike the first it cannot be narrowed by a better
+ *  checker — it is a limit of static reading, not of this implementation. */
+function dynamicallyReadInterfaces(): Set<string> {
+  const walk = (dir: string, out: string[] = []): string[] => {
+    for (const e of readdirSync(dir)) {
+      const p = join(dir, e);
+      if (statSync(p).isDirectory()) walk(p, out);
+      else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
+    }
+    return out;
+  };
+  const out = new Set<string>();
+  for (const f of walk(WEB)) {
+    if (f.startsWith(API) || isTest(f)) continue;
+    const src = readFileSync(f, "utf-8");
+    if (!/Object\.(keys|entries|values)|\.\.\./.test(src)) continue;
+    for (const m of src.matchAll(/\b([A-Z]\w+)\b/g)) out.add(m[1]!);
+  }
+  return out;
+}
+
 const { keyToFile, readers } = derive();
 const lits = stringLiterals();
+const dynIfaces = dynamicallyReadInterfaces();
 const readersOutsideDecl = (k: string) =>
   [...(readers.get(k) ?? [])].filter((r) => r !== keyToFile.get(k));
 
@@ -187,6 +215,20 @@ describe("DEAD-FIELD: the type-aware derivation", () => {
     expect(alsoNoLiteral.length,
       "the sound set is the INTERSECTION of both methods, and it is smaller than either")
       .toBeGreaterThan(50);
+
+    // THE SECOND BLIND SPOT, measured rather than described. A reviewer asked whether this audit
+    // overstates unused fields when values are read through dynamic paths. It can, it is bounded
+    // here, and unlike the string-literal gap this one CANNOT be closed by a better checker: a field
+    // consumed via `Object.entries(resp)` or a spread never has its name appear anywhere.
+    const iface = (k: string) => k.split(".")[0]!;
+    const atRisk = alsoNoLiteral.filter((k) => dynIfaces.has(iface(k)));
+    expect(atRisk.length,
+      "no candidate's interface is touched by a dynamic reader — that is implausible in this "
+      + "codebase and means the dynamic-read scan stopped matching, which would make the sound set "
+      + "look cleaner than it is").toBeGreaterThan(0);
+    expect(atRisk.length,
+      "the residual is now most of the candidate set, so the sound set is no longer sound — "
+      + "re-derive before quoting it").toBeLessThan(alsoNoLiteral.length);
   });
 
   it("the six fields the valuation panel was fixed to render now resolve to a reader", () => {

--- a/apps/web/src/api/deadFieldTyped.test.ts
+++ b/apps/web/src/api/deadFieldTyped.test.ts
@@ -1,0 +1,206 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+/**
+ * DEAD-FIELD, type-aware — the pass `deadFieldScope.test.ts` names as its own unblocking step.
+ *
+ * That file measures the IDENTIFIER-based derivation and argues it cannot support a gate: it matches
+ * a field by NAME across the tree, so `SpatialNode.elevation` counts as read because storeys, drawing
+ * grids, GIS overlays and draft gizmos all happen to have an `elevation`. Its closing instruction is
+ * to rewrite it *"rather than relaxing the assertion"* once a type-aware derivation exists. This is
+ * that derivation. It resolves every property access, destructuring binding and string-keyed element
+ * access through the TypeScript checker to the `PropertySignature` that declares it — so a reader
+ * counts only when it is reading THAT interface's field.
+ *
+ * ### Neither method bounds the population, and saying so is the point
+ *
+ * The typed pass is not simply better. Measured across both:
+ *
+ * | | |
+ * |---|---|
+ * | identifier-unread that the checker finds READ | **0** — the old bucket was a sound LOWER BOUND |
+ * | typed-unread that the identifier method called "read" | ~556 — pure name collisions |
+ * | of those, leaf name present as a STRING LITERAL outside `api/` | ~308 |
+ *
+ * That last row is the typed pass's OWN blind spot, in the opposite direction: this codebase reads
+ * plenty of fields through string keys in column configs, and no checker can see those. So the honest
+ * output is a PARTITION, not a number — and the sound candidate set is the intersection: no typed
+ * reader AND no string-literal reader. Reporting the typed count alone would have been the same
+ * mistake the identifier method makes, with the sign flipped.
+ *
+ * ### The positive control is not optional
+ *
+ * Every derivation in this repository that reported a clean tree did so because a predicate quietly
+ * excluded the thing it was looking for. So this asserts a KNOWN-RENDERED field resolves to a reader
+ * before it is allowed to report anything unread: if the checker stops resolving — a moved tsconfig,
+ * a changed API, a typo in the walk — every field would look unread and the population would balloon
+ * rather than vanish, which is the failure mode that looks like a finding.
+ */
+
+const WEB = resolve(process.cwd(), "src");
+const API = resolve(WEB, "api");
+const isApiDecl = (f: string) =>
+  f.startsWith(API) && !f.endsWith("schema.d.ts") && !f.endsWith(".test.ts");
+const isTest = (f: string) => f.endsWith(".test.ts") || f.endsWith(".test.tsx");
+
+/** One typed derivation over the whole program. Built once — `createProgram` is the expensive part. */
+function derive() {
+  const cfgPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists, "tsconfig.json");
+  if (!cfgPath) throw new Error("no tsconfig.json — the derivation cannot run, which is not 'clean'");
+  const parsed = ts.parseJsonConfigFileContent(
+    ts.readConfigFile(cfgPath, ts.sys.readFile).config, ts.sys, process.cwd());
+  const program = ts.createProgram(parsed.fileNames, parsed.options);
+  const checker = program.getTypeChecker();
+
+  /** declaring node -> "Interface.path", including NESTED object literals and array element types.
+   *  Anchoring on top-level members only is how the identifier version missed
+   *  `ResponsibilityMatrix.validation.*`, this axis's one load-bearing defect. */
+  const nodeToKey = new Map<ts.Node, string>();
+  const keyToFile = new Map<string, string>();
+  const collect = (members: ts.NodeArray<ts.TypeElement>, path: string, file: string) => {
+    for (const m of members) {
+      if (!ts.isPropertySignature(m) || !m.name) continue;
+      const key = `${path}.${m.name.getText()}`;
+      nodeToKey.set(m, key);
+      if (!keyToFile.has(key)) keyToFile.set(key, file);
+      const t = m.type;
+      if (t && ts.isTypeLiteralNode(t)) collect(t.members, key, file);
+      else if (t && ts.isArrayTypeNode(t) && ts.isTypeLiteralNode(t.elementType))
+        collect(t.elementType.members, `${key}[]`, file);
+    }
+  };
+  for (const sf of program.getSourceFiles()) {
+    if (!isApiDecl(sf.fileName)) continue;
+    const visit = (n: ts.Node): void => {
+      if (ts.isInterfaceDeclaration(n)
+          && n.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword))
+        collect(n.members, n.name.text, sf.fileName);
+      ts.forEachChild(n, visit);
+    };
+    visit(sf);
+  }
+
+  const readers = new Map<string, Set<string>>();
+  const note = (sym: ts.Symbol | undefined, f: string) => {
+    for (const d of sym?.declarations ?? []) {
+      const k = nodeToKey.get(d);
+      if (k === undefined) continue;
+      if (!readers.has(k)) readers.set(k, new Set());
+      readers.get(k)!.add(f);
+    }
+  };
+  // TWO OF THE THREE READ SHAPES BELOW CURRENTLY RESOLVE NOTHING, and saying so is better than
+  // letting them look load-bearing. Measured by removing each and re-counting: the read population is
+  // **999 with all three, 999 without the destructuring branch, and 999 without the string-key element
+  // access** — every destructured or bracket-indexed read in this tree also has a dotted read
+  // somewhere, so neither branch clears a field on its own today. They stay because their value is
+  // PROSPECTIVE: a future field read *only* by `const { x } = resp` would otherwise be reported unread,
+  // which is a false candidate rather than a missed defect. Neither is covered by a mutation, and that
+  // is a disclosure, not an oversight — an unexercised branch presented as tested is how a check rots.
+  for (const sf of program.getSourceFiles()) {
+    const f = sf.fileName;
+    if (!f.startsWith(WEB) || f.includes("node_modules")) continue;
+    const visit = (n: ts.Node): void => {
+      if (ts.isPropertyAccessExpression(n)) note(checker.getSymbolAtLocation(n.name), f);
+      else if (ts.isElementAccessExpression(n) && n.argumentExpression
+               && ts.isStringLiteralLike(n.argumentExpression))
+        note(checker.getSymbolAtLocation(n.argumentExpression), f);
+      else if (ts.isBindingElement(n)) {
+        const nm = n.propertyName ?? n.name;
+        if (ts.isIdentifier(nm) || ts.isStringLiteralLike(nm)) note(checker.getSymbolAtLocation(nm), f);
+      }
+      ts.forEachChild(n, visit);
+    };
+    visit(sf);
+  }
+  return { keyToFile, readers };
+}
+
+/** Every string literal appearing outside `api/` — the typed pass's blind spot, made measurable. */
+function stringLiterals(): Set<string> {
+  const walk = (dir: string, out: string[] = []): string[] => {
+    for (const e of readdirSync(dir)) {
+      const p = join(dir, e);
+      if (statSync(p).isDirectory()) walk(p, out);
+      else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
+    }
+    return out;
+  };
+  const out = new Set<string>();
+  for (const f of walk(WEB)) {
+    if (f.startsWith(API) || isTest(f)) continue;
+    for (const m of readFileSync(f, "utf-8").matchAll(/["'`]([A-Za-z_]\w*)["'`]/g)) out.add(m[1]!);
+  }
+  return out;
+}
+
+const { keyToFile, readers } = derive();
+const lits = stringLiterals();
+const readersOutsideDecl = (k: string) =>
+  [...(readers.get(k) ?? [])].filter((r) => r !== keyToFile.get(k));
+
+describe("DEAD-FIELD: the type-aware derivation", () => {
+  it("RESOLVES — a field the app demonstrably renders comes back READ (the positive control)", () => {
+    // Before any unread count may be believed. `Appraisal.reconciliation.value` is the opinion of
+    // value printed at the top of the valuation tab; if the checker stopped resolving, this reports
+    // unread and every other field would too — a broken derivation that looks like a huge finding.
+    expect(keyToFile.has("Appraisal.reconciliation.value"),
+      "the declaration walk no longer finds a known interface member").toBe(true);
+    expect(readersOutsideDecl("Appraisal.reconciliation.value").length,
+      "the checker resolved NO reader for a field the valuation panel renders — the derivation is "
+      + "broken, and an unread count taken from it would be fiction").toBeGreaterThan(0);
+  });
+
+  it("sees NESTED members, which the identifier derivation's two-space anchor could not", () => {
+    // `ResponsibilityMatrix.validation.*` is this axis's one load-bearing defect and it was nested.
+    const nested = [...keyToFile.keys()].filter((k) => k.split(".").length >= 3);
+    expect(nested.length).toBeGreaterThan(100);
+    expect(keyToFile.has("Appraisal.reconciliation.approaches_used")).toBe(true);
+  });
+
+  it("SpatialNode.elevation has no typed reader — the collision the old derivation could not see", () => {
+    // `deadFieldScope.test.ts` asserts the mirror of this: >10 files reference the IDENTIFIER. Both
+    // are true at once, and that pair IS the argument for the type-aware pass.
+    expect(keyToFile.has("SpatialNode.elevation")).toBe(true);
+    expect(readersOutsideDecl("SpatialNode.elevation")).toEqual([]);
+  });
+
+  it("reports a PARTITION, not a number — the typed pass has its own blind spot", () => {
+    const all = [...keyToFile.keys()];
+    const typedUnread = all.filter((k) => readersOutsideDecl(k).length === 0);
+    const leaf = (k: string) => k.split(".").pop()!.replace(/\[\]$/, "");
+    const alsoNoLiteral = typedUnread.filter((k) => !lits.has(leaf(k)));
+
+    // Bands, not pins: ordinary work adds interfaces and must not fail the build. What these catch
+    // is the derivation itself breaking — a silently-empty population reporting a clean axis.
+    expect(all.length, "declared members").toBeGreaterThan(1_000);
+    expect(typedUnread.length).toBeGreaterThan(100);
+    expect(typedUnread.length).toBeLessThan(all.length * 0.6);
+
+    // The blind spot is REAL and is asserted so it cannot be quietly forgotten: a large share of the
+    // typed-unread set has its leaf name as a string literal outside api/, which is how this codebase's
+    // column configs read a field. Those are candidates the checker cannot clear.
+    expect(alsoNoLiteral.length).toBeLessThan(typedUnread.length);
+    expect(alsoNoLiteral.length,
+      "the sound set is the INTERSECTION of both methods, and it is smaller than either")
+      .toBeGreaterThan(50);
+  });
+
+  it("the six fields the valuation panel was fixed to render now resolve to a reader", () => {
+    // The defects this derivation found, pinned as READ so a future edit that drops one of them from
+    // the panel fails HERE as well as in proforma.render.test.ts. Two independent derivations must
+    // now be evaded, which is the argument the seeding-sweep pair already made.
+    for (const k of ["Appraisal.reconciliation.approaches_used",
+                     "Appraisal.sales_comparison.implied_cap_rate",
+                     "Appraisal.sales_comparison.median_price_per_unit",
+                     "Appraisal.cost.depreciation_pct",
+                     "Appraisal.inputs.has_proforma",
+                     "Appraisal.excluded_comparables"]) {
+      expect(keyToFile.has(k), `${k} is no longer declared — re-derive before trusting this`).toBe(true);
+      expect(readersOutsideDecl(k).length, `${k} lost its reader`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -504,6 +504,16 @@ export interface Appraisal {
   reconciliation: { value: number; contributions: { approach: string; value: number; weight: number }[];
     approaches_used: string[]; range: { low: number; high: number; spread_pct: number } };
   comp_count: number;
+  /** Comparables the appraiser EXCLUDED, named rather than silently dropped.
+   *
+   *  `marketing.compute_appraisal` has returned this since the exclusion fix, with a comment saying
+   *  why: *"a valuation whose sample shrank without saying so reads as a thinner market rather than
+   *  as a decision somebody made"*. It was **declared nowhere in this client** until 2026-09-10 —
+   *  not here, not in the generated `schema.d.ts` — so the disclosure the server went out of its way
+   *  to compute reached no user. A field the client never declares is worse than one it declares and
+   *  ignores: no type error, no lint and no unread-field audit can see it, because every such audit
+   *  starts from the interfaces. */
+  excluded_comparables?: { id?: string; ref?: string; reason: string }[];
 }
 
 export interface ProformaResult {

--- a/apps/web/src/proforma/proforma.render.test.ts
+++ b/apps/web/src/proforma/proforma.render.test.ts
@@ -464,6 +464,17 @@ describe("renderAppraisal — the screen no longer says less than the PDF", () =
     expect(cell("Less depreciation")).toBe("-$1,500,000 (15%)");
   });
 
+  it("shows 0% depreciation rather than omitting it — new construction is the DEFAULT case", async () => {
+    // The assertion that would have caught the first version of this fix, which used a truthy guard
+    // and dropped "(0%)" precisely where `report_builders/finance.py` prints it unconditionally.
+    // For a development tool most subjects ARE new construction, so this is the common path.
+    const { cell } = await paint(base({
+      cost: { ...base().cost, replacement_cost_new: 9_000_000, depreciation_pct: 0,
+              depreciation_amount: 0, depreciated_improvements: 9_000_000, value: 9_000_000 },
+    }));
+    expect(cell("Less depreciation")).toBe("-$0 (0%)");
+  });
+
   it("shows a cap rate of zero as a dash, not as a 0.00% capitalisation rate", async () => {
     const { cell, txt } = await paint(base());
     expect(cell("Cap rate")).toBe("—");

--- a/apps/web/src/proforma/proforma.render.test.ts
+++ b/apps/web/src/proforma/proforma.render.test.ts
@@ -338,3 +338,149 @@ describe("the deal-memory strip follows the hard cost", () => {
     expect(api.dealMemoryBeside).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * DEAD-FIELD / renderAppraisal — the valuation panel says what the PDF of the same response says.
+ *
+ * Found by a TYPE-AWARE unread-field pass (the TS compiler API resolving each property access to its
+ * declaring `PropertySignature`, rather than matching identifiers). Every field asserted below is one
+ * the server computes, `report_builders/finance.py` prints, and this screen did not read — so a user
+ * comparing the on-screen valuation with the exported valuation report saw less on screen.
+ *
+ * The worst case is the first test. `reconcile()` drops any approach whose value is zero and returns
+ * `value: 0.0` when none is usable, and the panel printed `money(0)` — "$0" in 28px as an opinion of
+ * value. A property that could not be appraised was displayed as a property worth nothing, while the
+ * PDF printed "(insufficient data)". It is reachable with no exception in the way: `appraisal_inputs`
+ * coalesces every input through `float(x or 0.0)` and `income_approach` guards its own divide.
+ */
+describe("renderAppraisal — the screen no longer says less than the PDF", () => {
+  const ZERO_APPROACH = { approach: "", value: 0 };
+  const base = (over: Record<string, unknown> = {}) => ({
+    inputs: { replacement_cost_new: 0, land_value: 0, depreciation_pct: 0, stabilized_noi: 0,
+              cap_rate: 0, subject_sqft: 0, subject_units: null, has_proforma: false },
+    cost: { ...ZERO_APPROACH, approach: "cost", replacement_cost_new: 0, depreciation_pct: 0,
+            depreciation_amount: 0, depreciated_improvements: 0, land_value: 0 },
+    income: { ...ZERO_APPROACH, approach: "income", stabilized_noi: 0, cap_rate: 0,
+              method: "direct_capitalization" },
+    sales_comparison: { ...ZERO_APPROACH, approach: "sales_comparison", comp_count: 0, basis: "none",
+                        median_price_psf: null, median_price_per_unit: null, implied_cap_rate: null },
+    reconciliation: { value: 0, contributions: [], approaches_used: [],
+                      range: { low: 0, high: 0, spread_pct: 0 } },
+    comp_count: 0,
+    ...over,
+  });
+
+  /** Render the valuation tab against a canned appraisal response and return its text. */
+  const paint = async (v: Record<string, unknown>) => {
+    const { root, ui } = mount({ appraisal: vi.fn().mockResolvedValue(v), reportUrl: () => "#" }, "p1");
+    const host = document.createElement("div"); root.appendChild(host);
+    await (ui as unknown as { renderAppraisal(h: HTMLElement): Promise<void> }).renderAppraisal(host);
+    await flush();
+    /** The value cell of the approach-table row whose label cell is exactly `label`.
+     *
+     *  Reading the row rather than the page text on purpose: adjacent `<td>`s concatenate with no
+     *  separator, so `textContent` gives "Cap rate—" and an assertion written the natural way silently
+     *  never matches. Worse, a substring assertion over the whole panel can be satisfied by a DIFFERENT
+     *  card — "$0" appears in all three — so it would pass whatever the row under test said. */
+    const cell = (label: string): string | null => {
+      for (const tr of host.querySelectorAll("tr")) {
+        const [k, val] = tr.querySelectorAll("td");
+        if (k?.textContent?.trim() === label) return val?.textContent?.trim() ?? null;
+      }
+      return null;
+    };
+    return { host, cell, txt: (host.textContent ?? "").replace(/\s+/g, " ") };
+  };
+
+  it("a project nothing could value shows an em dash and why — never '$0' as an opinion of value", async () => {
+    const { host, txt } = await paint(base());
+    expect(txt).toContain("Insufficient data");
+    expect(txt).toContain("No proforma is saved");                 // reads `inputs.has_proforma`
+    // The headline itself must not be a money figure. Assert on the ELEMENT, not the page text:
+    // "$0" appears legitimately in the approach cards below, and matching the whole panel would pass
+    // whatever the headline said.
+    const headline = host.querySelector('div[style*="font-size:28px"]');
+    expect(headline?.textContent).toBe("—");
+  });
+
+  it("names which approaches reconciled into the value, and says the rest were excluded", async () => {
+    const { txt } = await paint(base({
+      inputs: { ...base().inputs, has_proforma: true },
+      cost: { ...base().cost, value: 4_000_000 },
+      income: { ...base().income, value: 5_000_000, cap_rate: 0.055, stabilized_noi: 275_000 },
+      reconciliation: { value: 4_600_000, approaches_used: ["income", "cost"],
+                        contributions: [{ approach: "income", value: 5_000_000, weight: 0.6 },
+                                        { approach: "cost", value: 4_000_000, weight: 0.4 }],
+                        range: { low: 4_000_000, high: 5_000_000, spread_pct: 0.217 } },
+    }));
+    expect(txt).toContain("Reconciled from 2 of 3 approaches: income, cost");
+    expect(txt).toContain("the rest produced no value and were excluded");
+  });
+
+  it("does not claim approaches were excluded when all three reconciled", async () => {
+    const { txt } = await paint(base({
+      reconciliation: { value: 5_000_000, approaches_used: ["income", "sales_comparison", "cost"],
+                        contributions: [], range: { low: 4e6, high: 6e6, spread_pct: 0.4 } },
+    }));
+    expect(txt).toContain("Reconciled from 3 of 3 approaches");
+    expect(txt).not.toContain("were excluded");
+  });
+
+  it("shows the median that MATCHES the basis — a $/unit basis is not a blank $/SF row", async () => {
+    const { cell } = await paint(base({
+      sales_comparison: { ...base().sales_comparison, basis: "$/unit", comp_count: 4,
+                          median_price_psf: null, median_price_per_unit: 210_000, value: 8_400_000 },
+      reconciliation: { value: 8_400_000, approaches_used: ["sales_comparison"], contributions: [],
+                        range: { low: 8_400_000, high: 8_400_000, spread_pct: 0 } },
+    }));
+    expect(cell("Median $/unit")).toBe("$210,000");
+    expect(cell("Median $/SF"), "the $/SF row must be GONE, not merely blank").toBeNull();
+  });
+
+  it("labels a raw-median basis as a sale price rather than a $/SF that is not one", async () => {
+    const { cell } = await paint(base({
+      sales_comparison: { ...base().sales_comparison, basis: "median price", comp_count: 3,
+                          value: 3_100_000 },
+    }));
+    expect(cell("Median sale price")).toBe("$3,100,000");
+    expect(cell("Median $/SF")).toBeNull();
+  });
+
+  it("shows the implied cap rate the comparables carry, and a dash when they carry none", async () => {
+    const withCap = await paint(base({
+      sales_comparison: { ...base().sales_comparison, basis: "$/SF", median_price_psf: 310,
+                          implied_cap_rate: 0.0545, comp_count: 5, value: 5_100_000 },
+    }));
+    expect(withCap.cell("Implied cap rate")).toBe("5.45%");
+    const without = await paint(base());
+    expect(without.cell("Implied cap rate")).toBe("—");
+  });
+
+  it("shows the depreciation PERCENTAGE beside the amount deducted", async () => {
+    const { cell } = await paint(base({
+      cost: { ...base().cost, replacement_cost_new: 10_000_000, depreciation_pct: 0.15,
+              depreciation_amount: 1_500_000, depreciated_improvements: 8_500_000, value: 8_500_000 },
+    }));
+    expect(cell("Less depreciation")).toBe("-$1,500,000 (15%)");
+  });
+
+  it("shows a cap rate of zero as a dash, not as a 0.00% capitalisation rate", async () => {
+    const { cell, txt } = await paint(base());
+    expect(cell("Cap rate")).toBe("—");
+    expect(txt).not.toContain("0.00%");
+  });
+
+  it("names comparables the appraiser excluded, so a shrunken sample is a decision and not a mood", async () => {
+    const { txt } = await paint(base({
+      excluded_comparables: [{ id: "c1", ref: "COMP-004", reason: "excluded by the appraiser" },
+                             { id: "c2", ref: "COMP-009", reason: "excluded by the appraiser" }],
+    }));
+    expect(txt).toContain("2 comparables were excluded by the appraiser");
+    expect(txt).toContain("COMP-004, COMP-009");
+  });
+
+  it("says nothing about exclusions when the server named none", async () => {
+    const { txt } = await paint(base());
+    expect(txt).not.toContain("excluded by the appraiser");
+  });
+});

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -319,11 +319,39 @@ export class ProformaUI {
     catch (e) { host.innerHTML = `<div class="meta">Couldn't value this project: ${escapeHtml((e as Error).message)}.<br>Save a proforma scenario (Underwriting) and add Comparables (Finance) first.</div>`; return; }
     host.innerHTML = "";
     const rec = v.reconciliation;
+    // `reconcile()` DROPS any approach whose value is zero or absent, and returns 0.0 when none is
+    // usable. This panel used to print `money(rec.value)` unconditionally, so a project nothing could
+    // value rendered "$0" in 28px as an opinion of value — a property that could not be appraised
+    // shown as a property worth nothing. The PDF built from the SAME response has always printed an
+    // explicit "(insufficient data)" row; the screen was the dishonest one of the pair.
+    const used = rec.approaches_used ?? [];
     const head = document.createElement("div"); head.className = "fin-card";
-    head.innerHTML = `<div class="section-title">Opinion of value</div>`
-      + `<div style="font-size:28px;font-weight:800">${money(rec.value)}</div>`
-      + `<div class="meta">Range ${money(rec.range.low)} – ${money(rec.range.high)} · spread ${pct(rec.range.spread_pct)} · `
-      + `${v.comp_count} comparable${v.comp_count === 1 ? "" : "s"}</div>`;
+    head.innerHTML = `<div class="section-title">Opinion of value</div>`;
+    if (!used.length) {
+      head.innerHTML += `<div style="font-size:28px;font-weight:800">—</div>`
+        + `<div class="meta">Insufficient data — no approach produced a value.`
+        + (v.inputs.has_proforma ? "" : " No proforma is saved, so the cost and income approaches have nothing to work from.")
+        + ` Add an estimate or proforma, or import comparables, then re-open this tab.</div>`;
+    } else {
+      head.innerHTML += `<div style="font-size:28px;font-weight:800">${money(rec.value)}</div>`
+        + `<div class="meta">Range ${money(rec.range.low)} – ${money(rec.range.high)} · spread ${pct(rec.range.spread_pct)} · `
+        + `${v.comp_count} comparable${v.comp_count === 1 ? "" : "s"}</div>`
+        // WHICH approaches reconciled into that number. The server has always said so and the PDF has
+        // always printed it as a KPI; nothing on this screen read the field.
+        + `<div class="meta">Reconciled from ${used.length} of 3 approaches: `
+        + `${escapeHtml(used.map((a) => a.replace(/_/g, " ")).join(", "))}`
+        + (used.length < 3 ? ` — the rest produced no value and were excluded` : "")
+        + `</div>`;
+    }
+    // An EXCLUDED comparable is the appraiser's stated decision, and the server names them for
+    // exactly this reason: a valuation whose sample shrank without saying so reads as a thinner
+    // market rather than as a choice somebody made. The field was declared nowhere in this client.
+    const dropped = v.excluded_comparables ?? [];
+    if (dropped.length) {
+      head.innerHTML += `<div class="meta" style="color:#b45309">${dropped.length} comparable`
+        + `${dropped.length === 1 ? " was" : "s were"} excluded by the appraiser and did not reach `
+        + `the sales approach: ${escapeHtml(dropped.map((d) => d.ref || d.id || "unnamed").join(", "))}</div>`;
+    }
     host.appendChild(head);
 
     // bar: indicated value by approach
@@ -338,20 +366,35 @@ export class ProformaUI {
     // three approach cards
     const cards = document.createElement("div"); cards.className = "fin-grid";
     const row = (a: string, b: string) => `<tr><td>${a}</td><td class="num">${b}</td></tr>`;
+    /** The median that actually produced the sales value — the one matching `basis`.
+     *
+     *  The card used to hard-code "Median $/SF". `sales_comparison()` prefers $/SF, falls back to
+     *  $/unit, then to the raw median price, so on a per-unit basis the row read "Median $/SF —"
+     *  while `median_price_per_unit` — the number the value was computed from — was never shown.
+     *  The card then displayed a basis and no median for it. */
+    const medianRow = (sc: Appraisal["sales_comparison"]) =>
+      sc.basis === "$/unit"
+        ? row("Median $/unit", sc.median_price_per_unit ? money(sc.median_price_per_unit) : "—")
+        : sc.basis === "median price"
+          ? row("Median sale price", money(sc.value))
+          : row("Median $/SF", sc.median_price_psf ? money(sc.median_price_psf) : "—");
     cards.innerHTML = `
       <div class="fin-card"><div class="section-title">Cost approach</div><table class="fin-table">
         ${row("Replacement cost new", money(v.cost.replacement_cost_new))}
-        ${row("Less depreciation", "-" + money(v.cost.depreciation_amount))}
+        ${row("Less depreciation", "-" + money(v.cost.depreciation_amount)
+              + (v.cost.depreciation_pct ? ` (${(v.cost.depreciation_pct * 100).toFixed(0)}%)` : ""))}
         ${row("Plus land", money(v.cost.land_value))}
         <tr class="fin-total"><td>Value</td><td class="num">${money(v.cost.value)}</td></tr></table></div>
       <div class="fin-card"><div class="section-title">Income approach</div><table class="fin-table">
         ${row("Stabilized NOI", money(v.income.stabilized_noi))}
-        ${row("Cap rate", (v.income.cap_rate * 100).toFixed(2) + "%")}
+        ${row("Cap rate", v.income.cap_rate ? (v.income.cap_rate * 100).toFixed(2) + "%" : "—")}
         <tr class="fin-total"><td>Value (direct cap)</td><td class="num">${money(v.income.value)}</td></tr></table></div>
       <div class="fin-card"><div class="section-title">Sales comparison</div><table class="fin-table">
         ${row("Comps used", String(v.sales_comparison.comp_count))}
         ${row("Basis", escapeHtml(v.sales_comparison.basis))}
-        ${row("Median $/SF", v.sales_comparison.median_price_psf ? money(v.sales_comparison.median_price_psf) : "—")}
+        ${medianRow(v.sales_comparison)}
+        ${row("Implied cap rate", v.sales_comparison.implied_cap_rate
+              ? (v.sales_comparison.implied_cap_rate * 100).toFixed(2) + "%" : "—")}
         <tr class="fin-total"><td>Value</td><td class="num">${money(v.sales_comparison.value)}</td></tr></table></div>`;
     host.appendChild(cards);
 

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -382,7 +382,12 @@ export class ProformaUI {
       <div class="fin-card"><div class="section-title">Cost approach</div><table class="fin-table">
         ${row("Replacement cost new", money(v.cost.replacement_cost_new))}
         ${row("Less depreciation", "-" + money(v.cost.depreciation_amount)
-              + (v.cost.depreciation_pct ? ` (${(v.cost.depreciation_pct * 100).toFixed(0)}%)` : ""))}
+              // `!= null`, NOT truthiness. `cost_approach` always sends a number and the PDF prints
+              // the percentage unconditionally, so a truthy guard omits "(0%)" exactly where the PDF
+              // shows it — and 0% is NEW CONSTRUCTION, the default case for a development tool
+              // rather than an edge one. The first version of this fix used `?` and reintroduced the
+              // very asymmetry this change exists to remove. Caught in review.
+              + (v.cost.depreciation_pct != null ? ` (${(v.cost.depreciation_pct * 100).toFixed(0)}%)` : ""))}
         ${row("Plus land", money(v.cost.land_value))}
         <tr class="fin-total"><td>Value</td><td class="num">${money(v.cost.value)}</td></tr></table></div>
       <div class="fin-card"><div class="section-title">Income approach</div><table class="fin-table">

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -852,6 +852,80 @@ instances:
   resolving each property access to its declaring symbol — not more reading. Until then the "unread"
   bucket is a **lower bound** and the "read" bucket is not evidence.
 
+  **BUILT 2026-09-10 — `apps/web/src/api/deadFieldTyped.test.ts`. The blocker is gone, and the result
+  is a PARTITION rather than the number this entry expected.** It resolves every property access,
+  destructuring binding and string-keyed element access through the checker to the declaring
+  `PropertySignature`, and it sees NESTED members, which the two-space anchor could not.
+
+  | | |
+  |---|---|
+  | declared members (typed, nested + array-element literals) | **1,648** (the regex saw 751) |
+  | identifier-unread that the checker finds READ | **0** — the old bucket was a sound LOWER BOUND |
+  | typed-unread that the identifier method called "read" | **556** — pure name collisions |
+  | of those, leaf name present as a STRING LITERAL outside `api/` | **308** |
+  | sound candidates: no typed reader AND no string-literal reader | **350** |
+  | └ declaring interface touched by `Object.keys`/`entries`/spread | 128 — not statically resolvable |
+
+  `SpatialNode.elevation` flips to **zero typed readers**, exactly as this entry predicted. But the
+  containment result is the more useful half: **the identifier method never called something unread
+  that the checker finds read**, so nothing previously triaged was wasted.
+
+  **The typed pass is not simply better — it has the OPPOSITE blind spot.** 308 of the 556 it newly
+  flags have their leaf name as a string literal outside `api/`, which is how this codebase's column
+  configs read a field. Reporting its count alone would have been the identifier method's mistake with
+  the sign flipped, and the first draft of this work nearly did: **658 was written down before anyone
+  asked which direction the new method was wrong in.** The sound set is the intersection, and it is
+  smaller than either.
+
+  **The strongest sub-population is not "unread" but ASYMMETRIC: 47 of the 350 ARE rendered by the
+  Python report builders.** Same data, two deliveries, and the screen omits what the PDF prints — so
+  the field's importance is not a judgement call, `report_builders/` already made it. Six of those
+  shipped as fixes to the valuation panel; see below.
+
+- ◧ **SCREEN-VS-REPORT — the printed valuation was more honest than the on-screen one** *(the six
+  found in the first pass are FIXED; the other ~41 asymmetric fields are unread)*
+
+  All six were in `renderAppraisal` in `apps/web/src/proforma/proforma.ts`, and the worst was not a
+  missing caveat but a false statement. `reconcile()` in `services/api/src/aec_api/appraisal.py` drops
+  any approach whose value is zero and returns `value: 0.0` when none is usable — and the panel
+  printed that through `money()`, so **a project nothing could value rendered "$0" in 28px as an
+  opinion of value.** A property that could not be appraised was displayed as a property worth
+  nothing. It is reachable with no exception in the way: `appraisal_inputs` coalesces every input
+  through `float(x or 0.0)` and `income_approach` guards its own divide, so the route returns zeros
+  rather than erroring into the panel's catch. The PDF built from the identical response has always
+  printed "(insufficient data)".
+
+  The other five: `reconciliation.approaches_used` (which approaches reconciled — a KPI in the PDF),
+  `sales_comparison.implied_cap_rate`, `sales_comparison.median_price_per_unit` (a `$/unit` basis
+  displayed "Median $/SF —", showing a basis and no median for it), `cost.depreciation_pct`, and a
+  cap rate of zero rendered as "0.00%" rather than as absent.
+
+  **A SEVENTH was invisible to the derivation by construction, and it names a new axis.**
+  `excluded_comparables` — comparables the appraiser deliberately excluded — is returned by
+  `marketing.compute_appraisal` with a comment saying exactly why it must not be dropped, and was
+  **declared nowhere in this client**: not in the `Appraisal` interface, not in the generated
+  `schema.d.ts`. Every unread-field audit starts from the client's interfaces, so a field the client
+  never declares cannot be seen by any of them, and no type error or lint can either. See
+  RESPONSE-UNDECLARED below.
+
+- ◧ **RESPONSE-UNDECLARED — the inverse of DEAD-FIELD** *(sized 2026-09-10, not yet triaged)*
+
+  DEAD-FIELD asks *does the client READ what it DECLARES*. This asks *does the client DECLARE what the
+  server SENDS*, and the second failure is strictly worse: an undeclared field is invisible to the
+  compiler, the linter, and every audit built on the interfaces.
+
+  Sound lower bound, since identifier matching OVER-counts readers and so a key with zero hits is
+  definitely unread: **536** distinct string keys are returned from dict literals inside decorated
+  route handlers under `services/api/src/aec_api/routers/`, and **46 of them appear nowhere in
+  `apps/web/src`, not even as a bare token.** (2,878 keys across all of `aec_api` with 531 unmentioned
+  — but most of those are internal helper returns that never reach a response, so the routers subset is
+  the defensible one.)
+
+  High-signal members, all the caveat-on-a-number shape: `deviations_without_photo` and `evidence_pct`
+  (how much evidence backs a verification), `changed_assumptions`, `cost_vintage`, `g703_totals` — a
+  payment-application schedule of values. Each of the 46 still needs reading to separate a real
+  disclosure gap from an internal or debug key.
+
   *Two bugs in the derivation itself were found on the way, both the same shape as the axis's own
   lesson.* Anchoring field matching at two-space indent cannot see a **nested** field — and this
   axis's one load-bearing defect, `ResponsibilityMatrix.validation.*`, was nested. Including the
@@ -1931,14 +2005,14 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · SCREEN-VS-REPORT *(the asymmetric sub-population: fields the Python report builders render and the screen does not. Derived from `apps/web/src/api/` interfaces against `services/api/src/aec_api/report_builders/`, but the EDIT is a caveat rendered beside a number a panel already shows, and the first six fixed all landed in `apps/web/src/proforma/proforma.ts` — same derived-here-fixed-there split as the cell beside it. **Naming a sibling item code inside a cell is how this row failed the disjointness check once**: the parser reads a mention as an assignment, so a cross-reference has to describe the other row rather than name it)* · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · PERF-WORKERS ① · R43-MASSINGBILL-CORE · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* *(**UX-3 left this cell 2026-09-06: all five of its items now ship** — see its entry. The cell had pointed at `apps/web/src/viewer/tools/authoringSection.ts`, which is a real file and the WRONG one: every one of the five landed under `apps/web/src/viewer/draft/`. Lanes are assigned by directory, so a pointer that resolves is not the same as a pointer that is right — a tracked-path gate cannot catch this, and did not)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | — |
-| **I · API client** | `apps/web/src/api/` | SCALE-SEAM *(the only open slice; ②–⓾ plus (81)–(91) have shipped. **Deliberately carries NO mark**: ⓾ is the last glyph in `MARKS` and the double-circled range it closes has no successor, so the next slice cannot be numbered at all — writing a mark the parser does not know would drop the item out of this table's own population.)* *(this cell said (81)–(87) until 2026-09-04, four slices after (88) landed — the same drift its own history below records, in the same cell, for the third time. It named ⓽ until 2026-09-03; ②–⓼ had shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
+| **I · API client** | `apps/web/src/api/` | RESPONSE-UNDECLARED *(the finding comes from `services/api/src/aec_api/routers/`, which is Lane G's, but the WORK is declaring the field on the client interface so something can read it — lanes go by the directory the work touches, the correction Lane E's cell already had to make. Rendering the newly-declared field afterwards is Lane B's)* · SCALE-SEAM *(the only open slice; ②–⓾ plus (81)–(91) have shipped. **Deliberately carries NO mark**: ⓾ is the last glyph in `MARKS` and the double-circled range it closes has no successor, so the next slice cannot be numbered at all — writing a mark the parser does not know would drop the item out of this table's own population.)* *(this cell said (81)–(87) until 2026-09-04, four slices after (88) landed — the same drift its own history below records, in the same cell, for the third time. It named ⓽ until 2026-09-03; ②–⓼ had shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
 | **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `apps/web/src/tooling/`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | R39-TSC-CACHE *(local typecheck once diverged from CI; cause unknown, prior explanation retracted — an OBSERVATION, not a defect with a known fix. Read the entry before "fixing" it: the proposed fix is named there and rejected)* |
 
 **Parked — not available to pick up.** These are decisions or multi-release commitments, listed so


### PR DESCRIPTION
# What & why

DEAD-FIELD's roadmap entry names a **type-aware pass** as its unblocking step and says the identifier
derivation cannot support a gate. This builds that pass, runs it, and fixes the **six defects it found
in one function** — plus a seventh the derivation could not have found, which names a new axis.

The worst one is not a missing caveat. **A property that could not be appraised was displayed as a
property worth nothing.**

## The instrument — `apps/web/src/api/deadFieldTyped.test.ts`

Resolves every property access, destructuring binding and string-keyed element access through the
TypeScript checker to the declaring `PropertySignature`, and sees **nested** members — which the old
two-space anchor could not, and this axis's one load-bearing defect (`ResponsibilityMatrix.validation.*`)
was nested.

| | |
|---|---|
| declared members (typed, nested + array-element literals) | **1,648** (the regex saw 751) |
| identifier-unread that the checker finds READ | **0** — the old bucket was a sound lower bound |
| typed-unread that the identifier method called "read" | **556** — pure name collisions |
| of those, leaf name a STRING LITERAL outside `api/` | **308** |
| sound candidates: no typed reader **and** no literal reader | **350** |

`SpatialNode.elevation` flips to zero typed readers, exactly as the entry predicted.

### It reports a partition, not a number, and that correction was earned

**The first run said 658 and I wrote it down before asking which *direction* the new method was wrong
in.** It over-reports: this codebase reads plenty of fields through string keys in column configs, and
no checker sees those. Quoting the typed count alone would have been the identifier method's mistake
with the sign flipped. The sound set is the intersection, and the test asserts the partition so the
number cannot be quoted out of it later.

### Two disclosures rather than a clean scorecard

**The positive control is not optional.** A known-rendered field must resolve to a reader before any
unread count may be believed — if the checker stops resolving, the population *balloons* rather than
empties, which is the failure that looks like a finding.

**One mutation survived and is disclosed, not papered over.** Removing the destructuring branch changes
nothing: measured **999 read fields with it and 999 without**, zero fields lost; same for string-keyed
element access. Both are dead code today. They stay because their value is prospective — a future
destructuring-only read would otherwise be a false candidate — and the file says plainly that neither
is mutation-covered. An unexercised branch presented as tested is how a check rots.

## The six defects — all in `renderAppraisal`

1. **A valuation that could not be computed read as a valuation of zero.** `reconcile()` in
   `services/api/src/aec_api/appraisal.py` drops any approach whose value is zero and returns `0.0`
   when none is usable; the panel printed that through `money()`, so a bare project rendered **"$0" in
   28px as an opinion of value**, with "Range $0 – $0". Reachable with no exception in the way:
   `appraisal_inputs` coalesces every input through `float(x or 0.0)` and `income_approach` guards its
   own divide, so the route returns zeros rather than erroring into the panel's catch. The PDF built
   from the identical response has always printed `(insufficient data)`. **Reproduced and asserted
   before fixing.**
2. `reconciliation.approaches_used` — which approaches reconciled. A KPI in the PDF, unread here.
3. `sales_comparison.implied_cap_rate` — rendered at `report_builders/finance.py`, unread here.
4. `sales_comparison.median_price_per_unit` — a `$/unit` basis displayed "Median $/SF —": a basis, and
   no median for it.
5. `cost.depreciation_pct` — the percentage behind the amount deducted.
6. A cap rate of zero printed as "0.00%" rather than as absent.

## A seventh was invisible to the derivation by construction

`marketing.compute_appraisal` returns `excluded_comparables` with a comment saying exactly why it must
not be dropped — *"a valuation whose sample shrank without saying so reads as a thinner market rather
than as a decision somebody made"* — and it was **declared nowhere in this client**: not in the
`Appraisal` interface, not in the generated `schema.d.ts`. Every unread-field audit starts from the
client's interfaces, so a field the client never declares is invisible to all of them, and to the
compiler and linter too. Declared and rendered here; the axis is filed as **RESPONSE-UNDECLARED** with
**46 route-handler keys** measured.

## Tests

10 new behavioural tests, **all 8 panel mutations firing the specific assertion they should**. They
assert on **table cells, not page text**: adjacent `<td>`s concatenate with no separator, so the natural
assertion silently never matches — and a substring over the whole panel can be satisfied by a *different*
card, since "$0" appears in all three.

## Two roadmap gates caught this change, and both were right

* `roadmapLanes.test.ts` rejected a cell that **named** a sibling item code — the parser reads a mention
  as an assignment, so a cross-reference has to *describe* the other row. That lesson is now in the cell.
* `roadmapSelfConsistent.test.ts` rejected "the six that shipped" on a ◧ item — 6 of ~47 is partial.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `ruff check ../..` over the whole tree — `All checks passed!`
- [x] Backend: **no Python changed by this PR.** The three gates it *can* affect —
      `test_claude_md_gates.py`, `test_changelog_current.py`, `test_file_sizes.py` — were run directly
      against the final tree and pass
- [x] Web: `npm run typecheck && npm run lint && npm run build` all clean
- [x] Web: **230 files / 2,372 tests pass**
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added — this one *does* change what a user sees
- [ ] Version bumped in both manifests — not a release PR
- [x] No secrets, no competitor names in shipped docs

## Verification

* `renderAppraisal`'s zero-value case was **reproduced first**, asserted as the defective behaviour,
  and only then fixed
* 8 panel mutations + 4 derivation mutations run individually, each checked for *which* assertion
  fired — 3 of the 4 derivation mutations caught, the 4th disclosed above
* Adding the type-aware program build costs ~10s in the web test job; `typescript` is a declared
  `devDependency` of `apps/web` (5.9.3), not a hoisted accident

**Stated verification limit.** The panel tests drive `ProformaUI` against a mocked `ApiClient`, so they
prove the *rendering* of a canned response, not that the server returns that shape. What backs the
shape is the reading of `appraisal.py` and `marketing.py` quoted above, and the `Appraisal` interface
the typecheck enforces — no test here exercises the real route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Valuations without sufficient data now show an em dash and an explanation instead of `$0`.
  - Valuation details now accurately display reconciled approaches, matching medians, implied cap rates, depreciation, and missing values.
  - Zero or unavailable cap rates now appear as an em dash rather than `0.00%`.
  - Appraiser-excluded comparables are now identified in the valuation view.
  - The valuation screen now indicates when approaches were excluded from reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->