### PR TITLE
DESKTOP-SMOKE: run the sidecar the release pipeline ships

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -139,6 +139,19 @@ jobs:
           npm --prefix apps/web run build:desktop
           python services/api/build_sidecar.py
 
+      # RUN what we just packaged. Every other check in this repository reads SOURCE, and
+      # DESKTOP-FROZEN was a startup crash in the frozen binary while every one of them was green:
+      # `repo_root()` counted `parents[4]`, which holds in a checkout and not in a PyInstaller
+      # bundle, so the shipped v0.3.1133 AppImage raised IndexError before binding a port. This
+      # builds nothing and asserts on the artifact: it starts the sidecar under a deliberately
+      # SHALLOW temp directory (the configuration that crash needed — a deep one passes against the
+      # broken binary), then requires /health, /ready, the full module catalog and the bundled SPA.
+      # Placed before the Tauri build so a dead sidecar fails in seconds rather than after three
+      # platform bundles. See services/api/smoke_sidecar.py for what it does NOT cover.
+      - name: Smoke-test the packaged sidecar
+        shell: bash
+        run: python services/api/smoke_sidecar.py
+
       # Windows Authenticode: if a code-signing cert is configured, import the PFX and point
       # tauri.conf at its thumbprint so `tauri build` signs the .exe/.msi. No secret → unsigned.
       - name: Configure Windows signing
@@ -220,6 +233,29 @@ jobs:
           # that job is skipped → releaseId is empty → tauri-action builds without touching a release.
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}
+
+      # The step above runs the sidecar as `build_sidecar.py` placed it. This runs the copy that is
+      # actually INSIDE the shipped artifact, which is a different question: `externalBin` has to
+      # have picked it up, under the name it expects, with its executable bit intact. The AppImage is
+      # the one bundle we can unpack on its own runner without installing anything.
+      #
+      # `find` rather than a hardcoded path on purpose — and `smoke_sidecar.py` FAILS on a missing
+      # binary rather than skipping, so a wrong guess here reds the build instead of quietly
+      # asserting nothing, which is the failure this whole item exists to end.
+      - name: Smoke-test the sidecar inside the AppImage
+        if: matrix.platform == 'ubuntu-22.04'
+        shell: bash
+        run: |
+          set -euo pipefail
+          img=$(find apps/web/src-tauri/target -name '*.AppImage' -print -quit)
+          if [ -z "$img" ]; then echo "::error::no AppImage was produced"; exit 1; fi
+          echo "unpacking $img"
+          chmod +x "$img"
+          ( cd "$(dirname "$img")" && "./$(basename "$img")" --appimage-extract >/dev/null )
+          root="$(dirname "$img")/squashfs-root"
+          side=$(find "$root" -type f -name 'aec-bim-server*' -print -quit || true)
+          echo "sidecar inside the bundle: ${side:-<none found>}"
+          python services/api/smoke_sidecar.py "$side"
 
       # manual runs don't make a release; keep the installers as downloadable artifacts
       - name: Upload bundles as artifacts (manual runs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,21 +20,25 @@ at all: every automated check reads the source code, and the fault only existed 
 copy. The checks were green and the app was broken, and those two facts had nothing to do with each
 other.
 
-Each build now starts the packaged app and uses it before the release is allowed to proceed — under
-the exact conditions the crash needed, since the same app started fine under slightly different
-ones. It has to answer, reach its database, list every one of the 139 registers, and serve the
-interface. The Linux build is checked twice: once as it comes out of the build, and once unpacked
-from the installer a user would actually download.
+Every build now starts the server the app runs on and uses it before the release is allowed to
+proceed — under the exact conditions the crash needed, since the same build started fine under
+slightly different ones. It has to answer, reach its database, list every one of the 139 registers,
+and serve the interface. On Linux that happens twice, and the second time is the one that counts:
+the server is taken back out of the finished installer, the file a user would actually download, and
+started from there. On Windows and macOS only the first check runs — the installers themselves are
+still built and published without being opened.
 
 The check is deliberately unable to pass quietly. If the app it is supposed to test is missing, that
 is a failure rather than a skip — "nothing was wrong" and "nothing was looked at" are the two
 outcomes that must never be confused. It compares the registers it gets against the registers the
-project defines, rather than against a round number, because an app that had silently lost thirty of
-them would clear a round number. And it was itself tested against three deliberately broken builds
-before being trusted, including a reproduction of the crash that shipped.
+project defines — by name, one for one — rather than against a round number, because an app that had
+silently lost thirty of them would clear a round number, and one that lost a register while
+double-loading another would clear a count. And it was itself tested against three deliberately
+broken builds before being trusted, including a reproduction of the crash that shipped.
 
-One thing it still does not do is convert a model, so that part of the packaged app remains checked
-by other means; that is recorded rather than left to be assumed.
+One thing it still does not do is convert a model. The converter itself is tested, but not from
+inside a finished build — so whether model conversion survives packaging is genuinely unknown rather
+than checked another way, and it is written down as an open item instead of being counted as done.
 
 ### The desktop app can show you the model it just built
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### The desktop app is now started and checked before it is published
+
+The installers for Windows, macOS and Linux were built, signed and put in front of users without
+anything ever launching them. That is how the Linux app shipped in a state where it could not start
+at all: every automated check reads the source code, and the fault only existed in the packaged
+copy. The checks were green and the app was broken, and those two facts had nothing to do with each
+other.
+
+Each build now starts the packaged app and uses it before the release is allowed to proceed — under
+the exact conditions the crash needed, since the same app started fine under slightly different
+ones. It has to answer, reach its database, list every one of the 139 registers, and serve the
+interface. The Linux build is checked twice: once as it comes out of the build, and once unpacked
+from the installer a user would actually download.
+
+The check is deliberately unable to pass quietly. If the app it is supposed to test is missing, that
+is a failure rather than a skip — "nothing was wrong" and "nothing was looked at" are the two
+outcomes that must never be confused. It compares the registers it gets against the registers the
+project defines, rather than against a round number, because an app that had silently lost thirty of
+them would clear a round number. And it was itself tested against three deliberately broken builds
+before being trusted, including a reproduction of the crash that shipped.
+
+One thing it still does not do is convert a model, so that part of the packaged app remains checked
+by other means; that is recorded rather than left to be assumed.
+
 ### The desktop app can show you the model it just built
 
 Install the desktop app, create a project, upload an IFC and publish it, and everything worked

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1150,10 +1150,14 @@ instances:
   no source-level check can ask — `datas` either carried those directories in or it did not, and the
   tree says nothing either way.
 
-  **The module count is DERIVED, not a floor.** `> 100` would pass a bundle that silently dropped
-  thirty catalogs, which is precisely what a `datas` glob does when it stops matching; the harness
-  counts `services/api/modules/*/module.json` in the checked-out tree and demands the served list
-  equal it. Vacuity guards for the same reason: a missing binary FAILS rather than skips, the port is
+  **The module set is DERIVED, and compared by IDENTITY rather than by count.** `> 100` would pass a
+  bundle that silently dropped thirty catalogs, which is precisely what a `datas` glob does when it
+  stops matching. A count comparison is better and still not enough: it passes a bundle that lost one
+  catalog and double-loaded another. So the harness reads each `services/api/modules/*/module.json`'s
+  `key` — the same field the route serves, rather than the directory name that happens to match it —
+  and requires the served list to be exactly that set, once each, naming which module went missing.
+  **That strengthening came from review of this change, and the mutation proving it is the one a
+  count could not kill**: 139 declared, 139 served, one swapped for a decoy, and it fails. Vacuity guards for the same reason: a missing binary FAILS rather than skips, the port is
   proven free before launch so a reply cannot have come from something already listening, and an
   early child exit prints the child's own output — for a frozen-path defect that traceback is the
   only evidence there is.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1129,16 +1129,66 @@ instances:
   `aec-bim-server` and curls `/health` would have caught this in the job that produced it. See
   DESKTOP-SMOKE below.
 
-- **DESKTOP-SMOKE — the release pipeline never runs what it ships** *(S — Lane J; opened 2026-09-10
-  by DESKTOP-FROZEN)*
+- ✅ **DESKTOP-SMOKE — the release pipeline never ran what it ships** *(S — Lane J; opened 2026-09-10
+  by DESKTOP-FROZEN, **CLOSED** the same day; the harness is `services/api/smoke_sidecar.py`, wired
+  into `.github/workflows/desktop.yml`)*
 
-  `.github/workflows/desktop.yml` builds the Tauri bundles, signs them and uploads them. No step
-  executes the result. DESKTOP-FROZEN was a startup crash on one of the three platforms it publishes,
-  and every check was green.
+  `desktop.yml` built the Tauri bundles, signed them and published them, and no step executed the
+  result. DESKTOP-FROZEN was a startup crash on one of the three platforms it publishes and every
+  check was green — because every check reads SOURCE. `repo_root()` counted `parents[4]`, which holds
+  in a checkout and not in a bundle.
 
-  The cheap version is one step on the Linux runner: extract the AppImage, run the bundled
-  `aec-bim-server` with a deliberately SHALLOW `TMPDIR`, and fail unless `/health` answers. That
-  exact configuration is what broke; a smoke test on a deep temp path would have passed.
+  **The temp-directory depth is the test, not a detail of the harness.** In a PyInstaller bundle
+  `__file__` is `$TMPDIR/_MEIxxxxxx/aec_api/desktop.py`; under `/tmp` that has exactly four parents,
+  which is what raised `IndexError`. A smoke test run on a deep temp path would have passed against
+  the broken binary, so the harness forces the shallow one on POSIX rather than inheriting whatever
+  the runner happens to set.
+
+  What it asserts, in the order the failures arrive: the process bound a port at all (`/health`); the
+  SQLite engine opened under a fresh data directory (`/ready`); `/modules` serves **every** module the
+  tree declares; and `/` serves the bundled SPA. The last two are questions about the ARCHIVE, which
+  no source-level check can ask — `datas` either carried those directories in or it did not, and the
+  tree says nothing either way.
+
+  **The module count is DERIVED, not a floor.** `> 100` would pass a bundle that silently dropped
+  thirty catalogs, which is precisely what a `datas` glob does when it stops matching; the harness
+  counts `services/api/modules/*/module.json` in the checked-out tree and demands the served list
+  equal it. Vacuity guards for the same reason: a missing binary FAILS rather than skips, the port is
+  proven free before launch so a reply cannot have come from something already listening, and an
+  early child exit prints the child's own output — for a frozen-path defect that traceback is the
+  only evidence there is.
+
+  Two steps, because they ask different questions: the binary as `services/api/build_sidecar.py`
+  placed it (all three platforms, before the Tauri build so a dead sidecar fails in seconds rather
+  than after three platform bundles), and the copy **inside** the produced AppImage, which is whether
+  `externalBin` picked it up under the name it expects.
+
+  **Verified by running it, not by reading it — and the verification is not the PR's checks.**
+  `desktop.yml` never runs on a pull request; its triggers are `push: tags` and `workflow_dispatch`,
+  which is itself part of why nothing executed the artifact for so long. So the steps were exercised
+  by a `workflow_dispatch` run against the branch, and this entry was not written as CLOSED until
+  that run had executed them on all three platforms. Three mutations were killed beforehand against a
+  source-tree stand-in: a binary that dies during import the way the shipped one did, one that starts
+  but never binds, and one serving a truncated catalog.
+
+- **DESKTOP-SMOKE-CONVERT — the smoke never converts a model, so the freeze is unproven where it
+  matters most** *(S — Lane J; opened 2026-09-10 by DESKTOP-SMOKE)*
+
+  DESKTOP-SMOKE proves the packaged sidecar boots and serves. It never converts anything, so
+  `aec_data.fragments` — and the module-scope `flatbuffers` import inside its `codec.py` — is still
+  unexercised in a frozen build. That is the gap DESKTOP-FRAGMENTS closed its own entry naming: the
+  spec's `collect_submodules("aec_data")` was checked by running the same `pkgutil` walk, and
+  PyInstaller's analysis *should* follow a module-scope import, with "should" doing real work.
+
+  **The obvious smoke would pass vacuously**, which is why this is filed rather than bolted on.
+  `edit_preview` is the only synchronous route that reaches the converter, it needs a project with an
+  uploaded source IFC, and it FAILS OPEN with a 503 — so a fresh install answers 503 whether the
+  import survived the freeze or not, and a check that accepts that answer is measuring nothing.
+
+  The honest shapes are a real publish against the running sidecar (create a project, upload a small
+  IFC, publish, fetch `model.frag`, open it with the reference reader), or a diagnostic the frozen
+  binary can be asked to run directly. The first needs a tracked IFC fixture; the second is a change
+  to shipped code and should be justified as a user-facing diagnostic rather than as test scaffolding.
 
 - **DESKTOP-CONVERT-TIMEOUT — the Python converter cannot be interrupted** *(M — Lane J; opened
   2026-09-10 by review of #504)*
@@ -2461,7 +2511,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | — |
 | **I · API client** | `apps/web/src/api/` | RESPONSE-UNDECLARED *(the finding comes from `services/api/src/aec_api/routers/`, which is Lane G's, but the WORK is declaring the field on the client interface so something can read it — lanes go by the directory the work touches, the correction Lane E's cell already had to make. Rendering the newly-declared field afterwards is Lane B's)* · SCALE-SEAM *(the only open slice; ②–⓾ plus (81)–(91) have shipped. **Deliberately carries NO mark**: ⓾ is the last glyph in `MARKS` and the double-circled range it closes has no successor, so the next slice cannot be numbered at all — writing a mark the parser does not know would drop the item out of this table's own population.)* *(this cell said (81)–(87) until 2026-09-04, four slices after (88) landed — the same drift its own history below records, in the same cell, for the third time. It named ⓽ until 2026-09-03; ②–⓼ had shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
-| **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `apps/web/src/tooling/`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | R39-TSC-CACHE *(local typecheck once diverged from CI; cause unknown, prior explanation retracted — an OBSERVATION, not a defect with a known fix. Read the entry before "fixing" it: the proposed fix is named there and rejected)* · DESKTOP-SMOKE *(the artifact `.github/workflows/desktop.yml` publishes is never executed by any job; the work is a boot-and-curl step in that workflow. Filed here rather than Lane C because the FIX is a build step, even though the crash that prompted it was backend code — the derived-here-fixed-there split Lanes B and E already had to make)* · DESKTOP-CONVERT-TIMEOUT *(the Python converter runs in-process and cannot be interrupted, so `edit_preview`'s 120 s deadline is unenforceable on the desktop path. Filed here rather than Lane C because the fix is process/packaging shape — killable child under PyInstaller, where spawn re-execs the frozen app — the same derived-here-fixed-there split as DESKTOP-SMOKE above)* |
+| **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `apps/web/src/tooling/`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | R39-TSC-CACHE *(local typecheck once diverged from CI; cause unknown, prior explanation retracted — an OBSERVATION, not a defect with a known fix. Read the entry before "fixing" it: the proposed fix is named there and rejected)* · DESKTOP-SMOKE-CONVERT *(the boot smoke that closed DESKTOP-SMOKE never converts a model, so `flatbuffers` surviving PyInstaller is still unproven; the fix is a fixture plus a step in `.github/workflows/desktop.yml`, so it stays in this lane rather than moving to Lane C with the code it exercises)* · DESKTOP-CONVERT-TIMEOUT *(the Python converter runs in-process and cannot be interrupted, so `edit_preview`'s 120 s deadline is unenforceable on the desktop path. Filed here rather than Lane C because the fix is process/packaging shape — killable child under PyInstaller, where spawn re-execs the frozen app — the same derived-here-fixed-there split as DESKTOP-SMOKE above)* |
 
 **Parked — not available to pick up.** These are decisions or multi-release commitments, listed so
 nobody starts one thinking it is a sprint item: QUALITY-ROOM · R26-V-TIMING · R24-PERSONA-SHAPE ·

--- a/services/api/smoke_sidecar.py
+++ b/services/api/smoke_sidecar.py
@@ -90,6 +90,13 @@ def free_port() -> int:
 
 
 def port_is_free(port: int) -> bool:
+    """Re-check the port `free_port` picked, after it released the socket.
+
+    Two functions rather than one because they answer different questions at different moments:
+    `free_port` chooses, this confirms the choice still holds at launch. The gap between them is the
+    race, and it is narrow but real — which is why the confirmation is an assertion the reader can
+    see fail rather than an assumption folded into the picking.
+    """
     with contextlib.closing(socket.socket()) as s:
         try:
             s.bind(("127.0.0.1", port))
@@ -99,6 +106,13 @@ def port_is_free(port: int) -> bool:
 
 
 def get(url: str, timeout: float = 10.0) -> tuple[int, bytes, str]:
+    """GET `url`, returning (status, body, content-type) — and status **0** when nothing answered.
+
+    The 0 is load-bearing, not a shortcut. While the sidecar is still starting there is no listener,
+    so a connection error is the expected reading and the poll loop must be able to tell it apart
+    from a real reply; raising would make "not up yet" and "up and broken" the same event. An HTTP
+    error status is NOT collapsed into it — a 500 is an answer, and comes back as 500.
+    """
     try:
         with urllib.request.urlopen(url, timeout=timeout) as r:      # noqa: S310 — fixed 127.0.0.1
             return r.status, r.read(), r.headers.get("content-type", "")
@@ -192,18 +206,40 @@ def main() -> int:
             if st == 200:
                 with contextlib.suppress(Exception):
                     mods = json.loads(body)
-            served = len(mods) if isinstance(mods, list) else -1
-            # DERIVED, not a floor. The tree is checked out beside the binary in CI, so the question
-            # is answerable exactly: the bundle must serve every module the tree declares. A ">100"
-            # threshold would pass a bundle that silently dropped thirty catalogs, which is the shape
-            # of defect the `datas` list produces when a glob stops matching.
-            declared = len(list(CATALOG.glob("*/module.json"))) if CATALOG.is_dir() else 0
+            served = [m.get("key") for m in mods] if isinstance(mods, list) else []
+
+            # DERIVED, and by IDENTITY rather than by count. The tree is checked out beside the
+            # binary in CI, so the question is answerable exactly: which modules does the bundle
+            # serve, and are they the ones the tree declares? A `>100` floor passes a bundle that
+            # silently dropped thirty catalogs — the shape of defect a `datas` glob produces when it
+            # stops matching — and a count comparison still passes one that dropped a module and
+            # double-loaded another. Comparing sets names WHICH module went missing, which is the
+            # difference between a failure you can act on and a number that went down.
+            #
+            # The declared id is read from each `module.json`'s `key`, not from its directory name.
+            # They agree today, all 139 of them, and that is exactly why the field is the right one:
+            # `key` is what the route serves, and a check should compare the thing itself rather than
+            # a proxy that happens to match.
+            declared = set()
+            for mj in sorted(CATALOG.glob("*/module.json")) if CATALOG.is_dir() else []:
+                with contextlib.suppress(Exception):
+                    declared.add(json.loads(mj.read_text(encoding="utf-8")).get("key"))
             check("the module catalog in the tree is non-empty — otherwise the comparison below "
-                  "compares nothing", declared > 0, f"{declared} module.json under {CATALOG}")
-            check("GET /modules serves every module the tree declares — the bundled module.json "
-                  "datas landed, all of them",
-                  st == 200 and served == declared > 0,
-                  f"status {st}, served {served}, declared {declared}")
+                  "compares nothing", bool(declared), f"{len(declared)} module.json under {CATALOG}")
+
+            missing = sorted(k for k in declared if k not in served)
+            extra = sorted(k for k in set(served) - declared if k is not None)
+            # Duplicate-aware: two entries for one key is not "the right modules". A bundle carrying
+            # a stale copy of a catalog alongside the current one would serve the same key twice, and
+            # a set comparison alone would call that correct.
+            dupes = sorted({k for k in served if served.count(k) > 1})
+            check("GET /modules serves exactly the modules the tree declares, once each — the "
+                  "bundled module.json datas landed, all of them and nothing else",
+                  st == 200 and bool(declared) and not missing and not extra and not dupes,
+                  f"status {st}, served {len(served)} of {len(declared)} declared"
+                  + (f", MISSING {missing[:8]}" if missing else "")
+                  + (f", UNEXPECTED {extra[:8]}" if extra else "")
+                  + (f", DUPLICATED {dupes[:8]}" if dupes else ""))
 
             st, body, ct = get(f"http://127.0.0.1:{port}/")
             check("GET / serves the bundled SPA — the packaged web/ datas landed and are mounted",

--- a/services/api/smoke_sidecar.py
+++ b/services/api/smoke_sidecar.py
@@ -206,7 +206,21 @@ def main() -> int:
             if st == 200:
                 with contextlib.suppress(Exception):
                     mods = json.loads(body)
-            served = [m.get("key") for m in mods] if isinstance(mods, list) else []
+            # Every entry must BE a module before its key can be compared to anything. An earlier
+            # draft read `m.get("key")` and then dropped `None` out of the difference — which made a
+            # response of all 139 valid entries PLUS a bare `{}` pass: nothing missing, nothing
+            # extra, no duplicates. **A filter that decides what to LOOK at is the fail-open shape**,
+            # and it hid a malformed catalog behind a correct one. Malformed entries are now counted
+            # and named rather than skipped. (Found in review of this file, which is fitting: the
+            # assertion exists because a check that cannot see its subject reports success.)
+            served: list[str] = []
+            malformed = 0
+            for m in mods if isinstance(mods, list) else []:
+                k = m.get("key") if isinstance(m, dict) else None
+                if isinstance(k, str) and k:
+                    served.append(k)
+                else:
+                    malformed += 1
 
             # DERIVED, and by IDENTITY rather than by count. The tree is checked out beside the
             # binary in CI, so the question is answerable exactly: which modules does the bundle
@@ -220,23 +234,39 @@ def main() -> int:
             # They agree today, all 139 of them, and that is exactly why the field is the right one:
             # `key` is what the route serves, and a check should compare the thing itself rather than
             # a proxy that happens to match.
+            #
+            # The same shape rule applies to THIS side. A `module.json` with no `key` would otherwise
+            # put `None` into `declared`, which then reports as a missing module named `None` — and
+            # `sorted()` over a set mixing `None` with strings raises, so the harness would die
+            # rather than report. Both sides are validated, and the counts are compared, so a
+            # catalog file the tree cannot parse is a failure here rather than a silent shortfall.
+            catalogs = sorted(CATALOG.glob("*/module.json")) if CATALOG.is_dir() else []
             declared = set()
-            for mj in sorted(CATALOG.glob("*/module.json")) if CATALOG.is_dir() else []:
+            for mj in catalogs:
                 with contextlib.suppress(Exception):
-                    declared.add(json.loads(mj.read_text(encoding="utf-8")).get("key"))
+                    k = json.loads(mj.read_text(encoding="utf-8")).get("key")
+                    if isinstance(k, str) and k:
+                        declared.add(k)
             check("the module catalog in the tree is non-empty — otherwise the comparison below "
                   "compares nothing", bool(declared), f"{len(declared)} module.json under {CATALOG}")
+            check("every module.json in the tree declares a distinct non-empty `key` — otherwise "
+                  "the set below is smaller than the catalog and the shortfall is invisible",
+                  len(declared) == len(catalogs),
+                  f"{len(declared)} usable keys from {len(catalogs)} catalog file(s)")
 
             missing = sorted(k for k in declared if k not in served)
-            extra = sorted(k for k in set(served) - declared if k is not None)
+            extra = sorted(set(served) - declared)
             # Duplicate-aware: two entries for one key is not "the right modules". A bundle carrying
             # a stale copy of a catalog alongside the current one would serve the same key twice, and
             # a set comparison alone would call that correct.
             dupes = sorted({k for k in served if served.count(k) > 1})
             check("GET /modules serves exactly the modules the tree declares, once each — the "
                   "bundled module.json datas landed, all of them and nothing else",
-                  st == 200 and bool(declared) and not missing and not extra and not dupes,
+                  st == 200 and bool(declared) and not missing and not extra and not dupes
+                  and not malformed,
                   f"status {st}, served {len(served)} of {len(declared)} declared"
+                  + (f", {malformed} MALFORMED entr{'y' if malformed == 1 else 'ies'} "
+                     f"(not an object with a non-empty string `key`)" if malformed else "")
                   + (f", MISSING {missing[:8]}" if missing else "")
                   + (f", UNEXPECTED {extra[:8]}" if extra else "")
                   + (f", DUPLICATED {dupes[:8]}" if dupes else ""))

--- a/services/api/smoke_sidecar.py
+++ b/services/api/smoke_sidecar.py
@@ -1,0 +1,230 @@
+"""Run the PACKAGED sidecar binary and prove it serves — the step the release pipeline never had.
+
+`.github/workflows/desktop.yml` built the Tauri bundles, signed them and uploaded them, and no step
+ever executed the result. DESKTOP-FROZEN was a startup crash on one of the three platforms it
+publishes and **every check was green**, because every check read source. `repo_root()` counted
+`parents[4]`; in a PyInstaller bundle `__file__` is `$TMPDIR/_MEIxxxxxx/aec_api/desktop.py`, which
+under the default `TMPDIR=/tmp` has exactly four parents, so `aec-bim-server` raised `IndexError: 4`
+and died before binding a port. Windows and macOS temp paths are eight parents deep, which is why it
+was only ever seen on Linux, by users, after v0.3.1133 shipped.
+
+**So this deliberately runs under a SHALLOW temp directory.** A smoke test on a deep temp path would
+have passed against the broken binary — the depth IS the test, and `--shallow-tmp` (the default on
+POSIX) is not a detail of the harness but the thing being asserted.
+
+WHAT IT PROVES, and the boundary. The binary starts; `/health` answers, so the process bound a port
+rather than dying during import; `/ready` answers, so the SQLite engine opened under a fresh data
+directory; `/modules` returns a non-empty catalog, so the `datas` carrying `services/api/modules`
+landed inside the bundle; and `/` serves HTML, so the bundled SPA did too. Those last two are the
+ones source-level checks cannot make at all: they are questions about the ARCHIVE, not the tree.
+
+WHAT IT DOES NOT PROVE. It never converts a model, so `aec_data.fragments` — and the `flatbuffers`
+import inside `codec.py` — is not exercised: the only route that reaches it needs a project with an
+uploaded source IFC, and `edit_preview` FAILS OPEN with a 503, so a smoke asserting it would pass
+vacuously on a fresh install. That gap is filed as DESKTOP-SMOKE-CONVERT rather than papered over.
+
+VACUITY GUARDS, because "the artifact was missing" and "the artifact is fine" must never look alike:
+
+* a missing binary is a FAILURE, not a skip — the whole class this file exists for is a check that
+  cannot see its own subject;
+* the port is proven free before launch, so a response cannot have come from something else already
+  listening;
+* the child exiting before `/health` answers is a failure that prints what it said, since a frozen
+  app's traceback is the only evidence of a frozen-path defect.
+
+Run locally against a binary you built:
+    python services/api/smoke_sidecar.py apps/web/src-tauri/binaries/aec-bim-server-<triple>
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent                 # services/api
+REPO = HERE.parents[1]
+BINARIES = REPO / "apps" / "web" / "src-tauri" / "binaries"
+CATALOG = HERE / "modules"                             # the module.json catalog the bundle carries
+
+FAILED: list[str] = []
+
+
+def check(label: str, ok: bool, detail: str = "") -> bool:
+    print(("PASS  " if ok else "FAIL  ") + label + (f"   {detail}" if detail else ""))
+    if not ok:
+        FAILED.append(label)
+    return ok
+
+
+def find_binary(explicit: str | None) -> Path | None:
+    """The sidecar to run. An explicit path wins; otherwise the single one `build_sidecar.py` placed.
+
+    Returns None rather than guessing when the directory holds none or several — a smoke test that
+    picked the wrong file would report on something nobody shipped.
+    """
+    if explicit:
+        return Path(explicit)
+    if not BINARIES.is_dir():
+        return None
+    found = sorted(p for p in BINARIES.iterdir()
+                   if p.is_file() and p.name.startswith("aec-bim-server-"))
+    return found[0] if len(found) == 1 else None
+
+
+def free_port() -> int:
+    """A port nothing is listening on, proven by binding it. Released immediately, so this is a
+    narrow race — but the alternative is a hardcoded 8765 that a leftover process may already own,
+    which would let this file report on the WRONG server."""
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def port_is_free(port: int) -> bool:
+    with contextlib.closing(socket.socket()) as s:
+        try:
+            s.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+def get(url: str, timeout: float = 10.0) -> tuple[int, bytes, str]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:      # noqa: S310 — fixed 127.0.0.1
+            return r.status, r.read(), r.headers.get("content-type", "")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(), e.headers.get("content-type", "")
+    except Exception:                                                # noqa: BLE001 — not up yet
+        return 0, b"", ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("binary", nargs="?", help="path to aec-bim-server-<triple>")
+    ap.add_argument("--timeout", type=float, default=180.0,
+                    help="seconds to wait for /health (onefile extraction + the API import are slow)")
+    ap.add_argument("--deep-tmp", action="store_true",
+                    help="use the default temp directory instead of a shallow one. This is the "
+                         "configuration under which the DESKTOP-FROZEN crash did NOT reproduce, so "
+                         "it exists to demonstrate that the shallow default is load-bearing")
+    args = ap.parse_args()
+
+    binary = find_binary(args.binary)
+    # THE VACUITY GUARD. Everything below is a statement about a binary; without one there is no
+    # population, and a pass would mean "did not look".
+    if not check("a sidecar binary was found to run", bool(binary) and binary.is_file(),
+                 str(binary) if binary else f"no single aec-bim-server-* in {BINARIES}"):
+        print("\nFAILED:", ", ".join(FAILED))
+        return 1
+    print(f"  binary: {binary}  ({binary.stat().st_size // (1024 * 1024)} MB)")
+
+    port = free_port()
+    check("the chosen port is free before launch — otherwise a reply could come from another server",
+          port_is_free(port), f"127.0.0.1:{port}")
+
+    env = dict(os.environ)
+    data_dir = tempfile.mkdtemp(prefix="aec-smoke-data-")
+    env["AEC_DATA_DIR"] = data_dir
+    env["AEC_HOST"] = "127.0.0.1"
+    env["AEC_PORT"] = str(port)
+    env["AEC_OPEN_BROWSER"] = "0"
+
+    # The point of the exercise on POSIX. `/tmp` gives `_MEIxxxxxx/aec_api/desktop.py` exactly four
+    # parents, which is what raised IndexError in the shipped v0.3.1133 AppImage. Windows has no
+    # TMPDIR and its temp paths are deep anyway, so there is nothing to force there.
+    shallow = os.name != "nt" and not args.deep_tmp
+    if shallow:
+        env["TMPDIR"] = "/tmp"
+    print(f"  temp: {'SHALLOW /tmp (the configuration DESKTOP-FROZEN died under)' if shallow else 'default'}"
+          f"   data: {data_dir}")
+
+    log = Path(tempfile.mkstemp(prefix="aec-smoke-log-", suffix=".txt")[1])
+    with log.open("wb") as sink:
+        proc = subprocess.Popen([str(binary)], env=env, stdout=sink, stderr=subprocess.STDOUT,
+                                cwd=str(REPO))
+
+        def output() -> str:
+            return log.read_text(encoding="utf-8", errors="replace").strip() or "(no output)"
+
+        try:
+            started = time.time()
+            deadline = started + args.timeout
+            status = 0
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    check(f"the sidecar stayed up long enough to answer /health "
+                          f"(it exited with {proc.returncode})", False,
+                          "a frozen-path defect kills the process during import, before any port is "
+                          "bound — the child's own traceback below is the only evidence there is")
+                    print("\n---- sidecar output ----\n" + output() + "\n------------------------")
+                    print("\nFAILED:", ", ".join(FAILED))
+                    return 1
+                status, _body, _ct = get(f"http://127.0.0.1:{port}/health", timeout=2.0)
+                if status == 200:
+                    break
+                time.sleep(1.0)
+
+            if not check("GET /health answers 200 — the packaged binary booted and bound a port",
+                         status == 200,
+                         f"last status {status} after {time.time() - started:.1f}s (bound {args.timeout:g}s)"):
+                print("\n---- sidecar output ----\n" + output() + "\n------------------------")
+                print("\nFAILED:", ", ".join(FAILED))
+                return 1
+
+            st, body, _ct = get(f"http://127.0.0.1:{port}/ready")
+            check("GET /ready answers 200 — the SQLite engine opened under a fresh data directory",
+                  st == 200, f"status {st}: {body[:200]!r}")
+
+            # `datas` questions, which no source-level check can ask: these directories are inside
+            # the archive or they are not, and the tree says nothing either way.
+            st, body, _ct = get(f"http://127.0.0.1:{port}/modules")
+            mods = []
+            if st == 200:
+                with contextlib.suppress(Exception):
+                    mods = json.loads(body)
+            served = len(mods) if isinstance(mods, list) else -1
+            # DERIVED, not a floor. The tree is checked out beside the binary in CI, so the question
+            # is answerable exactly: the bundle must serve every module the tree declares. A ">100"
+            # threshold would pass a bundle that silently dropped thirty catalogs, which is the shape
+            # of defect the `datas` list produces when a glob stops matching.
+            declared = len(list(CATALOG.glob("*/module.json"))) if CATALOG.is_dir() else 0
+            check("the module catalog in the tree is non-empty — otherwise the comparison below "
+                  "compares nothing", declared > 0, f"{declared} module.json under {CATALOG}")
+            check("GET /modules serves every module the tree declares — the bundled module.json "
+                  "datas landed, all of them",
+                  st == 200 and served == declared > 0,
+                  f"status {st}, served {served}, declared {declared}")
+
+            st, body, ct = get(f"http://127.0.0.1:{port}/")
+            check("GET / serves the bundled SPA — the packaged web/ datas landed and are mounted",
+                  st == 200 and "html" in ct.lower() and b"<" in body[:512],
+                  f"status {st}, content-type {ct!r}")
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=20)
+
+    if FAILED:
+        print("\n---- sidecar output ----\n"
+              + log.read_text(encoding="utf-8", errors="replace").strip() + "\n------------------------")
+        print("\nFAILED:", ", ".join(FAILED))
+        return 1
+    print("\nsmoke_sidecar OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# What & why

`.github/workflows/desktop.yml` built the Tauri bundles, signed them and published them, and no step ever launched the result. DESKTOP-FROZEN (roadmap, Lane J) was a crash-on-startup in the frozen binary while every check in this repository was green — because every check reads *source*: `repo_root()` counted `parents[4]`, which holds in a checkout and not in a PyInstaller bundle, so the shipped v0.3.1133 AppImage raised `IndexError: 4` and died before binding a port. This adds the step that would have caught it, in the job that produced it.

`services/api/smoke_sidecar.py` launches the built sidecar and asserts on the artifact:

- **under a deliberately SHALLOW temp directory** on POSIX — `/tmp` gives `_MEIxxxxxx/aec_api/desktop.py` exactly four parents, which is the configuration the crash needed. A smoke test on a deep temp path would have passed against the broken binary, so the depth *is* the test rather than a detail of the harness;
- `/health` — the process bound a port instead of dying during import;
- `/ready` — the SQLite engine opened under a fresh data directory;
- `/modules` serving **exactly the modules the tree declares, once each** — compared by identity, not by count, and not against a floor;
- `/` serving HTML — the bundled SPA landed.

The last two are questions about the *archive*, which no source-level check can ask at all.

Vacuity guards, because "the artifact was missing" and "the artifact is fine" must never look alike: a missing binary **fails** rather than skips; the port is proven free before launch, so a reply cannot have come from something already listening; and an early child exit prints the child's own output, which for a frozen-path defect is the only evidence there is.

Two steps in `desktop.yml` — the binary as `build_sidecar.py` placed it (all three platforms, before the Tauri build so a dead sidecar fails in seconds rather than after three platform bundles), and the copy **inside** the produced AppImage, which is the separate question of whether `externalBin` picked it up under the name it expects.

**What this does NOT cover, stated rather than left to be assumed.** No model is converted, so `aec_data.fragments` and the `flatbuffers` import in `codec.py` remain unexercised in a frozen build — the gap PR #504 closed its roadmap entry naming. The only route that reaches them needs a project with an uploaded source IFC, and `edit_preview` fails open with a 503, so a smoke asserting it would pass vacuously on a fresh install. Filed as DESKTOP-SMOKE-CONVERT, with a Lane J row.

Roadmap: DESKTOP-SMOKE closed; DESKTOP-SMOKE-CONVERT opened.

## Review rounds

Four findings from CodeRabbit, **all real, all fixed**, all settled with its explicit agreement. Two are worth naming because they are the same defect class this PR exists to fix, found one and two levels in:

1. **The `/modules` check compared counts** (`99a66057`). 139 served and 139 declared passed a bundle that had lost one catalog and double-loaded another. Now compared by identity, reading each `module.json`'s **`key`** — the field the route actually serves — rather than the directory name that happens to match it.
2. **That fix introduced a fail-open** (`023f03d2`). `extra = sorted(k for k in set(served) - declared if k is not None)` meant 139 valid entries **plus a bare `{}`** had nothing missing, nothing extra, no duplicates — and passed. Entries are now validated before comparison and malformed ones are counted and named. **A filter that decides what to LOOK at is more dangerous than one that decides what to report**, because everything it excludes is invisible to its own output; that is recorded beside the code.
3. The **mirror of (2) on the tree side**, which review could not see because it isn't in the diff: a `module.json` with no `key` put `None` into `declared`, and `sorted()` over a set mixing `None` with strings *raises* — the harness would have died rather than reported. Both populations are validated now, and the declared-key count is asserted against the number of catalog files.
4. Two changelog claims were **broader than the measurement** — the same defect as the pipeline's, committed in this change's own prose. Corrected to name which platforms get which check, and to say the frozen-build conversion gap is genuinely unknown rather than "checked by other means".

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree) — "All checks passed!"
- [x] Backend: no `test_*.py` behaviour changed. `smoke_sidecar.py` is deliberately **not** registered in `run_tests.py`, because it asserts on a built binary the API test job does not produce; it is invoked by `desktop.yml`, which is where the binary exists
- [x] Web: `roadmapLanes` / `roadmapSelfConsistent` / `roadmapStale` pass (33 tests) — the roadmap edit is TypeScript-visible even though no `.ts` changed, which is the trap #504 hit
- [x] No import cycles introduced — `smoke_sidecar.py` imports stdlib only
- [x] `CHANGELOG.md` entry added; DESKTOP-SMOKE closed and DESKTOP-SMOKE-CONVERT filed in `docs/roadmap.md`
- [x] Version bump — n/a, not a release PR
- [x] No secrets, no competitor names

**On the one failing pre-merge check (Docstring Coverage, 57%).** Left as is, deliberately. There is no repository-side docstring gate — that 80% threshold is CodeRabbit's own — and the three functions still bare are a `check` reporting helper identical in shape to the one in every other gate in this tree, a `main` that already passes `description=__doc__` so a docstring would restate the module docstring, and a nested one-liner. Docstrings *were* added where they carry information a reader cannot get from the code: `get` returning status `0` rather than raising is load-bearing (it is how the poll loop separates "not up yet" from "up and broken"), and `port_is_free` is unexplained without its relationship to `free_port`. Writing three more to move a percentage is padding, and padding a coverage number is the same move as a check that reports success without looking.

## Verification

**`desktop.yml` never runs on a pull request** — its triggers are `push: tags` and `workflow_dispatch`, which is itself part of why nothing executed the artifact for so long. So the PR's own checks cannot exercise these steps. Verification is [`workflow_dispatch` run 34538156342](https://github.com/ibuilder/massing/actions/runs/34538156342) against this branch **at head `023f03d2`**:

| step | ubuntu-22.04 | macos-latest (arm64) | windows-latest |
|---|---|---|---|
| Smoke-test the packaged sidecar | ✅ 23s | ✅ 14s | ✅ 64s |
| Smoke-test the sidecar inside the AppImage | ✅ 19s | skipped (Linux only) | skipped (Linux only) |

This is the **third** full three-platform dispatch. The earlier two verified `892bdc65` and `99a66057`; the harness changed materially in each round, and a green run against superseded code is not evidence about the code under review.

The AppImage step is the one whose path into `squashfs-root` was a guess rather than a measurement. It passing means the `find` located the sidecar — and, since the harness fails on a missing binary rather than skipping, that it actually ran it.

**Six mutations, all killed** (against a stand-in serving the real 139-key catalog plus one crafted entry, and against the real app):

| mutation | result |
|---|---|
| binary dies during import the way the shipped one did (`IndexError: 4`) | FAIL, and prints the child's traceback |
| binary starts but never binds a port | FAIL on the `/health` deadline |
| truncated catalog (3 of 139) | FAIL — `served 3 of 139, MISSING [...]` |
| **same count, one module swapped for a decoy** | FAIL — `139 of 139, MISSING ['action_item'], UNEXPECTED ['decoy_register']` |
| **139 valid entries plus a bare `{}`** | FAIL — `1 MALFORMED entry` (the old logic returned `missing=[] extra=[] dupes=[]` and passed) |
| a bare string / `{"key": ""}` / `{"key": 7}` | FAIL — `1 MALFORMED entry` |

Plus the vacuity guard: a non-existent binary path fails rather than passing quietly. And the roadmap lane row was checked the same way — renaming the `DESKTOP-SMOKE-CONVERT` cell reds `roadmapLanes.test.ts` naming that code, so the new item is genuinely in its population rather than outside its regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA