### PR TITLE
RESPONSE-UNDECLARED: fix the remaining nine gaps, and the gate that could not see its own subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### A check that looks for unreachable features stopped being fooled by coincidences
+
+Massing has an automated check whose job is to notice when part of the server ships with nothing in
+the app able to reach it — a feature that exists, is tested, and that no user can get to. It decided
+whether something was reachable by searching the app's source for the feature's name, and it searched
+for that name *anywhere*, including in the middle of longer words.
+
+So it could be satisfied by an accident. Adding a field called `available_public` to the cost screen
+was enough to convince it that an entirely unrelated public-listing feature had been reached, because
+the letters matched. The check then reported all clear — for something nobody had ever wired up. It
+had been fooled this way twice before, each time noticed only by chance.
+
+It now requires a whole-word match. That change found five more features the app cannot currently
+reach, which are recorded for a later pass; it was verified not to lose any of the ones that really
+are reachable. The first attempt at the fix was stricter still and would have wrongly declared 23
+working features unreachable — the drawing exports among them — so the check now carries examples of
+both what it must reject and what it must accept.
+
 ### Clearing an imported schedule now tells you whether it cleared anything
 
 The "Clear import" button in the schedule panel undoes a Primavera P6 or MS-Project import by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Clearing an imported schedule now tells you whether it cleared anything
+
+The "Clear import" button in the schedule panel undoes a Primavera P6 or MS-Project import by
+deleting the activities that import created, leaving anything hand-entered alone. It reported
+success the same way whether it removed four hundred activities or found no import at all — the
+server always answers "cleared", and the count that distinguishes the two was never read. It now
+says how many activities were removed, or that there was no import on record to remove.
+
+That was one of nine places where the app was throwing away something the server had already told
+it. All nine now read the field; five of them show it:
+
+- **Project health** reports what the incidents *were*, not just how many. The safety figures are
+  broken down by OSHA classification — the first thing the server works out, and the one figure the
+  card could not display — so five incidents no longer read the same whether they were near-misses
+  or recordables.
+- **Waiting for a model to convert** shows how long it has been going. A large model legitimately
+  takes minutes, and the status said "running" from the first second to the last, which is also what
+  a stuck job looks like. The elapsed time comes from the server, so it stays right across a page
+  reload — and it is left out entirely rather than guessed at if the two clocks disagree.
+- **Saving a pro forma scenario** reports the returns it solved to. The server solves the scenario
+  as it saves it and sends the result back; the app discarded it, so a scenario that solved to
+  nothing looked exactly like one that solved well until you opened the Portfolio.
+- **The cost-database card** says what can still be installed. With nothing installed it read "0
+  vintages installed", which sounds like there is no cost data to be had — when an offline public
+  baseline needs no subscription at all.
+
+The remaining four are values that repeat something the app already knew, or belong to screens that
+do not exist yet; they are declared so the compiler and the audits can see them, and noted as such.
+
 ### The app now checks that it declares every field the server sends it
 
 A field the server returns but the web app never declares is invisible — not just on screen, but to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ The "Clear import" button in the schedule panel undoes a Primavera P6 or MS-Proj
 deleting the activities that import created, leaving anything hand-entered alone. It reported
 success the same way whether it removed four hundred activities or found no import at all — the
 server always answers "cleared", and the count that distinguishes the two was never read. It now
-says how many activities were removed, or that there was no import on record to remove.
+says how many activities were removed, or that there was no import on record to remove — and when
+it is talking to an older server that does not send the count, it keeps the previous wording rather
+than guessing which of the two happened.
 
 That was one of nine places where the app was throwing away something the server had already told
 it. All nine now read the field; five of them show it:

--- a/apps/web/src/api/authoring.ts
+++ b/apps/web/src/api/authoring.ts
@@ -260,8 +260,13 @@ export function withAuthoring<TBase extends Ctor<HttpCore>>(Base: TBase) {
       return this.json<{ order: string[]; results: Record<string, Record<string, unknown>>; node_count: number }>(
         "/compute/graph", { method: "POST", body: JSON.stringify(graph) });
     }
+    /** Poll the async publish job. `at` is the ISO timestamp the current state was written — the
+     *  server already relies on it to declare an interrupted worker dead after 900 s, and it is the
+     *  only thing that lets a client tell "converting, two minutes in" from a poll loop that has
+     *  been saying `running` since the page loaded. Absent on the `{state: "idle"}` reply. */
     publishStatus(pid: string) {
-      return this.json<{ state: "idle" | "running" | "done" | "error"; detail?: Record<string, unknown> }>(
+      return this.json<{ state: "idle" | "running" | "done" | "error"; detail?: Record<string, unknown>;
+        at?: string }>(
         `/projects/${pid}/publish/status`);
     }
     /** Generative massing — zoning envelope → program (+ proforma) WITHOUT writing a model. Instant. */

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -165,22 +165,6 @@ export class ApiClient extends withCoverageMaps(withAcceptanceGates(withCounterp
                  opts: { height?: number; cols?: number; rows?: number } = {}, publish = true) {
     return this.editIfc(pid, "add_curtain_wall", { start, end, ...opts }, publish);
   }
-  /** PROD-ACTUALS: installed-rate actual vs planned + crew utilization over field productivity actuals. */
-  progressActuals(pid: string, actuals: Record<string, unknown>[], planned?: Record<string, unknown>) {
-    type Group = {
-      group: string; material_class: string; unit: string; entries: number;
-      installed_qty: number; productive_hours: number; idle_hours: number;
-      installed_rate: number | null; utilization: number | null; planned_rate: number | null;
-      variance_pct: number | null; status: "ahead" | "on_track" | "behind" | null;
-      planned_qty: number | null; pct_complete: number | null; remaining_qty: number | null;
-      projected_hours_at_rate: number | null;
-    };
-    return this.json<{
-      group_count: number; groups: Group[]; overall_utilization: number | null;
-      total_productive_hours: number; total_idle_hours: number; planned_compared: number;
-      ahead: number; on_track: number; behind: number; worst: string | null; note: string;
-    }>(`/projects/${pid}/progress/actuals`, { method: "POST", body: JSON.stringify({ actuals, planned }) });
-  }
   /** W11 F0: establish the view-keyed representation contexts (Model+Plan; Body/Axis/Box/Annotation/
    *  FootPrint) the drawing pipeline needs. Idempotent. */
   ensureContexts(pid: string, publish = false) {

--- a/apps/web/src/api/cost.ts
+++ b/apps/web/src/api/cost.ts
@@ -149,6 +149,10 @@ export function withCost<TBase extends Ctor<HttpCore>>(Base: TBase) {
     return this.json<{
       datasets: { id: string; name?: string; vintage?: number; quarter?: number | null;
         origin?: string; is_latest?: boolean }[];
+      /** What the offline public importer could build but has not — the half of this route's own
+       *  docstring ("plus what the offline public importer can build") that the type never named.
+       *  `datasets` alone cannot distinguish "no vintage installed" from "no vintage obtainable". */
+      available_public: { source_set?: string; origin?: string; tier?: string; note?: string }[];
     }>("/cost/datasets");
   }
   /** The vintage this project's estimate resolves through (pinned, else latest). */

--- a/apps/web/src/api/model.ts
+++ b/apps/web/src/api/model.ts
@@ -727,7 +727,12 @@ export function withModel<TBase extends Ctor<NeedsEditIfc>>(Base: TBase) {
   /** saveViewTemplates — replace the project's saved view-template list. */
   saveViewTemplates(pid: string, templates: { id?: string; name: string; hide_classes?: string[];
     isolate?: string | null; rules?: { selector: string; color: string }[] }[]) {
-    return this.json<{ saved: number }>(`/projects/${pid}/view-templates`,
+    // The route validates and NORMALISES every template before writing (ids assigned, colors and
+    // selectors canonicalised) and returns the stored form as `templates`. Declaring only `saved`
+    // left a caller with no way to learn what was actually persisted except by re-reading it.
+    return this.json<{ saved: number; templates: { id: string; name: string; hide_classes: string[];
+      isolate: string | null; rules: { selector: string; color: string }[] }[] }>(
+      `/projects/${pid}/view-templates`,
       { method: "PUT", body: JSON.stringify({ templates }) });
   }
   /** resolveViewTemplate — visible GUIDs and colors after applying one view template. */

--- a/apps/web/src/api/models.ts
+++ b/apps/web/src/api/models.ts
@@ -109,7 +109,10 @@ export function withModels<TBase extends Ctor<HttpCore>>(Base: TBase) {
                         onProgress?: (sent: number, total: number) => void) {
     if (file.size >= RESUMABLE_ABOVE_BYTES) {
       const up = await this._uploadResumable(pid, file, onProgress);
-      const res = await this.json<{ id: string; discipline: string; size: number }>(
+      // `from_upload` marks which of this method's two branches the server served. The caller is the
+      // branch, so it is redundant HERE — but it is the only provenance a reader of the reply gets,
+      // and leaving it undeclared is what made the multipart and resumable replies look identical.
+      const res = await this.json<{ id: string; discipline: string; size: number; from_upload: boolean }>(
         `/projects/${pid}/models/from-upload`,
         { method: "POST", body: JSON.stringify({ key: up.key, discipline }) });
       return { ...res, deduplicated: up.deduplicated };

--- a/apps/web/src/api/procurement.ts
+++ b/apps/web/src/api/procurement.ts
@@ -176,7 +176,11 @@ export function withProcurement<TBase extends Ctor<HttpCore>>(Base: TBase) {
   }
   /** inviteBidders — record companies invited to bid on a package. */
   inviteBidders(pid: string, packageId: string, companies: string[]) {
-    return this.json<{ bidders_invited: number; invited_companies: string[] }>(
+    // `package` echoes the `packageId` this call passed in, so it tells the caller nothing it does
+    // not already hold. Declared anyway: an undeclared key is invisible to the compiler and to every
+    // audit built on these interfaces, and "redundant" is a judgement that has to be written down
+    // somewhere a reader can find it rather than inferred from a type's silence.
+    return this.json<{ package: string; bidders_invited: number; invited_companies: string[] }>(
       `/projects/${pid}/bidding/packages/${packageId}/invite`,
       { method: "POST", body: JSON.stringify({ companies }) });
   }

--- a/apps/web/src/api/proforma.ts
+++ b/apps/web/src/api/proforma.ts
@@ -75,9 +75,16 @@ export function withProforma<TBase extends Ctor<HttpCore>>(Base: TBase) {
     return this.json<{ deal_count: number; totals: Record<string, number | null>; deals: { id: string; name: string; total_uses: number; equity: number; loan: number; equity_irr: number | null; equity_multiple: number | null }[] }>(`/proforma/portfolio`);
   }
 
+  /** Save a solve as a named scenario. The route **solves the assumptions server-side** and returns
+   *  that solve as `result` — so the returns the scenario will show in the Portfolio are already in
+   *  this reply. Declaring only `id` meant the caller had to re-fetch to learn whether what it had
+   *  just saved solved to anything, and in practice it simply did not ask. */
   createScenario(name: string, projectId: string | null, assumptions: unknown) {
-    return this.json<{ id: string }>(`/proforma/scenarios`, {
-      method: "POST", body: JSON.stringify({ name, project_id: projectId, assumptions }) });
+    return this.json<{ id: string; name: string;
+      result: { returns?: { equity_irr?: number | null; equity_multiple?: number | null;
+        project_irr?: number | null; yield_on_cost?: number | null; npv?: number | null } | null } | null }>(
+      `/proforma/scenarios`, {
+        method: "POST", body: JSON.stringify({ name, project_id: projectId, assumptions }) });
   }
 
   /** Saved proforma scenarios for a project (with their solved returns), oldest→newest. */

--- a/apps/web/src/api/responseUndeclared.test.ts
+++ b/apps/web/src/api/responseUndeclared.test.ts
@@ -69,19 +69,10 @@ const CONTROL = "GET /projects/{}/verification/coverage";
 const KNOWN_GAPS: Record<string, string[]> = {
   "GET /reference/disciplines": ["disciplines", "masterformat_divisions", "uniformat_crosswalk"],
   "POST /projects/{}/modules/{}/views": ["mine", "owner", "scope"],
-  "POST /proforma/scenarios": ["name", "result"],
   "POST /proforma/scenarios/{}/draw-package": ["forecast_returns", "g703_totals"],
-  "DELETE /projects/{}/schedule/import-xer": ["removed_activities"],
   "GET /asset-rights/status": ["public_key"],
   "GET /auth/providers": ["saml"],
-  "GET /cost/datasets": ["available_public"],
-  "GET /projects/{}/publish/status": ["at"],
-  "GET /projects/{}/safety/metrics": ["by_class"],
   "POST /proforma/solve": ["provenance"],
-  "POST /projects/{}/bidding/packages/{}/invite": ["package"],
-  "POST /projects/{}/models/from-upload": ["from_upload"],
-  "POST /projects/{}/progress/actuals": ["source"],
-  "PUT /projects/{}/view-templates": ["templates"],
 };
 
 /** Routes the gate compares whose server key set is a LOWER BOUND — the response literal carries a

--- a/apps/web/src/api/schedule.ts
+++ b/apps/web/src/api/schedule.ts
@@ -263,8 +263,13 @@ export function withSchedule<TBase extends Ctor<HttpCore>>(Base: TBase) {
     if (!res.ok) { const e = await res.json().catch(() => ({ detail: res.statusText })); throw new HttpError(e.detail || `import -> ${res.status}`, res.status); }
     return res.json() as Promise<{ count: number; start: string | null; finish: string | null; preview: { activity_id: string; name: string; start: string; finish: string }[] }>;
   }
+  /** Undo the last P6/MSP import. `cleared` is **unconditionally true** — the route deletes what its
+   *  code→id index names and reports success whether that index held 412 activities or did not exist
+   *  at all. `removed_activities` is therefore the only key that separates "undid your import" from
+   *  "there was nothing to undo", and it went undeclared, so the button said "cleared" either way. */
   clearXer(pid: string) {
-    return this.json<{ cleared: boolean }>(`/projects/${pid}/schedule/import-xer`, { method: "DELETE" });
+    return this.json<{ cleared: boolean; removed_activities: number }>(
+      `/projects/${pid}/schedule/import-xer`, { method: "DELETE" });
   }
   /** SCHED-P6 — export the live schedule for round-trip into a scheduler's tool: Primavera P6 `.xer`
    *  or MS-Project XML (MSPDI). Reflects the current edited state, keyed by the P6 activity code. */
@@ -751,8 +756,35 @@ export function withSchedule<TBase extends Ctor<HttpCore>>(Base: TBase) {
   // --- The recordable-rate metrics behind that summary ---
   /** Safety analytics — incidents by OSHA class, recordable/lost-time counts, TRIR/DART. */
   safetyMetrics(pid: string) {
-    return this.json<{ incident_count: number; recordable_count: number; lost_time_count: number; lost_days: number; hours_worked: number; trir: number | null; dart: number | null; observation_count: number; toolbox_talk_count: number }>(
+    // `by_class` is the breakdown the route's own docstring leads with — incidents per OSHA
+    // classification — and it was the one key this type did not name, so the health card could
+    // report five incidents without being able to say what any of them were.
+    return this.json<{ incident_count: number; by_class: Record<string, number>; recordable_count: number; lost_time_count: number; lost_days: number; hours_worked: number; trir: number | null; dart: number | null; observation_count: number; toolbox_talk_count: number }>(
       `/projects/${pid}/safety/metrics`);
+  }
+  // SCALE-SEAM — PROD-ACTUALS came here from `client.ts` when the size ratchet on that file
+  // asked the question it exists to ask. It belongs beside the safety and field-log rollups:
+  // same question (what happened on site), same records, same `require_role("viewer")`.
+  /** PROD-ACTUALS: installed-rate actual vs planned + crew utilization over field productivity actuals. */
+  progressActuals(pid: string, actuals: Record<string, unknown>[], planned?: Record<string, unknown>) {
+    type Group = {
+      group: string; material_class: string; unit: string; entries: number;
+      installed_qty: number; productive_hours: number; idle_hours: number;
+      installed_rate: number | null; utilization: number | null; planned_rate: number | null;
+      variance_pct: number | null; status: "ahead" | "on_track" | "behind" | null;
+      planned_qty: number | null; pct_complete: number | null; remaining_qty: number | null;
+      projected_hours_at_rate: number | null;
+    };
+    return this.json<{
+      group_count: number; groups: Group[]; overall_utilization: number | null;
+      total_productive_hours: number; total_idle_hours: number; planned_compared: number;
+      ahead: number; on_track: number; behind: number; worst: string | null; note: string;
+      /** WHICH rows were analysed: `"request"` for the `actuals` this call passed, or
+       *  `"progress_actual module"` when that list was empty and the route fell back to the field
+       *  crew's persisted log. The route silently substitutes one for the other, so an ahead/behind
+       *  read means nothing without it — and it was the one key the type did not name. */
+      source: string;
+    }>(`/projects/${pid}/progress/actuals`, { method: "POST", body: JSON.stringify({ actuals, planned }) });
   }
   /** fieldLogSummary — manpower trend, weather-impact lost-days, reporting coverage. */
   fieldLogSummary(pid: string) {

--- a/apps/web/src/portal/moduleEvidenceHint.test.ts
+++ b/apps/web/src/portal/moduleEvidenceHint.test.ts
@@ -23,7 +23,9 @@ import type { ModuleDef } from "../api/types";
  *   which is exactly how this shipped unnoticed.
  */
 
-/** The rule as `statusCell` applies it. Kept in lockstep with portal.ts by the assertions below. */
+/** The rule as `statusCell` applies it — `register/register.ts`, NOT `portal.ts`, which this said
+ *  until 2026-09-11 and which is the file the lane table would have placed this test under on the
+ *  strength of that sentence. Kept in lockstep with that method by the assertions below. */
 export function transitionLabel(
   action: string,
   to: string,

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -600,8 +600,14 @@ export async function renderBudget(ctx: PanelContext) {
         // when in fact the offline public baseline is buildable without a subscription. That key
         // was undeclared, so the card could not distinguish "none installed" from "none available".
         if (ds.available_public?.length) {
+          // Worded as what it MEANS to the reader — "offline public build(s)" restated the field
+          // name rather than the fact, and a cost manager does not need the importer's vocabulary
+          // to learn that a baseline is available without paying for one. (It also stops the bare
+          // word from colliding with the leaf of `/projects/{pid}/listings/{lid}/public` in
+          // `services/api/test_route_reachability.py`, which matches route segments against the web
+          // source — a real constraint on prose, and the second reason rather than the first.)
           const note = ds.available_public[0]?.note;
-          bits.push(`${ds.available_public.length} offline public build(s) available`
+          bits.push(`${ds.available_public.length} offline baseline(s) installable — no subscription`
             + (note ? ` (${note})` : ""));
         }
       }

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -593,7 +593,18 @@ export async function renderBudget(ctx: PanelContext) {
         const name = v.resolved?.name || (v.resolved?.vintage != null ? String(v.resolved.vintage) : "none");
         bits.push(v.pinned_id ? `Pinned vintage: ${name}` : `Following latest vintage: ${name}`);
       }
-      if (ds) bits.push(`${ds.datasets.length} vintage(s) installed`);
+      if (ds) {
+        bits.push(`${ds.datasets.length} vintage(s) installed`);
+        // The other half of what this route answers. With no vintage installed, `datasets.length`
+        // is 0 and the card said only that — which reads as "there is no cost data to be had",
+        // when in fact the offline public baseline is buildable without a subscription. That key
+        // was undeclared, so the card could not distinguish "none installed" from "none available".
+        if (ds.available_public?.length) {
+          const note = ds.available_public[0]?.note;
+          bits.push(`${ds.available_public.length} offline public build(s) available`
+            + (note ? ` (${note})` : ""));
+        }
+      }
       if (five) {
         bits.push(`${five.priced} of ${five.element_count} elements priced · $${Math.round(five.total_cost).toLocaleString()}`);
       }

--- a/apps/web/src/portal/panels/schedule.ts
+++ b/apps/web/src/portal/panels/schedule.ts
@@ -73,8 +73,18 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
       "Remove the activities created by the last P6/MSP import? Hand-entered activities are NOT affected. "
       + "Re-import the file to restore them.", ""))) return;
     try {
-      await ctx.host.api.clearXer(pid);
-      toast("imported schedule cleared", "success");
+      // The route's `cleared` is true unconditionally — it reports success whether its code→id index
+      // named 412 activities or did not exist. So this said "cleared" identically after undoing an
+      // import and after doing nothing at all, and the reload that follows looks the same either
+      // way. `removed_activities` is the only key that tells them apart; say which one happened.
+      const r = await ctx.host.api.clearXer(pid);
+      // THREE outcomes, not two. A server too old to send the count leaves it undefined, and
+      // reporting that as "nothing to clear" would invent the very false negative this fix exists
+      // to remove — swapping one collapsed pair for another. Unknown falls back to the old wording.
+      const n = r.removed_activities;
+      if (typeof n !== "number") toast("imported schedule cleared", "success");
+      else if (n > 0) toast(`imported schedule cleared — ${n} imported activit${n === 1 ? "y" : "ies"} removed`, "success");
+      else toast("nothing to clear — no P6/MSP import is on record for this project", "info");
       void renderScheduleViews(ctx, m);
     } catch (e) { toast(`clear failed: ${(e as Error).message}`, "error"); }
   };

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -8,6 +8,7 @@ import { mountReadinessStrip } from "./panels/readinessStrip";
 import type { PanelContext } from "./panelContext";
 import { type RegisterFilter, RegisterUI } from "./register/register";
 import { cycleDensity, readDensity, readFavs, readRecents, readRoomOpen, setRoomOpen, toggleFav } from "./prefs";
+import { safetyClassLine, safetyHeadline } from "./safetyCard";
 import { renderAnalyseHome } from "../shell/analyseHome";
 import { ALL_DESTS, type Dest, destButtonActive, destsForRail, destTitle, stagesFor } from "../shell/destinations";
 import { FALLBACK_ROOMS, ROOM_HOME, type SpineState, destRoom, loadSpine, portalRooms, preselectedRoom, unroomedDests, visibleRooms } from "../shell/spine";
@@ -1102,10 +1103,9 @@ export class PortalUI {
         health.appendChild(cd);
       }
       const safety = el("div", "meta"); safety.style.margin = "2px 0"; health.appendChild(safety);
+      const sCls = el("div", "meta"); sCls.style.cssText = "margin:1px 0 2px 0;opacity:0.8"; health.appendChild(sCls);
       void this.host.api.safetyMetrics(pid).then((s) => {
-        if (!s.incident_count) { safety.textContent = "Safety: no recordable incidents ✓"; return; }
-        const trir = s.trir != null ? ` · TRIR ${s.trir}` : ""; const dart = s.dart != null ? ` · DART ${s.dart}` : "";
-        safety.textContent = `Safety: ${s.recordable_count} recordable / ${s.incident_count} incidents · ${s.lost_days} lost days${trir}${dart}`;
+        safety.textContent = safetyHeadline(s); sCls.textContent = safetyClassLine(s.by_class) ?? "";
       }).catch(() => {});
       const lean = el("div", "meta"); lean.style.margin = "2px 0"; health.appendChild(lean);
       void this.host.api.leanPpc(pid).then((l) => {

--- a/apps/web/src/portal/safetyCard.test.ts
+++ b/apps/web/src/portal/safetyCard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { type SafetyRollup, safetyClassLine, safetyHeadline } from "./safetyCard";
+
+const base: SafetyRollup = {
+  incident_count: 0, recordable_count: 0, lost_days: 0, trir: null, dart: null, by_class: {},
+};
+
+describe("safetyHeadline", () => {
+  it("says so plainly when there is nothing to report", () => {
+    expect(safetyHeadline(base)).toBe("Safety: no recordable incidents ✓");
+  });
+
+  it("omits TRIR and DART when hours are unknown rather than printing null", () => {
+    // The route returns null for both when it could not derive man-hours; a rate of "null per
+    // 200k hours" is not a safety statistic, it is a missing denominator.
+    const s = { ...base, incident_count: 5, recordable_count: 2, lost_days: 9 };
+    expect(safetyHeadline(s)).toBe("Safety: 2 recordable / 5 incidents · 9 lost days");
+  });
+
+  it("carries both rates when the hours are known", () => {
+    const s = { ...base, incident_count: 5, recordable_count: 2, lost_days: 9, trir: 1.4, dart: 0.7 };
+    expect(safetyHeadline(s)).toBe("Safety: 2 recordable / 5 incidents · 9 lost days · TRIR 1.4 · DART 0.7");
+  });
+});
+
+describe("safetyClassLine", () => {
+  it("ranks by count, biggest first", () => {
+    expect(safetyClassLine({ "Near miss": 4, Recordable: 7, "First aid": 1 }))
+      .toBe("↳ Recordable 7 · Near miss 4 · First aid 1");
+  });
+
+  it("breaks ties alphabetically, so the card does not reshuffle between renders", () => {
+    // Equal counts would otherwise fall out in object key order, which is insertion order here and
+    // therefore whatever the server happened to iterate — the same project, two different cards.
+    expect(safetyClassLine({ Zeta: 2, Alpha: 2 })).toBe("↳ Alpha 2 · Zeta 2");
+  });
+
+  it("summarises the tail instead of listing every class", () => {
+    expect(safetyClassLine({ a: 9, b: 8, c: 7, d: 6, e: 5 })).toBe("↳ a 9 · b 8 · c 7 · +2 more");
+  });
+
+  it("returns null — not an empty arrow — when there is nothing to show", () => {
+    // The caller writes this straight into textContent, so "↳ " alone would render as a stray glyph.
+    expect(safetyClassLine({})).toBeNull();
+    expect(safetyClassLine(undefined)).toBeNull();
+    expect(safetyClassLine({ "Near miss": 0 })).toBeNull();   // a class present but empty
+  });
+});

--- a/apps/web/src/portal/safetyCard.ts
+++ b/apps/web/src/portal/safetyCard.ts
@@ -1,0 +1,49 @@
+/**
+ * The project-health card's safety lines: the headline rollup, and what the incidents actually were.
+ *
+ * Extracted from `portal.ts` rather than grown in place — the size ratchet in
+ * `services/api/test_file_sizes.py` asked the question it exists to ask, and for two pure
+ * string-shaping functions over one response the answer is plainly yes. Pure on purpose: both take
+ * the response and return text, so the breakdown below can be tested without a DOM or a server.
+ */
+
+/** The response fields these lines read. Narrower than `safetyMetrics`' full return on purpose —
+ *  this module should not be a second place that has to change when an unrelated key moves. */
+export type SafetyRollup = {
+  incident_count: number;
+  recordable_count: number;
+  lost_days: number;
+  trir: number | null;
+  dart: number | null;
+  by_class: Record<string, number>;
+};
+
+/** The headline: recordables against total, lost days, and the two rates when hours are known. */
+export function safetyHeadline(s: SafetyRollup): string {
+  if (!s.incident_count) return "Safety: no recordable incidents ✓";
+  const trir = s.trir != null ? ` · TRIR ${s.trir}` : "";
+  const dart = s.dart != null ? ` · DART ${s.dart}` : "";
+  return `Safety: ${s.recordable_count} recordable / ${s.incident_count} incidents `
+    + `· ${s.lost_days} lost days${trir}${dart}`;
+}
+
+/**
+ * WHAT the incidents were — the OSHA-classification breakdown.
+ *
+ * `by_class` is the first thing the route computes and the first thing its docstring names, and it
+ * was the one key the client type omitted, so this card could report five incidents without being
+ * able to say that four of them were near-misses.
+ *
+ * Ordered by count and then alphabetically: the tie-break is not cosmetic, because the card
+ * re-renders on every project open and two classes on equal counts would otherwise swap places
+ * depending on object key order. Returns null when there is nothing to add, so the caller appends
+ * no empty element.
+ */
+export function safetyClassLine(by: Record<string, number> | undefined, top = 3): string | null {
+  const classes = Object.entries(by ?? {})
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  if (!classes.length) return null;
+  const shown = classes.slice(0, top).map(([k, n]) => `${k} ${n}`).join(" · ");
+  return `↳ ${shown}${classes.length > top ? ` · +${classes.length - top} more` : ""}`;
+}

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -1664,8 +1664,18 @@ export class ProformaUI {
     save.onclick = async () => {
       if (!pid) { this.setStatus("open a project to save a scenario"); return; }
       const name = await askText("Save scenario", { label: "Save scenario as:", value: "Base case" }); if (!name) return;
-      try { await this.api.createScenario(name, pid, this.a); this.setStatus(`saved scenario “${name}” — now in the Portfolio`); }
-      catch (e) { this.setStatus(`save failed: ${(e as Error).message}`); }
+      // The route solves the assumptions server-side and hands that solve back as `result`. The
+      // reply was typed as `{id}` alone, so the only thing this could report was that a POST had
+      // succeeded — a scenario that solved to nothing looked exactly like one that solved well,
+      // until somebody opened the Portfolio. The returns are already here; say what was saved.
+      try {
+        const sc = await this.api.createScenario(name, pid, this.a);
+        const r = sc.result?.returns;
+        const irr = r?.equity_irr != null ? `${(r.equity_irr * 100).toFixed(1)}% equity IRR` : null;
+        const mult = r?.equity_multiple != null ? `${r.equity_multiple.toFixed(2)}× equity` : null;
+        const solved = [irr, mult].filter(Boolean).join(" · ");
+        this.setStatus(`saved scenario “${name}” — ${solved || "solved with no returns"} · now in the Portfolio`);
+      } catch (e) { this.setStatus(`save failed: ${(e as Error).message}`); }
     };
     tools.append(save, Object.assign(document.createElement("span"), { className: "meta",
       textContent: pid ? "Saved scenarios roll into the Portfolio's developer returns." : "Open a project to save scenarios." }));

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -715,7 +715,17 @@ const NOT_A_LANE = (rel: string) =>
 //: taken from a different reader is a threshold for a different question. `surface.test.ts` records
 //: being bitten by precisely this (698 from a probe vs 696 from the gate), so the number is read back
 //: out of the assertion that enforces it.
-const UNOWNED_CEILING = 34;  // 53 → 48: Lane J claimed `apps/web/src/tooling/` (v0.3.1017).
+const UNOWNED_CEILING = 25;  // 53 → 48: Lane J claimed `apps/web/src/tooling/` (v0.3.1017).
+//: 34 → 25 (2026-09-11): Lanes A and B split the eleven loose `portal/` files between them,
+//: derived by IMPORTER rather than by name (the table below `roadmapLanes` records which went
+//: where and why). Extracting `safetyCard.ts` out of `portal.ts` under the size ratchet is what
+//: tripped this — one ratchet handing work to another — and the remedy it names took NINE files
+//: out of the unowned set rather than the two that tripped it, the same shape as `proforma/`.
+//: Re-seated to the MEASURED 25, not to 32: see the note below about unspent slack.
+//: *Two files would have gone to the wrong lane on their names*, and the lane rows themselves
+//: failed this file's DISJOINTNESS check on the first try — a backticked `portal/` written as
+//: prose inside a path cell is parsed as a CLAIM of that directory, which is the same hazard
+//: Lane B's cell already records for item codes, one column over.
 //: 39 → 34 (2026-09-09): Lane B claimed `apps/web/src/proforma/`. PARCEL-SHAPE added two files
 //: to that directory, this ratchet went red, and the remedy it names — a row, not a bigger
 //: number — took SEVEN files out of the unowned set rather than the two that tripped it. The

--- a/apps/web/src/viewer/fileIO.ts
+++ b/apps/web/src/viewer/fileIO.ts
@@ -25,7 +25,10 @@ export interface FileIODeps {
   referenceModels: Map<string, { object: THREE.Object3D; label: string; dispose?: () => void }>;
   refreshFederation: () => void;
   fitToModels: () => Promise<void>;
-  waitForPublish: (pid: string, onTick?: (s: string) => void) => Promise<string>;
+  /** `onTick`'s second argument is how long the server has been in that state (null when it
+   *  cannot be known) — see `elapsedSince` in `publishWait.ts`. The other modules declaring
+   *  this seam still take the one-argument form; widen theirs when they want the figure. */
+  waitForPublish: (pid: string, onTick?: (s: string, elapsed: string | null) => void) => Promise<string>;
   loadProjectModel: () => Promise<boolean>;
   buildToolsPanel: () => Promise<void> | void;
   buildClashPanel: () => Promise<void> | void;
@@ -114,7 +117,7 @@ export function installFileIO(d: FileIODeps) {
       d.notify(`${file.name} is large (${mb(file.size)} MB) — converting on the server for smooth streaming…`, "info");
       try {
         await d.api.uploadSourceIfc(pid, file);          // saves + sets source_ifc + publishes off-thread
-        const state = await d.waitForPublish(pid, (s) => d.setStatus(`processing model: ${s}…`));
+        const state = await d.waitForPublish(pid, (s, e) => d.setStatus(`processing model: ${s}${e ? ` · ${e}` : ""}…`));
         if (state === "done") {
           if (created) { enterProject(pid); return; }     // brand-new container: land in it, fully wired
           await d.loadProjectModel();                    // stream the optimized fragments with progress
@@ -146,7 +149,7 @@ export function installFileIO(d: FileIODeps) {
     d.notify(`Adding ${file.name} to the project — generating drawings & analysis…`, "info");
     try {
       await d.api.uploadSourceIfc(pid, file);            // saves + sets source_ifc + publishes off-thread
-      const state = await d.waitForPublish(pid, (s) => d.setStatus(`processing model: ${s}…`));
+      const state = await d.waitForPublish(pid, (s, e) => d.setStatus(`processing model: ${s}${e ? ` · ${e}` : ""}…`));
       void d.buildToolsPanel();                          // re-checks has_source_ifc → un-gates the tools
       void d.buildClashPanel();
       d.notify(state === "done"

--- a/apps/web/src/viewer/publishWait.test.ts
+++ b/apps/web/src/viewer/publishWait.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { makeWaitForPublish } from "./publishWait";
+import { elapsedSince, makeWaitForPublish } from "./publishWait";
 
 /**
  * Nine lines, 24 call sites, no test until now.
@@ -66,5 +66,69 @@ describe("waitForPublish", () => {
     const r = reader(["running"]);
     expect(await makeWaitForPublish(r, { intervalMs: 0, timeoutMs: -1 })("p1")).toBe("running");
     expect(r.calls()).toBe(0);
+  });
+});
+
+/**
+ * `elapsedSince` subtracts a SERVER timestamp from a BROWSER clock, which is the only way to answer
+ * "how long has this convert been running" for a page that reloaded mid-job — and is also the one
+ * arithmetic in this file that can produce a confidently wrong answer. Every implausible result is
+ * asserted to come back as null rather than as a formatted string.
+ */
+describe("elapsedSince", () => {
+  const NOW = Date.parse("2026-09-11T12:00:00Z");
+
+  it("formats seconds under a minute and minutes above it", () => {
+    expect(elapsedSince("2026-09-11T11:59:17Z", NOW)).toBe("43s");
+    expect(elapsedSince("2026-09-11T11:57:38Z", NOW)).toBe("2m 22s");
+    expect(elapsedSince("2026-09-11T11:59:00Z", NOW)).toBe("1m 00s");   // seconds are zero-padded
+  });
+
+  it("parses the stamp the SERVER actually writes, offset and all", () => {
+    // `_set_pub_status` writes `datetime.now(timezone.utc).isoformat()`, which is
+    // `…+00:00` with microseconds — NOT a `Z` suffix, and not a naive datetime. The distinction is
+    // the whole correctness of this function: `Date.parse` reads an offset-less datetime as LOCAL
+    // time, so a naive server stamp would be wrong by the viewer's UTC offset — silently right in
+    // London and hours out everywhere else, which is exactly the bug no developer reproduces.
+    expect(elapsedSince("2026-09-11T11:57:38.123456+00:00", NOW)).toBe("2m 21s");
+    expect(elapsedSince("2026-09-11T11:57:38Z", NOW)).toBe("2m 22s");          // Z form too
+  });
+
+  it("returns null when there is no stamp, or the stamp is not a date", () => {
+    // `{state: "idle"}` carries no `at` at all — the common case, and it must not render "NaNs".
+    expect(elapsedSince(undefined, NOW)).toBeNull();
+    expect(elapsedSince("", NOW)).toBeNull();
+    expect(elapsedSince("not a date", NOW)).toBeNull();
+  });
+
+  it("returns null for a FUTURE stamp rather than a negative duration", () => {
+    // A browser clock behind the server's. Showing "-4m 00s" is worse than showing nothing, and
+    // this is the branch a naive implementation gets wrong because it never fires in development.
+    expect(elapsedSince("2026-09-11T12:04:00Z", NOW)).toBeNull();
+  });
+
+  it("returns null beyond a day — a stale blob is not a 400-hour convert", () => {
+    expect(elapsedSince("2026-09-10T11:00:00Z", NOW)).toBeNull();       // 25h
+    expect(elapsedSince("2026-09-10T12:00:01Z", NOW)).toBe("1439m 59s"); // 24h minus 1s: still shown
+  });
+});
+
+describe("waitForPublish elapsed", () => {
+  it("hands onTick the elapsed time beside the state", async () => {
+    const at = new Date(Date.now() - 90_000).toISOString();
+    const api = { publishStatus: vi.fn(async () => ({ state: "done", at })) };
+    const seen: [string, string | null][] = [];
+    await makeWaitForPublish(api, fast)("p1", (s, e) => seen.push([s, e]));
+    expect(seen).toHaveLength(1);
+    expect(seen[0]![0]).toBe("done");
+    expect(seen[0]![1]).toMatch(/^1m \d\ds$/);
+  });
+
+  it("hands onTick null when the reply carries no timestamp", async () => {
+    // Every pre-existing caller is `(s) => …` and ignores the second argument; this asserts the
+    // no-stamp path produces a value those callers can also ignore rather than a thrown error.
+    const seen: (string | null)[] = [];
+    await makeWaitForPublish(reader(["done"]), fast)("p1", (_s, e) => seen.push(e));
+    expect(seen).toEqual([null]);
   });
 });

--- a/apps/web/src/viewer/publishWait.ts
+++ b/apps/web/src/viewer/publishWait.ts
@@ -13,8 +13,31 @@
  */
 
 export type PublishStatusReader = {
-  publishStatus: (pid: string) => Promise<{ state: string }>;
+  publishStatus: (pid: string) => Promise<{ state: string; at?: string }>;
 };
+
+/**
+ * How long the server has been in this state, from the `at` stamp it writes beside it.
+ *
+ * Measured against the SERVER's stamp rather than against when this loop started, because the case
+ * that needs it most is the one where the loop did not see the beginning: a reload mid-convert
+ * leaves a fresh poller watching a job that is already minutes old, and elapsed-since-we-started
+ * would confidently report 3 s.
+ *
+ * That means subtracting a server clock from a browser clock, so the answer is only trusted when it
+ * is plausible: a negative figure (browser behind the server) or one beyond a day (a bad stamp, a
+ * misconfigured timezone) returns null and the caller simply says nothing. **Showing no elapsed
+ * time is honest; showing "-4m" is worse than the silence it replaced.**
+ */
+export function elapsedSince(at: string | undefined, now: number): string | null {
+  if (!at) return null;
+  const t = Date.parse(at);
+  if (!Number.isFinite(t)) return null;
+  const ms = now - t;
+  if (ms < 0 || ms > 24 * 60 * 60 * 1000) return null;
+  const s = Math.floor(ms / 1000);
+  return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, "0")}s`;
+}
 
 export type WaitOptions = {
   /** Gap between polls. 1.5 s in the app — fast enough to feel live, slow enough not to hammer. */
@@ -44,12 +67,16 @@ export function makeWaitForPublish(api: PublishStatusReader, opts: WaitOptions =
   const intervalMs = opts.intervalMs ?? 1500;
   const timeoutMs = opts.timeoutMs ?? 12 * 60 * 1000;
 
-  return async function waitForPublish(pid: string, onTick?: (s: string) => void): Promise<string> {
+  return async function waitForPublish(
+    pid: string, onTick?: (s: string, elapsed: string | null) => void): Promise<string> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-      let s: { state: string };
+      let s: { state: string; at?: string };
       try { s = await api.publishStatus(pid); } catch { return "error"; }
-      onTick?.(s.state);
+      // Second argument, not a changed first one: every existing `(s) => …` caller keeps working
+      // untouched, and the ones that want to show progress opt in. A convert legitimately runs for
+      // minutes, so "running" on its own is indistinguishable from a stuck job.
+      onTick?.(s.state, elapsedSince(s.at, Date.now()));
       if (s.state === "done" || s.state === "error") return s.state;
       await new Promise((r) => setTimeout(r, intervalMs));
     }

--- a/apps/web/src/viewer/tools/authoringPlaceStatus.test.ts
+++ b/apps/web/src/viewer/tools/authoringPlaceStatus.test.ts
@@ -5,12 +5,51 @@ import { describe, expect, it } from "vitest";
 
 const SRC = readFileSync(resolve(process.cwd(), "src/viewer/tools/authoringSection.ts"), "utf8");
 
+/**
+ * Does the Place button report publish progress, or sit on "converting…" for the whole convert?
+ *
+ * ### This gate could not fail for its own reason, and did not for its whole life
+ *
+ * It sliced the file from `indexOf("⊕ Place selected family")` — which finds the **docstring that
+ * mentions the button** (offset 2076) hundreds of lines before the `toolBtn2(...)` that builds it
+ * (offset 6312). The slice therefore opened above **Republish** and ran to the next button after
+ * Place, so Republish's `onTick` satisfied an assertion whose name, comment and purpose were all
+ * about Place. Removing Place's callback entirely left it green; so did removing Republish's.
+ *
+ * **An anchor that matches a MENTION of the subject instead of the subject is not a narrower
+ * search, it is a different one** — and the failure is silent in the safe-looking direction,
+ * because a passing test is what you get either way.
+ *
+ * Two changes, and the second is the one that matters: the slice is anchored on the button's
+ * CONSTRUCTION (`toolBtn2("⊕ …`), which cannot collide with prose about it; and the slice is
+ * asserted to exclude Republish, so a future edit that widens it back fails here rather than
+ * quietly restoring the hole. The arity of the callback is deliberately NOT pinned — the previous
+ * version pinned `(s)` and went red when `onTick` gained its elapsed-time argument and this very
+ * call site opted in, reporting an improvement to the protected behaviour as a regression of it.
+ */
+function sliceForButton(label: string): string {
+  const start = SRC.indexOf(`toolBtn2("${label}"`);
+  expect(start, `no toolBtn2("${label}") in authoringSection.ts`).toBeGreaterThan(-1);
+  const next = SRC.indexOf("toolBtn2(", start + 1);
+  return next === -1 ? SRC.slice(start) : SRC.slice(start, next);
+}
+
 describe("Place reports the publish pipeline", () => {
+  it("slices the Place button itself, not the docstring that names it", () => {
+    // The defect above, asserted directly: the anchor must land on the construction, and the slice
+    // must not reach back over Republish, whose callback used to be what made this pass.
+    const place = sliceForButton("⊕ Place selected family");
+    expect(place).toContain("⊕ Place selected family");
+    expect(place).not.toContain("⟳ Republish");
+    expect(place.length).toBeLessThan(SRC.length / 2);   // a slice, not "most of the file"
+  });
+
   it("passes onTick into waitForPublish, the same path Republish already had", () => {
-    // Without the second argument the Place button sits on "converting…" for the whole convert.
-    const place = SRC.slice(SRC.indexOf("⊕ Place selected family"));
-    const end = place.indexOf("Import IFC families");
-    const body = end === -1 ? place : place.slice(0, end);
-    expect(body).toMatch(/waitForPublish\(pid,\s*\(s\)/);
+    // Without a callback the Place button sits on "converting…" for the whole convert.
+    expect(sliceForButton("⊕ Place selected family")).toMatch(/waitForPublish\(pid,\s*\(/);
+  });
+
+  it("Republish keeps its own onTick — the call this gate used to be reading by mistake", () => {
+    expect(sliceForButton("⟳ Republish (reconvert + reindex)")).toMatch(/waitForPublish\(pid,\s*\(/);
   });
 });

--- a/apps/web/src/viewer/tools/authoringSection.ts
+++ b/apps/web/src/viewer/tools/authoringSection.ts
@@ -39,7 +39,10 @@ export interface AuthoringDeps {
   activeStorey: () => string | null;
   /** The tools panel element — this section dims itself for non-editors via `data-cap`. */
   panel: HTMLElement;
-  waitForPublish: (pid: string, onTick?: (s: string) => void) => Promise<string>;
+  /** `onTick`'s second argument is how long the server has been in that state (null when it
+   *  cannot be known) — see `elapsedSince` in `publishWait.ts`. The other modules declaring
+   *  this seam still take the one-argument form; widen theirs when they want the figure. */
+  waitForPublish: (pid: string, onTick?: (s: string, elapsed: string | null) => void) => Promise<string>;
   loadProjectModel: () => Promise<boolean>;
 }
 
@@ -68,7 +71,7 @@ export function buildAuthoringSection(d: AuthoringDeps): void {
         const pub = toolBtn2("⟳ Republish (reconvert + reindex)", async () => {
           out.textContent = "publishing… (running in background)";
           await api.publish(pid);
-          const state = await waitForPublish(pid, (s) => (out.textContent = `publish: ${s}…`));
+          const state = await waitForPublish(pid, (s, e) => (out.textContent = `publish: ${s}${e ? ` · ${e}` : ""}…`));
           if (state === "done") await loadProjectModel();
           out.textContent = `publish ${state}`;
         });
@@ -104,7 +107,7 @@ export function buildAuthoringSection(d: AuthoringDeps): void {
           out.textContent = `${label} added · converting…`;
           // Same tick path Republish already had: without onTick the Place button sits on
           // "converting…" for the whole convert, which reads as a hang.
-          const state = await waitForPublish(pid, (s) => { out.textContent = `publish: ${s}…`; });
+          const state = await waitForPublish(pid, (s, e) => { out.textContent = `publish: ${s}${e ? ` · ${e}` : ""}…`; });
           if (state === "done") await loadProjectModel();
           out.innerHTML = `added <b>${escapeHtml(label)}</b>${pos ? ` at ${pos[0].toFixed(1)}, ${pos[1].toFixed(1)} m` : " at origin"}<br>publish: ${escapeHtml(state)}`;
         });

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1406,7 +1406,7 @@ instances:
   bigger than the one remaining instance.
 
 - ◧ **RESPONSE-UNDECLARED — the inverse of DEAD-FIELD** *(sized 2026-09-10; DERIVED AND GATED
-  2026-09-11; 6 of 15 triaged)*
+  2026-09-11; **all 15 triaged, 9 fixed, 6 open**)*
 
   DEAD-FIELD asks *does the client READ what it DECLARES*. This asks *does the client DECLARE what the
   server SENDS*, and the second failure is strictly worse: an undeclared field is invisible to the
@@ -1446,8 +1446,64 @@ instances:
   template literal only, and reported two perfectly resolvable call sites as UNRESOLVED — a
   concatenation and a conditional query suffix. It now folds `+` and `?:`, and a self-test pins that.
 
-  **TRIAGE: 6 of 15 read, 6 real**, in four categories — and only one is the "invisible field" this
-  item was scoped around:
+  **TRIAGE: all 15 read. Nine are fixed (below); the six still open are listed after them.**
+
+  **THE NINE FIXED 2026-09-11 — every one declared, five of them rendered.** `KNOWN_GAPS` in the gate
+  is asserted exactly in both directions, so this list could only shrink by fixing, and it did: 15 → 6.
+
+  * *a success message that could not distinguish success from nothing-happened* — **the one real
+    defect in the nine.** `DELETE /schedule/import-xer` returns `cleared: true` **unconditionally**:
+    it deletes whatever its code→id index names and reports success whether that index held 412
+    activities or did not exist. `removed_activities` is the only key that separates the two, and the
+    client declared neither, so "⌫ Clear import" showed the same green toast either way and the
+    reload behind it looks identical. Now: the count when there was one, and *"nothing to clear — no
+    P6/MSP import is on record"* when there was not.
+  * *the headline the docstring leads with* — `GET /safety/metrics` computes `by_class` first and
+    names it first (*"incidents by OSHA class"*); the client type omitted it alone, so the project
+    health card could report five incidents without being able to say what any of them were. Now
+    rendered under the safety line, biggest class first.
+  * *a poll loop with no sense of time* — `GET /publish/status` writes an `at` stamp beside the
+    state, and the server already relies on it to declare an interrupted worker dead after 900 s.
+    Undeclared client-side, so a convert that legitimately takes minutes showed `running…` from the
+    first poll to the twelfth, indistinguishable from a stuck job — worst after a reload, where the
+    poller has no idea the job is already old. `elapsedSince` in `apps/web/src/viewer/publishWait.ts`
+    turns it into `2m 14s`; it subtracts a server clock from a browser one, so a future stamp or one
+    beyond a day returns null and the UI says nothing. **Showing no elapsed time is honest; showing
+    `-4m` is worse than the silence it replaced.**
+  * *half the route's own answer* — `GET /cost/datasets` documents itself as vintages *"plus what the
+    offline public importer can build"*, and only the first half was declared. With nothing installed
+    the card said `0 vintage(s) installed`, which reads as *no cost data is obtainable* when the
+    offline public baseline needs no subscription.
+  * *a save that could not report what it saved* — `POST /proforma/scenarios` **solves the assumptions
+    server-side** and hands that solve back as `result`. Typed as `{id}` alone, so "💾 Save scenario"
+    could only report that a POST succeeded; a scenario that solved to nothing looked exactly like one
+    that solved well until somebody opened the Portfolio. Now reports the equity IRR and multiple.
+  * *declared, not rendered, and correctly so* — four keys carry no new information at their one call
+    site and are declared to make them visible to the compiler and to every audit built on these
+    interfaces: `from_upload` and `package` echo what the caller passed in, and `source` (which
+    actuals were analysed — the request's, or the field crew's persisted log when it was empty) and
+    `templates` (the normalised list the server stored) belong to `progressActuals` and
+    `saveViewTemplates`, **neither of which has a UI caller anywhere in `apps/web/src`** — a separate
+    gap, not fixed here.
+
+  **AND A FAIL-OPEN GATE FOUND BY MUTATING THE THING IT GUARDS.**
+  `apps/web/src/viewer/tools/authoringPlaceStatus.test.ts` asserts the Place button passes an
+  `onTick`. It sliced the file from `indexOf("⊕ Place selected family")` — which matches the
+  **docstring that mentions the button**, hundreds of lines above the `toolBtn2(...)` that builds it.
+  The slice therefore opened above **Republish** and ran past Place, so *Republish's* callback
+  satisfied an assertion whose name, comment and purpose were all about Place: deleting Place's
+  `onTick` entirely left it green. **An anchor that matches a MENTION of the subject instead of the
+  subject is not a narrower search, it is a different one** — and it fails in the direction that
+  looks safe, because a pass is what you get either way. Now anchored on the construction, with the
+  slice asserted to exclude Republish, and both callbacks mutated separately to prove each bites.
+  *Its other pin was wrong in the opposite direction:* it matched `\(s\)`, the callback's **arity**,
+  so it went red the moment `onTick` gained the elapsed argument and this very call site opted in —
+  **an improvement to the protected behaviour reported as a regression of it.** A source-text gate
+  should match the narrowest thing that would actually be wrong; everything else it happens to match
+  becomes a tripwire under the next person to improve the line.
+
+  **THE SIX STILL OPEN**, in four categories — and only one is the "invisible field" this item was
+  scoped around. Three need *declare **and** render*, not just declare:
 
   * *server ships, client dark* — `/auth/providers` never declares `saml`, and `saml` appears nowhere
     in `apps/web/src`, so the SAML sign-in the server fully implements has no affordance at all ·
@@ -2574,8 +2630,8 @@ two rows share a path, so two agents in different rows cannot collide.
 
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
-| **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts` | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `reportCenter.ts`, `apps/web/src/reportCenter.verification.test.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · SCREEN-VS-REPORT *(the asymmetric sub-population: fields the Python report builders render and the screen does not. Derived from `apps/web/src/api/` interfaces against `services/api/src/aec_api/report_builders/`, but the EDIT is a caveat rendered beside a number a panel already shows, and the first six fixed all landed in `apps/web/src/proforma/proforma.ts` — same derived-here-fixed-there split as the cell beside it. **Naming a sibling item code inside a cell is how this row failed the disjointness check once**: the parser reads a mention as an assignment, so a cross-reference has to describe the other row rather than name it)* · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
+| **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts`, `apps/web/src/portal/prefs.ts`, `apps/web/src/portal/prefs.test.ts`, `apps/web/src/portal/safetyCard.ts`, `apps/web/src/portal/safetyCard.test.ts`, `apps/web/src/portal/registerEmpty.test.ts` *(the loose portal files whose importers are A's — claimed 2026-09-11; see the derivation below the table. **Unbackticked on purpose**: every backtick in THIS cell is parsed as a path claim, so writing the directory name as a citation here claimed the whole of it and clashed with Lane B)* | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `apps/web/src/portal/panelContext.ts`, `apps/web/src/portal/offlineQueue.ts`, `apps/web/src/portal/offlineQueue.test.ts`, `apps/web/src/portal/fieldTypeCoverage.test.ts`, `apps/web/src/portal/tableRefColumn.test.ts`, `apps/web/src/portal/moduleEvidenceHint.test.ts` *(the loose portal files whose importers are B's — claimed 2026-09-11; see the derivation below the table)*, `reportCenter.ts`, `apps/web/src/reportCenter.verification.test.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · SCREEN-VS-REPORT *(the asymmetric sub-population: fields the Python report builders render and the screen does not. Derived from `apps/web/src/api/` interfaces against `services/api/src/aec_api/report_builders/`, but the EDIT is a caveat rendered beside a number a panel already shows, and the first six fixed all landed in `apps/web/src/proforma/proforma.ts` — same derived-here-fixed-there split as the cell beside it. **Naming a sibling item code inside a cell is how this row failed the disjointness check once**: the parser reads a mention as an assignment, so a cross-reference has to describe the other row rather than name it)* · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py`, `services/api/test_pin_population.py`, `services/api/test_pin_anchor.py`, `services/api/test_desktop_paths.py`, `services/api/test_frozen_paths.py` | R22-ENTITLEMENT · PERF-WORKERS ① · R43-MASSINGBILL-CORE · PIN-ONE-CALL · JSON-NULL-CLASS · PIN-SWEEP-PGNULL *(the pin sweep skips the rows it exists to convert, on PostgreSQL only — a `json` column holding scalar `null` is non-NULL in SQL and decodes to Python `None`. Filed here rather than Lane B because the code is a migration under `services/api/migrations/`, and it landed in `main` via #503 rather than in the PR that found it)* · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* *(**UX-3 left this cell 2026-09-06: all five of its items now ship** — see its entry. The cell had pointed at `apps/web/src/viewer/tools/authoringSection.ts`, which is a real file and the WRONG one: every one of the five landed under `apps/web/src/viewer/draft/`. Lanes are assigned by directory, so a pointer that resolves is not the same as a pointer that is right — a tracked-path gate cannot catch this, and did not)* |
@@ -2610,8 +2666,33 @@ had to be fixed under a one-change lane assignment because there was no row to p
 
 **It is now a ratchet rather than a proposal.** `roadmapLanes.test.ts` counts unowned files against a
 ceiling that only ever goes down, and the way down is adding a row here. Rows still to agree:
-`proforma/` · `drawings/` · `kernel/` · `pins/` · `studio/` · `tools/` · the loose `portal/`
-files · `dev/` · `account/` · `connections/` · `deploy/`.
+`drawings/` · `kernel/` · `pins/` · `studio/` · `tools/` · `dev/` · `connections/` · `deploy/`.
+
+**The loose `portal/` files came off that list on 2026-09-11, DERIVED the same way `tree/` was** —
+`safetyCard.ts` was extracted from `portal.ts` under the size ratchet, the unowned ratchet went red at
+36 > 34, and the remedy it names is a row. All eleven remaining loose files were placed by asking *who
+imports this*, never by where the name suggests they belong:
+
+| file | importers | owner |
+|---|---|---|
+| `prefs.ts` | `main.ts`, `portal.ts`, `shell/pinnedRail.ts`, `favourites.test.ts` (A) · `register/register.ts` (B) | **A**, 4 of 5 |
+| `safetyCard.ts` | `portal.ts` only | **A**, the one-importer case — same shape as `tree/` |
+| `registerEmpty.test.ts` | imports `PortalUI` from `./portal` | **A** |
+| `panelContext.ts` | 44 files under `portal/panels/`, `register/`, `ui/` (B) · `portal.ts` (A) | **B**, 44 of 45 |
+| `offlineQueue.ts` | `register/uploadQueue.ts` and its test only | **B** |
+| `fieldTypeCoverage.test.ts`, `tableRefColumn.test.ts` | both read `register/register.ts` | **B** |
+| `moduleEvidenceHint.test.ts` | asserts `statusCell`, which is in `register/register.ts` | **B** |
+
+**Two of these would have gone to the wrong lane on their names.** `registerEmpty.test.ts` reads as
+register work (B) and imports `PortalUI` (A); `moduleEvidenceHint.test.ts` carried a docstring saying
+it was *"kept in lockstep with portal.ts"* when the `statusCell` it mirrors has lived in
+`register/register.ts` — corrected in that file at the same time. *A name is a claim about ownership
+that nothing checks; an import is one the compiler already enforces.*
+
+The claims are per-FILE rather than the directory, deliberately: Lane A holds `portal/portal.ts` and
+Lane B holds `portal/panels/`, so a wholesale `portal/` claim would recreate the 2026-07-30 nested
+overlap described below — the one that put the two lanes least likely to be watching each other in
+the same directory. `proforma/` left this list on 2026-09-09 (Lane B).
 
 **`tree/` came off that list on 2026-08-21, and it was DERIVED rather than agreed.** The paragraph
 above warns that guessing an owner for a directory is how the register problem was made, so the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1486,6 +1486,47 @@ instances:
     `saveViewTemplates`, **neither of which has a UI caller anywhere in `apps/web/src`** — a separate
     gap, not fixed here.
 
+  **AND A SECOND FAIL-OPEN GATE, WHICH CI FOUND RATHER THAN I DID.**
+  `services/api/test_route_reachability.py` asks *which server routes has no client ever called?* and
+  decided it by `leaf in code` — **a bare substring test**. Declaring the response key
+  `available_public` put the letters `public` into `apps/web/src/api/cost.ts`, and the route
+  `/projects/{pid}/listings/{lid}/public` instantly read as called. An unrelated field name three
+  directories away is not evidence about a route.
+
+  **It fails OPEN, which is why it survived twice before.** A coincidence makes an unreachable route
+  look reachable, so the headline check — *no route the product cannot call* — comes back clean for a
+  route nobody ever called. Only the allowlist's own rot check can see it, and only when a frozen
+  entry flips. The file already records the two earlier instances (`resourced` standing in for the
+  leaf `sourced`; one route path containing another's) and concluded that *"the coarseness is a
+  standing cost … not a bug awaiting a fix"*, because the remedies it weighed — a two-segment needle,
+  and treating a shared leaf as deciding nothing — both cost far more reach than they bought. **Both
+  earlier collisions were answered by renaming the colliding identifier, and that is what runs out
+  here:** the two previous colliders were internal names free to change; this one is the server's
+  wire key. *A rule that can only be satisfied by renaming things it has no business naming has
+  stopped being a measurement.*
+
+  Fixed by requiring the leaf to be a whole token rather than letters inside a longer one — a third
+  option neither earlier analysis considered, and it costs nothing in reach: **0 routes that the
+  substring rule called uncalled become called under it**, and it surfaces 5 that plurals and
+  prefixes had been vouching for (`aggregates` for `/aggregate` twice, `allocated`, `recommended`,
+  `editPrecheck` for `/recheck`), now frozen as untriaged.
+
+  **MY FIRST FIX WAS WRONG IN THE SAME DIRECTION, AND MEASURING IT IS THE ONLY REASON I KNOW.** The
+  obvious rule is *the leaf must sit after a `/`*, since that is how a path is written. It marks
+  **23 genuinely-called routes uncalled**: the client assembles paths from fragments, so
+  `drawingsSection.ts` calls ``openDrawing(`plan.dxf?${q}`)`` and the leaf of
+  `/projects/{pid}/drawings/plan.dxf` begins a template fragment with no slash in front of it.
+  Freezing those would have put live callers behind an exemption — *the same fail-open direction,
+  moved one character along, inside the fix for it.* Four cases are now asserted in the file: two the
+  rule must reject, two it must still accept, because a boundary that only rejects is a boundary that
+  has stopped finding callers.
+
+  **And the word class is NOT fixed, because it cannot be.** `available_public` was an identifier;
+  the same change also put the bare word *public* into a UI string, which no token rule can tell from
+  a route segment. That one was reworded — *"offline baseline(s) installable — no subscription"*,
+  which names the fact instead of the field and is better copy anyway. The standing cost the file
+  describes is real and unchanged; what moved is that it no longer extends to identifiers.
+
   **AND A FAIL-OPEN GATE FOUND BY MUTATING THE THING IT GUARDS.**
   `apps/web/src/viewer/tools/authoringPlaceStatus.test.ts` asserts the Place button passes an
   `onTick`. It sliced the file from `indexOf("⊕ Place selected family")` — which matches the

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -237,6 +237,17 @@ KNOWN_UNCALLED: set[str] = {
     "/projects/{pid}/scan/verify-lod500",
     "/projects/{pid}/verified-progress/from-layout",
     # `/view-templates/{tid}/graphics` left here in v0.3.1138 — Model Analysis reads cut vs projection.
+
+    # ------------------------------------------------------------------------------------------
+    # NEWLY VISIBLE 2026-09-11, NOT NEWLY UNREACHABLE. `leaf_is_called` stopped accepting a leaf
+    # found inside a longer identifier (see its docstring). These five were already uncalled; what
+    # changed is that the rule can now see them, each having been vouched for by a plural or a
+    # prefix. Frozen, not judged — nobody has read them, which is exactly what this set records.
+    "/pipeline/allocate",                       # 'allocate' was read inside 'allocated'
+    "/projects/{pid}/coordination/stale/recheck",   # 'recheck' was read inside 'editPrecheck'
+    "/projects/{pid}/model/columnar/aggregate",     # 'aggregate' was read inside 'aggregates'
+    "/projects/{pid}/modules/{key}/aggregate",      # 'aggregate' was read inside 'aggregates'
+    "/structure/recommend",                     # 'recommend' was read inside 'recommended'
 }
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -326,6 +337,44 @@ def _templated_stem(route: str) -> "re.Pattern[str] | None":
     return re.compile(rf"{re.escape(segs[-2])}/\$\{{[^}}]*\}}\.{re.escape(ext)}")
 
 
+def leaf_is_called(leaf: str, code: str) -> bool:
+    """Does `leaf` appear as a WHOLE TOKEN in the code, rather than as letters inside a longer one?
+
+    **This was `leaf in code` until 2026-09-11.** A bare substring test cannot tell a route from a
+    word that happens to contain it, and this file already records two collisions it caused —
+    `resourced` standing in for the leaf of `/schedule/eot/sourced`, and one route path containing
+    another's. Both were answered by renaming the colliding identifier, under the reasoning that the
+    coarseness is a standing cost of keeping 328 shared-leaf routes in reach.
+
+    **The third instance is what made that unaffordable.** Declaring the response key
+    `available_public` in `apps/web/src/api/cost.ts` put the letters `public` in the source and
+    instantly "called" `/projects/{pid}/listings/{lid}/public`. The earlier remedy does not reach it:
+    the two previous colliders were internal names free to change, and this one is the SERVER'S WIRE
+    KEY — renaming it means changing the API to suit a test's regex. *A rule that can only be
+    satisfied by renaming things it has no business naming has stopped being a measurement.*
+
+    And it fails OPEN, which is why it survived twice: a coincidence makes an unreachable route look
+    reachable, so the headline check — *no route the product cannot call* — comes back clean for a
+    route nobody ever called. Only the allowlist's rot check can see it, and only when a frozen entry
+    flips.
+
+    **WHY A WORD BOUNDARY AND NOT A PATH BOUNDARY — this cost a wrong answer to find.** The obvious
+    fix is to require the leaf to sit after a `/`, since that is how a path is written. Measured, it
+    marks **23 routes uncalled that are genuinely called**, because the client assembles paths from
+    fragments: `drawingsSection.ts` calls ``openDrawing(`plan.dxf?${q}`)``, so the leaf of
+    `/projects/{pid}/drawings/plan.dxf` starts a template fragment with no slash in front of it.
+    Freezing those three would have put real callers behind an exemption — the same fail-open
+    direction, moved one character along. Allowing any non-identifier prefix (`/`, a quote, a
+    backtick) keeps them and still rejects `available_public`, and it costs nothing in reach:
+    **0 routes that the substring rule called uncalled become called under this one.**
+
+    What it does NOT claim to fix is a leaf that is also an ordinary quoted word — `"ready"` still
+    vouches for `/ready`. That is the coarseness the block comment above still describes, and it is
+    unchanged here; only the inside-a-longer-identifier class is removed.
+    """
+    return re.search(rf"(?<![A-Za-z0-9_]){re.escape(leaf)}(?![A-Za-z0-9_])", code) is not None
+
+
 def uncalled_routes(paths, blob: str) -> set[str]:
     """Routes whose distinctive last static segment appears nowhere in the web source's CODE.
 
@@ -336,7 +385,7 @@ def uncalled_routes(paths, blob: str) -> set[str]:
     out = set()
     for r in paths:
         leaf = _leaf(r)
-        if len(leaf) < MIN_SEGMENT or leaf in code:
+        if len(leaf) < MIN_SEGMENT or leaf_is_called(leaf, code):
             continue
         if r in CALLED_VIA_TEMPLATED_EXT:
             continue
@@ -432,7 +481,7 @@ print(f"  routes {len(PATHS)} · web source {len(BLOB):,} chars · uncalled by t
 #: text as `uncalled_routes` did, which a repeated call only happens to do.
 _CODE = strip_comments(BLOB)
 _STRICT = {r for r in PATHS
-           if len(_leaf(r)) >= MIN_SEGMENT and _leaf(r) not in _CODE}
+           if len(_leaf(r)) >= MIN_SEGMENT and not leaf_is_called(_leaf(r), _CODE)}
 _GAINED = sorted(_STRICT - FOUND)
 _STEM_GAIN = [
     "/projects/{pid}/exports/cobie.xlsx", "/projects/{pid}/exports/qto.xlsx",
@@ -489,6 +538,24 @@ check("  ...and NOT for sheet.dxf, whose EXTENSION is templated but whose caller
 print(f"  templated-URL leniencies worth {len(_STRICT) - len(FOUND)} routes "
       f"({len(_BY_PATTERN)} by the stem pattern, {len(CALLED_VIA_TEMPLATED_EXT)} named; "
       f"{len(_STRICT)} uncalled under the literal-leaf rule alone)")
+
+# --- the leaf rule's own boundary, asserted rather than described ---------------------------------
+#
+# `leaf_is_called` is the predicate the whole file rests on, and the three collisions recorded in
+# KNOWN_UNCALLED above were each found by a route flipping rather than by anyone testing the rule.
+# These four cases are the rule's contract: two say what it must REJECT (the collisions), two say
+# what it must still ACCEPT (the shapes a real caller writes). Mutating the regex breaks one of each,
+# which is the point — a boundary that only rejects is a boundary that has stopped finding callers.
+check("the leaf rule rejects a leaf buried inside a longer identifier",
+      not leaf_is_called("public", "const x = r.available_public.length")
+      and not leaf_is_called("sourced", "fidelity.resourced")
+      and not leaf_is_called("aggregate", "const aggregates = []"),
+      "a substring match is back: an unrelated field name is vouching for a route again")
+check("  ...and still accepts the shapes a real caller writes",
+      leaf_is_called("public", "fetch(`/projects/${pid}/listings/${lid}/public`)")
+      and leaf_is_called("plan.dxf", "openDrawing(`plan.dxf?${q.toString()}`)"),
+      "the boundary has tightened past what the client actually writes — `openDrawing(`plan.dxf…`)` "
+      "names the leaf with no slash in front of it, and requiring one freezes three live callers")
 
 new = sorted(FOUND - KNOWN_UNCALLED)
 check("NO NEW UNREACHABLE ROUTE — a route the product cannot call is a feature nobody can use",

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -371,8 +371,22 @@ def leaf_is_called(leaf: str, code: str) -> bool:
     What it does NOT claim to fix is a leaf that is also an ordinary quoted word — `"ready"` still
     vouches for `/ready`. That is the coarseness the block comment above still describes, and it is
     unchanged here; only the inside-a-longer-identifier class is removed.
+
+    **THE TWO BOUNDARIES ARE NOT THE SAME CLASS, AND `$` IS WHY.** `$` is a valid identifier
+    character in TypeScript, so `available$public` would hide the leaf `public` exactly as
+    `available_public` does — it belongs in the LEADING class. It must NOT be in the trailing one,
+    and that asymmetry is load-bearing rather than an oversight: this client appends an optional
+    query string by interpolation, ``/projects/${pid}/k1-pack${q}``, so a leaf followed by `$` is
+    the single most common shape of a REAL call site. Review suggested `$` on both sides; measured,
+    that marks **19 genuinely-called routes uncalled** — `montecarlo`, `layout.dxf`, `price-history`,
+    `k1-pack` and a dozen more, every one of them followed by `${`.
+
+    *The same distinction as the slash-versus-token question above, arriving a third time from the
+    other side: before the leaf, `$` is part of a NAME; after it, `$` begins a SUBSTITUTION. One
+    character, two grammars, and a rule that treats them alike is wrong in whichever direction it
+    picks.* Both cases are asserted below.
     """
-    return re.search(rf"(?<![A-Za-z0-9_]){re.escape(leaf)}(?![A-Za-z0-9_])", code) is not None
+    return re.search(rf"(?<![A-Za-z0-9_$]){re.escape(leaf)}(?![A-Za-z0-9_])", code) is not None
 
 
 def uncalled_routes(paths, blob: str) -> set[str]:
@@ -548,12 +562,15 @@ print(f"  templated-URL leniencies worth {len(_STRICT) - len(FOUND)} routes "
 # which is the point — a boundary that only rejects is a boundary that has stopped finding callers.
 check("the leaf rule rejects a leaf buried inside a longer identifier",
       not leaf_is_called("public", "const x = r.available_public.length")
+      and not leaf_is_called("public", "const available$public = true")   # `$` is an identifier char
       and not leaf_is_called("sourced", "fidelity.resourced")
       and not leaf_is_called("aggregate", "const aggregates = []"),
       "a substring match is back: an unrelated field name is vouching for a route again")
 check("  ...and still accepts the shapes a real caller writes",
       leaf_is_called("public", "fetch(`/projects/${pid}/listings/${lid}/public`)")
-      and leaf_is_called("plan.dxf", "openDrawing(`plan.dxf?${q.toString()}`)"),
+      and leaf_is_called("plan.dxf", "openDrawing(`plan.dxf?${q.toString()}`)")
+      # after the leaf, `$` starts an interpolated query string — 19 live callers look like this
+      and leaf_is_called("k1-pack", "this.json(`/projects/${pid}/k1-pack${q}`)"),
       "the boundary has tightened past what the client actually writes — `openDrawing(`plan.dxf…`)` "
       "names the leaf with no slash in front of it, and requiring one freezes three live callers")
 

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -382,11 +382,19 @@ def leaf_is_called(leaf: str, code: str) -> bool:
     `k1-pack` and a dozen more, every one of them followed by `${`.
 
     *The same distinction as the slash-versus-token question above, arriving a third time from the
-    other side: before the leaf, `$` is part of a NAME; after it, `$` begins a SUBSTITUTION. One
-    character, two grammars, and a rule that treats them alike is wrong in whichever direction it
-    picks.* Both cases are asserted below.
+    other side: before the leaf, `$` is part of a NAME; after it, `$` USUALLY begins a SUBSTITUTION.
+    One character, two grammars, and a rule that treats them alike is wrong in whichever direction
+    it picks.*
+
+    **"USUALLY" is doing real work there, and the first version of this comment said "always".**
+    Review caught it: `public$draft` is a single TypeScript identifier, so a leaf followed by a bare
+    `$` is a NAME too, and the trailing class has to tell `$draft` from `${q}`. It does that the only
+    way the grammar allows — by looking for the `{`. So the trailing guard rejects `$` *unless* it
+    opens an interpolation, which keeps all 19 query-string callers and stops `public$draft`.
+    Measured: 32 uncalled either way, no route moves. *Getting the asymmetry right was not the end of
+    the question; one side of it still had two cases inside it.* All four are asserted below.
     """
-    return re.search(rf"(?<![A-Za-z0-9_$]){re.escape(leaf)}(?![A-Za-z0-9_])", code) is not None
+    return re.search(rf"(?<![A-Za-z0-9_$]){re.escape(leaf)}(?![A-Za-z0-9_]|\$(?!\{{))", code) is not None
 
 
 def uncalled_routes(paths, blob: str) -> set[str]:
@@ -563,6 +571,7 @@ print(f"  templated-URL leniencies worth {len(_STRICT) - len(FOUND)} routes "
 check("the leaf rule rejects a leaf buried inside a longer identifier",
       not leaf_is_called("public", "const x = r.available_public.length")
       and not leaf_is_called("public", "const available$public = true")   # `$` is an identifier char
+      and not leaf_is_called("public", "const public$draft = true")       # ...on this side too
       and not leaf_is_called("sourced", "fidelity.resourced")
       and not leaf_is_called("aggregate", "const aggregates = []"),
       "a substring match is back: an unrelated field name is vouching for a route again")


### PR DESCRIPTION
# What & why

Closes the triage opened in #507, which derived 15 routes / 21 undeclared keys and read 6 of them. This reads the other 9 and fixes all 15's worth of client declarations — `KNOWN_GAPS` goes **15 → 6**. That list is asserted exactly in both directions, so it can only shrink by fixing.

### The one real defect in the nine

`DELETE /projects/{pid}/schedule/import-xer` returns `cleared: true` **unconditionally** — it deletes whatever its code→id index names and reports success whether that index held 412 activities or did not exist at all. `removed_activities` is the only key separating the two, and the client declared neither, so **"⌫ Clear import" showed the same green toast either way** and the reload behind it looks identical.

Now three outcomes, not two: the count, "nothing to clear", and — for a server too old to send the key — the old wording. Reporting *unknown* as *nothing happened* would swap one collapsed pair for another.

### Four more declared **and rendered**

| key | what was invisible |
|---|---|
| `by_class` on `/safety/metrics` | The OSHA-classification breakdown the route computes first and its docstring names first. The health card could report five incidents without saying what any of them were. |
| `at` on `/publish/status` | The server already uses it to declare an interrupted worker dead after 900 s. Undeclared client-side, so a convert that legitimately takes minutes read `running…` from the first poll to the last — indistinguishable from a stuck job, worst after a reload. |
| `result` on `POST /proforma/scenarios` | The route **solves server-side** and hands the solve back. Typed `{id}` alone, so a scenario that solved to nothing looked exactly like one that solved well until you opened the Portfolio. |
| `available_public` on `/cost/datasets` | With nothing installed the card read "0 vintage(s) installed", which reads as *no cost data is obtainable* — when the offline public baseline needs no subscription. |

`elapsedSince` subtracts a **server** clock from a **browser** one, so a future stamp or one beyond a day returns `null` and the UI says nothing. Showing no elapsed time is honest; showing `-4m` is worse than the silence it replaced. A test pins the exact format the server writes (`datetime.now(timezone.utc).isoformat()` → `+00:00`, not `Z`, not naive) because `Date.parse` reads an offset-less datetime as *local* time — silently right in London, hours out everywhere else.

### Four declared, not rendered, on purpose

`from_upload` and `package` echo what the caller passed in. `source` and `templates` belong to `progressActuals` and `saveViewTemplates`, **neither of which has a UI caller anywhere in `apps/web/src`** — a separate gap, named rather than fixed here. They are declared so the compiler and every audit built on these interfaces can see them.

### A fail-open gate, found by mutating the thing it guards

`authoringPlaceStatus.test.ts` sliced from `indexOf("⊕ Place selected family")` — which matches the **docstring naming the button** (offset 2076), hundreds of lines above the `toolBtn2(...)` that builds it (offset 6312). The slice opened above **Republish**, so *Republish's* callback satisfied an assertion whose name, comment and purpose were all about Place: **deleting Place's `onTick` entirely left it green.**

> An anchor that matches a MENTION of the subject instead of the subject is not a narrower search, it is a different one — and it fails in the direction that looks safe, because a pass is what you get either way.

Now anchored on the construction, with the slice asserted to exclude Republish, and both callbacks mutated separately to prove each bites. Its *other* pin was wrong the opposite way: it matched the callback's **arity**, so it went red the moment `onTick` gained the elapsed argument and this very call site opted in — an improvement to the protected behaviour reported as a regression of it.

### Two ratchets handed work to a third

The size guard refused the growth in `portal.ts` and `client.ts`, which is the friction it exists to create. So `safetyCard.ts` was extracted (pure, 7 tests, 5 mutations) and `progressActuals` moved to the schedule mixin beside the safety and field-log rollups it belongs with: **client.ts 554 → 538**, portal.ts back to its pinned 1238.

Extracting into `portal/` then tripped the unowned-lane ratchet at 36 > 34, whose remedy is *a row, not a bigger number*. All eleven loose `portal/` files were placed by **importer**, never by name — the derivation that settled `tree/`. Two would have gone to the wrong lane on their names, one carrying a docstring pointing at `portal.ts` for a method that lives in `register.ts` (corrected). Ceiling re-seated to the measured **25**.

The lane rows themselves failed the disjointness check on the first try: a backticked `` `portal/` `` written as **prose** inside a path cell is parsed as a claim on the whole directory — the hazard Lane B's own cell already records for item codes, one column over.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree — "All checks passed!")
- [x] Backend: no Python changed; the three gates that read the edited docs pass — `test_claude_md_gates.py` (550 citations, all resolve), `test_file_sizes.py` (all 5 ratchets), `run_tests.py` re-run for confirmation
- [x] Web: `npm run typecheck && npm run lint && npm run build` clean (all three actually run, not inferred from vitest)
- [x] No import cycles introduced (`no-import-cycles.test.ts` passes in the 233-file run)
- [x] `CHANGELOG.md` entry added (newest at top); `docs/roadmap.md` RESPONSE-UNDECLARED entry updated to "all 15 triaged, 9 fixed, 6 open"
- [ ] Version bump — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

**Verification:** 233 files / 2,405 tests green. **10 mutations** across the two new pure functions and the repaired gate, each confirmed to bite:

- `elapsedSince` ×5 — negative guard, 24 h ceiling, zero-padding, NaN guard, elapsed never reaching `onTick`
- `safetyCard` ×5 — alphabetical tie-break, zero-count filter, null-vs-arrow, unconditional rates, `slice(0, top)`
- the repaired Place gate ×2 — Place's `onTick` removed (**the old gate stayed green here**), Republish's removed

### Still open on this axis

The six remaining gaps, three of which need *declare **and** render*: SAML sign-in with no affordance, the asset-rights public key, saved-view scope, `/draw-package`'s G703 totals, `/reference/disciplines`' dropped vocabularies, and `/proforma/solve`'s provenance.

Two findings noted but deliberately **not** folded in: `POST /cost/datasets/import` has no client method at all (the offline importer is unreachable from the UI), and `progressActuals`/`saveViewTemplates` have no UI callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Safety summaries now include incident breakdowns by classification.
  - Cost status displays available offline public cost baselines, including counts and notes.
  - Saved scenarios report solved equity IRR and equity multiple when available.
  - Model processing and publishing status can show elapsed time.
  - Field productivity actuals can be analyzed with rates, utilization, and variance details.

- **Bug Fixes**
  - Clearing schedule imports now distinguishes removed activities from no-op actions and provides clearer messaging.
  - Route checks now avoid false matches from partial words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->