### PR TITLE
RESPONSE-UNDECLARED ①: the verification card says how much of the work is photographed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Field-verification coverage says how much of the work is actually photographed
+
+The coverage card showed how much of the model is verified and installed, and how many deviations
+were logged. It did not say how much of that is backed by a photo — even though the server has been
+computing exactly that, including the count of deviations with no photo at all, which it describes as
+the handover number: a deviation with no photo is an assertion with nothing behind it.
+
+The card now shows the share of tracked work that is photographed, names the denominator it is
+measured against, and warns when deviations are unevidenced. Twelve deviations and twelve deviations
+with nine unphotographed are different things to hand a client at closeout.
+
 ### A valuation that could not be computed no longer reads as a valuation of zero
 
 When a project has no proforma and no comparables, none of the three appraisal approaches produces a

--- a/apps/web/src/api/model.ts
+++ b/apps/web/src/api/model.ts
@@ -737,10 +737,25 @@ export function withModel<TBase extends Ctor<NeedsEditIfc>>(Base: TBase) {
       `/projects/${pid}/view-templates/${encodeURIComponent(tid)}/resolve`);
   }
 
-  /** verificationCoverage — installed/verified % vs the model total, plus deviation count. */
+  /** verificationCoverage — installed/verified % vs the model total, the deviation count, and HOW
+   *  MUCH OF IT IS PHOTOGRAPHED.
+   *
+   *  The evidence half was returned by the route and declared by nobody. `/verification/coverage`
+   *  sends thirteen keys; this type named eight, so the five below could not be read, and a field the
+   *  client never declares is invisible to the compiler, the linter and every unread-field audit —
+   *  all of which start from these interfaces. RESPONSE-UNDECLARED.
+   *
+   *  `deviations_without_photo` is the one that matters. The route's own comment calls it *"the
+   *  handover number. A deviation with no photo is an assertion with nothing behind it."* Twelve
+   *  deviations and twelve deviations with nine unphotographed are different things to hand a client.
+   *
+   *  Percentages here are against TRACKED elements, not the model total — the route is deliberate
+   *  about that: an element nobody has looked at yet is not missing evidence, it has not been started. */
   verificationCoverage(pid: string) {
     return this.json<{ total_elements: number; tracked: number; verified: number; installed: number;
-      deviations: number; verified_pct: number; installed_pct: number; by_status: Record<string, number> }>(
+      deviations: number; verified_pct: number; installed_pct: number; by_status: Record<string, number>;
+      with_photo: number; photo_by_status: Record<string, number>; evidence_pct: number;
+      verified_with_photo: number; deviations_without_photo: number }>(
       `/projects/${pid}/verification/coverage`);
   }
   /** setVerification — write an element's field-verification status (installed | verified | deviation | pending). */

--- a/apps/web/src/reportCenter.ts
+++ b/apps/web/src/reportCenter.ts
@@ -1,3 +1,33 @@
+
+/** The field-verification coverage card, as HTML.
+ *
+ *  Pure and exported so the evidence disclosure below can be driven directly: `reportCenter` builds
+ *  its tools inside a closure over a live `ApiClient`, and a card nobody can render alone is a card
+ *  whose behaviour nobody can assert.
+ *
+ *  **Why the second line exists.** The route returns five evidence fields and this client declared
+ *  none of them, so the card showed "N verified · M deviations" with no indication of how much of
+ *  that is photographed. The route's own comment on `deviations_without_photo` says why that matters:
+ *  *"the handover number. A deviation with no photo is an assertion with nothing behind it."*
+ *
+ *  Evidence percentages are against TRACKED elements, which is the route's deliberate choice — an
+ *  element nobody has looked at yet is not missing evidence, it simply has not been started — so the
+ *  denominator is named on screen rather than left for the reader to assume. */
+export function verificationCoverageCard(c: {
+  total_elements: number; tracked: number; verified: number; installed: number; deviations: number;
+  verified_pct: number; installed_pct: number; with_photo: number; evidence_pct: number;
+  deviations_without_photo: number;
+}): string {
+  const unphotographed = c.deviations_without_photo;
+  return `<div style="font-size:22px;font-weight:700">${c.verified_pct}% verified · ${c.installed_pct}% installed</div>`
+    + `<div class="meta">${c.verified} verified · ${c.installed} installed · ${c.deviations} deviations · of ${c.total_elements} elements</div>`
+    + `<div class="meta">${c.evidence_pct}% photographed (${c.with_photo} of ${c.tracked} tracked)</div>`
+    + (unphotographed > 0
+        ? `<div class="meta" style="color:#b45309">${unphotographed} of ${c.deviations} deviation`
+          + `${c.deviations === 1 ? "" : "s"} ha${unphotographed === 1 ? "s" : "ve"} no photo — `
+          + `not evidenced for handover</div>`
+        : "");
+}
 import type { ApiClient, ProfessionalLicense, StampTemplate } from "./api/client";
 import { money } from "./ui/charts";
 import { toast, escapeHtml } from "./ui/feedback";
@@ -574,9 +604,7 @@ export async function openReportCenter(api: ApiClient, projectId: string | null,
   }));
   tool("✓ Field-verification coverage", () => showResult("Field-verification coverage", async (body) => {
     body.innerHTML = `<div class="meta">Loading…</div>`;
-    try { const c = await api.verificationCoverage(pid); body.innerHTML =
-      `<div style="font-size:22px;font-weight:700">${c.verified_pct}% verified · ${c.installed_pct}% installed</div>`
-      + `<div class="meta">${c.verified} verified · ${c.installed} installed · ${c.deviations} deviations · of ${c.total_elements} elements</div>`; }
+    try { body.innerHTML = verificationCoverageCard(await api.verificationCoverage(pid)); }
     catch (e) { body.innerHTML = `<div class="meta">${escapeHtml((e as Error).message)}</div>`; }
   }));
 

--- a/apps/web/src/reportCenter.verification.test.ts
+++ b/apps/web/src/reportCenter.verification.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { verificationCoverageCard } from "./reportCenter";
+
+/**
+ * RESPONSE-UNDECLARED — `/verification/coverage` returns thirteen keys and `api/model.ts` declared
+ * eight, so the five evidence fields could not be read by anything.
+ *
+ * A field the client never declares is worse than one it declares and ignores: no type error, no
+ * lint, and no unread-field audit can see it, because every such audit starts from the client's
+ * interfaces. This one was found by reading the route beside the panel, not by any derivation.
+ *
+ * The card showed "N verified · M deviations" with no indication of how much was photographed, while
+ * the route computed `deviations_without_photo` under the comment *"the handover number. A deviation
+ * with no photo is an assertion with nothing behind it."*
+ */
+const base = {
+  total_elements: 400, tracked: 300, verified: 210, installed: 250, deviations: 12,
+  verified_pct: 70.0, installed_pct: 83.3, with_photo: 180, evidence_pct: 60.0,
+  deviations_without_photo: 9,
+};
+
+describe("verificationCoverageCard — the evidence half is on screen", () => {
+  it("states how much of the tracked work is photographed, and against which denominator", () => {
+    const html = verificationCoverageCard(base);
+    expect(html).toContain("60% photographed (180 of 300 tracked)");
+    // "of 300 tracked", not "of 400" — the route divides by tracked on purpose, and a percentage
+    // whose denominator is left to the reader is the ambiguity this card is fixing.
+    expect(html).not.toContain("of 400 tracked");
+  });
+
+  it("names unphotographed deviations — the handover number", () => {
+    const html = verificationCoverageCard(base);
+    expect(html).toContain("9 of 12 deviations have no photo");
+    expect(html).toContain("not evidenced for handover");
+  });
+
+  it("says nothing about unphotographed deviations when every one is evidenced", () => {
+    // The warning must be ABSENT, not zeroed: "0 of 12 deviations have no photo" is noise on a
+    // card whose whole job is to surface the exception.
+    const html = verificationCoverageCard({ ...base, deviations_without_photo: 0 });
+    expect(html).not.toContain("no photo");
+    expect(html).not.toContain("handover");
+    expect(html).toContain("60% photographed");        // the coverage line still shows
+  });
+
+  it("agrees in number with a single unphotographed deviation", () => {
+    const html = verificationCoverageCard({ ...base, deviations: 1, deviations_without_photo: 1 });
+    expect(html).toContain("1 of 1 deviation has no photo");
+  });
+
+  it("still shows the headline the card has always shown", () => {
+    const html = verificationCoverageCard(base);
+    expect(html).toContain("70% verified · 83.3% installed");
+    expect(html).toContain("210 verified · 250 installed · 12 deviations · of 400 elements");
+  });
+});

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -926,6 +926,30 @@ instances:
   payment-application schedule of values. Each of the 46 still needs reading to separate a real
   disclosure gap from an internal or debug key.
 
