### PR TITLE
DB-URL-BOOT: the ambient-DSN gate could not see a schema built by the app's lifespan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### The guard against a test writing into your database was itself half blind
+
+An earlier change added a rule: a test that can create a schema must decide which database it creates
+it in, rather than inheriting whatever the shell is carrying. That rule was real and the check for it
+was real. What the check *looked at* was not — it decided whether a test could create a schema by
+searching for a literal call to the table-creating function.
+
+Starting the application creates the schema too, and a test that starts the application contains no
+such call. **355 test files were in that blind spot, and four of them named no database at all.** One
+of them, run the way its own instructions describe with the variable set, was measured creating 173
+tables in the wrong database and reporting success — the same number that motivated the original
+rule, in the part of the codebase the rule could not see.
+
+The four are fixed, and the check now recognises a test that starts the application. The rule was
+being enforced on 32 files; it is now enforced on 383.
+
 ### An issue tied to a wall shows on the model, whatever register it lives in
 
 Binding a record to an element by GlobalId is how you say *this problem is here*. It worked for RFIs

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -998,8 +998,8 @@ instances:
   anchor and no element still reaches the 3D viewer and not the sheet, so `/pins/all` is not yet the
   superset that would let the viewer drop its second call. See PIN-ANCHOR below.
 
-- ⭐ **DB-URL-BOOT — the ambient-DSN gate cannot see a schema built by the app's lifespan** *(S —
-  Lane C; opened 2026-09-10 while writing PIN-POPULATION's gate)*
+- ✅ ⭐ **DB-URL-BOOT — the ambient-DSN gate could not see a schema built by the app's lifespan** *(S —
+  Lane C; **CLOSED**, fix in this change; gated by `services/api/test_db_url_isolation.py`, widened)*
 
   `services/api/test_db_url_isolation.py` closed DB-URL-AMBIENT: a test run the way its own docstring
   tells you to could build a schema in the operator's database, because `os.environ.setdefault` looks
@@ -1022,6 +1022,20 @@ instances:
   a **bare** `TestClient(app)` does not run the lifespan and creates nothing, which
   `services/api/test_samples.py` documents in a comment; the predicate is the `with` form, not the
   constructor.
+
+  **Measured, not argued.** `services/api/test_samples.py`, run directly with `DATABASE_URL` pointing
+  at a decoy database, created **173 tables** in it and **exited 0** — the same number
+  `test_view_config.py` produced for the original DB-URL-AMBIENT finding. The defect survived at full
+  severity in the population its own gate could not look at. With the declaration in place the decoy
+  database is not created at all.
+
+  The predicate now counts a `with TestClient(...)` boot alongside a literal `create_all`, which
+  moves the enforced population from **32 files to 383** — 347 were already safe by convention and
+  are now actually *checked*, and the four that were not are fixed. Four mutations: the old predicate
+  with one file un-fixed **passes** (the blind spot, demonstrated rather than asserted); the new one
+  fails; narrowing `_boots_the_app` back and matching the constructor instead of the `with` each
+  break a self-test, and the gate then **refuses to report at all** rather than printing verdicts it
+  cannot stand behind.
 
   Not folded into PIN-POPULATION: unrelated axis, and two in one change makes both harder to read.
 
@@ -2160,7 +2174,7 @@ two rows share a path, so two agents in different rows cannot collide.
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* |
 | **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts`, `apps/web/src/reportCenter.verification.test.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · SCREEN-VS-REPORT *(the asymmetric sub-population: fields the Python report builders render and the screen does not. Derived from `apps/web/src/api/` interfaces against `services/api/src/aec_api/report_builders/`, but the EDIT is a caveat rendered beside a number a panel already shows, and the first six fixed all landed in `apps/web/src/proforma/proforma.ts` — same derived-here-fixed-there split as the cell beside it. **Naming a sibling item code inside a cell is how this row failed the disjointness check once**: the parser reads a mention as an assignment, so a cross-reference has to describe the other row rather than name it)* · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
-| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py`, `services/api/test_pin_population.py` | R22-ENTITLEMENT · PERF-WORKERS ① · R43-MASSINGBILL-CORE · PIN-ANCHOR · DB-URL-BOOT · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
+| **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py`, `services/api/test_pin_population.py` | R22-ENTITLEMENT · PERF-WORKERS ① · R43-MASSINGBILL-CORE · PIN-ANCHOR · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* *(**UX-3 left this cell 2026-09-06: all five of its items now ship** — see its entry. The cell had pointed at `apps/web/src/viewer/tools/authoringSection.ts`, which is a real file and the WRONG one: every one of the five landed under `apps/web/src/viewer/draft/`. Lanes are assigned by directory, so a pointer that resolves is not the same as a pointer that is right — a tracked-path gate cannot catch this, and did not)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |

--- a/services/api/test_db_url_isolation.py
+++ b/services/api/test_db_url_isolation.py
@@ -35,11 +35,15 @@ already built.
 
 ## Not covered, stated rather than left implicit
 
-The 236 tests that create no schema and declare no database are **not** required to declare one. They
-never call `create_all`, so the worst an ambient DSN does is give them a connection they never write
-a table into. That is a judgement, not an oversight, and it is the reason this file counts them and
-prints the number instead of quietly excluding them — a population you cannot see is one you cannot
-argue with.
+The tests that create no schema and declare no database are **not** required to declare one. They
+neither call `create_all` nor enter a `TestClient`, so the worst an ambient DSN does is give them a
+connection they never write a table into. That is a judgement, not an oversight, and it is the reason
+this file counts them and prints the number instead of quietly excluding them — a population you
+cannot see is one you cannot argue with.
+
+*This paragraph used to say "the 236 tests". It was 304 by the time anyone re-read it, and it moved
+because the `create_all`/lifespan widening below reclassified 347 files out of it — a number in prose
+beside a number the run prints is a copy, and the copy is what drifts. The printed one is the answer.*
 
 The three non-test tools — `loadtest.py`, `mcp_server.py`, `seed_scale.py` — keep `setdefault` on
 purpose: pointing a load test or the seeder at a real database is what they are for. They are not
@@ -69,9 +73,47 @@ def check(label: str, ok: bool, detail: object = "") -> None:
 # still REPORTED a site, so a mutation that routed every site to "safe" passed. Reporting a file and
 # classifying it are different questions, and asserting one is not asserting the other.
 
+def _boots_the_app(tree: ast.AST) -> bool:
+    """Does this module enter a `TestClient(...)` as a context manager?
+
+    **This gate made, one level down, the exact mistake its own docstring warns about.** It keyed on
+    the risk — "can this file create a schema" — and then answered that question by looking for a
+    literal `create_all`. But `with TestClient(app)` runs the app's lifespan, and the lifespan calls
+    `init_db()`, which calls `Base.metadata.create_all`. No literal appears in the test. So **355
+    files** that build the whole schema were classified as *creates no schema* and never checked;
+    four of them declared no `DATABASE_URL` at all.
+
+    **The `with` is load-bearing and is not a style preference.** A bare `TestClient(app)` does NOT
+    run the lifespan — `test_samples.py` says so in a comment, and it is why that file wraps its
+    client. Matching the constructor instead of the context manager would report every file holding
+    a non-entering client, which is a different and larger population that carries no risk.
+
+    Both `with X() as c:` and `with X():` are matched, and multi-item `with` statements too, since
+    the risk is entering the client at all.
+    """
+    for n in ast.walk(tree):
+        if not isinstance(n, (ast.With, ast.AsyncWith)):
+            continue
+        for item in n.items:
+            call = item.context_expr
+            if not isinstance(call, ast.Call):
+                continue
+            fn = call.func
+            name = fn.id if isinstance(fn, ast.Name) else (fn.attr if isinstance(fn, ast.Attribute) else "")
+            if name == "TestClient":
+                return True
+    return False
+
+
 def _creates_schema(tree: ast.AST) -> bool:
-    """Does this module call `create_all` anywhere? That is what turns a DSN into tables."""
-    return any(isinstance(n, ast.Attribute) and n.attr == "create_all" for n in ast.walk(tree))
+    """Can this module turn a DSN into tables?
+
+    Two ways, and the second was invisible until 2026-09-10: calling `create_all` directly, or
+    entering a `TestClient` whose lifespan calls it for you. See `_boots_the_app`.
+    """
+    if any(isinstance(n, ast.Attribute) and n.attr == "create_all" for n in ast.walk(tree)):
+        return True
+    return _boots_the_app(tree)
 
 
 #: memo for `_reaches_db`; also the cycle guard, since a provisional False is stored
