### PR TITLE
DESKTOP-SMOKE-CONVERT: convert a model inside the artifact, and check which converter did it

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -145,12 +145,22 @@ jobs:
       # bundle, so the shipped v0.3.1133 AppImage raised IndexError before binding a port. This
       # builds nothing and asserts on the artifact: it starts the sidecar under a deliberately
       # SHALLOW temp directory (the configuration that crash needed — a deep one passes against the
-      # broken binary), then requires /health, /ready, the full module catalog and the bundled SPA.
+      # broken binary), then requires /health, /ready, the full module catalog and the bundled SPA —
+      # and then AUTHORS AND PUBLISHES A MODEL, so the converter runs inside the bundle too. That
+      # last part is DESKTOP-SMOKE-CONVERT: `aec_data.fragments` is imported lazily and `codec.py`
+      # imports `flatbuffers` at module scope, so nothing on the boot path touches either, and a
+      # build that dropped them boots perfectly and fails the first time a user publishes.
       # Placed before the Tauri build so a dead sidecar fails in seconds rather than after three
-      # platform bundles. See services/api/smoke_sidecar.py for what it does NOT cover.
+      # platform bundles.
       - name: Smoke-test the packaged sidecar
         shell: bash
-        run: python services/api/smoke_sidecar.py
+        # `--expect-converter python` is not a preference, it is the assertion. A bundle carries no
+        # Node runtime — `apppaths.repo_root()` returns None when frozen without even walking — so
+        # the Python converter is the one that must run, and it is the path that needs `flatbuffers`
+        # to have survived PyInstaller's analysis. Accepting either converter would let this pass on
+        # a runner where Node is installed (which is every runner here, two steps up) without ever
+        # exercising the code under test.
+        run: python services/api/smoke_sidecar.py --expect-converter python
 
       # Windows Authenticode: if a code-signing cert is configured, import the PFX and point
       # tauri.conf at its thumbprint so `tauri build` signs the .exe/.msi. No secret → unsigned.
@@ -255,7 +265,7 @@ jobs:
           root="$(dirname "$img")/squashfs-root"
           side=$(find "$root" -type f -name 'aec-bim-server*' -print -quit || true)
           echo "sidecar inside the bundle: ${side:-<none found>}"
-          python services/api/smoke_sidecar.py "$side"
+          python services/api/smoke_sidecar.py "$side" --expect-converter python
 
       # manual runs don't make a release; keep the installers as downloadable artifacts
       - name: Upload bundles as artifacts (manual runs)

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -249,9 +249,14 @@ jobs:
       # have picked it up, under the name it expects, with its executable bit intact. The AppImage is
       # the one bundle we can unpack on its own runner without installing anything.
       #
-      # `find` rather than a hardcoded path on purpose — and `smoke_sidecar.py` FAILS on a missing
-      # binary rather than skipping, so a wrong guess here reds the build instead of quietly
-      # asserting nothing, which is the failure this whole item exists to end.
+      # `find` rather than a hardcoded path on purpose — and BOTH `find`s are checked for an empty
+      # result. An earlier version of this step checked only the AppImage one and passed `$side`
+      # straight through; `find` answers "nothing" with an empty string, which `smoke_sidecar.py`
+      # then read as "no path was given" and resolved by scanning the build-output directory — one
+      # binary, already smoke-tested two steps up. This step would have re-tested the wrong artifact
+      # and gone green forever, which is exactly the failure this whole item exists to end. The
+      # harness now refuses a blank path outright; this guard says so here as well, because a step
+      # that computes nothing should fail where the nothing was computed.
       - name: Smoke-test the sidecar inside the AppImage
         if: matrix.platform == 'ubuntu-22.04'
         shell: bash
@@ -265,6 +270,10 @@ jobs:
           root="$(dirname "$img")/squashfs-root"
           side=$(find "$root" -type f -name 'aec-bim-server*' -print -quit || true)
           echo "sidecar inside the bundle: ${side:-<none found>}"
+          if [ -z "$side" ]; then
+            echo "::error::no aec-bim-server sidecar inside the AppImage — the bundle ships without a backend"
+            exit 1
+          fi
           python services/api/smoke_sidecar.py "$side" --expect-converter python
 
       # manual runs don't make a release; keep the installers as downloadable artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,22 @@ silently lost thirty of them would clear a round number, and one that lost a reg
 double-loading another would clear a count. And it was itself tested against three deliberately
 broken builds before being trusted, including a reproduction of the crash that shipped.
 
-One thing it still does not do is convert a model. The converter itself is tested, but not from
-inside a finished build — so whether model conversion survives packaging is genuinely unknown rather
-than checked another way, and it is written down as an open item instead of being counted as done.
+It also builds a model and opens it, which is the part that matters most and the part a startup
+check cannot reach. The machinery that turns a building model into something the 3D view can draw is
+only loaded at the moment someone publishes — so an installer that lost it along the way starts
+perfectly, passes every other check, and disappoints the first person who tries to use it. That is
+exactly what happened once already. Each build now creates a small model inside the packaged app,
+publishes it, and requires the finished geometry back before the release may continue.
+
+It insists on the right machinery, too. The desktop app has no copy of the tooling the server
+version uses, so it has to fall back to its own — and every machine that assembles these builds
+happens to have the server tooling installed. A check that accepted either would pass without ever
+testing what a user actually runs, so this one names which is required and fails if the other
+answers.
+
+Proven both ways before being trusted: a deliberately broken build fails in one second and says
+exactly what is missing, and a correctly built one passes and produces real geometry — because a
+test that only ever fails could be failing for the wrong reason.
 
 ### The desktop app can show you the model it just built
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1175,24 +1175,43 @@ instances:
   source-tree stand-in: a binary that dies during import the way the shipped one did, one that starts
   but never binds, and one serving a truncated catalog.
 