+  **FIRST CASE FIXED, AND THE SIZING TOOK FIVE TRIES TO BECOME HONEST.** `/verification/coverage`
+  returns thirteen keys; `apps/web/src/api/model.ts` declared eight. The five missing were the whole
+  evidence half, and the route's own comment on `deviations_without_photo` calls it *"the handover
+  number. A deviation with no photo is an assertion with nothing behind it."* Now declared and
+  rendered, with `apps/web/src/reportCenter.verification.test.ts` pinning it and five mutations.
+
+  *The derivation was wrong four times before it was right, each time in a way that looked rigorous:*
+  ranking by undeclared-key count put the LEAST actionable case top, because a high score means the
+  client never calls the route at all (`/bcf/2.1/auth` scores 4/4 and is correct as-is — BCF serves
+  third-party tools). Matching a client by path PREFIX made siblings under `/proforma/scenarios/` look
+  consumed when neither the GET nor the PUT has a client method. Then the fix for that was too tight:
+  normalising `{pid}` before `${pid}` left a stray `$`, so **six real cases collapsed to one** and only
+  a hand-verified case going missing revealed it. And the key-presence test matched identifiers
+  tree-wide — the very flaw the identifier derivation above has — so `forecast_returns` on
+  `/draw-package` was silently excluded. **A predicate that decides what to LOOK at hides its own
+  misses, in both directions.** The remaining candidates need the checker, not another regex: a
+  textual scan of a typed language cannot resolve a named return type, a nested literal, or a
+  multi-line span, and this one reported `id` undeclared on a route that plainly declares it.
+
+  **A SEPARATE FINDING, deliberately not folded in: 19 route handlers have NO web client at all.**
+  That is a different question with a different answer each time — `/bcf/2.1/auth` is correct,
+  `/projects/{pid}/pins/all` looks like a gap. `ARCH-REACH` cannot see it: it asks whether a MODULE is
+  reachable from a route, not whether a ROUTE has a caller.
+
   *Two bugs in the derivation itself were found on the way, both the same shape as the axis's own
   lesson.* Anchoring field matching at two-space indent cannot see a **nested** field — and this
   axis's one load-bearing defect, `ResponsibilityMatrix.validation.*`, was nested. Including the
@@ -2005,7 +2029,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · SCREEN-VS-REPORT *(the asymmetric sub-population: fields the Python report builders render and the screen does not. Derived from `apps/web/src/api/` interfaces against `services/api/src/aec_api/report_builders/`, but the EDIT is a caveat rendered beside a number a panel already shows, and the first six fixed all landed in `apps/web/src/proforma/proforma.ts` — same derived-here-fixed-there split as the cell beside it. **Naming a sibling item code inside a cell is how this row failed the disjointness check once**: the parser reads a mention as an assignment, so a cross-reference has to describe the other row rather than name it)* · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts`, `apps/web/src/reportCenter.verification.test.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · SCREEN-VS-REPORT *(the asymmetric sub-population: fields the Python report builders render and the screen does not. Derived from `apps/web/src/api/` interfaces against `services/api/src/aec_api/report_builders/`, but the EDIT is a caveat rendered beside a number a panel already shows, and the first six fixed all landed in `apps/web/src/proforma/proforma.ts` — same derived-here-fixed-there split as the cell beside it. **Naming a sibling item code inside a cell is how this row failed the disjointness check once**: the parser reads a mention as an assignment, so a cross-reference has to describe the other row rather than name it)* · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py` | R22-ENTITLEMENT · PERF-WORKERS ① · R43-MASSINGBILL-CORE · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* *(**UX-3 left this cell 2026-09-06: all five of its items now ship** — see its entry. The cell had pointed at `apps/web/src/viewer/tools/authoringSection.ts`, which is a real file and the WRONG one: every one of the five landed under `apps/web/src/viewer/draft/`. Lanes are assigned by directory, so a pointer that resolves is not the same as a pointer that is right — a tracked-path gate cannot catch this, and did not)* |


### PR DESCRIPTION
# What & why

`/verification/coverage` returns **thirteen** keys; `apps/web/src/api/model.ts` declared **eight**. The
five missing were the entire evidence half, so the field-verification card showed *"N verified · M
deviations"* with no indication that any of it was backed by a photograph.

The route computes `deviations_without_photo` under its own comment:

> *"The handover number. A deviation with no photo is an assertion with nothing behind it."*

Twelve deviations, and twelve deviations with nine unphotographed, are different things to hand a
client at closeout.

**A field the client never declares is worse than one it declares and ignores.** No type error, no
lint, and no unread-field audit can see it — including the type-aware one merged in #498 — because
every such audit starts from these interfaces. This was found by reading the route beside the panel.

## The fix

`verificationCoverageCard` is extracted, pure and exported: `reportCenter` builds its tools inside a
closure over a live `ApiClient`, and a card nobody can render alone is a card whose behaviour nobody
can assert. It now shows the share of tracked work photographed, **names the denominator**, and warns
when deviations are unevidenced.

The denominator is on screen on purpose — the route divides by *tracked*, not the model total, and
says why: an element nobody has looked at yet is not missing evidence, it has not been started.

## The sizing was wrong FIVE ways before it was right

This is the part worth reading. A scan that opened claiming *46 undeclared keys across 20 handlers*
resolves to **1 real, 3 non-defects, 1 artifact, 1 unresolved** — and every intermediate version
looked rigorous:

| # | flaw | effect |
|---|---|---|
| 1 | key-presence matched identifiers **tree-wide** | silently excluded `forecast_returns` — the exact flaw the identifier derivation has |
| 2 | ranked by **undeclared-key count** | put the *least* actionable case top: a high score means the client never calls the route |
| 3 | matched a client by path **prefix** | siblings under `/proforma/scenarios/` looked consumed when neither GET nor PUT has a client method |
| 4 | normalised `{pid}` **before** `${pid}` | left a stray `$` — **six real cases collapsed to one** |
| 5 | ignored the **HTTP verb** | compared `POST /cost/lien-waiver`'s response to `GET`'s declared type |

Only #4 was caught by a mechanism — a hand-verified case going missing, which is now a self-test
assertion. The rest needed reading the actual code. **A predicate that decides what to LOOK at hides
its own misses, in both directions.**

## Classification of the six candidates

| route | verdict |
|---|---|
| `verification/coverage` | **REAL — fixed here** |
| `reference/disciplines` | not a defect — client takes `tree` deliberately; the UI gets divisions from the spec manual |
| `verification/{guid}/photo` | not a defect — `has_photo: True` is a literal constant |
| `models/from-upload` | not a defect — `from_upload: True` is a literal constant |
| `draw-package` | unresolved — needs the checker |
| `cost/lien-waiver` | scan artifact — POST vs GET |

**The conclusion recorded in the roadmap is that this axis is not derivable by textual scanning.** It
needs the TypeScript checker on the client side and verb-aware route parsing on the server side. Said
plainly rather than leaving a candidate list that reads like a defect list.

**Filed separately, not folded in:** 19 route handlers have no web client at all. That is a different
question with a different answer each time — `/bcf/2.1/auth` is correct as-is (BCF serves third-party
tools), `/projects/{pid}/pins/all` looks like a gap. `ARCH-REACH` cannot see it: it asks whether a
*module* is reachable from a route, not whether a *route* has a caller.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `ruff check ../..` — `All checks passed!`
- [x] Backend: **no Python changed.** The four gates this diff can affect —
      `test_claude_md_gates.py`, `test_file_sizes.py`, `test_changelog_current.py` and `ruff` — were
      run directly against the final tree and pass
- [x] Web: `npm run typecheck && npm run lint` clean
- [x] Web: **231 files / 2,378 tests pass**
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added — this changes what a user sees
- [ ] Version bumped in both manifests — not a release PR
- [x] No secrets, no competitor names in shipped docs

## Verification

* 5 tests, **5 mutations**, each firing the assertion it should: dropping the evidence line, switching
  its denominator to the model total, showing the unphotographed warning always, showing it never,
  and breaking singular/plural agreement
* Two of the repo's own gates fired during the work and were obeyed rather than worked around: the
  unowned-file ratchet on the new test, and the citation gate refusing the backticked path until it
  was tracked

**Stated verification limit.** The card is tested as a pure function against a canned response, so it
proves the *rendering*, not that the server returns that shape. What backs the shape is the reading of
`routers/verification.py` quoted above and the client type the typecheck enforces — no test here
exercises the real route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Field-verification coverage now shows the percentage of tracked work supported by photographs.
  * Displays photographed item counts and clarifies the tracked-work denominator used for evidence coverage.
  * Highlights deviations that do not have photographic evidence, including the number affected.
* **Bug Fixes**
  * The verification coverage report now consistently displays available photographic evidence metrics alongside existing coverage statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->