@@ -309,6 +351,37 @@ from aec_api import models
 models.Base.metadata.create_all(engine)
 '''
 
+
+#: DB-URL-BOOT — the shape that was invisible for two months. No `create_all` anywhere; the schema is
+#: built by the app's lifespan when the client is ENTERED. 355 files in this suite are this shape,
+#: and four of them declared no DSN at all: one, run with the variable exported, was measured
+#: creating **173 tables** in it and exiting 0 — the same number `test_view_config.py` produced for
+#: the original finding, in the population this gate could not look at.
+_LIFESPAN_BOOT = '''
+from fastapi.testclient import TestClient
+from aec_api.main import app
+with TestClient(app) as c:
+    c.get("/health")
+'''
+#: The same shape, declared. Must be accepted, or the rule is always-fail rather than a rule.
+_LIFESPAN_BOOT_FIXED = '''
+import os
+os.environ["DATABASE_URL"] = "sqlite:///./_x.db"
+from fastapi.testclient import TestClient
+from aec_api.main import app
+with TestClient(app) as c:
+    c.get("/health")
+'''
+#: **The `with` is the whole distinction.** A bare `TestClient(app)` does not run the lifespan and
+#: creates nothing — `test_samples.py` says so in a comment. Matching the constructor instead would
+#: demand a DSN from every file merely holding a client: a larger population carrying no risk, and a
+#: gate that cries wolf gets edited to be quiet, which is where the real rule dies.
+_BARE_CLIENT_NO_LIFESPAN = '''
+from fastapi.testclient import TestClient
+from aec_api.main import app
+c = TestClient(app)
+'''
+
 for _label, _src, _want in (
     ("the undeclared original is caught", _PRE_FIX, "NEEDS-DECLARATION"),
     ("declaring AFTER the aec_api import is caught — the engine is already built",
@@ -327,6 +400,12 @@ for _label, _src, _want in (
      _ASSIGN_NOT_OS, "NEEDS-DECLARATION"),
     ("...but `import os as _os` IS os, and two real files in this suite write it that way",
      _ALIASED_OS, "SAFE"),
+    ("DB-URL-BOOT: entering a TestClient builds the schema via the lifespan, with no `create_all` "
+     "in sight — the blind spot this gate had until 2026-09-10",
+     _LIFESPAN_BOOT, "NEEDS-DECLARATION"),
+    ("...and the same file with a declaration is accepted", _LIFESPAN_BOOT_FIXED, "SAFE"),
+    ("a BARE TestClient never enters the lifespan, so it creates nothing and is not asked to declare",
+     _BARE_CLIENT_NO_LIFESPAN, "NO-SCHEMA"),
 ):
     got = verdict(_src)
     check(f"self-test: {_label}", got == _want, f"got {got}")

--- a/services/api/test_dispatcher_privilege_coverage.py
+++ b/services/api/test_dispatcher_privilege_coverage.py
@@ -37,7 +37,14 @@ ways to fail, all mutation-verified below:
 Kinds and tools register on import, so the app must actually be started — `app.routes` at import time
 sees a fraction of the real surface, and the same is true here.
 """
+import os
 import sys
+
+# DB-URL-BOOT: assignment BEFORE `aec_api` is imported. This file enters a `TestClient`,
+# whose lifespan calls `init_db()` -> `Base.metadata.create_all`, so run directly with
+# `DATABASE_URL` exported it would build the whole schema in whatever that names. No literal
+# `create_all` appears here, which is exactly why `test_db_url_isolation` could not see it.
+os.environ["DATABASE_URL"] = "sqlite:///./_dispatcher_privilege.db"
 
 from fastapi.testclient import TestClient
 

--- a/services/api/test_generate.py
+++ b/services/api/test_generate.py
@@ -6,6 +6,12 @@ import tempfile
 
 # IFC_DIR is read at import time by the authoring router; point it at a temp dir before importing.
 os.environ["IFC_DIR"] = tempfile.mkdtemp(prefix="gen_ifc_")
+
+# DB-URL-BOOT: assignment BEFORE `aec_api` is imported. This file enters a `TestClient`,
+# whose lifespan calls `init_db()` -> `Base.metadata.create_all`, so run directly with
+# `DATABASE_URL` exported it would build the whole schema in whatever that names. No literal
+# `create_all` appears here, which is exactly why `test_db_url_isolation` could not see it.
+os.environ["DATABASE_URL"] = "sqlite:///./_generate.db"
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "data", "src"))
 
 import warnings  # noqa: E402

--- a/services/api/test_samples.py
+++ b/services/api/test_samples.py
@@ -33,6 +33,14 @@ sys.path.insert(0, "../data/src")
 # merge train an hour via test_model_ensure.
 os.environ.setdefault("IFC_DIR", "./test_ifc_samples")
 
+# DB-URL-BOOT: assignment BEFORE `aec_api` is imported. This file enters a `TestClient`, whose
+# lifespan calls `init_db()` -> `Base.metadata.create_all`, so run directly with `DATABASE_URL`
+# exported it would build the whole schema in whatever that names. No literal `create_all`
+# appears here, which is exactly why `test_db_url_isolation` could not see it. Assignment, not
+# `setdefault` like the IFC_DIR line above: that one is a fallback for a path, this one has to
+# DECIDE, because yielding to the ambient value is the whole defect.
+os.environ["DATABASE_URL"] = "sqlite:///./_samples.db"
+
 FAILED = []
 
 

--- a/services/api/test_schema_diag.py
+++ b/services/api/test_schema_diag.py
@@ -17,6 +17,12 @@ from __future__ import annotations
 
 import gc
 import os
+
+# DB-URL-BOOT: assignment BEFORE `aec_api` is imported. This file enters a `TestClient`,
+# whose lifespan calls `init_db()` -> `Base.metadata.create_all`, so run directly with
+# `DATABASE_URL` exported it would build the whole schema in whatever that names. No literal
+# `create_all` appears here, which is exactly why `test_db_url_isolation` could not see it.
+os.environ["DATABASE_URL"] = "sqlite:///./_schema_diag.db"
 from shutil import rmtree as shutil_rmtree
 
 from aec_data import schema_diag as SD


### PR DESCRIPTION
# What & why

`services/api/test_db_url_isolation.py` closed DB-URL-AMBIENT with the right rule — *a test that can
create a schema must decide its own `DATABASE_URL`, by assignment, before `aec_api` is imported*. Its
own docstring says why it is keyed on the **risk** rather than on `setdefault`:

> *A predicate that decides what to LOOK at is more dangerous than one that decides what to report,
> because everything it excludes is invisible to its own output.*

It then answered that risk question by searching the file's AST for a literal `create_all`.

**`with TestClient(app)` runs the app's lifespan, and the lifespan calls `init_db()`, which calls
`Base.metadata.create_all`.** No literal appears in the test. So the gate made, one level down, the
exact mistake it warns about: **355 files** that build the entire schema were classified as *creates
no schema* and never checked — and four of them declared no `DATABASE_URL` at all.

## Measured, not argued

`services/api/test_samples.py`, run directly with `DATABASE_URL` pointing at a decoy:

```
WITHOUT the fix →  173 tables created in the decoy, exit 0
WITH    the fix →  decoy database not created at all
```

**173 is the same number `test_view_config.py` produced for the original DB-URL-AMBIENT finding.** The
defect survived at full severity in the population its own gate could not look at.

## The fix

`_boots_the_app` counts a `with TestClient(...)` boot alongside a literal `create_all`. The enforced
population moves from **32 files to 383** — 347 were already safe by convention and are now actually
*checked*; the four that were not are fixed with an assignment before the `aec_api` import:

* `services/api/test_dispatcher_privilege_coverage.py`
* `services/api/test_generate.py`
* `services/api/test_samples.py`
* `services/api/test_schema_diag.py`

**The `with` is load-bearing.** A *bare* `TestClient(app)` does not run the lifespan and creates
nothing — `test_samples.py` documents this in a comment, and it is why that file wraps its client.
Matching the constructor instead would demand a DSN from every file merely holding a client: a larger
population carrying no risk. A gate that cries wolf gets edited to be quiet, and the edit is where the
real rule dies.

## Verification — four mutations, and the first is the point

| # | mutation | result |
|---|---|---|
| 1 | old predicate (`create_all` only) + one file un-fixed | **PASSES** — the blind spot, demonstrated rather than asserted |
| 2 | new predicate, same tree | fails, and names the file |
| 3 | narrow `_boots_the_app` back | self-test fails → the gate **refuses to report** |
| 4 | match the constructor instead of the `with` | self-test fails → the gate **refuses to report** |

Three self-tests pin it, inside the file's existing *"cannot see its own motivating defect"* guard, so
a future narrowing cannot quietly return verdicts it has no basis for.

## One stale number corrected

The gate's docstring said *"the 236 tests that create no schema"*; the run printed **304**, because
this widening reclassified 347 files out of that bucket. The number is removed from the prose rather
than updated — a number beside one the run prints is a copy, and the copy is what drifts.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `ruff check ../..` — `All checks passed!`
- [x] Backend: affected `test_*.py` pass — `test_db_url_isolation` plus all four fixed files,
      re-run against this base after the cherry-pick
- [x] Web: no web source changed; the four doc gates pass (57 assertions)
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; roadmap item added and closed
- [ ] Version bumped in both manifests — not a release PR
- [x] No secrets, no competitor names in shipped docs

## Stated verification limit

The four fixed files were verified to still pass and, for `test_samples.py`, to no longer write to an
exported DSN. The other 379 files in the newly-enforced population are covered by the gate's static
check, not by running each one against a hostile `DATABASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database-safety detection for tests that start the application, including synchronous and asynchronous client usage.
  * Updated affected tests to use an isolated local database, preventing unintended schema creation in configured databases.
  * Added coverage for lifespan-starting clients and confirmed that non-starting clients are not incorrectly flagged.

* **Documentation**
  * Updated the changelog and roadmap to reflect expanded isolation enforcement and completed roadmap work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->