-- **DESKTOP-SMOKE-CONVERT — the smoke never converts a model, so the freeze is unproven where it
-  matters most** *(S — Lane J; opened 2026-09-10 by DESKTOP-SMOKE)*
+- ✅ **DESKTOP-SMOKE-CONVERT — the smoke never converted a model, so the freeze was unproven where it
+  matters most** *(S — Lane J; opened 2026-09-10 by DESKTOP-SMOKE, **CLOSED** the same day in
+  `services/api/smoke_sidecar.py`)*
 
-  DESKTOP-SMOKE proves the packaged sidecar boots and serves. It never converts anything, so
-  `aec_data.fragments` — and the module-scope `flatbuffers` import inside its `codec.py` — is still
-  unexercised in a frozen build. That is the gap DESKTOP-FRAGMENTS closed its own entry naming: the
-  spec's `collect_submodules("aec_data")` was checked by running the same `pkgutil` walk, and
-  PyInstaller's analysis *should* follow a module-scope import, with "should" doing real work.
+  DESKTOP-SMOKE proved the packaged sidecar boots and serves. It converted nothing, so
+  `aec_data.fragments` — and the module-scope `flatbuffers` import inside its `codec.py` — was still
+  unexercised in a frozen build. **A build that packaged neither boots perfectly**: the import is
+  lazy, inside `fragconvert.convert_ifc`, so nothing on the boot path touches it and the user finds
+  out the first time they publish, with the 3D view staying empty — the DESKTOP-FRAGMENTS symptom
+  exactly.
 
-  **The obvious smoke would pass vacuously**, which is why this is filed rather than bolted on.
-  `edit_preview` is the only synchronous route that reaches the converter, it needs a project with an
-  uploaded source IFC, and it FAILS OPEN with a 503 — so a fresh install answers 503 whether the
-  import survived the freeze or not, and a check that accepts that answer is measuring nothing.
+  **The obvious smoke would have passed vacuously**, which is why the entry warned against it.
+  `edit_preview` is the only synchronous route reaching the converter and it FAILS OPEN with a 503, so
+  a fresh install answers 503 whether the import survived or not. Publish is the path that *reports*
+  instead of swallowing: `convert_ifc` raising is caught in `authoring._publish`, recorded as
+  `reconvert_error`, and turned into publish state `error` carrying the exception.
 
-  The honest shapes are a real publish against the running sidecar (create a project, upload a small
-  IFC, publish, fetch `model.frag`, open it with the reference reader), or a diagnostic the frozen
-  binary can be asked to run directly. The first needs a tracked IFC fixture; the second is a change
-  to shipped code and should be justified as a user-facing diagnostic rather than as test scaffolding.
+  **No IFC fixture is tracked, and that is better than the shape this entry proposed.**
+  `POST /projects/{pid}/model/blank` generates one server-side through `aec_data.massing`, so the
+  model is authored BY the artifact rather than handed to it — more of the bundle exercised, and
+  nothing that can drift from a checked-in file.
+
+  **It asserts WHICH converter ran, and that is the load-bearing part.** Publish reports `node` or
+  `python`; a bundle carries no Node runtime, so it must report `python`. Accepting either would let
+  the check pass on any runner with Node installed — which is every runner this workflow uses — while
+  never touching the code under test. `--expect-converter` is declared by the caller rather than
+  inferred from the environment, because a check that guesses what it should require can guess wrong
+  and still look green. The bundle taking the Python path is structural rather than lucky:
+  `apppaths.repo_root()` returns `None` when frozen *without even walking*, so `have_converter()` is
+  False no matter what is installed on the host.
+
+  Proven in both directions rather than asserted. A **genuinely broken build** — `flatbuffers`
+  blocked at import and `have_converter` forced False, which is what a bad bundle on a desktop is —
+  fails in 1.0s with `reconvert_error: "No module named 'flatbuffers'"` in the failure line. The
+  **positive control** matters as much: the same setup with `flatbuffers` present passes, reporting
+  `converter: python` and a 694-byte fragment that decompresses to 1,424 bytes with a valid
+  flatbuffer root — without it, the first mutation could have been failing for an unrelated reason.
 
 - **DESKTOP-CONVERT-TIMEOUT — the Python converter cannot be interrupted** *(M — Lane J; opened
   2026-09-10 by review of #504)*
@@ -2515,7 +2534,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | — |
 | **I · API client** | `apps/web/src/api/` | RESPONSE-UNDECLARED *(the finding comes from `services/api/src/aec_api/routers/`, which is Lane G's, but the WORK is declaring the field on the client interface so something can read it — lanes go by the directory the work touches, the correction Lane E's cell already had to make. Rendering the newly-declared field afterwards is Lane B's)* · SCALE-SEAM *(the only open slice; ②–⓾ plus (81)–(91) have shipped. **Deliberately carries NO mark**: ⓾ is the last glyph in `MARKS` and the double-circled range it closes has no successor, so the next slice cannot be numbered at all — writing a mark the parser does not know would drop the item out of this table's own population.)* *(this cell said (81)–(87) until 2026-09-04, four slices after (88) landed — the same drift its own history below records, in the same cell, for the third time. It named ⓽ until 2026-09-03; ②–⓼ had shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
-| **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `apps/web/src/tooling/`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | R39-TSC-CACHE *(local typecheck once diverged from CI; cause unknown, prior explanation retracted — an OBSERVATION, not a defect with a known fix. Read the entry before "fixing" it: the proposed fix is named there and rejected)* · DESKTOP-SMOKE-CONVERT *(the boot smoke that closed DESKTOP-SMOKE never converts a model, so `flatbuffers` surviving PyInstaller is still unproven; the fix is a fixture plus a step in `.github/workflows/desktop.yml`, so it stays in this lane rather than moving to Lane C with the code it exercises)* · DESKTOP-CONVERT-TIMEOUT *(the Python converter runs in-process and cannot be interrupted, so `edit_preview`'s 120 s deadline is unenforceable on the desktop path. Filed here rather than Lane C because the fix is process/packaging shape — killable child under PyInstaller, where spawn re-execs the frozen app — the same derived-here-fixed-there split as DESKTOP-SMOKE above)* |
+| **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `apps/web/src/tooling/`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | R39-TSC-CACHE *(local typecheck once diverged from CI; cause unknown, prior explanation retracted — an OBSERVATION, not a defect with a known fix. Read the entry before "fixing" it: the proposed fix is named there and rejected)*  · DESKTOP-CONVERT-TIMEOUT *(the Python converter runs in-process and cannot be interrupted, so `edit_preview`'s 120 s deadline is unenforceable on the desktop path. Filed here rather than Lane C because the fix is process/packaging shape — killable child under PyInstaller, where spawn re-execs the frozen app — the same derived-here-fixed-there split as DESKTOP-SMOKE above)* |
 
 **Parked — not available to pick up.** These are decisions or multi-release commitments, listed so
 nobody starts one thinking it is a sprint item: QUALITY-ROOM · R26-V-TIMING · R24-PERSONA-SHAPE ·

--- a/services/api/smoke_sidecar.py
+++ b/services/api/smoke_sidecar.py
@@ -18,10 +18,19 @@ directory; `/modules` returns a non-empty catalog, so the `datas` carrying `serv
 landed inside the bundle; and `/` serves HTML, so the bundled SPA did too. Those last two are the
 ones source-level checks cannot make at all: they are questions about the ARCHIVE, not the tree.
 
-WHAT IT DOES NOT PROVE. It never converts a model, so `aec_data.fragments` — and the `flatbuffers`
-import inside `codec.py` — is not exercised: the only route that reaches it needs a project with an
-uploaded source IFC, and `edit_preview` FAILS OPEN with a 503, so a smoke asserting it would pass
-vacuously on a fresh install. That gap is filed as DESKTOP-SMOKE-CONVERT rather than papered over.
+AND IT CONVERTS A MODEL, which is the half none of that reaches. `aec_data.fragments` is imported
+lazily inside `fragconvert.convert_ifc`, and `codec.py` imports `flatbuffers` at module scope — so a
+build that packaged neither BOOTS PERFECTLY and fails the first time a user publishes. The check
+authors a blank model through `POST /projects/{pid}/model/blank` (generated server-side by
+`aec_data.massing`, so no IFC fixture has to be tracked), publishes it, and requires the published
+fragment back. It also asserts WHICH converter ran: a bundle carries no Node runtime, so it must be
+the Python one, and accepting either would let this pass on any runner with Node installed without
+touching the code under test.
+
+The obvious version of that check would have been worthless: `edit_preview` FAILS OPEN with a 503, so
+a fresh install answers 503 whether the frozen import works or not. Publish is the path that reports
+the failure instead of swallowing it — `convert_ifc` raising is recorded as `reconvert_error` and
+turns the publish state to `error`, carrying the exception.
 
 VACUITY GUARDS, because "the artifact was missing" and "the artifact is fine" must never look alike:
 
@@ -48,6 +57,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+import zlib
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent                 # services/api
@@ -122,11 +132,131 @@ def get(url: str, timeout: float = 10.0) -> tuple[int, bytes, str]:
         return 0, b"", ""
 
 
+def post(url: str, payload: dict, timeout: float = 300.0) -> tuple[int, bytes]:
+    """POST `payload` as JSON, returning (status, body) — and status **0** when nothing answered.
+
+    Same 0 convention as `get`, for the same reason: the caller has to tell a dead server apart from
+    one that answered badly. The timeout is generous because the call this drives runs a whole
+    IFC->Fragments conversion on the server before it returns a status.
+    """
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(), method="POST",
+                                 headers={"content-type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:                  # noqa: S310
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+    except Exception:                                                # noqa: BLE001 — not up / refused
+        return 0, b""
+
+
+def convert_a_model(port: int, expect: str, timeout: float) -> None:
+    """Author a model and publish it, so the CONVERTER runs inside the artifact under test.
+
+    This is the half `/health` and `/modules` cannot reach. `aec_data.fragments` is imported lazily,
+    inside `fragconvert.convert_ifc`, so nothing on the boot path touches it — and `codec.py` imports
+    `flatbuffers` at module scope, which PyInstaller's analysis *should* follow. "Should" was doing
+    real work in that sentence until this existed.
+
+    **No IFC fixture is tracked, deliberately.** `POST /projects/{pid}/model/blank` generates one
+    server-side through `aec_data.massing`, so the model is authored by the artifact rather than
+    handed to it — which exercises more of the bundle and cannot drift from a checked-in file.
+
+    **Why this is not vacuous.** A converter that raises is caught in `authoring._publish`, recorded
+    as `reconvert_error`, and `run_publish` turns that into publish state `error` — so a missing
+    `flatbuffers` surfaces here as a named failure rather than a quiet skip. The obvious alternative
+    check would have been vacuous: `edit_preview` FAILS OPEN with a 503, so a fresh install answers
+    503 whether the frozen import works or not.
+
+    **And it asserts WHICH converter ran.** Publish reports `node` or `python`. The bundle carries no
+    Node runtime, so it must report `python` — the path that needs `flatbuffers`. Accepting either
+    would let this pass for the wrong reason on a machine where Node happens to be reachable, which
+    is every CI runner this workflow uses. `expect` is declared by the caller rather than guessed
+    from the environment, because a check that infers what it should require can infer wrongly and
+    still look green.
+    """
+    base = f"http://127.0.0.1:{port}"
+
+    st, body = post(f"{base}/projects", {"name": "smoke-convert"})
+    pid = ""
+    if st in (200, 201):
+        with contextlib.suppress(Exception):
+            pid = str(json.loads(body).get("id") or "")
+    if not check("POST /projects creates a project — the model has to hang off something",
+                 bool(pid), f"status {st}: {body[:200]!r}"):
+        return
+
+    st, body = post(f"{base}/projects/{pid}/model/blank", {"name": "Smoke", "storeys": 1})
+    if not check("POST /projects/{id}/model/blank authors an IFC inside the artifact — "
+                 "`aec_data.massing` runs in the bundle, so no fixture has to be shipped",
+                 st == 200, f"status {st}: {body[:300]!r}"):
+        return
+
+    # Publish is off-thread; the client polls. `error` is the state a failed convert produces, and it
+    # carries the exception — which for a missing frozen import is the whole diagnosis.
+    started = time.time()
+    deadline = started + timeout
+    state, detail = "", {}
+    while time.time() < deadline:
+        st, body, _ct = get(f"{base}/projects/{pid}/publish/status")
+        if st == 200:
+            with contextlib.suppress(Exception):
+                s = json.loads(body)
+                state, detail = str(s.get("state") or ""), s.get("detail") or {}
+        if state not in ("", "idle", "running"):
+            break
+        time.sleep(1.0)
+
+    if not check("the publish finished, and the CONVERSION inside it did not fail — a frozen build "
+                 "missing `flatbuffers` raises here and is recorded as `reconvert_error`",
+                 state == "done",
+                 f"publish state {state!r} after {time.time() - started:.1f}s (bound {timeout:g}s); "
+                 f"detail {json.dumps(detail)[:400]}"):
+        return
+
+    ran = str(detail.get("converter") or "")
+    check(f"the {expect!r} converter is the one that ran — otherwise this passed without "
+          f"exercising the path it exists to test",
+          ran == expect, f"publish reports converter {ran!r}, expected {expect!r}")
+
+    st, frag, _ct = get(f"{base}/projects/{pid}/model.frag", timeout=60.0)
+    if not check("GET /model.frag serves the converted geometry the viewer would draw",
+                 st == 200 and len(frag) > 0, f"status {st}, {len(frag)} bytes"):
+        return
+
+    # `.frag` is zlib(flatbuffers). Decompressing proves real content rather than a stub, and the
+    # flatbuffer root offset has to land inside the buffer — a cheap structural check that a
+    # truncated or empty write fails. Not a size floor: a floor is a number, this is a property.
+    raw, why = b"", ""
+    try:
+        raw = zlib.decompress(frag)
+    except Exception as e:                                           # noqa: BLE001 — reported below
+        why = f"{type(e).__name__}: {e}"
+    root = int.from_bytes(raw[:4], "little") if len(raw) >= 4 else -1
+    check("the served bytes are a real fragment — zlib-compressed flatbuffers whose root offset "
+          "lands inside the buffer",
+          bool(raw) and 4 <= root < len(raw),
+          f"{len(frag)} compressed -> {len(raw)} bytes, root offset {root}"
+          + (f"; zlib {why}" if why else ""))
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("binary", nargs="?", help="path to aec-bim-server-<triple>")
     ap.add_argument("--timeout", type=float, default=180.0,
                     help="seconds to wait for /health (onefile extraction + the API import are slow)")
+    ap.add_argument("--expect-converter", default="python", choices=("node", "python"),
+                    help="which converter the publish must report having used. Defaults to `python` "
+                         "because that is what the packaged bundle has to use — it carries no Node "
+                         "runtime — and it is the path that needs `flatbuffers` to survive freezing. "
+                         "Pass `node` when running against a source checkout, where Node is present "
+                         "and IS the right answer. Declared rather than inferred: a check that "
+                         "guesses what it should require can guess wrong and still look green.")
+    ap.add_argument("--convert-timeout", type=float, default=300.0,
+                    help="seconds to wait for the publish to leave `running`")
+    ap.add_argument("--skip-convert", action="store_true",
+                    help="boot checks only. For diagnosing a sidecar that will not start — NOT for "
+                         "getting a red build green, which is how the gap this closes stayed open")
     ap.add_argument("--deep-tmp", action="store_true",
                     help="use the default temp directory instead of a shallow one. This is the "
                          "configuration under which the DESKTOP-FROZEN crash did NOT reproduce, so "
@@ -275,6 +405,13 @@ def main() -> int:
             check("GET / serves the bundled SPA — the packaged web/ datas landed and are mounted",
                   st == 200 and "html" in ct.lower() and b"<" in body[:512],
                   f"status {st}, content-type {ct!r}")
+
+            # The half the boot checks cannot reach: run the converter inside the artifact.
+            if args.skip_convert:
+                print("  SKIPPED the conversion checks (--skip-convert) — this run does NOT show "
+                      "that model conversion survives packaging")
+            else:
+                convert_a_model(port, args.expect_converter, args.convert_timeout)
         finally:
             proc.terminate()
             try:

--- a/services/api/smoke_sidecar.py
+++ b/services/api/smoke_sidecar.py
@@ -102,6 +102,45 @@ def find_binary(explicit: str | None) -> Path | None:
     return found[0] if len(found) == 1 else None
 
 
+def flatbuffer_root_table(raw: bytes) -> tuple[str, tuple[int, int, int, int] | None]:
+    """Walk a FlatBuffers buffer as far as its root TABLE, without a schema. Returns a reason and,
+    on success, `(root, vtable, vtable_size, table_size)`.
+
+    **Why not parse the real `Model` schema.** Review asked for that, and it would be a stronger
+    check — but it would import `aec_data.fragments.codec` into a harness that is deliberately
+    stdlib-only, so that it runs against a SHIPPED BINARY on a runner with nothing installed. The
+    thing under test is the bundle; a harness that needs the tree's Python environment to make its
+    assertion has moved the subject.
+
+    **Why the offset check alone was too weak, which review was right about.** It asked only that
+    the first word land inside the buffer, so a 5-byte payload starting `04 00 00 00` satisfied it.
+    A root table is more than an offset: at `root` sits a SIGNED backwards offset to a vtable, and
+    the vtable's first two `uint16`s are its own size and the table's. Requiring those to resolve
+    and be plausible costs no dependency and is a real structural parse.
+
+    Measured rather than argued, because "stronger" is a claim a check can fail to deliver: both
+    converters' real output passes (python root=36 vtable=10, node root=40 vtable=8), review's
+    5-byte counterexample fails, and of 2,000 random 1,424-byte buffers carrying a valid-looking
+    root offset, 0 were accepted.
+    """
+    if len(raw) < 8:
+        return f"too small to hold a root table ({len(raw)} bytes)", None
+    root = int.from_bytes(raw[:4], "little")
+    if not (4 <= root <= len(raw) - 4):
+        return f"root offset {root} outside the buffer", None
+    soffset = int.from_bytes(raw[root:root + 4], "little", signed=True)
+    vtable = root - soffset                       # tables point BACKWARDS to their vtable
+    if not (0 <= vtable <= len(raw) - 4):
+        return f"vtable at {vtable} outside the buffer (root {root}, soffset {soffset})", None
+    vtable_size = int.from_bytes(raw[vtable:vtable + 2], "little")
+    table_size = int.from_bytes(raw[vtable + 2:vtable + 4], "little")
+    if not (4 <= vtable_size <= len(raw) - vtable):
+        return f"vtable size {vtable_size} implausible", None
+    if not (4 <= table_size <= len(raw) - root):
+        return f"table size {table_size} implausible", None
+    return "root table resolves", (root, vtable, vtable_size, table_size)
+
+
 def free_port() -> int:
     """A port nothing is listening on, proven by binding it. Released immediately, so this is a
     narrow race — but the alternative is a hardcoded 8765 that a leftover process may already own,
@@ -259,18 +298,19 @@ def convert_a_model(port: int, expect: str, timeout: float) -> None:
         return
 
     # `.frag` is zlib(flatbuffers). Decompressing proves real content rather than a stub, and the
-    # flatbuffer root offset has to land inside the buffer — a cheap structural check that a
-    # truncated or empty write fails. Not a size floor: a floor is a number, this is a property.
+    # root TABLE is then walked — see `flatbuffer_root_table`. Not a size floor: a floor is a
+    # number, this is a property.
     raw, why = b"", ""
     try:
         raw = zlib.decompress(frag)
     except Exception as e:                                           # noqa: BLE001 — reported below
         why = f"{type(e).__name__}: {e}"
-    root = int.from_bytes(raw[:4], "little") if len(raw) >= 4 else -1
-    check("the served bytes are a real fragment — zlib-compressed flatbuffers whose root offset "
-          "lands inside the buffer",
-          bool(raw) and 4 <= root < len(raw),
-          f"{len(frag)} compressed -> {len(raw)} bytes, root offset {root}"
+    reason, shape = flatbuffer_root_table(raw)
+    check("the served bytes are a real fragment — zlib-compressed flatbuffers with a root table "
+          "whose vtable resolves inside the buffer",
+          shape is not None,
+          f"{len(frag)} compressed -> {len(raw)} bytes; {reason}"
+          + (f"; root {shape}" if shape else "")
           + (f"; zlib {why}" if why else ""))
 
 

--- a/services/api/smoke_sidecar.py
+++ b/services/api/smoke_sidecar.py
@@ -9,8 +9,9 @@ and died before binding a port. Windows and macOS temp paths are eight parents d
 was only ever seen on Linux, by users, after v0.3.1133 shipped.
 
 **So this deliberately runs under a SHALLOW temp directory.** A smoke test on a deep temp path would
-have passed against the broken binary — the depth IS the test, and `--shallow-tmp` (the default on
-POSIX) is not a detail of the harness but the thing being asserted.
+have passed against the broken binary — the depth IS the test. A shallow temp directory is the
+POSIX default here and is not a detail of the harness but the thing being asserted; `--deep-tmp`
+opts out of it, and exists only to demonstrate that opting out makes the check stop working.
 
 WHAT IT PROVES, and the boundary. The binary starts; `/health` answers, so the process bound a port
 rather than dying during import; `/ready` answers, so the SQLite engine opened under a fresh data
@@ -80,8 +81,19 @@ def find_binary(explicit: str | None) -> Path | None:
 
     Returns None rather than guessing when the directory holds none or several — a smoke test that
     picked the wrong file would report on something nobody shipped.
+
+    **A blank explicit path is an ERROR, not a fallback**, and that distinction is the whole reason
+    this raises. `desktop.yml` computes the AppImage's sidecar with `find`, whose "found nothing"
+    answer is an empty string; `if explicit:` treated that as "no path was given" and fell through
+    to the scan below — which in CI holds exactly one file, the BUILD OUTPUT that a previous step
+    already smoke-tested. The AppImage check would have re-tested the wrong artifact and passed,
+    green, forever. A caller that names a path meant that path; not naming one is `None`.
     """
-    if explicit:
+    if explicit is not None:
+        if not explicit.strip():
+            raise ValueError(
+                "a blank path was passed. The caller meant to name a binary and computed nothing — "
+                "falling back to a directory scan here would test a DIFFERENT artifact and pass")
         return Path(explicit)
     if not BINARIES.is_dir():
         return None
@@ -192,6 +204,18 @@ def convert_a_model(port: int, expect: str, timeout: float) -> None:
                  st == 200, f"status {st}: {body[:300]!r}"):
         return
 
+    # The route starts the publish itself (`create_blank_model` calls `_publish_bg`, which sets the
+    # status to "running" synchronously before submitting to the pool) and says so in its response.
+    # Asserting that here is not redundant with the poll below: a build where the publish never
+    # STARTS leaves the status at "idle", and the poll cannot tell "idle" from "not finished yet"
+    # until the full timeout expires. Same verdict, five minutes earlier and with a cause attached.
+    reported = ""
+    with contextlib.suppress(Exception):
+        reported = str(json.loads(body).get("publish") or "")
+    check("the route reports the publish as started — otherwise the poll below cannot distinguish "
+          "`never started` from `not finished yet` until it times out",
+          reported == "running", f"response reports publish {reported!r}")
+
     # Publish is off-thread; the client polls. `error` is the state a failed convert produces, and it
     # carries the exception — which for a missing frozen import is the whole diagnosis.
     started = time.time()
@@ -218,6 +242,16 @@ def convert_a_model(port: int, expect: str, timeout: float) -> None:
     check(f"the {expect!r} converter is the one that ran — otherwise this passed without "
           f"exercising the path it exists to test",
           ran == expect, f"publish reports converter {ran!r}, expected {expect!r}")
+
+    # The OTHER half of publish, and the one the fragment bytes below say nothing about: `_publish`
+    # also rebuilds the properties index through `aec_data.properties_index`, and reports how many
+    # elements it saw. A blank model is small but never empty — measured at 1 element / 1 class /
+    # 1 storey for `storeys=1` — so `>= 1` is a floor with a reason rather than a magic number, and
+    # a bundle whose ifcopenshell read back nothing fails here instead of shipping an empty model.
+    indexed = detail.get("reindexed")
+    check("the properties index was rebuilt over real content — the half of publish the fragment "
+          "bytes cannot speak for",
+          isinstance(indexed, int) and indexed >= 1, f"publish reports reindexed={indexed!r}")
 
     st, frag, _ct = get(f"{base}/projects/{pid}/model.frag", timeout=60.0)
     if not check("GET /model.frag serves the converted geometry the viewer would draw",
@@ -260,11 +294,15 @@ def main() -> int:
                          "it exists to demonstrate that the shallow default is load-bearing")
     args = ap.parse_args()
 
-    binary = find_binary(args.binary)
+    try:
+        binary = find_binary(args.binary)
+        why = f"no single aec-bim-server-* in {BINARIES}"
+    except ValueError as exc:
+        binary, why = None, str(exc)
     # THE VACUITY GUARD. Everything below is a statement about a binary; without one there is no
     # population, and a pass would mean "did not look".
     if not check("a sidecar binary was found to run", bool(binary) and binary.is_file(),
-                 str(binary) if binary else f"no single aec-bim-server-* in {BINARIES}"):
+                 str(binary) if binary else why):
         print("\nFAILED:", ", ".join(FAILED))
         return 1
     print(f"  binary: {binary}  ({binary.stat().st_size // (1024 * 1024)} MB)")

--- a/services/api/smoke_sidecar.py
+++ b/services/api/smoke_sidecar.py
@@ -254,9 +254,6 @@ def main() -> int:
                          "guesses what it should require can guess wrong and still look green.")
     ap.add_argument("--convert-timeout", type=float, default=300.0,
                     help="seconds to wait for the publish to leave `running`")
-    ap.add_argument("--skip-convert", action="store_true",
-                    help="boot checks only. For diagnosing a sidecar that will not start — NOT for "
-                         "getting a red build green, which is how the gap this closes stayed open")
     ap.add_argument("--deep-tmp", action="store_true",
                     help="use the default temp directory instead of a shallow one. This is the "
                          "configuration under which the DESKTOP-FROZEN crash did NOT reproduce, so "
@@ -407,11 +404,15 @@ def main() -> int:
                   f"status {st}, content-type {ct!r}")
 
             # The half the boot checks cannot reach: run the converter inside the artifact.
-            if args.skip_convert:
-                print("  SKIPPED the conversion checks (--skip-convert) — this run does NOT show "
-                      "that model conversion survives packaging")
-            else:
-                convert_a_model(port, args.expect_converter, args.convert_timeout)
+            #
+            # There is deliberately NO flag to skip this. An earlier draft had one, justified as
+            # "for diagnosing a sidecar that will not start" — which is false: that case already
+            # fails at `/health` above and returns before reaching here, printing the child's output,
+            # which is strictly better diagnosis. What the flag actually was is an escape hatch that
+            # turns a red build green while printing a warning, and its own help text said not to use
+            # it that way. **A hazard you answer with a comment is a hazard you built**, and this file
+            # exists because a check that stops looking still reports success.
+            convert_a_model(port, args.expect_converter, args.convert_timeout)
         finally:
             proc.terminate()
             try:


### PR DESCRIPTION
# What & why

DESKTOP-SMOKE (#505) proved the packaged sidecar boots and serves. It converted nothing — so `aec_data.fragments`, and the module-scope `flatbuffers` import in its `codec.py`, was still unexercised in a frozen build.

That import is **lazy**, inside `fragconvert.convert_ifc`. So a build that packaged neither **boots perfectly**, passes `/health`, `/ready`, the full module catalog and the SPA, ships — and fails the first time a user publishes a model, with the 3D view staying empty. That is the DESKTOP-FRAGMENTS symptom exactly, which is why #504 closed its own roadmap entry naming this gap.

The harness now authors a blank model, publishes it, and requires the fragment back.

**No IFC fixture is tracked — better than the shape the roadmap entry proposed.** `POST /projects/{pid}/model/blank` generates one server-side through `aec_data.massing`, so the model is authored *by* the artifact rather than handed to it: more of the bundle exercised, and nothing that can drift from a checked-in file.

**Publish, not `edit_preview`.** The entry warned the obvious check would be vacuous, and it was right — `edit_preview` fails open with a 503, so a fresh install answers 503 whether the frozen import works or not. Publish *reports* instead of swallowing: `convert_ifc` raising is caught in `authoring._publish`, recorded as `reconvert_error`, and turned into publish state `error` carrying the exception.

**It asserts which converter ran, and that is the load-bearing part.** Publish reports `node` or `python`. A bundle carries no Node runtime, so it must report `python`. Accepting either would let this pass on any runner with Node installed — which is every runner this workflow uses, two steps above the smoke — without ever touching the code under test. `--expect-converter` is declared by the caller rather than inferred from the environment, because a check that guesses what it should require can guess wrong and still look green.

Roadmap: DESKTOP-SMOKE-CONVERT closed (Lane J).

## Verification

Measured against the real app before anything was written — the chain, not a guess:

```
POST /projects            -> 201
POST .../model/blank      -> 200   {"publish": "running"}
GET  .../publish/status   -> {"state":"done","detail":{"reconverted":true,"converter":"node",...}}
GET  .../model.frag       -> 200, 1471 bytes -> zlib -> 3296, flatbuffer root offset 40
```

**Seven mutations. The positive control is the one worth checking hardest:**

| mutation | result |
|---|---|
| **`flatbuffers` blocked at import + `have_converter` forced False** — what a bad bundle on a desktop actually is | **FAIL in 1.0s** — `publish state 'error'`, `reconvert_error: "No module named 'flatbuffers'"` |
| **positive control**: same setup, `flatbuffers` present | **PASS** — `converter: python`, 694-byte fragment → 1,424 decompressed, valid root table |
| node ran where `python` was expected | FAIL — `publish reports converter 'node', expected 'python'` |
| the `model/blank` response stops reporting the publish as started *(review round)* | FAIL — `response reports publish ''` |
| the properties index is rebuilt over nothing *(review round)* | FAIL — `publish reports reindexed=0` |
| the converter "succeeds" and writes an 8-byte stub *(review round)* | FAIL — `vtable at -1145258557 outside the buffer` |
| happy path against a source checkout with `--expect-converter node` | PASS — 16 assertions green |

Each mutant fails on **its own** assertion and moves nothing else — that clean-kill signature is what says the check is aimed where it claims. Without the control, the first row could have been failing for an unrelated reason and would prove nothing. (The Python converter produces a smaller fragment than Node for the same model — different tessellators, expected, and `services/api/test_fragments_python.py` already measures the two against each other.)

### In CI, on the real frozen bundles

`desktop.yml` never runs on a pull request, so this is verified by `workflow_dispatch` against the branch.

**[Run 34543648131](https://github.com/ibuilder/massing/actions/runs/34543648131) at `8a95361c`, the head under review — conclusion: success on all three platforms.**

| step | ubuntu-22.04 | macos-latest (arm64) | windows-latest |
|---|---|---|---|
| Smoke-test the packaged sidecar | ✅ 15s | ✅ 10s | ✅ 36s |
| Smoke-test the sidecar inside the AppImage | ✅ 19s | skipped (Linux only) | skipped (Linux only) |

The AppImage step **ran** rather than being skipped — worth stating explicitly, because a silently-skipped verification step is the exact failure this item exists to end, and the review round below found that this step could previously pass while testing the wrong binary.

**That run settled something that had been reasoning rather than measurement.** The PR was opened saying the frozen bundle *must* take the Python path — `apppaths.repo_root()` returns `None` when frozen without even walking, so `have_converter()` is False whatever the host has — but every one of these runners installs Node two steps earlier. Had any bundle reached for it, the step would have failed with `publish reports converter 'node', expected 'python'`. None did, on any platform, on any of the three heads below.

The AppImage step is the strongest of the set: it unpacks the installer a user downloads, runs the server from inside it, and that server authors an IFC, converts it with the Python converter, and serves back a fragment whose flatbuffer root table resolves.

**Each head was verified separately rather than letting one green run stand for code it never saw** — that rule cost three dispatches on #505 and it applies here too.

| head | run | result |
|---|---|---|
| `f69d95cb` | [34540915605](https://github.com/ibuilder/massing/actions/runs/34540915605) | ✅ success |
| `cef83185` — `--skip-convert` removed | [34542705907](https://github.com/ibuilder/massing/actions/runs/34542705907) | ✅ success |
| `8a95361c` — the review round below | [34543648131](https://github.com/ibuilder/massing/actions/runs/34543648131) | ✅ success — table above |

## Self-review before merge: removed the `--skip-convert` escape hatch (`cef83185`)

I had added a flag to skip the conversion checks, justified as *"for diagnosing a sidecar that will not start"*. **That justification is false.** A sidecar that will not start already fails at the `/health` check and returns before the convert block is reached, printing the child's captured output — strictly better diagnosis than skipping later checks.

What the flag actually was: an escape hatch that turns a red build green while printing a warning, whose own help text said not to use it that way. **A hazard you answer with a comment is a hazard you built.** This file exists because a check that stops looking still reports success, and `services/api/test_ruff_scope.py` exists in this repository because a CI command drifted to a narrow scope while printing "All checks passed!". Shipping a documented switch for exactly that, in this file, was the wrong call.

No behaviour change on any path CI takes — `desktop.yml` never passed the flag. The argument against it is recorded where the flag was, so the next person who wants one finds the reasoning rather than empty space.

## Review round (`c8c59e97`, `8a95361c`): the AppImage step was passing on the wrong artifact

Three findings, all verified against the code rather than taken on trust. One was a live fail-open, in the worst possible place.

**① The AppImage step could smoke-test the sidecar it had already tested — and pass.** `find` answers "nothing" with an empty string; `find_binary` tested that with `if explicit:`, so an empty result read as *"no path was given"* and fell through to the directory scan. Reconstructed against a CI-shaped directory rather than argued:

```
directory as CI has it after build_sidecar.py: ['aec-bim-server-x86_64-unknown-linux-gnu']

OLD find_binary("")  -> apps/web/src-tauri/binaries/aec-bim-server-x86_64-unknown-linux-gnu
NEW find_binary("")  -> ValueError: a blank path was passed...
NEW find_binary(None) -> ...same binary  (unchanged: no argument still scans)
```

So it would not have asserted nothing — it would have **passed**, on the build-output binary a step two above had already covered. Green forever, on the wrong artifact, inside the one file whose entire purpose is that a check which cannot see its subject reports success. The comment beside that step claimed the opposite ("a wrong guess here reds the build"); it is corrected rather than deleted, because the false claim is why nobody looked. Fixed in both places on purpose: the workflow fails where the nothing was computed, and `find_binary` refuses a blank explicit path — not naming a binary is `None`, naming nothing is an error — which is the class fix, since any caller that *computes* a path can compute an empty one.

**② "Start the publish before polling" — declined; the premise doesn't hold, but the failure mode it names is now closed.** `create_blank_model` ends with `_publish_bg(pid)`, and `_publish_bg` sets the status to `running` *synchronously* before submitting to the pool, so the status is already `running` when the route returns and an extra `POST /publish` would just publish the same model twice. But if a publish ever *didn't* start, the poll could not tell `idle` from "not finished yet" until the full 300s elapsed — fails closed, slowly, with no cause. The route's own report is now asserted, so that verdict arrives five minutes earlier and names the reason. *(The reviewer withdrew this finding on reading the routes.)*

**③ The fragment check was too weak, and the counterexample was exact.** It asked only that the first word land inside the buffer, so `zlib(04 00 00 00 41 42 43 44)` passed (`4 <= 4 < 8`). Not fixed by parsing the `Model` schema, which would import `aec_data.fragments.codec` into a harness that is stdlib-only *so that it can run against a shipped binary on a runner with nothing installed* — a check needing the tree's environment has changed its subject from the artifact to the tree, which is the substitution DESKTOP-FROZEN got away with. Instead it now walks the root **table**: at `root` sits a signed backwards offset to a vtable whose first two `uint16`s are its own size and the table's. Schema-free, dependency-free, and measured — python output (root=36, vtable=10) and node output (root=40, vtable=8) accepted; the 5-byte payload and the 8-byte stub rejected; **0 of 2,000** random 1,424-byte buffers with a valid-looking root offset accepted. The schema-level half — a root without `meshes` is not drawable geometry — is *not* answered, and the docstring says so rather than implying coverage; the nearest honest content assertion available here is `reindexed >= 1`, floored at a value measured from a 1-storey blank model (1 element / 1 class / 1 storey) rather than picked.

**Also found while there:** the module docstring named a `--shallow-tmp` flag that has never existed (the real one is `--deep-tmp`, which opts *out*). Prose describing an interface it cannot be checked against is the drift this repository keeps paying for.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree)
- [x] Backend: no `test_*.py` behaviour changed; `smoke_sidecar.py` stays out of `run_tests.py` for the same reason as #505 — it asserts on a built binary the API test job does not produce
- [x] `test_claude_md_gates.py`, `test_file_sizes.py`, `test_ruff_scope.py`, `test_declared_imports.py` all pass
- [x] Web: `roadmapLanes` / `roadmapSelfConsistent` / `roadmapStale` pass (33 tests) — the roadmap edit is TypeScript-visible
- [x] No import cycles — `smoke_sidecar.py` is still stdlib-only (`zlib` added)
- [x] `CHANGELOG.md` entry; DESKTOP-SMOKE-CONVERT closed in `docs/roadmap.md` and removed from the Lane J cell
- [x] Version bump — n/a, not a release PR
- [x] No secrets, no competitor names

**Also fixed while writing this:** the publish-wait detail printed the timeout *bound* instead of elapsed time — the same misleading-number bug this file already had once, in its `/health` line.

**On the docstring-coverage pre-merge warning:** same position as #505 and for the same reason. There is no repository-side docstring gate; that threshold is CodeRabbit's own. Docstrings were added where they carry information the code doesn't (`post`, `convert_a_model` and `flatbuffer_root_table` all have substantial ones here). Writing them for a `check` helper, a `main` that already passes `description=__doc__`, and a nested one-liner to move a percentage is padding — and padding a coverage number is the same move as a check that reports success without looking, which is the thing this PR exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA