### PR TITLE
RESPONSE-UNDECLARED closes: all 15 gaps, and the SAML cookie underneath one of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### A pro forma now says how much of it you actually supplied
+
+Solve a deal and Massing reports an equity IRR, a yield on cost, a development spread. Some of the
+inputs behind those are yours; the rest the engine filled in with defaults. Until now the screen
+could not tell you which, even though it had the answer — the server works it out on every single
+solve and the app was discarding it.
+
+Under the underwriting guardrails you'll now see a line like *"4 inputs behind these 6 figures were
+defaulted by the engine: exit.cap_rate, debt.rate, ..."*, or confirmation that every input was
+declared. It doesn't change any number. It tells you which numbers are worth arguing about, which is
+the difference between a pro forma you can review and one you can only read.
+
+If your server is older and doesn't send the breakdown, the line is omitted rather than claiming
+everything was declared.
+
 ### A mistyped spec section is now caught while you can still fix it
 
 Attaching a MasterFormat or UniFormat code to an element used to be typing into an empty box with an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Sealing a project now tells you the key people need to check it
+
+When you save a project as a sealed `.mass` file, Massing signs it so that anyone else can confirm
+the file is authentic and unaltered. The dialog said exactly that — and then could not tell you
+which verification key to publish, because the app was never given it. It now names the issuer and
+prints the key alongside, so you can hand it to whoever needs to check your releases. On a server
+with sealing switched on but no signing key configured, nothing is shown, because there would be
+nothing to verify against.
+
+### SAML single sign-on now works, and has a button
+
+If your organisation runs its own identity provider — Okta, Entra ID, Ping, Google Workspace as a
+SAML IdP, anything that speaks SAML 2.0 — Massing could already be configured to accept it, and the
+sign-in screen still had nowhere to click. Worse, a server with SAML configured and no OAuth
+provider showed a note advising you to set up Google or Microsoft sign-in instead, which was the
+opposite of the truth. The login window now leads with **Continue with single sign-on** whenever
+your server has an IdP configured and your plan includes SSO.
+
+Two things had to be true for that button to be worth adding, and only one of them was. Signing in
+through SAML had never actually worked: the server verified the assertion, created or found the
+account, issued a valid session — and then stored it under a name the rest of the server does not
+read, so the browser came back to Massing still signed out. The automated test covering that flow
+checked that *a* session cookie was written, using the same wrong name the code did, so it reported
+success for a sign-in that had never once let anybody in. Both are fixed; the test now asks the
+server who it thinks you are, which is a question no spelling mistake can answer correctly.
+
+If you had SAML configured and gave up on it, it is worth another try.
+
 ### A check that looks for unreachable features stopped being fooled by coincidences
 
 Massing has an automated check whose job is to notice when part of the server ships with nothing in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### You can share a saved view — and delete now tells the truth about it
+
+Saved views on a register could already be shared with the whole project. The app just never offered
+it, so every view anyone made here was private whether they wanted it or not. Saving one now asks.
+
+Three related things were wrong and are fixed together. Shared views from colleagues looked exactly
+like your own private filters in the dropdown — they now say whose they are. The delete list offered
+every view on screen, including other people's, which the server refuses; picking one reported *"was
+already gone"* and then it was still there. It now offers only views you can actually delete. And the
+confirmation claimed a view was *"yours alone"* even when deleting it would remove it for everyone
+using it — it now says which.
+
+### A lender draw package shows the schedule of values it was computed from
+
+Generating a G702 draw package reported the payment due and how many schedule-of-values lines were
+created, and stopped there. Two things it had already worked out went unseen: the G703 totals the
+certificate is computed from — completed to date, retainage held, balance to finish — and the deal's
+returns re-forecast with your actuals folded in.
+
+That second one is the entire point of running the draw off the underwriting model: it answers "is
+this still the deal we signed?" Both are now on screen beside the payment due.
+
 ### A pro forma now says how much of it you actually supplied
 
 Solve a deal and Massing reports an equity IRR, a yield on cost, a development spread. Some of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### A mistyped spec section is now caught while you can still fix it
+
+Attaching a MasterFormat or UniFormat code to an element used to be typing into an empty box with an
+example beside it. `80 51 00` instead of `08 51 00` — two digits swapped, into a division that does
+not exist — was accepted without comment and became a permanent classification on that element.
+
+Massing already knew the answer: the server publishes the full MasterFormat division master and the
+UniFormat-to-MasterFormat crosswalk, and the app was throwing both away as they arrived. It now
+reads your code back to you as you name it: *"Division 08 · Openings (Architectural)"* for a section
+it recognises, and a warning for one it does not. UniFormat codes get the crosswalk — *"B20 ·
+Exterior Enclosure → MasterFormat 04, 07, 08"* — so you can see what an element will be bought
+through.
+
+It warns, it never blocks: MasterFormat reserves whole ranges for divisions you define yourself, and
+those are legitimate codes. If the reference can't be reached, classifying works exactly as before.
+
 ### Sealing a project now tells you the key people need to check it
 
 When you save a project as a sealed `.mass` file, Massing signs it so that anyone else can confirm

--- a/apps/web/src/account/accountUI.ts
+++ b/apps/web/src/account/accountUI.ts
@@ -12,6 +12,7 @@ import { modalShell, confirmModal } from "../ui/modal";
 import { askText } from "../ui/prompt";
 import { escapeHtml, toast } from "../ui/feedback";
 import { renderChip, type ChipIdentity } from "./accountChip";
+import { signInDoors, collapsedDoors, type SignInDoor } from "./signInDoors";
 import { cloudLoginUrl, cloudStatus, cloudRefresh, cloudDisconnect, type CloudStatus } from "../api/cloud";
 
 export interface AccountDeps {
@@ -112,40 +113,45 @@ function loginModal() {
     card.insertBefore(hint, b.nextSibling);
   }).catch(() => { /* status unavailable — the password form below still works */ });
 
-  // SSO buttons (only the providers configured on the server), shown above the password form
-  void D.api.authProviders().then(({ providers }) => {
-    if (!providers.length) {
-      // no OAuth configured — tell the operator SSO is available rather than silently hiding it
+  // Sign-in doors (only the ones configured on the server), shown above the password form.
+  // The ORDER is `signInDoors` — a pure function with its own tests — so that the rule about which
+  // doors lead is not something you have to read DOM code to find out.
+  void D.api.authProviders().then(({ providers, saml }) => {
+    const doors = signInDoors(providers, saml);
+    if (!doors.length) {
+      // no sign-in door configured — tell the operator SSO is available rather than silently hiding
+      // it. This branch used to be `!providers.length`, which is why a workspace that had wired a
+      // SAML IdP and paid for the tier that entitles it was told, on its own login screen, to go and
+      // configure OAuth.
       const hint = document.createElement("div"); hint.className = "meta";
       hint.style.cssText = "margin-top:8px;font-size:11px";
-      hint.innerHTML = "Single sign-on (Google · Microsoft · Procore) is supported — set the "
-        + "<code>AEC_OAUTH_*</code> client IDs on the server to show the buttons here.";
+      hint.innerHTML = "Single sign-on (Google · Microsoft · Procore, or your own SAML IdP) is supported"
+        + " — set the <code>AEC_OAUTH_*</code> client IDs, or the <code>AEC_SAML_IDP_*</code> settings,"
+        + " on the server to show the buttons here.";
       card.appendChild(hint);
       return;
     }
-    // A1/C1: the modal LEADS with big Google + Microsoft buttons (co-equal defaults); when neither
-    // is configured the first configured provider takes the lead slot instead.
+    // A1/C1: the modal LEADS with big buttons (co-equal defaults) and collapses the rest.
     const wrap = document.createElement("div"); wrap.style.cssText = "display:flex;flex-direction:column;gap:8px";
-    const go2 = (pv: { id: string }) => { window.location.href = D.api.url(`/auth/oauth/${pv.id}/login`); };
-    const PRIMARY = new Set(["google", "microsoft"]);
-    const primary = providers.filter((pv) => PRIMARY.has(pv.id));
-    const lead = primary.length ? primary : providers.slice(0, 1);
-    for (const pv of lead) {
+    // Every door is a full-page navigation, SAML included: each one ends at a server redirect that
+    // sets the session cookie, so there is nothing for fetch to carry back.
+    const go2 = (d: SignInDoor) => { window.location.href = D.api.url(d.path); };
+    for (const d of doors.filter((x) => x.lead)) {
       const b = document.createElement("button"); b.className = "file-btn";
       b.style.cssText = "padding:11px 14px;font-size:14px;font-weight:600";
-      b.textContent = `Continue with ${pv.label}`;
-      b.onclick = () => go2(pv);
+      b.textContent = `Continue with ${d.label}`;
+      b.onclick = () => go2(d);
       wrap.appendChild(b);
     }
-    // A2: every other provider collapses behind "More sign-in options"
-    const others = providers.filter((pv) => !lead.includes(pv));
+    // A2: every other door collapses behind "More sign-in options"
+    const others = collapsedDoors(doors);
     if (others.length) {
       const hidden = document.createElement("div");
       hidden.style.cssText = "display:none;flex-direction:column;gap:6px";
-      for (const pv of others) {
+      for (const d of others) {
         const b = document.createElement("button"); b.className = "tool-btn";
-        b.textContent = `Continue with ${pv.label}`;
-        b.onclick = () => go2(pv);
+        b.textContent = `Continue with ${d.label}`;
+        b.onclick = () => go2(d);
         hidden.appendChild(b);
       }
       const more = document.createElement("a"); more.href = "#";

--- a/apps/web/src/account/signInDoors.test.ts
+++ b/apps/web/src/account/signInDoors.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { signInDoors, collapsedDoors } from "./signInDoors";
+
+const G = { id: "google", label: "Google" };
+const M = { id: "microsoft", label: "Microsoft" };
+const P = { id: "procore", label: "Procore" };
+
+describe("signInDoors", () => {
+  it("offers the SAML door when the server says the workspace has one", () => {
+    // The regression this file exists for: `GET /auth/providers` returns `saml`, the client type did
+    // not declare it, and the modal branched on `providers.length` alone — so a workspace with a
+    // configured IdP and a tier that entitles SSO saw a hint telling it to configure OAuth.
+    const doors = signInDoors([], true);
+    expect(doors.map((d) => d.key)).toEqual(["saml"]);
+    expect(doors[0]!.path).toBe("/auth/saml/login");
+    expect(doors[0]!.lead).toBe(true);
+  });
+
+  it("is empty only when NEITHER door is configured", () => {
+    expect(signInDoors([], false)).toEqual([]);
+    expect(signInDoors([], true).length).toBe(1);
+    expect(signInDoors([P], false).length).toBe(1);
+  });
+
+  it("puts SAML ahead of the OAuth providers", () => {
+    expect(signInDoors([G, M], true).map((d) => d.key)).toEqual(["saml", "google", "microsoft"]);
+  });
+
+  it("never routes SAML through the OAuth login path", () => {
+    // SAML is not an entry in `providers` and has no `/auth/oauth/{id}/login` URL; sending it there
+    // would 404 on a provider id the server has never heard of.
+    for (const d of signInDoors([G, P], true)) {
+      expect(d.path).toBe(d.key === "saml" ? "/auth/saml/login" : `/auth/oauth/${d.key}/login`);
+    }
+  });
+
+  it("leads with Google and Microsoft and collapses the rest", () => {
+    const doors = signInDoors([P, G, M], false);
+    expect(doors.filter((d) => d.lead).map((d) => d.key)).toEqual(["google", "microsoft"]);
+    expect(collapsedDoors(doors).map((d) => d.key)).toEqual(["procore"]);
+  });
+
+  it("promotes the first provider when neither primary is configured", () => {
+    // Otherwise a server with only Procore hides its only OAuth door behind a disclosure link.
+    const doors = signInDoors([P], false);
+    expect(doors[0]!.lead).toBe(true);
+    expect(collapsedDoors(doors)).toEqual([]);
+  });
+
+  it("does not promote an OAuth provider just because SAML is present", () => {
+    // SAML leading must not change which OAuth doors collapse — the two rules are independent.
+    const withSaml = signInDoors([P, G, M], true);
+    const without = signInDoors([P, G, M], false);
+    expect(collapsedDoors(withSaml).map((d) => d.key)).toEqual(collapsedDoors(without).map((d) => d.key));
+  });
+
+  it("keeps the server's provider order inside each group", () => {
+    const doors = signInDoors([M, G], false);
+    expect(doors.filter((d) => d.lead).map((d) => d.key)).toEqual(["microsoft", "google"]);
+  });
+
+  it("carries the server's label, not the id", () => {
+    const doors = signInDoors([{ id: "google", label: "Google Workspace" }], false);
+    expect(doors[0]!.label).toBe("Google Workspace");
+  });
+});

--- a/apps/web/src/account/signInDoors.ts
+++ b/apps/web/src/account/signInDoors.ts
@@ -1,0 +1,40 @@
+/** Which sign-in doors the login modal offers, and in what order.
+ *
+ *  Pure, and separate from the modal, because the ordering is the part with a rule in it and the
+ *  modal is the part with a `document` in it. It was inline, and while it was inline the one door
+ *  nobody could see was the one that is not an OAuth provider at all: a workspace's own SAML IdP
+ *  has no `/auth/oauth/{id}/login` URL, so it could never be an entry in `providers`, and the modal
+ *  had no other way to render a door. `GET /auth/providers` had been returning `saml` the whole
+ *  time; the client type did not declare it, so nothing downstream could reach it.
+ *
+ *  `lead` is the big-button group; the rest collapse behind "More sign-in options".
+ */
+export type OauthProvider = { id: string; label: string };
+export type SignInDoor = { key: string; label: string; path: string; lead: boolean };
+
+/** Providers that lead when configured — the two consumer identities most people already have. */
+const PRIMARY = new Set(["google", "microsoft"]);
+
+export function signInDoors(providers: OauthProvider[], saml: boolean): SignInDoor[] {
+  const doors: SignInDoor[] = [];
+  if (saml) {
+    // First, deliberately: an organisation that wired its own IdP signs its people in through that,
+    // not through a consumer provider that happens to also be configured on the same server. The
+    // caller may render this true ONLY because the server already checked both halves — an IdP is
+    // configured AND the tier entitles `sso` — so the button cannot 402 on click.
+    doors.push({ key: "saml", label: "single sign-on", path: "/auth/saml/login", lead: true });
+  }
+  const primary = providers.filter((pv) => PRIMARY.has(pv.id));
+  // No primary provider configured: the first one still takes a lead slot, so a server with only
+  // Procore does not hide its only OAuth door behind a disclosure link.
+  const lead = new Set(primary.length ? primary : providers.slice(0, 1));
+  for (const pv of providers) {
+    doors.push({ key: pv.id, label: pv.label, path: `/auth/oauth/${pv.id}/login`, lead: lead.has(pv) });
+  }
+  return doors;
+}
+
+/** The doors that collapse — i.e. how many "More sign-in options" is offering. */
+export function collapsedDoors(doors: SignInDoor[]): SignInDoor[] {
+  return doors.filter((d) => !d.lead);
+}

--- a/apps/web/src/api/assetRights.test.ts
+++ b/apps/web/src/api/assetRights.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { sealIdentity, type AssetRightsStatus } from "./assetRights";
+
+const st = (o: Partial<AssetRightsStatus>): AssetRightsStatus =>
+  ({ enabled: true, signing: true, issuer: "did:web:example.com", public_key: "k".repeat(43), ...o });
+
+describe("sealIdentity", () => {
+  it("names the issuer and the key a verifier would check against", () => {
+    const id = sealIdentity(st({}));
+    expect(id).toEqual({ issuer: "did:web:example.com", key: "k".repeat(43) });
+  });
+
+  it("is null when the deployment cannot sign at all", () => {
+    // Sealing still works unsigned — tamper-evident, no attribution — and the dialog must not offer
+    // an identity in that case, because there is nothing anyone could verify it against.
+    expect(sealIdentity(st({ signing: false, public_key: "" }))).toBeNull();
+  });
+
+  it("is null when signing is claimed but NO key is published", () => {
+    // The case worth having a test for: `signing: true` with an empty `public_key` would otherwise
+    // render "Verification key:" followed by nothing, which reads as an identity a third party can
+    // check and is not one. The server sends "" deliberately so "no key here" is distinguishable
+    // from "key withheld"; this is the client honouring that distinction.
+    expect(sealIdentity(st({ public_key: "" }))).toBeNull();
+    expect(sealIdentity(st({ public_key: "   " }))).toBeNull();
+  });
+
+  it("refuses a key when `signing` is false, even if one is somehow present", () => {
+    // Mutation-driven. The first version of the "cannot sign" test above set `public_key: ""` too,
+    // so it passed with the `signing` check deleted — the empty-key guard caught it instead, and the
+    // two guards were indistinguishable from the tests. Today's server cannot produce this state
+    // (it sends "" whenever signing is unavailable), but the TYPE permits it and the meaning is not
+    // ambiguous: `signing` is the field that says whether this deployment signs, so a key beside a
+    // false is a server bug and must not be advertised as an identity.
+    expect(sealIdentity(st({ signing: false }))).toBeNull();
+  });
+
+  it("still returns the key when no issuer NAME is configured", () => {
+    // An unnamed issuer is a real state, not an error: the key alone is what the signature is
+    // checked against. Dropping the identity here would hide a publishable key.
+    expect(sealIdentity(st({ issuer: "" }))).toEqual({ issuer: "", key: "k".repeat(43) });
+  });
+
+  it("trims, so whitespace around a configured value is not rendered", () => {
+    expect(sealIdentity(st({ issuer: "  did:web:x  ", public_key: " abc " })))
+      .toEqual({ issuer: "did:web:x", key: "abc" });
+  });
+});

--- a/apps/web/src/api/assetRights.ts
+++ b/apps/web/src/api/assetRights.ts
@@ -23,8 +23,36 @@ type Ctor<T> = new (...args: any[]) => T;
 export interface AssetRightsStatus {
   enabled: boolean;
   signing: boolean;
-  /** Public issuer identifier (e.g. a `did:web:` name). Never a key. */
+  /** Public issuer identifier (e.g. a `did:web:` name). */
   issuer: string;
+  /**
+   * The deployment's Ed25519 **public** verification key, base64url, or `""` when signing is
+   * unavailable — so a caller can tell "no key here" from "key withheld".
+   *
+   * This field went undeclared, under a comment on `issuer` that read *"Never a key."* — a rule the
+   * server had already corrected and removed. Withholding it protected nothing: the same key is
+   * embedded in every signed manifest we emit, so the only effect was that a third party had to
+   * trust the document's own copy of it, which is precisely the copy an attacker who rewrote the
+   * manifest would have replaced. Publishing it out of band is the entire point.
+   */
+  public_key: string;
+}
+
+/**
+ * What to tell someone sealing a release about the identity it will carry — or `null` when there is
+ * no identity to name, so the caller renders nothing rather than an empty label.
+ *
+ * Pure and separate from the dialog because the interesting part is the four-way split, not the
+ * markup: sealing can be unsigned (no identity at all), signed by a named issuer with a publishable
+ * key, signed with a key but no issuer name, or — the case worth having a test for — configured with
+ * an issuer name and NO key, which must not be described as something a third party can verify.
+ */
+export function sealIdentity(st: AssetRightsStatus): { issuer: string; key: string } | null {
+  if (!st.signing) return null;
+  const key = (st.public_key || "").trim();
+  const issuer = (st.issuer || "").trim();
+  if (!key) return null;                       // nothing a verifier can check against
+  return { issuer, key };
 }
 
 export function withAssetRights<TBase extends Ctor<HttpCore>>(Base: TBase) {

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -39,9 +39,17 @@ type Ctor<T> = new (...args: any[]) => T;
 
 export function withAuth<TBase extends Ctor<HttpCore>>(Base: TBase) {
   return class Auth extends Base {
-  /** Enabled SSO providers (Google/Microsoft/Procore) for the login UI. */
+  /** Enabled sign-in doors for the login UI.
+   *
+   *  `providers` is the OAuth list (Google/Microsoft/Procore). `saml` is the workspace's OWN IdP,
+   *  and it is a separate door, not an entry in that list: it has no `/auth/oauth/{id}/login` URL —
+   *  its button goes to `/auth/saml/login`. It went undeclared, so the login modal could not see
+   *  it, and a workspace that had wired a SAML IdP saw the empty-`providers` branch telling it to
+   *  configure OAuth. The server has already checked BOTH halves before saying true (an IdP is
+   *  configured AND the tier entitles `sso`), which is what lets the button be rendered at all —
+   *  advertising from configuration alone would offer a button that 402s on click. */
   authProviders() {
-    return this.json<{ providers: { id: string; label: string }[] }>("/auth/providers");
+    return this.json<{ providers: { id: string; label: string }[]; saml: boolean }>("/auth/providers");
   }
   /** Re-prove the account password for ONE action, yielding a short-lived assertion.
    *

--- a/apps/web/src/api/classificationRef.test.ts
+++ b/apps/web/src/api/classificationRef.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { codeAnnotation, crosswalkFor, divisionOf, type ClassificationRefs } from "./classificationRef";
+
+/** A slice of what `GET /reference/disciplines` actually serves, shapes and values from
+ *  `services/api/src/aec_api/classification.py` (MF_DIVISIONS / UNIFORMAT / DISCIPLINES). */
+const REFS: ClassificationRefs = {
+  disciplines: [{ code: "A", name: "Architectural" }, { code: "M", name: "Mechanical" },
+                { code: "S", name: "Structural" }],
+  masterformat_divisions: [
+    { code: "03", title: "Concrete", discipline: "S" },
+    { code: "08", title: "Openings", discipline: "A" },
+    { code: "23", title: "Heating, Ventilating and Air Conditioning", discipline: "M" },
+    { code: "31", title: "Earthwork", discipline: null },
+  ],
+  uniformat_crosswalk: [
+    { code: "A", title: "Substructure", masterformat_divisions: ["03", "31"] },
+    { code: "B20", title: "Exterior Enclosure", masterformat_divisions: ["04", "07", "08"] },
+    { code: "D30", title: "HVAC", masterformat_divisions: ["23"] },
+  ],
+};
+
+describe("divisionOf", () => {
+  it("reads the division out of every way a section gets typed", () => {
+    expect(divisionOf("08 51 00")).toBe("08");
+    expect(divisionOf("085100")).toBe("08");
+    expect(divisionOf("08-51-00")).toBe("08");
+  });
+  it("is null when there are not two digits to read", () => {
+    expect(divisionOf("8")).toBeNull();
+    expect(divisionOf("")).toBeNull();
+    expect(divisionOf("B2020")).toBe("20");   // digits only — the caller picks the right system
+  });
+});
+
+describe("crosswalkFor", () => {
+  it("resolves a code to its element", () => {
+    expect(crosswalkFor("B2020", REFS.uniformat_crosswalk)?.code).toBe("B20");
+    expect(crosswalkFor("A1010", REFS.uniformat_crosswalk)?.code).toBe("A");
+  });
+
+  it("takes the LONGEST matching prefix when a parent and a child BOTH appear", () => {
+    // Mutation-driven, and the first version of this test could not see the rule it was named for:
+    // it asserted against the served table, where no two entries are prefixes of each other ("A",
+    // "B10", "B20", "D30"...), so first-match and longest-match agree on every code and replacing
+    // one with the other passed. Uniformat II is a hierarchy and the served table is one level of
+    // it; the day "A10" joins "A", a first-match rule silently reports every A10xx as bare
+    // "Substructure". The competing rows have to be IN the fixture for the assertion to mean
+    // anything.
+    const nested = [{ code: "A", title: "Substructure", masterformat_divisions: ["03", "31"] },
+                    { code: "A10", title: "Foundations", masterformat_divisions: ["03"] }];
+    expect(crosswalkFor("A1010", nested)?.code).toBe("A10");
+    expect(crosswalkFor("A1010", [...nested].reverse())?.code).toBe("A10");   // order must not decide
+    expect(crosswalkFor("A20", nested)?.code).toBe("A");
+  });
+  it("is case- and punctuation-insensitive", () => {
+    expect(crosswalkFor("b20-20", REFS.uniformat_crosswalk)?.code).toBe("B20");
+  });
+  it("is null for a code under no element", () => {
+    expect(crosswalkFor("Z99", REFS.uniformat_crosswalk)).toBeNull();
+    expect(crosswalkFor("", REFS.uniformat_crosswalk)).toBeNull();
+  });
+});
+
+describe("codeAnnotation", () => {
+  it("names the division and the discipline it rolls up to", () => {
+    expect(codeAnnotation("MasterFormat", "08 51 00", REFS))
+      .toEqual({ text: "Division 08 · Openings (Architectural)", known: true });
+  });
+
+  it("flags a division the master does not carry — the transposition case", () => {
+    // `80 51 00` for `08 51 00`. This is the defect the whole change exists for: before it, the
+    // prompt offered an example and the typo became a classification on an IFC element in silence.
+    const ann = codeAnnotation("MasterFormat", "80 51 00", REFS);
+    expect(ann?.known).toBe(false);
+    expect(ann?.text).toContain("80");
+  });
+
+  it("does not refuse an unknown division, it reports one", () => {
+    // MasterFormat reserves 48-49 and the 80s-90s for user-defined divisions, so `known: false` is
+    // a thing to say, never a thing to block on. The annotation is still returned.
+    expect(codeAnnotation("MasterFormat", "48 00 00", REFS)).not.toBeNull();
+  });
+
+  it("omits the discipline when the division rolls up to none", () => {
+    expect(codeAnnotation("MasterFormat", "31 20 00", REFS))
+      .toEqual({ text: "Division 31 · Earthwork", known: true });
+  });
+
+  it("crosses a Uniformat element over to the divisions it procures through", () => {
+    expect(codeAnnotation("UniFormat", "B2020", REFS))
+      .toEqual({ text: "B20 · Exterior Enclosure → MasterFormat 04, 07, 08", known: true });
+  });
+
+  it("says nothing for a system this route carries no reference for", () => {
+    // OmniClass and Uniclass are not served here. An annotation that appears for two systems and
+    // not the others is information; a fabricated one is not.
+    expect(codeAnnotation("OmniClass", "23-17 11 11", REFS)).toBeNull();
+    expect(codeAnnotation("Uniclass", "SS_25_10", REFS)).toBeNull();
+  });
+
+  it("matches the system name however it is cased", () => {
+    // The caller passes the UI's label ("UniFormat"); the rule must not depend on that spelling.
+    expect(codeAnnotation("uniformat", "D3010", REFS)?.known).toBe(true);
+    expect(codeAnnotation("MASTERFORMAT", "23 00 00", REFS)?.known).toBe(true);
+  });
+});

--- a/apps/web/src/api/classificationRef.ts
+++ b/apps/web/src/api/classificationRef.ts
@@ -1,0 +1,80 @@
+/** Reading a code against the served classification reference.
+ *
+ *  `GET /reference/disciplines` returns four payloads and the client kept one. `tree` drove the
+ *  viewer's colours; `masterformat_divisions` (the division master — code, title, and the discipline
+ *  each rolls up to) and `uniformat_crosswalk` (Uniformat II element → the MasterFormat divisions it
+ *  procures through) were dropped at the `.then`, and they are the two that exist nowhere else in
+ *  this shape: `tree.disciplines[].divisions` carries only the subset belonging to one discipline,
+ *  and nothing else in the client knows that B2020 buys out of Division 08.
+ *
+ *  That mattered where someone types a code by hand. The Detailing panel asked for a MasterFormat
+ *  section with the hint *"e.g. 08 51 00"* and had no way to say what 08 IS — so `80 51 00`, a
+ *  transposition into a division that does not exist, was accepted in silence and became a
+ *  classification on an IFC element.
+ *
+ *  Pure, so the reading is testable without a dialog. Nothing here REFUSES a code: MasterFormat
+ *  reserves 48-49 and the 80s-90s for user-defined divisions, so an unknown division is a thing to
+ *  say out loud, not a thing to block.
+ */
+
+/** One row of the division master. */
+export interface MfDivision { code: string; title: string; discipline: string | null }
+/** One Uniformat II element and the MasterFormat divisions it maps to. */
+export interface UfCrosswalk { code: string; title: string; masterformat_divisions: string[] }
+/** The flat discipline catalog — code → display name, for naming what a division rolls up to. */
+export interface DisciplineRef { code: string; name: string }
+
+export interface ClassificationRefs {
+  disciplines: DisciplineRef[];
+  masterformat_divisions: MfDivision[];
+  uniformat_crosswalk: UfCrosswalk[];
+}
+
+/** The leading division of a MasterFormat section — "08 51 00" and "085100" both sit in `08`. */
+export function divisionOf(code: string): string | null {
+  const digits = code.replace(/[^0-9]/g, "");
+  return digits.length >= 2 ? digits.slice(0, 2) : null;
+}
+
+/** The Uniformat entry a code belongs to: the LONGEST declared prefix, because the table holds both
+ *  `B` and `B20` and the coarser one must not win over the finer. */
+export function crosswalkFor(code: string, crosswalk: UfCrosswalk[]): UfCrosswalk | null {
+  const want = code.replace(/[^0-9A-Za-z]/g, "").toUpperCase();
+  if (!want) return null;
+  let best: UfCrosswalk | null = null;
+  for (const x of crosswalk) {
+    const c = x.code.toUpperCase();
+    if (want.startsWith(c) && (!best || c.length > best.code.length)) best = x;
+  }
+  return best;
+}
+
+/**
+ * What to tell the person about the code they just typed, or `null` when this system has no
+ * reference to read it against (OmniClass and Uniclass are not served here, and saying nothing is
+ * correct — an annotation that appears for two systems and not the others is information, whereas a
+ * fabricated one is not).
+ *
+ * `known: false` is the one worth acting on: it means the code names a division the master does not
+ * carry, which is either a user-defined division or a typo, and the caller says so without refusing.
+ */
+export function codeAnnotation(system: string, code: string, refs: ClassificationRefs):
+    { text: string; known: boolean } | null {
+  const sys = system.toLowerCase();
+  if (sys === "masterformat") {
+    const div = divisionOf(code);
+    if (!div) return null;
+    const row = refs.masterformat_divisions.find((d) => d.code === div);
+    if (!row) return { text: `Division ${div} is not in the MasterFormat division master`, known: false };
+    const disc = refs.disciplines.find((d) => d.code === row.discipline);
+    return { text: `Division ${row.code} · ${row.title}${disc ? ` (${disc.name})` : ""}`, known: true };
+  }
+  if (sys === "uniformat") {
+    const row = crosswalkFor(code, refs.uniformat_crosswalk);
+    if (!row) return { text: `${code} is not under any Uniformat II element in the crosswalk`, known: false };
+    const divs = row.masterformat_divisions;
+    return { text: `${row.code} · ${row.title}${divs.length ? ` → MasterFormat ${divs.join(", ")}` : ""}`,
+             known: true };
+  }
+  return null;
+}

--- a/apps/web/src/api/classificationRef.ts
+++ b/apps/web/src/api/classificationRef.ts
@@ -1,4 +1,9 @@
-/** Reading a code against the served classification reference.
+import { HttpCore } from "./httpCore";
+import type { DisciplineTree } from "./types";
+
+type Ctor<T> = new (...args: any[]) => T;
+
+/** The served classification reference: fetching it, and reading a code against it.
  *
  *  `GET /reference/disciplines` returns four payloads and the client kept one. `tree` drove the
  *  viewer's colours; `masterformat_divisions` (the division master — code, title, and the discipline
@@ -77,4 +82,37 @@ export function codeAnnotation(system: string, code: string, refs: Classificatio
              known: true };
   }
   return null;
+}
+
+/** Everything `GET /reference/disciplines` sends — and the declared type used to be `{ tree }`
+ *  alone, which is not what the route sends: the other three payloads arrived on every call and
+ *  were dropped at the `.then`. One alias, so the two cached call sites below cannot drift apart. */
+type ClassificationReference = { tree: DisciplineTree } & ClassificationRefs;
+
+/** A mixin, not two more methods on `client.ts`: the size ratchet in
+ *  `services/api/test_file_sizes.py` refused the growth, which is the pin working exactly as its
+ *  comment says it should. `disciplineTree` came across with the new accessor rather than being
+ *  left behind — they are one question (*what does the served vocabulary say?*) answered from one
+ *  cached request, and splitting them would put the cache in a different file from its readers. */
+export function withClassification<TBase extends Ctor<HttpCore>>(Base: TBase) {
+  return class Classification extends Base {
+    private _classRef?: Promise<ClassificationReference>;
+    /** The unified discipline tree (colors + IFC-class→discipline map) — the viewer, model browser,
+     *  and any legend share one served vocabulary. */
+    disciplineTree(): Promise<DisciplineTree> {
+      return (this._classRef ??= this.json<ClassificationReference>("/reference/disciplines")).then((r) => r.tree);
+    }
+    /** The division master + Uniformat crosswalk + flat discipline catalog, for reading back a code
+     *  the user typed. Shares the cached request above rather than issuing a second one.
+     *
+     *  The `??=` is repeated rather than factored into a private helper on purpose:
+     *  `apps/web/src/api/clientCallers.test.ts` asks which CLIENT METHODS no screen can reach, and
+     *  it reads the application outside `api/`, so a helper called only from in here reads as an
+     *  endpoint nobody wired. Two explicit call sites keep that gate measuring what it means to. */
+    classificationRefs(): Promise<ClassificationRefs> {
+      return (this._classRef ??= this.json<ClassificationReference>("/reference/disciplines")).then(
+        ({ disciplines, masterformat_divisions, uniformat_crosswalk }) =>
+          ({ disciplines, masterformat_divisions, uniformat_crosswalk }));
+    }
+  };
 }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -63,14 +63,11 @@ export type { ModuleGraph, ModuleGraphEdge, ModuleGraphNode } from "./modules";
 export * from "./authoring";
 export * from "./library";
 export type { ClashResult } from "./clash";
-import type { ClassificationRefs } from "./classificationRef";
-/** Everything `GET /reference/disciplines` sends — one alias so the two cached call sites below
- *  cannot drift apart on the type. */
-type ClassificationReference = { tree: DisciplineTree } & ClassificationRefs;
+import { withClassification } from "./classificationRef";
 export type { ClassificationRefs, MfDivision, UfCrosswalk } from "./classificationRef";
 import type {
   Dashboard,
-  DisciplineTree, ModulePin, RoomAllocation,
+  ModulePin, RoomAllocation,
   PropMapRule,
     SpecManual, WorkItem, VitalsPayload,
     MasterBuilderBrief } from "./types";
@@ -78,7 +75,7 @@ import type {
 
 // Transport (baseUrl, token, json/_pdfPost/url/health) lives in HttpCore; ApiClient adds the typed
 // domain methods below. Every `api.method()` call site is unchanged by the split.
-export class ApiClient extends withCoverageMaps(withAcceptanceGates(withCounterpartyRisk(withDesignPerformance(withDetailing(withAnnotate(withCreDeal(withClientPortal(withResilience(withResponsibility(withOperations(withAccounting(withDealMemory(withPdfTools(withCodeCheck(withSpecialty(withIds(withEvm(withRisk(withEntitlements(withPrecon(withAi(withTopics(withMep(withDocuments(withModels(withElements(withDrawingSheets(withDrawingSet(withMarkup(withSync(withConnections(withDocQa(withFinance(withContracts(withAuth(withProforma(withDesignOptions(withRoutines(withCost(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAssetRights(withAuthoring(HttpCore)))))))))))))))))))))))))))))))))))))))))))))))) {
+export class ApiClient extends withCoverageMaps(withAcceptanceGates(withCounterpartyRisk(withDesignPerformance(withDetailing(withAnnotate(withCreDeal(withClientPortal(withResilience(withResponsibility(withOperations(withAccounting(withDealMemory(withPdfTools(withCodeCheck(withSpecialty(withIds(withEvm(withRisk(withEntitlements(withPrecon(withAi(withTopics(withMep(withDocuments(withModels(withElements(withDrawingSheets(withDrawingSet(withMarkup(withSync(withConnections(withDocQa(withFinance(withContracts(withAuth(withProforma(withDesignOptions(withRoutines(withCost(withProcurement(withEstimate(withModules(withModel(withSchedule(withLibrary(withAssetRights(withClassification(withAuthoring(HttpCore))))))))))))))))))))))))))))))))))))))))))))))))) {
   /**
    * R22-PHOTO-CV — attach a field photo to an element and get the server's read on it back.
    *
@@ -110,32 +107,6 @@ export class ApiClient extends withCoverageMaps(withAcceptanceGates(withCounterp
     return this.json<{ schema: string; counts: Record<string, number>; facets: { classes: string[]; storeys: string[] } }>(
       `/projects/${pid}/properties/meta`,
     );
-  }
-
-  /** The whole classification reference, cached for the session — project-independent, and ONE
-   *  request serves both readers below.
-   *
-   *  The declared type used to be `{ tree }` alone, which is not what the route sends: the other
-   *  three payloads were arriving and being dropped at the `.then`. Two of them exist nowhere else
-   *  in this shape — the MasterFormat division master, and the Uniformat→MasterFormat crosswalk —
-   *  and their absence is why a hand-typed spec code had nothing to be read against. */
-  private _classRef?: Promise<ClassificationReference>;
-  /** The unified discipline tree (colors + IFC-class→discipline map) — the viewer, model browser,
-   *  and any legend share one served vocabulary. */
-  disciplineTree(): Promise<DisciplineTree> {
-    return (this._classRef ??= this.json<ClassificationReference>(`/reference/disciplines`)).then((r) => r.tree);
-  }
-  /** The division master + Uniformat crosswalk + flat discipline catalog, for reading back a code
-   *  the user typed. Shares the cached request above rather than issuing a second one.
-   *
-   *  The `??=` is repeated rather than factored into a third method on purpose:
-   *  `apps/web/src/api/clientCallers.test.ts` asks which CLIENT METHODS no screen can reach, and it
-   *  reads the application outside `api/`, so a private helper called only from in here reads as an
-   *  endpoint nobody wired. Two explicit call sites keep the gate measuring what it means to. */
-  classificationRefs(): Promise<ClassificationRefs> {
-    return (this._classRef ??= this.json<ClassificationReference>(`/reference/disciplines`)).then(
-      ({ disciplines, masterformat_divisions, uniformat_crosswalk }) =>
-        ({ disciplines, masterformat_divisions, uniformat_crosswalk }));
   }
 
   /** Batch 5D heatmap: bucket every element GUID by schedule %-complete (by=progress) or cost

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -63,6 +63,11 @@ export type { ModuleGraph, ModuleGraphEdge, ModuleGraphNode } from "./modules";
 export * from "./authoring";
 export * from "./library";
 export type { ClashResult } from "./clash";
+import type { ClassificationRefs } from "./classificationRef";
+/** Everything `GET /reference/disciplines` sends — one alias so the two cached call sites below
+ *  cannot drift apart on the type. */
+type ClassificationReference = { tree: DisciplineTree } & ClassificationRefs;
+export type { ClassificationRefs, MfDivision, UfCrosswalk } from "./classificationRef";
 import type {
   Dashboard,
   DisciplineTree, ModulePin, RoomAllocation,
@@ -107,11 +112,30 @@ export class ApiClient extends withCoverageMaps(withAcceptanceGates(withCounterp
     );
   }
 
-  /** The unified discipline tree (colors + IFC-class→discipline map). Project-independent, so cached
-   * for the session — the viewer, model browser, and any legend share one served vocabulary. */
-  private _discTree?: Promise<DisciplineTree>;
+  /** The whole classification reference, cached for the session — project-independent, and ONE
+   *  request serves both readers below.
+   *
+   *  The declared type used to be `{ tree }` alone, which is not what the route sends: the other
+   *  three payloads were arriving and being dropped at the `.then`. Two of them exist nowhere else
+   *  in this shape — the MasterFormat division master, and the Uniformat→MasterFormat crosswalk —
+   *  and their absence is why a hand-typed spec code had nothing to be read against. */
+  private _classRef?: Promise<ClassificationReference>;
+  /** The unified discipline tree (colors + IFC-class→discipline map) — the viewer, model browser,
+   *  and any legend share one served vocabulary. */
   disciplineTree(): Promise<DisciplineTree> {
-    return (this._discTree ??= this.json<{ tree: DisciplineTree }>(`/reference/disciplines`).then((r) => r.tree));
+    return (this._classRef ??= this.json<ClassificationReference>(`/reference/disciplines`)).then((r) => r.tree);
+  }
+  /** The division master + Uniformat crosswalk + flat discipline catalog, for reading back a code
+   *  the user typed. Shares the cached request above rather than issuing a second one.
+   *
+   *  The `??=` is repeated rather than factored into a third method on purpose:
+   *  `apps/web/src/api/clientCallers.test.ts` asks which CLIENT METHODS no screen can reach, and it
+   *  reads the application outside `api/`, so a private helper called only from in here reads as an
+   *  endpoint nobody wired. Two explicit call sites keep the gate measuring what it means to. */
+  classificationRefs(): Promise<ClassificationRefs> {
+    return (this._classRef ??= this.json<ClassificationReference>(`/reference/disciplines`)).then(
+      ({ disciplines, masterformat_divisions, uniformat_crosswalk }) =>
+        ({ disciplines, masterformat_divisions, uniformat_crosswalk }));
   }
 
   /** Batch 5D heatmap: bucket every element GUID by schedule %-complete (by=progress) or cost

--- a/apps/web/src/api/modules.ts
+++ b/apps/web/src/api/modules.ts
@@ -161,9 +161,14 @@ export function withModules<TBase extends Ctor<HttpCore>>(Base: TBase) {
   listViews(pid: string, key: string) {
     return this.json<SavedViewDef[]>(`/projects/${pid}/modules/${key}/views`);
   }
-  saveView(pid: string, key: string, name: string, config: Record<string, unknown>) {
+  /** Create or replace one of MY saved views. `scope` is sent explicitly: the route defaults it to
+   *  `"private"`, and omitting it meant that default decided for every view the web UI had ever
+   *  created — the sharing half of R22-REPORT-BUILDER item 4 was reachable only from outside this
+   *  app. */
+  saveView(pid: string, key: string, name: string, config: Record<string, unknown>,
+           scope: "private" | "project" = "private") {
     return this.json<SavedViewDef>(`/projects/${pid}/modules/${key}/views`, {
-      method: "POST", body: JSON.stringify({ name, config }) });
+      method: "POST", body: JSON.stringify({ name, config, scope }) });
   }
   deleteView(pid: string, key: string, vid: string) {
     return this.json<{ deleted: boolean }>(`/projects/${pid}/modules/${key}/views/${vid}`, { method: "DELETE" });

--- a/apps/web/src/api/proforma.ts
+++ b/apps/web/src/api/proforma.ts
@@ -95,9 +95,25 @@ export function withProforma<TBase extends Ctor<HttpCore>>(Base: TBase) {
       `/proforma/scenarios?project_id=${encodeURIComponent(projectId)}`);
   }
 
+  /** Bridge underwriting → construction draws: the scenario's cost tree becomes Schedule-of-Values
+   *  records, and out come the AIA G702/G703.
+   *
+   *  `g703_totals` and `forecast_returns` went undeclared, and they are the two halves of what this
+   *  route is FOR. The G703 totals are the schedule of values the G702 certificate is computed from
+   *  — a payment due with no visible completed-to-date or retainage is a number nobody can check.
+   *  And `forecast_returns` is the whole premise in the route's own docstring, *"so the IRR you
+   *  underwrote and the lender draw run off the SAME cost tree"*: it is the re-forecast IRR with the
+   *  actuals folded in, which is the answer to "is this deal still the deal we signed?". Both were
+   *  computed on every draw and shown on none. */
   drawPackage(sid: string, body: unknown) {
-    return this.json<{ sov_lines_created: number; g702: Record<string, number>; g702_pdf: string }>(
-      `/proforma/scenarios/${sid}/draw-package`, { method: "POST", body: JSON.stringify(body) });
+    return this.json<{
+      sov_lines_created: number; g702: Record<string, number>; g702_pdf: string;
+      /** AIA G703 column totals across the schedule of values, in whole currency units. */
+      g703_totals: { scheduled: number; prev: number; this: number; stored: number;
+                     completed: number; balance: number; retainage: number; retainage_prev: number };
+      /** The deal's returns RE-FORECAST with the actuals in — not the underwritten ones. */
+      forecast_returns: { equity_irr: number | null; equity_multiple: number };
+    }>(`/proforma/scenarios/${sid}/draw-package`, { method: "POST", body: JSON.stringify(body) });
   }
 
   // --- The development budget, its GMP reconciliation, and the draws against it ---

--- a/apps/web/src/api/responseUndeclared.test.ts
+++ b/apps/web/src/api/responseUndeclared.test.ts
@@ -70,8 +70,6 @@ const KNOWN_GAPS: Record<string, string[]> = {
   "GET /reference/disciplines": ["disciplines", "masterformat_divisions", "uniformat_crosswalk"],
   "POST /projects/{}/modules/{}/views": ["mine", "owner", "scope"],
   "POST /proforma/scenarios/{}/draw-package": ["forecast_returns", "g703_totals"],
-  "GET /asset-rights/status": ["public_key"],
-  "GET /auth/providers": ["saml"],
   "POST /proforma/solve": ["provenance"],
 };
 

--- a/apps/web/src/api/responseUndeclared.test.ts
+++ b/apps/web/src/api/responseUndeclared.test.ts
@@ -67,8 +67,6 @@ const CONTROL = "GET /projects/{}/verification/coverage";
  *  fixed rather than rotting into a freeze-list nobody re-checked. (`KNOWN_UNCALLED` is the
  *  cautionary tale this shape is built against.) */
 const KNOWN_GAPS: Record<string, string[]> = {
-  "POST /projects/{}/modules/{}/views": ["mine", "owner", "scope"],
-  "POST /proforma/scenarios/{}/draw-package": ["forecast_returns", "g703_totals"],
 };
 
 /** Routes the gate compares whose server key set is a LOWER BOUND — the response literal carries a

--- a/apps/web/src/api/responseUndeclared.test.ts
+++ b/apps/web/src/api/responseUndeclared.test.ts
@@ -67,7 +67,6 @@ const CONTROL = "GET /projects/{}/verification/coverage";
  *  fixed rather than rotting into a freeze-list nobody re-checked. (`KNOWN_UNCALLED` is the
  *  cautionary tale this shape is built against.) */
 const KNOWN_GAPS: Record<string, string[]> = {
-  "GET /reference/disciplines": ["disciplines", "masterformat_divisions", "uniformat_crosswalk"],
   "POST /projects/{}/modules/{}/views": ["mine", "owner", "scope"],
   "POST /proforma/scenarios/{}/draw-package": ["forecast_returns", "g703_totals"],
   "POST /proforma/solve": ["provenance"],

--- a/apps/web/src/api/responseUndeclared.test.ts
+++ b/apps/web/src/api/responseUndeclared.test.ts
@@ -69,7 +69,6 @@ const CONTROL = "GET /projects/{}/verification/coverage";
 const KNOWN_GAPS: Record<string, string[]> = {
   "POST /projects/{}/modules/{}/views": ["mine", "owner", "scope"],
   "POST /proforma/scenarios/{}/draw-package": ["forecast_returns", "g703_totals"],
-  "POST /proforma/solve": ["provenance"],
 };
 
 /** Routes the gate compares whose server key set is a LOWER BOUND — the response literal carries a

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -428,7 +428,18 @@ export interface NotifItem {
   module: string; module_name: string; icon: string; record_id: string; ref: string;
   title: string | null; action: string; actor: string | null; ts: string | null; reason: string;
 }
-export interface SavedViewDef { id: string; name: string; config: { q?: string; state?: string; sort?: { col: string; dir: 1 | -1 } }; }
+export interface SavedViewDef {
+  id: string; name: string;
+  config: { q?: string; state?: string; sort?: { col: string; dir: 1 | -1 } };
+  /** `private` — only the owner lists it. `project` — anyone who can read this project's registers. */
+  scope: "private" | "project";
+  /** The identity that owns the row (the key, not a display name). */
+  owner: string;
+  /** Whether the CALLER owns it. Sent per row rather than derived from `owner === me` because the
+   *  two disagree the moment a display name is not the identity key — and this is what decides
+   *  whether Delete is offered, which has to match what the server will actually allow. */
+  mine: boolean;
+}
 export interface DueItem {
   module: string; module_name: string; icon: string; id: string; ref: string;
   title: string | null; state: string; assignee: string | null; due_date: string; days: number;

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -524,6 +524,34 @@ export interface ProformaResult {
   waterfall: { lp_irr: number | null; gp_irr: number | null; lp_equity_multiple: number; gp_equity_multiple: number; lp_distributions: number; gp_distributions: number; style: string };
   cash_flow: { dates: string[]; equity: number[]; project: number[]; noi_monthly: number[] };
   guardrails?: { ok: boolean; flags: { level: "high" | "med" | "info"; metric: string; message: string }[] };
+  /** Input provenance: for every headline figure, which assumptions the CALLER declared and which
+   *  the ENGINE defaulted. Computed on every solve and, until now, undeclared here — so a deal
+   *  showed an IRR with no way to say how much of it rested on numbers nobody supplied.
+   *  `defaulted_inputs` is the server's own "the number a reviewer actually wants". */
+  provenance?: ProformaProvenance;
+}
+
+/** @see ProformaResult.provenance — `services/api/src/aec_api/proforma/provenance.py`. */
+export interface ProformaProvenance {
+  figure_count: number;
+  /** How many figures rest on each basis: `declared` | `defaulted` | `mixed` | `none`. */
+  by_basis: Record<string, number>;
+  /** Every assumption path the engine had to default, deduped across figures and sorted, so two
+   *  runs of the same deal diff cleanly. */
+  defaulted_inputs: string[];
+  defaulted_input_count: number;
+  figures: Record<string, {
+    value: number | null;
+    basis: string;
+    declared: { path: string; value: unknown }[];
+    defaulted: { path: string; value: null }[];
+    declared_count: number;
+    defaulted_count: number;
+    /** Always null, with the reason beside it — never a guessed terminus. */
+    element_link: null;
+    element_link_reason: string;
+  }>;
+  note: string;
 }
 
 export interface ProformaForecast {

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,6 +1,7 @@
 import "./style.css";
 import { PortalUI } from "./portal/portal";   // eager: the default Construction/Developer workspace
 import { ApiClient, type MassingParams } from "./api/client";
+import { sealIdentity } from "./api/assetRights";
 import { toast, escapeHtml, safeUrl } from "./ui/feedback";
 import { showResult } from "./ui/result";
 import { buildRoomTabs, renderRoomTabs, roomForWorkspace } from "./shell/roomTabs";
@@ -399,13 +400,23 @@ async function saveProjectBundle() {
   try {
     const st = await api.assetRightsStatus();
     if (st.enabled) {
+      // NAME THE IDENTITY, rather than referring to it. The text below promises that "anyone holding
+      // the issuer's published verification key" can check the file — and until now the dialog could
+      // not say what that key IS, because `public_key` was undeclared on the client type under a
+      // comment reading "Never a key." The key is 43 base64url characters and is embedded in every
+      // signed manifest we emit, so showing it here is not a disclosure; it is the one thing the
+      // person sealing has to publish for the promise to mean anything.
+      const id = sealIdentity(st);
+      const idLine = id
+        ? `\n\nIssued by ${id.issuer || "(no issuer name configured)"}\nVerification key: ${id.key}`
+        : "";
       sealed = await askConfirm("Save project", {
         body: st.signing
           ? "Seal this file with a release manifest?\n\nIt records a SHA-256 of everything in the "
             + "container and signs it, so anyone holding the issuer's published verification key "
             + "can confirm the file is authentic and unaltered. The pre-converted geometry tile is "
             + "recorded but left out of the release identity, because it can be regenerated.\n\n"
-            + "Sealing gives the project a permanent asset id that travels with the file."
+            + "Sealing gives the project a permanent asset id that travels with the file." + idLine
           : "Seal this file with a release manifest?\n\nIt records a SHA-256 of everything in the "
             + "container, so any later change to the file is detectable.\n\nNo signing key is "
             + "configured on this server, so the file will be tamper-evident but will NOT carry a "

--- a/apps/web/src/portal/register/register.ts
+++ b/apps/web/src/portal/register/register.ts
@@ -2,6 +2,7 @@ import type { ModuleDef, ModuleRecord, RecordBrief } from "../../api/client";
 import type { ModuleFilterOp } from "../../api/types";
 import { money as usd } from "../../ui/charts";
 import { statusChip } from "../../ui/chips";
+import { deletableViews, deleteWarning, pickedView, scopeFromAnswer, viewLabel } from "./savedViews";
 import { type RegisterEmptyKind, registerEmptyEl } from "../../ui/empty";
 import { emptyHint } from "../../ui/emptyGuide";
 import { escapeHtml as esc, toast } from "../../ui/feedback";
@@ -320,46 +321,40 @@ export class RegisterUI {
     const views = await this.ctx.host.api.listViews(pid, m.key).catch(() => []);
     const viewSel = document.createElement("select"); viewSel.className = "sb-sel"; viewSel.title = "Saved views";
     const vNone = document.createElement("option"); vNone.value = ""; vNone.textContent = "views…"; viewSel.appendChild(vNone);
-    for (const v of views) { const o = document.createElement("option"); o.value = v.id; o.textContent = v.name; viewSel.appendChild(o); }
+    // `viewLabel` says whose a view is — see savedViews.ts for what that was hiding.
+    for (const v of views) { const o = document.createElement("option"); o.value = v.id; o.textContent = viewLabel(v); viewSel.appendChild(o); }
     viewSel.onchange = () => { const v = views.find((x) => x.id === viewSel.value); if (v) { this.sort[m.key] = v.config.sort; void this.ctx.host.api.markViewSeen(pid, m.key, v.id).catch(() => {}); void this.openModule(m, { q: v.config.q, state: v.config.state }); } };
     const saveView = document.createElement("button"); saveView.className = "tool-btn"; saveView.textContent = "＋view";
-    saveView.title = "Save current filter/sort as a view (synced to your account)";
+    saveView.title = "Save current filter/sort as a view — keep it to yourself or share it with the project";
     saveView.onclick = async () => {
-      const v = await promptModal("Save view", [{ name: "name", label: "View name", required: true }], "Save");
+      // `saveView` used to send no scope, so the route's `default="private"` decided for every view
+      // this app has ever created — see savedViews.ts.
+      const v = await promptModal("Save view", [
+        { name: "name", label: "View name", required: true },
+        { name: "share", label: "Share with the project? (yes / no)" }], "Save");
       if (!v) return;
-      await this.ctx.host.api.saveView(pid, m.key, v.name ?? "", { q: filter.q, state: filter.state, sort: this.sort[m.key] });
+      await this.ctx.host.api.saveView(pid, m.key, v.name ?? "",
+        { q: filter.q, state: filter.state, sort: this.sort[m.key] }, scopeFromAnswer(v.share));
       void this.openModule(m, filter);
     };
-    // R41-REACH-WRITES — retire a saved view. Views could be created and applied since they shipped
-    // and never removed, so a mistyped one stayed in the dropdown of whoever made it forever.
-    //
-    // WHY A PICK-THEN-CONFIRM AND NOT AN ✕ ON THE SELECT. `viewSel.onchange` applies the view and
-    // re-renders this whole toolbar, so the select never HOLDS a selection — a "delete the selected
-    // one" button would have nothing to read. The number-pick matches the Templates control beside
-    // it, and the confirm step is what turns a number back into a name: agreeing to delete "3" is
-    // not consent, agreeing to delete "Overdue — mine" is.
-    //
-    // AND IT READS THE `deleted` FLAG RATHER THAN ASSUMING. This is the endpoint that returned
-    // "deleted": true for a row it had not touched until v0.3.892; the reason it is safe to wire now
-    // is that the flag became true only when the delete happened, and a UI that ignored it would put
-    // that defect straight back on the screen.
+    // R41-REACH-WRITES — retire a saved view. It READS the `deleted` flag rather than assuming: this
+    // is the endpoint that returned "deleted": true for a row it had not touched until v0.3.892, and
+    // a UI that ignored the flag would put that defect straight back on the screen. It offers only
+    // the views the server will actually delete, and `pickedView` carries why the control is a
+    // pick-then-confirm — both in savedViews.ts.
+    const own = deletableViews(views);
     const delView = document.createElement("button"); delView.className = "tool-btn";
     delView.textContent = "🗑 view"; delView.dataset.cap = "editor";
-    delView.title = views.length ? "Delete one of your saved views" : "No saved views to delete";
-    delView.disabled = !views.length;
+    delView.title = own.length ? "Delete one of your saved views" : "No saved views of yours to delete";
+    delView.disabled = !own.length;
     delView.onclick = async () => {
       const picked = await promptModal("Delete a saved view",
         [{ name: "pick", label: "View # to delete", required: true }], "Next",
-        views.map((v, i) => `${i + 1}. ${v.name}`).join("\n"));
+        own.map((v, i) => `${i + 1}. ${viewLabel(v)}`).join("\n"));
       if (!picked) return;
-      // `parseInt` returns NaN for "abc" and 3 for "3abc"; both must be refused rather than
-      // silently deleting the third view because the string happened to start with a digit.
-      const n = Number((picked.pick ?? "").trim());
-      const target = Number.isInteger(n) ? views[n - 1] : undefined;
+      const target = pickedView(picked.pick, own);
       if (!target) { toast(`No view numbered "${picked.pick}" — nothing deleted.`, "error"); return; }
-      const ok = await confirmModal(`Delete the view "${target.name}"?`,
-        "Saved views are yours alone, so this removes it only for you. The records it filters are "
-        + "not touched.\n\nThere is no undo — the filter and sort would have to be set up again.",
+      const ok = await confirmModal(`Delete the view "${target.name}"?`, deleteWarning(target),
         "Delete view", true);
       if (!ok) return;
       let res: { deleted: boolean };

--- a/apps/web/src/portal/register/savedViews.test.ts
+++ b/apps/web/src/portal/register/savedViews.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { deletableViews, deleteWarning, pickedView, scopeFromAnswer, viewLabel } from "./savedViews";
+import type { SavedViewDef } from "../../api/client";
+
+const v = (o: Partial<SavedViewDef>): SavedViewDef =>
+  ({ id: "v1", name: "Overdue — mine", config: {}, scope: "private", owner: "me@x.com", mine: true, ...o });
+
+describe("viewLabel", () => {
+  it("names the owner of a view that is not yours", () => {
+    expect(viewLabel(v({ mine: false, owner: "sam@x.com", scope: "project" })))
+      .toBe("Overdue — mine · shared by sam@x.com");
+  });
+  it("marks your own view as shared when it is", () => {
+    expect(viewLabel(v({ scope: "project" }))).toBe("Overdue — mine · shared");
+  });
+  it("leaves a private view of yours alone", () => {
+    expect(viewLabel(v({}))).toBe("Overdue — mine");
+  });
+  it("trusts `mine`, not `owner`, when the two disagree", () => {
+    // The server sends `mine` per row for exactly this reason: `owner` is the identity key and a
+    // display name is not, so a client comparing strings gets it wrong the moment they differ.
+    expect(viewLabel(v({ mine: false, owner: "Sam Okafor" }))).toContain("shared by Sam Okafor");
+  });
+});
+
+describe("deletableViews", () => {
+  it("offers only what DELETE will accept", () => {
+    // The route refuses a view that is not yours and returns `deleted: false`, which the register
+    // reports as "was already gone". Offering the row at all is what turns a refusal into that lie.
+    const mine = v({ id: "a" });
+    const theirs = v({ id: "b", mine: false, owner: "sam@x.com", scope: "project" });
+    expect(deletableViews([mine, theirs])).toEqual([mine]);
+  });
+  it("keeps your own shared view, which you CAN delete", () => {
+    const shared = v({ scope: "project" });
+    expect(deletableViews([shared])).toEqual([shared]);
+  });
+  it("is empty, not undefined, when nothing is yours", () => {
+    expect(deletableViews([v({ mine: false })])).toEqual([]);
+  });
+});
+
+describe("deleteWarning", () => {
+  it("says a shared view goes for everyone", () => {
+    const w = deleteWarning(v({ scope: "project" }));
+    expect(w).toContain("SHARED with the project");
+    expect(w).toContain("removes it for everyone");
+    expect(w).not.toContain("yours alone");
+  });
+  it("says a private view goes only for you", () => {
+    const w = deleteWarning(v({}));
+    expect(w).toContain("yours alone");
+    expect(w).not.toContain("everyone");
+  });
+  it("always says the records survive and there is no undo", () => {
+    for (const scope of ["private", "project"] as const) {
+      const w = deleteWarning(v({ scope }));
+      expect(w).toContain("records it filters are not touched");
+      expect(w).toContain("no undo");
+    }
+  });
+});
+
+describe("scopeFromAnswer", () => {
+  it("shares only on an explicit yes", () => {
+    for (const yes of ["yes", "Yes", " y ", "YEP"]) expect(scopeFromAnswer(yes)).toBe("project");
+  });
+  it("keeps everything else private", () => {
+    // The cost of guessing wrong is asymmetric: a view wrongly kept private is a second click, and
+    // a view wrongly published is already read. An ambiguous, empty or dismissed answer stays in.
+    for (const no of ["no", "n", "", "   ", "maybe", "sure", undefined]) {
+      expect(scopeFromAnswer(no)).toBe("private");
+    }
+  });
+});
+
+describe("pickedView", () => {
+  const own = [v({ id: "a", name: "One" }), v({ id: "b", name: "Two" }), v({ id: "c", name: "Three" })];
+  it("resolves a 1-based number", () => {
+    expect(pickedView("2", own)?.id).toBe("b");
+    expect(pickedView(" 3 ", own)?.id).toBe("c");
+  });
+  it("refuses a number that only STARTS the string", () => {
+    // `parseInt("3abc")` is 3 and would delete the third view. `Number` rejects it outright.
+    expect(pickedView("3abc", own)).toBeUndefined();
+  });
+  it("refuses text, blanks, fractions and out-of-range picks", () => {
+    for (const bad of ["abc", "", "   ", "2.5", "0", "4", "-1", undefined]) {
+      expect(pickedView(bad, own), `"${bad}" must name no view`).toBeUndefined();
+    }
+  });
+  it("indexes the DELETABLE list, not everything on screen", () => {
+    // The number the user typed was rendered from `deletableViews`, so resolving it against the full
+    // list would delete a different view than the one they read.
+    const all = [v({ id: "theirs", mine: false }), v({ id: "mine" })];
+    expect(pickedView("1", deletableViews(all))?.id).toBe("mine");
+  });
+});

--- a/apps/web/src/portal/register/savedViews.ts
+++ b/apps/web/src/portal/register/savedViews.ts
@@ -1,0 +1,73 @@
+/** Saved views: whose they are, and what may be done to them.
+ *
+ *  `GET/POST /projects/{pid}/modules/{key}/views` return `scope`, `owner` and `mine` on every row,
+ *  and `SavedViewDef` declared none of them. The server's own comment says why `mine` is sent rather
+ *  than inferred from `owner == me` — *"the two can disagree the moment a display name is not the
+ *  identity key … and the UI uses it to decide whether to offer Delete, which must match what the
+ *  server will actually allow"*. The UI could not read it, so it did not match, and the mismatch
+ *  compounded three ways:
+ *
+ *  * the dropdown showed a colleague's shared report identically to your own private filter;
+ *  * the delete picker offered every listed view, including ones `DELETE` refuses -- picking one
+ *    returned `deleted: false`, which the UI reports as *"was already gone — refreshing the list"*,
+ *    after which it is still there, because it was never gone and was never yours;
+ *  * the confirmation said *"Saved views are yours alone, so this removes it only for you"*, which
+ *    stopped being true the day sharing shipped (R22-REPORT-BUILDER item 4).
+ *
+ *  And `saveView` sent no `scope` at all, so the server's `default="private"` decided for every view
+ *  the web UI has ever created: the sharing half was reachable only from outside this app.
+ *
+ *  Pure, so all of that is testable without a register on screen.
+ */
+import type { SavedViewDef } from "../../api/client";
+
+/** How a view reads in the dropdown — its name, plus whose it is when that is not obvious. */
+export function viewLabel(v: SavedViewDef): string {
+  if (!v.mine) return `${v.name} · shared by ${v.owner}`;
+  return v.scope === "project" ? `${v.name} · shared` : v.name;
+}
+
+/** The views this user may actually delete — the server refuses the rest, so offering them is how a
+ *  refusal gets reported to the user as "already gone". */
+export function deletableViews(views: SavedViewDef[]): SavedViewDef[] {
+  return views.filter((v) => v.mine);
+}
+
+/** What deleting this view really does. A shared view is not "yours alone", and saying so to the one
+ *  person who can remove it for the whole project is the wrong moment to be reassuring. */
+export function deleteWarning(v: SavedViewDef): string {
+  const who = v.scope === "project"
+    ? "This view is SHARED with the project, so deleting it removes it for everyone who uses it."
+    : "This view is yours alone, so this removes it only for you.";
+  return `${who} The records it filters are not touched.\n\nThere is no undo — the filter and sort `
+    + "would have to be set up again.";
+}
+
+/**
+ * The scope a free-text "share with the project?" answer asks for.
+ *
+ * Anything but an explicit yes stays private. A saved view becoming visible to the whole project is
+ * not a good default for an ambiguous answer, an empty one, or a dismissed prompt — the cost of
+ * guessing wrong is asymmetric, and only one direction of it is recoverable in private.
+ */
+export function scopeFromAnswer(answer: string | undefined): "private" | "project" {
+  return (answer ?? "").trim().toLowerCase().startsWith("y") ? "project" : "private";
+}
+
+/**
+ * The view a free-text "which number?" answer names, or `undefined` for an answer that names none.
+ *
+ * `parseInt` returns NaN for `"abc"` and **3** for `"3abc"`; both have to be refused, rather than
+ * deleting the third view because the string happened to start with a digit. `Number` rejects the
+ * second outright, and `Number.isInteger` rejects `"2.5"` and the empty string.
+ *
+ * WHY THE CONTROL IS A PICK-THEN-CONFIRM AND NOT AN ✕ ON THE SELECT (moved here from the register,
+ * whose extraction ratchet is what asked for it): applying a view re-renders the whole toolbar, so
+ * the select never HOLDS a selection and a "delete the selected one" button would have nothing to
+ * read. The confirm step is what turns a number back into a name — agreeing to delete "3" is not
+ * consent, agreeing to delete "Overdue — mine" is.
+ */
+export function pickedView(answer: string | undefined, own: SavedViewDef[]): SavedViewDef | undefined {
+  const n = Number((answer ?? "").trim());
+  return Number.isInteger(n) ? own[n - 1] : undefined;
+}

--- a/apps/web/src/proforma/drawPackage.test.ts
+++ b/apps/web/src/proforma/drawPackage.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { drawPackageLines, type DrawPackageReply } from "./drawPackage";
+
+const dp = (o: Partial<DrawPackageReply> = {}): DrawPackageReply => ({
+  sov_lines_created: 12,
+  g702: { line8_current_payment_due: 412_500.4 },
+  g703_totals: { scheduled: 8_200_000, completed: 3_150_000, balance: 5_050_000, retainage: 157_500 },
+  forecast_returns: { equity_irr: 0.1847, equity_multiple: 1.92 },
+  ...o,
+});
+
+describe("drawPackageLines", () => {
+  it("reports the payment due and the schedule of values it was computed from", () => {
+    const [due, g703] = drawPackageLines(dp());
+    expect(due).toContain("SOV 12 lines");
+    expect(due).toContain("$412,500");
+    // Retainage is the line owners and subs argue about; it must be on screen, not only in the PDF.
+    expect(g703).toContain("$3,150,000 completed of $8,200,000 scheduled");
+    expect(g703).toContain("$157,500 retained");
+    expect(g703).toContain("$5,050,000 to finish");
+  });
+
+  it("reports the RE-FORECAST returns, which is what the bridge exists to produce", () => {
+    expect(drawPackageLines(dp())[2]).toBe(
+      "Forecast with these actuals: equity IRR 18.5% · 1.92× multiple");
+  });
+
+  it("says n/a for an unsolvable IRR, never 0%", () => {
+    // `equity_irr` is null when the cash flows do not support a rate. Printing 0% there reports a
+    // specific and wrong answer on the screen a draw request is assembled from.
+    expect(drawPackageLines(dp({ forecast_returns: { equity_irr: null, equity_multiple: 0.8 } }))[2])
+      .toContain("equity IRR n/a");
+  });
+
+  it("does not swallow a legitimate zero IRR", () => {
+    expect(drawPackageLines(dp({ forecast_returns: { equity_irr: 0, equity_multiple: 1 } }))[2])
+      .toContain("equity IRR 0.0%");
+  });
+
+  it("survives a G702 with no payment-due line", () => {
+    // `g702` is a loose number map; an app with nothing due omits the key rather than sending 0.
+    expect(drawPackageLines(dp({ g702: {} }))[0]).toContain("$0");
+  });
+
+  it("agrees with itself in the singular", () => {
+    expect(drawPackageLines(dp({ sov_lines_created: 1 }))[0]).toContain("SOV 1 line ");
+  });
+});

--- a/apps/web/src/proforma/drawPackage.ts
+++ b/apps/web/src/proforma/drawPackage.ts
@@ -1,0 +1,43 @@
+/** What a lender draw package actually says, once you read the whole reply.
+ *
+ *  `POST /proforma/scenarios/{sid}/draw-package` returns five keys and the client declared three,
+ *  so the status line could report a payment due and a line count and nothing else. The two it
+ *  dropped are the two the route exists for:
+ *
+ *  * `g703_totals` — the schedule of values the G702 certificate is computed FROM. A payment due
+ *    with no visible completed-to-date and no visible retainage is a number nobody downstream can
+ *    check, and retainage is the line owners and subcontractors argue about.
+ *  * `forecast_returns` — the route's own docstring says the point is *"so the IRR you underwrote
+ *    and the lender draw run off the SAME cost tree"*. This is that IRR, re-forecast with the
+ *    actuals folded in. It answers *is this still the deal we signed?* and it was computed on every
+ *    draw and shown on none.
+ *
+ *  Pure, so the money formatting and the null handling are testable without a scenario.
+ */
+import { usd } from "../ui/charts";
+
+export interface DrawPackageReply {
+  sov_lines_created: number;
+  g702: Record<string, number>;
+  g703_totals: { scheduled: number; completed: number; balance: number; retainage: number };
+  forecast_returns: { equity_irr: number | null; equity_multiple: number };
+}
+
+/**
+ * The lines to show beside the generated package, most load-bearing first.
+ *
+ * `equity_irr` is `null` when the cash flows do not support a rate — an unsolvable IRR, not a zero.
+ * It renders as `n/a`, because printing `0%` there would report a specific and wrong answer on the
+ * screen a draw request is assembled from.
+ */
+export function drawPackageLines(dp: DrawPackageReply): string[] {
+  const t = dp.g703_totals, f = dp.forecast_returns;
+  const due = dp.g702.line8_current_payment_due ?? 0;
+  return [
+    `SOV ${dp.sov_lines_created} line${dp.sov_lines_created === 1 ? "" : "s"} → G702 due ${usd(due)}`,
+    `G703: ${usd(t.completed)} completed of ${usd(t.scheduled)} scheduled · `
+      + `${usd(t.retainage)} retained · ${usd(t.balance)} to finish`,
+    `Forecast with these actuals: equity IRR ${f.equity_irr === null ? "n/a" : `${(f.equity_irr * 100).toFixed(1)}%`}`
+      + ` · ${f.equity_multiple}× multiple`,
+  ];
+}

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -3,6 +3,7 @@ import { escapeHtml } from "../ui/feedback";
 import { askText } from "../ui/prompt";
 import { signedBars, donut, lineChart, stackedBar, tornado, groupedBar, money as cmoney } from "../ui/charts";
 import { showQrModal } from "../ui/qr";
+import { provenanceLine } from "./provenanceLine";
 import { money, pct } from "./format";
 import { renderMassingTab } from "./massingTab";
 import { renderTestFitTab } from "./testfitTab";
@@ -1757,6 +1758,27 @@ export class ProformaUI {
         gc.insertAdjacentHTML("beforeend", `<div class="meta" style="margin:1px 0"><span style="color:${col}">${f.level === "info" ? "✓" : "△"}</span> ${f.message}</div>`);
       }
       host.appendChild(gc);
+    }
+    // How much of the answer above rests on numbers nobody supplied. The server computes this on
+    // every solve and the client type had omitted it, so a deal could report an equity IRR with no
+    // way to tell an underwritten input from an engine default — which is what makes a pro forma
+    // reviewable or not. Sits under the guardrails because it is the same kind of caveat.
+    const prov = provenanceLine(r.provenance);
+    if (prov) {
+      const pc = card();
+      pc.appendChild(Object.assign(document.createElement("div"),
+        { className: "section-title", textContent: "Input provenance" }));
+      const col = prov.level === "warn" ? "var(--status-warn)" : "var(--status-good)";
+      const line = Object.assign(document.createElement("div"), { className: "meta" });
+      line.style.margin = "1px 0";
+      const mark = Object.assign(document.createElement("span"),
+        { textContent: prov.level === "warn" ? "△ " : "✓ " });
+      mark.style.color = col;
+      // textContent, not innerHTML: `defaulted_inputs` are assumption paths from the request body,
+      // so they are caller-controlled strings and have no business being parsed as markup.
+      line.append(mark, document.createTextNode(prov.text));
+      pc.appendChild(line);
+      host.appendChild(pc);
     }
   }
 

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -4,6 +4,7 @@ import { askText } from "../ui/prompt";
 import { signedBars, donut, lineChart, stackedBar, tornado, groupedBar, money as cmoney } from "../ui/charts";
 import { showQrModal } from "../ui/qr";
 import { provenanceLine } from "./provenanceLine";
+import { drawPackageLines } from "./drawPackage";
 import { money, pct } from "./format";
 import { renderMassingTab } from "./massingTab";
 import { renderTestFitTab } from "./testfitTab";
@@ -1479,7 +1480,10 @@ export class ProformaUI {
             .map((x) => ({ actual_to_date: parseFloat(x.value) || 0 }));
           const sc = await this.api.createScenario("Draw package", pid, this.a);
           const dp = await this.api.drawPackage(sc.id, { project_id: pid, actuals, as_of_month: 9, app_no: 1 });
-          this.setStatus(`SOV (${dp.sov_lines_created} lines) → G702 due $${Math.round(dp.g702.line8_current_payment_due ?? 0).toLocaleString()}`);
+          // The status used to stop at the payment due. `g703_totals` is the schedule of values that
+          // figure is computed from, and `forecast_returns` is the re-forecast IRR the whole bridge
+          // exists to produce — both arrived on every draw and neither was shown.
+          this.setStatus(drawPackageLines(dp).join("  ·  "));
           { const { openPdfUrl, saveToDocuments } = await import("../drawings/openPdf");
             await openPdfUrl(this.api, this.api.url(dp.g702_pdf), "G702-draw.pdf", { saveLabel: "Save to Documents", onSave: saveToDocuments(this.api, pid) }); }
         } catch (e) { this.setStatus(`draw package error: ${(e as Error).message}`); }

--- a/apps/web/src/proforma/provenanceLine.test.ts
+++ b/apps/web/src/proforma/provenanceLine.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { provenanceLine } from "./provenanceLine";
+import type { ProformaProvenance } from "../api/types";
+
+const p = (o: Partial<ProformaProvenance>): ProformaProvenance => ({
+  figure_count: 6, by_basis: { declared: 6 }, defaulted_inputs: [], defaulted_input_count: 0,
+  figures: {}, note: "Input provenance only", ...o,
+});
+
+describe("provenanceLine", () => {
+  it("names the defaulted assumptions, because that is the number a reviewer wants", () => {
+    const line = provenanceLine(p({ defaulted_inputs: ["exit.cap_rate", "debt.rate"], defaulted_input_count: 2 }));
+    expect(line?.level).toBe("warn");
+    expect(line?.text).toContain("2 inputs");
+    expect(line?.text).toContain("exit.cap_rate, debt.rate");
+    expect(line?.paths).toEqual(["exit.cap_rate", "debt.rate"]);
+  });
+
+  it("says so plainly when every input was declared", () => {
+    expect(provenanceLine(p({}))).toEqual({
+      text: "Every input behind these 6 figures was declared.", level: "ok", paths: [] });
+  });
+
+  it("is NULL when the server sent no provenance — absent must not read as clean", () => {
+    // An older server, or a route that does not compute it. Rendering the "all declared" line here
+    // would assert the opposite of what is known, on the one screen where that distinction decides
+    // whether a number can be relied on.
+    expect(provenanceLine(undefined)).toBeNull();
+  });
+
+  it("is null when there are no figures to qualify", () => {
+    expect(provenanceLine(p({ figure_count: 0 }))).toBeNull();
+  });
+
+  it("caps the named paths and counts the rest", () => {
+    const many = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    const line = provenanceLine(p({ defaulted_inputs: many, defaulted_input_count: 8 }));
+    expect(line?.text).toContain("a, b, c, d, e, f +2 more");
+    expect(line?.paths).toEqual(many);          // the full list is still carried, only the TEXT is cut
+  });
+
+  it("agrees with itself in the singular", () => {
+    const line = provenanceLine(p({ defaulted_inputs: ["debt.rate"], defaulted_input_count: 1 }));
+    expect(line?.text).toContain("1 input behind");
+    expect(line?.text).toContain("was defaulted");
+  });
+
+  it("trusts the server's count, not the length of the list it names", () => {
+    // `defaulted_input_count` is the server's dedupe of the same paths; if the two ever disagree the
+    // COUNT is the claim and the list is the sample. Asserting this pins which one the line reports.
+    const line = provenanceLine(p({ defaulted_inputs: ["a", "b"], defaulted_input_count: 5 }));
+    expect(line?.text).toContain("5 inputs");
+  });
+});

--- a/apps/web/src/proforma/provenanceLine.ts
+++ b/apps/web/src/proforma/provenanceLine.ts
@@ -1,0 +1,41 @@
+/** How much of a solved pro forma rests on numbers nobody supplied.
+ *
+ *  `POST /proforma/solve` has always returned `provenance` — per headline figure, which assumptions
+ *  the caller DECLARED and which the engine DEFAULTED — and the client type declared seven keys
+ *  without it, so the caveat was computed on every solve and shown on none. A deal screen that
+ *  reports a 19% equity IRR without saying that eleven of its inputs were engine defaults is not
+ *  wrong, it is unreviewable: the reader cannot tell an underwritten number from a placeholder.
+ *
+ *  Pure, because the rule about when this is worth saying is the part worth pinning.
+ */
+import type { ProformaProvenance } from "../api/types";
+
+export interface ProvenanceLine { text: string; level: "ok" | "warn"; paths: string[] }
+
+/** At most this many defaulted paths are named inline; the rest are counted. */
+const NAMED = 6;
+
+/**
+ * The line to show under the returns, or `null` when there is nothing to say.
+ *
+ * Null on a missing `provenance` (an older server, or a route that does not compute it) — an absent
+ * caveat must read as absent, never as "all inputs declared", which is the opposite claim.
+ */
+export function provenanceLine(p: ProformaProvenance | undefined): ProvenanceLine | null {
+  if (!p) return null;
+  if (!p.figure_count) return null;
+  const n = p.defaulted_input_count;
+  if (!n) {
+    return { text: `Every input behind these ${p.figure_count} figures was declared.`,
+             level: "ok", paths: [] };
+  }
+  const named = p.defaulted_inputs.slice(0, NAMED);
+  const more = p.defaulted_inputs.length - named.length;
+  const tail = more > 0 ? `${named.join(", ")} +${more} more` : named.join(", ");
+  return {
+    text: `${n} input${n === 1 ? "" : "s"} behind these ${p.figure_count} figures `
+      + `${n === 1 ? "was" : "were"} defaulted by the engine: ${tail}`,
+    level: "warn",
+    paths: p.defaulted_inputs,
+  };
+}

--- a/apps/web/src/viewer/tools/detailingSection.ts
+++ b/apps/web/src/viewer/tools/detailingSection.ts
@@ -1,4 +1,5 @@
 import type { ApiClient } from "../../api/client";
+import { codeAnnotation } from "../../api/classificationRef";
 import { askText } from "../../ui/prompt";
 import { kvTable, resultNote, showResult } from "../../ui/result";
 
@@ -66,7 +67,21 @@ export function buildDetailingSection(d: DetailingDeps) {
         for (const [sys, hint] of CLS) {
           body.appendChild(d.toolBtn2(`＋ ${sys} code`, async () => {
             const code = await askText(`${sys} code`, { label: hint, value: "" }); if (!code) return;
-            const title = await askText(`${sys} code`, { label: "Title (optional)", value: "" });
+            // READ THE CODE BACK before it becomes a classification on an IFC element. The server has
+            // always served the MasterFormat division master and the Uniformat crosswalk on
+            // `/reference/disciplines`; the client declared neither, so this prompt could offer an
+            // example and nothing else, and `80 51 00` — a transposition into a division that does
+            // not exist — was accepted in silence. Annotating the title prompt puts the answer in
+            // front of the person at the one moment they can still fix it. It never REFUSES:
+            // MasterFormat reserves divisions for user-defined use, so an unrecognised one is worth
+            // saying and not worth blocking. A reference that fails to load must not block
+            // classifying either — that is what the catch is for.
+            let note = "";
+            try {
+              const ann = codeAnnotation(sys, code.trim(), await d.api.classificationRefs());
+              if (ann) note = (ann.known ? " — " : " — ⚠ ") + ann.text;
+            } catch { /* reference unavailable: classify without the annotation, never instead of it */ }
+            const title = await askText(`${sys} code`, { label: `Title (optional)${note}`, value: "" });
             await d.authorAndReload("classify", { guids: [guid], system: sys, code: code.trim(), name: title?.trim() || undefined }, `${sys} ${code.trim()}`);
             await reopen();
           }));

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1406,7 +1406,7 @@ instances:
   bigger than the one remaining instance.
 
 - ◧ **RESPONSE-UNDECLARED — the inverse of DEAD-FIELD** *(sized 2026-09-10; DERIVED AND GATED
-  2026-09-11; **all 15 triaged, 9 fixed, 6 open**)*
+  2026-09-11; **all 15 triaged, 11 fixed, 4 open**)*
 
   DEAD-FIELD asks *does the client READ what it DECLARES*. This asks *does the client DECLARE what the
   server SENDS*, and the second failure is strictly worse: an undeclared field is invisible to the
@@ -1446,7 +1446,7 @@ instances:
   template literal only, and reported two perfectly resolvable call sites as UNRESOLVED — a
   concatenation and a conditional query suffix. It now folds `+` and `?:`, and a self-test pins that.
 
-  **TRIAGE: all 15 read. Nine are fixed (below); the six still open are listed after them.**
+  **TRIAGE: all 15 read. Eleven are fixed (below); the four still open are listed after them.**
 
   **THE NINE FIXED 2026-09-11 — every one declared, five of them rendered.** `KNOWN_GAPS` in the gate
   is asserted exactly in both directions, so this list could only shrink by fixing, and it did: 15 → 6.
@@ -1543,14 +1543,51 @@ instances:
   should match the narrowest thing that would actually be wrong; everything else it happens to match
   becomes a tripwire under the next person to improve the line.
 
-  **THE SIX STILL OPEN**, in four categories — and only one is the "invisible field" this item was
-  scoped around. Three need *declare **and** render*, not just declare:
+  **A TENTH, LATER THE SAME DAY — and it was never really about a declared key.** `/auth/providers`
+  returns `saml`; the client type named only `providers`, so the login modal branched on
+  `providers.length` alone and a workspace that had wired its own SAML IdP **and** paid for the tier
+  that entitles `sso` was shown a hint on its own sign-in screen telling it to go and configure
+  OAuth. Not a missing button: a *wrong instruction*, on the one screen nobody can get past. Now a
+  "Continue with single sign-on" door leading the modal, with the ordering rule pulled out into
+  `apps/web/src/account/signInDoors.ts` — pure, nine tests, five mutations — because the rule about
+  which doors lead is the part worth pinning and the `document` calls are not.
 
-  * *server ships, client dark* — `/auth/providers` never declares `saml`, and `saml` appears nowhere
-    in `apps/web/src`, so the SAML sign-in the server fully implements has no affordance at all ·
-    `/asset-rights/status` never declares `public_key`, so out-of-band verification is unreachable,
-    **and the client interface still carries the comment `Never a key.`, which is the exact rule the
-    server correction removed** · `/modules/{key}/views` returns `scope`, `owner` and `mine`
+  **AND UNDERNEATH IT, THE REASON THE MISSING BUTTON HAD NEVER BEEN REPORTED: the flow could not
+  have worked anyway.** `routers/saml.py` carried its own `_cookie` whose docstring said it *"mirrors
+  routers/auth._cookie"*. It had drifted, and to the one thing that is not a preference — the NAME.
+  It set `aec-token`; the cookie `rbac.current_user` reads is `aec_token`. So a correctly signed,
+  in-window, right-audience assertion was verified, the account provisioned, a real session token
+  minted — and put somewhere nothing reads. The browser returned to the app signed out.
+  `services/api/test_saml.py` asserted `"aec-token" in r.cookies`, **using the name the code under
+  test had chosen**, so it was green over a flow that had never once logged anybody in: a check that
+  can fail for a typo but not for the defect. It now asks `/auth/me` who the caller is, which has one
+  right answer and no spelling of a cookie can fake; with the old helper restored it fails with
+  *"ACS set a cookie the server does not read — /auth/me says 'dev'"*. The copy is gone rather than
+  corrected — `saml.py` imports auth's — which also recovers the two things the copy had lost,
+  `AEC_COOKIE_SECURE` and the 7-day max-age. *A duplicated helper does not drift where you are
+  looking; it drifts in the one field both sides only ever write.*
+
+  **AN ELEVENTH, the same afternoon — a promise the dialog could not keep.** `/asset-rights/status`
+  returns `public_key`; the client type omitted it, under a comment on the neighbouring `issuer`
+  field reading *"Never a key."* — a rule the server had already examined and removed, because the
+  same key is embedded in every signed manifest we emit, so withholding it protected nothing and
+  only meant a verifier had to trust the document's own copy, which is the copy an attacker who
+  rewrote the manifest would have replaced. Meanwhile the seal dialog promised that *"anyone holding
+  the issuer's published verification key can confirm the file is authentic"* while being unable to
+  say what that key is. It now names the issuer and prints the key beside the promise.
+  `sealIdentity` in `apps/web/src/api/assetRights.ts` decides when there IS an identity to name, and
+  its interesting case is `signing: true` with an empty key — which must render nothing rather than
+  an empty label that reads as verifiable. *`issuer` was also declared-and-never-read, so one edit
+  closed a DEAD-FIELD and a RESPONSE-UNDECLARED on the same route, in opposite directions.*
+  **One of the four mutations survived the first pass**: the `signing` guard was covered only
+  incidentally, because the test for it also emptied the key, so deleting the guard still passed.
+  *Two guards that always fire together are one guard as far as the tests can tell* — the state is
+  now constructed deliberately and pinned.
+
+  **THE FOUR STILL OPEN**, in four categories — and only one is the "invisible field" this item was
+  scoped around. One needs *declare **and** render*, not just declare:
+
+  * *server ships, client dark* — `/modules/{key}/views` returns `scope`, `owner` and `mine`
     on both the GET and the POST and the client type declares none of them, so a shared view is
     indistinguishable from a private one; separately, `saveView` sends no `scope` in its request
     body, so the server's `default="private"` decides for every view the web UI creates. *(This

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1406,7 +1406,7 @@ instances:
   bigger than the one remaining instance.
 
 - ◧ **RESPONSE-UNDECLARED — the inverse of DEAD-FIELD** *(sized 2026-09-10; DERIVED AND GATED
-  2026-09-11; **all 15 triaged, 12 fixed, 3 open**)*
+  2026-09-11; **all 15 triaged, 13 fixed, 2 open**)*
 
   DEAD-FIELD asks *does the client READ what it DECLARES*. This asks *does the client DECLARE what the
   server SENDS*, and the second failure is strictly worse: an undeclared field is invisible to the
@@ -1446,7 +1446,7 @@ instances:
   template literal only, and reported two perfectly resolvable call sites as UNRESOLVED — a
   concatenation and a conditional query suffix. It now folds `+` and `?:`, and a self-test pins that.
 
-  **TRIAGE: all 15 read. Twelve are fixed (below); the three still open are listed after them.**
+  **TRIAGE: all 15 read. Thirteen are fixed (below); the two still open are listed after them.**
 
   **THE NINE FIXED 2026-09-11 — every one declared, five of them rendered.** `KNOWN_GAPS` in the gate
   is asserted exactly in both directions, so this list could only shrink by fixing, and it did: 15 → 6.
@@ -1608,7 +1608,21 @@ instances:
   written for tomorrow's* — the competing rows are now in the fixture, and the third undeclared key,
   the flat `disciplines` catalog, is what names the discipline a division rolls up to.
 
-  **THE THREE STILL OPEN** — and only one is the "invisible field" this item was scoped around.
+  **A THIRTEENTH — the caveat that decides whether a number can be relied on.** `POST /proforma/solve`
+  computes `provenance` on every solve: for each headline figure, which assumptions the CALLER
+  declared and which the ENGINE defaulted, plus `defaulted_inputs`, which the server's own comment
+  calls *"the number a reviewer actually wants"*. The client declared seven keys without it, so a
+  deal screen reported an equity IRR with no way to tell an underwritten input from a placeholder.
+  **That is not a wrong number, it is an unreviewable one.** `provenanceLine` in
+  `apps/web/src/proforma/provenanceLine.ts` now sits under the underwriting guardrails — same kind
+  of caveat, same place — naming up to six defaulted paths and counting the rest. It returns **null**
+  on a missing `provenance` rather than the all-declared line, because an absent caveat must read as
+  absent: asserting "every input was declared" from the absence of evidence is the opposite claim, on
+  the one screen where the distinction decides whether the figure can be relied on. Six mutations,
+  all biting. The paths are caller-supplied strings from the request body, so the line is built with
+  `textContent`, never `innerHTML`.
+
+  **THE TWO STILL OPEN** — and neither is quite the "invisible field" this item was scoped around.
   One needs *declare **and** render*, not just declare:
 
   * *server ships, client dark* — `/modules/{key}/views` returns `scope`, `owner` and `mine`
@@ -1620,8 +1634,6 @@ instances:
     this axis measures.)*
   * *money-document rendering gap* — `/draw-package` declares neither `g703_totals` (the AIA G703
     schedule of values behind a pay application) nor `forecast_returns`.
-  * *computed-then-invisible caveat* — `/proforma/solve` derives `provenance` for its inputs and the
-    client declares seven keys without it.
 
   **A SEPARATE FINDING, not folded in: 106 dict-returning routes have NO typed client call site.**
   That is a different question from the "19 route handlers have no web client" counted below by a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1406,7 +1406,7 @@ instances:
   bigger than the one remaining instance.
 
 - ◧ **RESPONSE-UNDECLARED — the inverse of DEAD-FIELD** *(sized 2026-09-10; DERIVED AND GATED
-  2026-09-11; **all 15 triaged, 11 fixed, 4 open**)*
+  2026-09-11; **all 15 triaged, 12 fixed, 3 open**)*
 
   DEAD-FIELD asks *does the client READ what it DECLARES*. This asks *does the client DECLARE what the
   server SENDS*, and the second failure is strictly worse: an undeclared field is invisible to the
@@ -1446,7 +1446,7 @@ instances:
   template literal only, and reported two perfectly resolvable call sites as UNRESOLVED — a
   concatenation and a conditional query suffix. It now folds `+` and `?:`, and a self-test pins that.
 
-  **TRIAGE: all 15 read. Eleven are fixed (below); the four still open are listed after them.**
+  **TRIAGE: all 15 read. Twelve are fixed (below); the three still open are listed after them.**
 
   **THE NINE FIXED 2026-09-11 — every one declared, five of them rendered.** `KNOWN_GAPS` in the gate
   is asserted exactly in both directions, so this list could only shrink by fixing, and it did: 15 → 6.
@@ -1584,8 +1584,32 @@ instances:
   *Two guards that always fire together are one guard as far as the tests can tell* — the state is
   now constructed deliberately and pinned.
 
-  **THE FOUR STILL OPEN**, in four categories — and only one is the "invisible field" this item was
-  scoped around. One needs *declare **and** render*, not just declare:
+  **A TWELFTH — and this one had somewhere to land.** `/reference/disciplines` returns four payloads
+  and `disciplineTree()` declared `{ tree }`, so the MasterFormat division master and the
+  Uniformat↔MasterFormat crosswalk arrived and were dropped at the `.then`. Both exist nowhere else
+  in this shape: `tree.disciplines[].divisions` carries only the subset under one discipline, and
+  nothing in the client knew that B2020 buys out of Division 08. **What that cost is visible at the
+  Detailing panel**, which asks for a spec section with the hint *"e.g. 08 51 00"* and had nothing to
+  read the answer against — so `80 51 00`, a transposition into a division that does not exist, was
+  accepted in silence and became a classification on an IFC element. `codeAnnotation` in
+  `apps/web/src/api/classificationRef.ts` now answers the title prompt with *"Division 08 · Openings
+  (Architectural)"*, or a ⚠ when the master does not carry the division. It never refuses: MasterFormat
+  reserves 48–49 and the 80s–90s for user-defined divisions, so an unrecognised one is worth saying
+  and not worth blocking, and a reference that fails to load must not block classifying either.
+
+  Two things the fix ran into. The client now makes **one** cached request where a second accessor
+  would have made two — but factoring the cache into a private helper made
+  `apps/web/src/api/clientCallers.test.ts` report a client method no screen can reach, because that
+  gate reads the application OUTSIDE `api/` and a helper called only from inside it looks exactly
+  like an unwired endpoint. *The honest fix was to not create the method, rather than to exempt it.*
+  And **a mutation survived**: the longest-prefix rule in `crosswalkFor` was asserted against the
+  served table, where no two entries are prefixes of each other, so first-match and longest-match
+  agree on every code and swapping them passed. *A fixture drawn from today's data cannot test a rule
+  written for tomorrow's* — the competing rows are now in the fixture, and the third undeclared key,
+  the flat `disciplines` catalog, is what names the discipline a division rolls up to.
+
+  **THE THREE STILL OPEN** — and only one is the "invisible field" this item was scoped around.
+  One needs *declare **and** render*, not just declare:
 
   * *server ships, client dark* — `/modules/{key}/views` returns `scope`, `owner` and `mine`
     on both the GET and the POST and the client type declares none of them, so a shared view is
@@ -1596,9 +1620,6 @@ instances:
     this axis measures.)*
   * *money-document rendering gap* — `/draw-package` declares neither `g703_totals` (the AIA G703
     schedule of values behind a pay application) nor `forecast_returns`.
-  * *fetched-and-discarded* — `/reference/disciplines` returns four payloads and the client's only
-    call site keeps `tree`, dropping the MasterFormat division master and the Uniformat↔MasterFormat
-    crosswalk at the `.then`.
   * *computed-then-invisible caveat* — `/proforma/solve` derives `provenance` for its inputs and the
     client declares seven keys without it.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1405,8 +1405,8 @@ instances:
   ever the subject of a NULL test, derived from the model metadata and the AST — worth writing, and
   bigger than the one remaining instance.
 
-- ◧ **RESPONSE-UNDECLARED — the inverse of DEAD-FIELD** *(sized 2026-09-10; DERIVED AND GATED
-  2026-09-11; **all 15 triaged, 13 fixed, 2 open**)*
+- ✅ **RESPONSE-UNDECLARED — the inverse of DEAD-FIELD** *(sized 2026-09-10; DERIVED AND GATED
+  2026-09-11; **CLOSED the same day — all 15 triaged, all 15 fixed, `KNOWN_GAPS` is EMPTY**)*
 
   DEAD-FIELD asks *does the client READ what it DECLARES*. This asks *does the client DECLARE what the
   server SENDS*, and the second failure is strictly worse: an undeclared field is invisible to the
@@ -1446,7 +1446,10 @@ instances:
   template literal only, and reported two perfectly resolvable call sites as UNRESOLVED — a
   concatenation and a conditional query suffix. It now folds `+` and `?:`, and a self-test pins that.
 
-  **TRIAGE: all 15 read. Thirteen are fixed (below); the two still open are listed after them.**
+  **TRIAGE: all 15 read, ALL 15 FIXED.** `KNOWN_GAPS` in the gate is now `{}` — and because it is
+  asserted exactly in both directions, an empty list is a *claim under test*: the next undeclared
+  key anywhere in the tree fails the build instead of joining a backlog. The fourteenth and
+  fifteenth are below the thirteenth.
 
   **THE NINE FIXED 2026-09-11 — every one declared, five of them rendered.** `KNOWN_GAPS` in the gate
   is asserted exactly in both directions, so this list could only shrink by fixing, and it did: 15 → 6.
@@ -1622,18 +1625,36 @@ instances:
   all biting. The paths are caller-supplied strings from the request body, so the line is built with
   `textContent`, never `innerHTML`.
 
-  **THE TWO STILL OPEN** — and neither is quite the "invisible field" this item was scoped around.
-  One needs *declare **and** render*, not just declare:
+  **A FOURTEENTH — three defects downstream of three undeclared keys.**
+  `GET/POST /projects/{pid}/modules/{key}/views` return `scope`, `owner` and `mine` on every row and
+  `SavedViewDef` declared none. The server's own comment says why `mine` is SENT rather than inferred
+  from `owner == me` — *"the two can disagree the moment a display name is not the identity key … and
+  the UI uses it to decide whether to offer Delete, which must match what the server will actually
+  allow"*. The UI could not read it, so it did not match, and the mismatch compounded:
 
-  * *server ships, client dark* — `/modules/{key}/views` returns `scope`, `owner` and `mine`
-    on both the GET and the POST and the client type declares none of them, so a shared view is
-    indistinguishable from a private one; separately, `saveView` sends no `scope` in its request
-    body, so the server's `default="private"` decides for every view the web UI creates. *(This
-    sentence previously said the route "never sends or declares `scope`", conflating the response
-    the route RETURNS with the request the client POSTS — two different halves, only one of which
-    this axis measures.)*
-  * *money-document rendering gap* — `/draw-package` declares neither `g703_totals` (the AIA G703
-    schedule of values behind a pay application) nor `forecast_returns`.
+  * a colleague's shared report and your own private filter read identically in the dropdown;
+  * the delete picker offered every listed view, **including ones `DELETE` refuses** — picking one
+    returns `deleted: false`, which the register reports as *"was already gone — refreshing the
+    list"*, after which it is still there, because it was never gone and was never yours. *The only
+    thing telling the truth was the list not changing.*
+  * the confirmation said *"Saved views are yours alone, so this removes it only for you"*, which
+    stopped being true the day sharing shipped.
+
+  And `saveView` sent **no `scope` at all**, so the route's `default="private"` decided for every view
+  this app has ever created: the sharing half of R22-REPORT-BUILDER item 4 was reachable only from
+  outside it. `apps/web/src/portal/register/savedViews.ts` — five mutations, all biting.
+
+  **A FIFTEENTH, and the axis closes on it.** `POST /proforma/scenarios/{sid}/draw-package` returns
+  five keys; three were declared. The two dropped are the two the route exists for. `g703_totals` is
+  the schedule of values the G702 certificate is computed FROM — a payment due with no visible
+  completed-to-date and no visible retainage is a number nobody downstream can check, and retainage is
+  the line owners and subcontractors argue about. `forecast_returns` is the route's own premise,
+  *"so the IRR you underwrote and the lender draw run off the SAME cost tree"*: the re-forecast IRR
+  with the actuals folded in, which answers *is this still the deal we signed?* Both computed on every
+  draw, shown on none. `apps/web/src/proforma/drawPackage.ts`, six mutations. A seventh check found it
+  too: `apps/web/src/ui/charts.test.ts` refused the local `const usd` the first draft defined —
+  **eighteen local copies had disagreed about where the minus sign goes**, and the gate that ended
+  that does not care that this one was new.
 
   **A SEPARATE FINDING, not folded in: 106 dict-returning routes have NO typed client call site.**
   That is a different question from the "19 route handlers have no web client" counted below by a
@@ -2749,7 +2770,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
 | **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
 | **H · Registers** | `services/api/modules/*/module.json` | — |
-| **I · API client** | `apps/web/src/api/` | RESPONSE-UNDECLARED *(the finding comes from `services/api/src/aec_api/routers/`, which is Lane G's, but the WORK is declaring the field on the client interface so something can read it — lanes go by the directory the work touches, the correction Lane E's cell already had to make. Rendering the newly-declared field afterwards is Lane B's)* · SCALE-SEAM *(the only open slice; ②–⓾ plus (81)–(91) have shipped. **Deliberately carries NO mark**: ⓾ is the last glyph in `MARKS` and the double-circled range it closes has no successor, so the next slice cannot be numbered at all — writing a mark the parser does not know would drop the item out of this table's own population.)* *(this cell said (81)–(87) until 2026-09-04, four slices after (88) landed — the same drift its own history below records, in the same cell, for the third time. It named ⓽ until 2026-09-03; ②–⓼ had shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
+| **I · API client** | `apps/web/src/api/` | RESPONSE-UNDECLARED *(**CLOSED 2026-09-11** — all 15 gaps declared and rendered, `KNOWN_GAPS` is empty and asserted empty. The finding came from `services/api/src/aec_api/routers/`, which is Lane G's, but the WORK is declaring the field on the client interface so something can read it — lanes go by the directory the work touches, the correction Lane E's cell already had to make. Rendering the newly-declared field afterwards is Lane B's)* · SCALE-SEAM *(the only open slice; ②–⓾ plus (81)–(91) have shipped. **Deliberately carries NO mark**: ⓾ is the last glyph in `MARKS` and the double-circled range it closes has no successor, so the next slice cannot be numbered at all — writing a mark the parser does not know would drop the item out of this table's own population.)* *(this cell said (81)–(87) until 2026-09-04, four slices after (88) landed — the same drift its own history below records, in the same cell, for the third time. It named ⓽ until 2026-09-03; ②–⓼ had shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
 | **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `apps/web/src/tooling/`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | R39-TSC-CACHE *(local typecheck once diverged from CI; cause unknown, prior explanation retracted — an OBSERVATION, not a defect with a known fix. Read the entry before "fixing" it: the proposed fix is named there and rejected)*  · DESKTOP-CONVERT-TIMEOUT *(the Python converter runs in-process and cannot be interrupted, so `edit_preview`'s 120 s deadline is unenforceable on the desktop path. Filed here rather than Lane C because the fix is process/packaging shape — killable child under PyInstaller, where spawn re-execs the frozen app — the same derived-here-fixed-there split as DESKTOP-SMOKE above)* |
 
 **Parked — not available to pick up.** These are decisions or multi-release commitments, listed so

--- a/services/api/src/aec_api/routers/saml.py
+++ b/services/api/src/aec_api/routers/saml.py
@@ -17,6 +17,16 @@ from .. import audit, auth, licensing, saml
 from ..db import get_db
 from ..models import User
 
+# The session cookie is auth's, not a copy of it. This module used to carry its own `_cookie` that
+# claimed to mirror that one, and it had drifted to the wrong NAME: it set `aec-token`, while the
+# cookie `rbac.current_user` reads is `aec_token`. So a correctly verified assertion minted a real
+# token, put it somewhere nothing reads, and returned the browser to the app still signed out --
+# SAML sign-in could not work at all. The paired test asserted the cookie was SET, using the name
+# the copy itself used, so it stayed green over a flow that never once logged anyone in. Importing
+# the one definition removes the way the two can differ again, and picks up the two things the copy
+# had also lost: AEC_COOKIE_SECURE and the 7-day max-age.
+from .auth import _cookie
+
 router = APIRouter()
 
 
@@ -77,12 +87,6 @@ def _acs(request: Request) -> str:
     """Our ACS URL: the configured value (needed behind a reverse proxy where the internal URL
     differs from the public one), else computed from the request."""
     return saml.acs_url() or str(request.url_for("saml_acs"))
-
-
-def _cookie(resp: Response, token: str, request: Request) -> None:
-    """Set the session cookie (mirrors routers/auth._cookie; secure when the request is https)."""
-    secure = request.url.scheme == "https" or request.headers.get("x-forwarded-proto") == "https"
-    resp.set_cookie("aec-token", token, httponly=True, secure=secure, samesite="lax", path="/")
 
 
 @router.get("/auth/saml/metadata")

--- a/services/api/test_saml.py
+++ b/services/api/test_saml.py
@@ -1,7 +1,8 @@
 """SAML 2.0 SP — the security-critical path is response verification, so this drives real signed
 assertions (self-signed cert via `cryptography`, signed with `signxml`) through the ACS and asserts:
-  * a correctly-signed, in-window, right-audience assertion logs the user in (303 + session cookie,
-    account auto-provisioned);
+  * a correctly-signed, in-window, right-audience assertion logs the user in -- asserted by asking
+    /auth/me who the caller is, not by looking for a Set-Cookie header (303, account
+    auto-provisioned);
   * every attack is rejected with 403: tampered payload (digest break), unsigned assertion,
     assertion signed by a DIFFERENT key than the pinned IdP cert, expired Conditions, wrong audience.
 Run: PYTHONPATH=src ./.venv/Scripts/python.exe test_saml.py"""
@@ -121,7 +122,19 @@ with TestClient(app) as client:
     good = build_response(IDP_KEY, IDP_CERT, email="engineer@corp.com")
     r = post(good)
     assert r.status_code == 303, f"good assertion should log in: {r.status_code} {r.text[:200]}"
-    assert "aec-token" in r.cookies or "aec-token" in r.headers.get("set-cookie", ""), r.headers
+    # Assert the SESSION, not the Set-Cookie header. The line here used to be
+    #   assert "aec-token" in r.cookies or "aec-token" in r.headers.get("set-cookie", "")
+    # which is a check that cannot fail for the reason that matters: it asserted a cookie was set,
+    # under the name the code being tested had chosen, so it stayed green while that name
+    # (`aec-token`) was one nothing reads -- the reader is `aec_token`. Every verified assertion
+    # minted a real token and dropped it in a cookie the server ignores. Ask the server who it
+    # thinks the caller is instead; that question has only one right answer and no spelling of the
+    # cookie can fake it.
+    me = client.get("/auth/me")
+    assert me.status_code == 200, me.text[:200]
+    assert me.json().get("username") == "engineer@corp.com", (
+        f"ACS set a cookie the server does not read -- /auth/me says {me.json().get('username')!r}")
+    assert "aec_token" in r.cookies or "aec_token=" in r.headers.get("set-cookie", ""), r.headers
     with SessionLocal() as db:
         u = db.get(User, "engineer@corp.com")
         assert u and u.provisioned is True and u.email == "engineer@corp.com", u


### PR DESCRIPTION
# What & why

Closes the **RESPONSE-UNDECLARED** axis in `docs/roadmap.md`. `KNOWN_GAPS` in `apps/web/src/api/responseUndeclared.test.ts` is now `{}` — and because it is asserted exactly in both directions, an empty list is a *claim under test*: the next undeclared key anywhere in the tree fails the build rather than joining a backlog. **6 → 0.**

Four of the six turned out not to be about a declared key at all.

### 1. SAML — and the cookie that meant it had never worked

The server implements the whole SP flow and `/auth/providers` returns `saml` to say so, checking *both* halves first (an IdP is configured **and** the tier entitles `sso`) so the button cannot 402 on click. The client named only `providers`, so the login modal branched on `providers.length` and a workspace that had wired its own IdP **and** paid for the entitling tier was shown a hint on its own sign-in screen telling it to go configure OAuth. Not a missing button — a *wrong instruction*, on the one screen nobody can get past.

**Underneath it, the reason nobody had reported the missing button.** `services/api/src/aec_api/routers/saml.py` carried its own `_cookie` whose docstring said it *"mirrors routers/auth._cookie"*. It had drifted — to the one field that is not a preference, the **name**. It set `aec-token`; the cookie `rbac.current_user` reads is `aec_token`. A correctly signed, in-window, right-audience assertion was verified, the account provisioned, a real session minted — and put somewhere nothing reads, so the browser returned signed out. `services/api/test_saml.py` asserted `"aec-token" in r.cookies`, **using the name the code under test had chosen**, and stayed green over a flow that had never once let anyone in. It now asks `/auth/me` who the caller is; with the old helper restored it fails with `ACS set a cookie the server does not read -- /auth/me says 'dev'`. The copy is **deleted**, not corrected, which also recovers `AEC_COOKIE_SECURE` and the 7-day max-age it had lost.

> A duplicated helper does not drift where you are looking. It drifts in the one field both sides only ever write.

### 2. Asset rights — a promise the dialog could not keep

The seal dialog promised that *"anyone holding the issuer's published verification key can confirm the file is authentic"* and could not say what that key **is**: `public_key` was undeclared under a comment on the adjacent `issuer` reading *"Never a key."* — a rule the server had already examined and removed, since the same key ships inside every signed manifest. Now named and printed. `issuer` was itself declared-and-never-read, so one edit closes a DEAD-FIELD and a RESPONSE-UNDECLARED on one route, in opposite directions.

### 3. `/reference/disciplines` — a spec code with nothing to read it against

Four payloads served, `{ tree }` declared. **What that cost shows at the Detailing panel**, which asks for a section with the hint *"e.g. 08 51 00"* and had nothing to check the answer against — so `80 51 00`, two digits transposed into a division that does not exist, was accepted in silence and became a classification on an IFC element. It now answers with *"Division 08 · Openings (Architectural)"*, or a ⚠. It never refuses: MasterFormat reserves 48–49 and the 80s–90s for user-defined divisions.

### 4. `/proforma/solve` — the caveat that decides whether a number can be relied on

`provenance` is computed on every solve: per figure, which assumptions the caller declared and which the engine defaulted, plus `defaulted_inputs` — the server's own *"the number a reviewer actually wants"*. **Not a wrong number, an unreviewable one.** `provenanceLine` now sits under the underwriting guardrails, and returns **null** on a missing `provenance` rather than the all-declared line: inferring "everything was declared" from absence of evidence is the opposite claim.

### 5. Saved views — three defects downstream of three undeclared keys

The route returns `scope`, `owner` and `mine` on every row and `SavedViewDef` declared none. The server's own comment says why `mine` is *sent* rather than inferred from `owner == me`. The UI could not read it, so it did not match:

- a colleague's shared report and your own private filter read **identically** in the dropdown;
- the delete picker offered every listed view, **including ones `DELETE` refuses** — picking one returns `deleted: false`, which the register reports as *"was already gone — refreshing the list"*, after which it is still there. *The only thing telling the truth was the list not changing.*
- the confirmation said *"Saved views are yours alone"*, which stopped being true the day sharing shipped.

And `saveView` sent **no `scope` at all**, so the route's `default="private"` decided for every view this app has ever created: the sharing half of R22-REPORT-BUILDER item 4 was reachable only from outside it.

### 6. `/draw-package` — the two keys the route exists for

`g703_totals` is the schedule of values the G702 certificate is computed **from** — a payment due with no visible completed-to-date and no visible retainage is a number nobody downstream can check. `forecast_returns` is the route's own premise, *"so the IRR you underwrote and the lender draw run off the SAME cost tree"*. Both computed on every draw, shown on none.

### Gates that pushed back, and were right each time

| gate | what it caught |
|---|---|
| `test_file_sizes.py` | `client.ts` 554 → 562, then `register.ts` 2452 → 2468. Fixed the way the files' own comments require — **extract, never raise the cap**: a `withClassification` mixin (client.ts → **540**) and `savedViews.ts` (register.ts → **2447**) |
| `docStranded.test.ts` | the doc comment my extraction left stranded above the *next* method's comment |
| `charts.test.ts` | the local `const usd` the draw-package formatter defined — eighteen local copies had disagreed about where the minus sign goes |
| `clientCallers.test.ts` | a private cache helper read as an unwired endpoint. The honest fix was not to create the method, rather than to exempt it |
| `roadmapLanes.test.ts` | the lane cell still advertising this axis as available work once the item was closed |
| eslint | an import left unused by the extraction |

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean — whole tree, `All checks passed!`
- [x] Backend: **695/695 suites passed** (`run_tests.py`, 1217s wall) on the SAML commit — the only one touching backend code. `test_saml.py` already registered; no new backend test file. `test_claude_md_gates.py` and `test_file_sizes.py` re-run green on every later commit.
- [x] Web: `npm run typecheck && npm run lint && npm run build` clean; full vitest **2462/2462** across 239 files
- [x] No import cycles introduced (`test_import_cycles.py`, `no-import-cycles.test.ts`)
- [x] `CHANGELOG.md` entries added (six, newest at top); roadmap item **marked ✅ closed**, lane cell updated, all fifteen fixes recorded
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs — the CHANGELOG names IdPs as SSO providers (interop), which `test_no_comparative_names.py` passes

### Mutation testing — 36 mutations, every one confirmed to bite

| target | n | notes |
|---|---|---|
| `signInDoors` | 5 | drop the SAML door, reorder it last, route it through the OAuth path, drop the first-provider promotion, mark it non-lead |
| `sealIdentity` | 4 | **one survived the first pass** — the `signing` guard was covered only incidentally, because the test for it also emptied the key. *Two guards that always fire together are one guard as far as the tests can tell.* |
| `classificationRef` | 6 | **one survived the first pass** — the longest-prefix rule was asserted against the served table, where no two entries are prefixes of each other. *A fixture drawn from today's data cannot test a rule written for tomorrow's.* |
| `provenanceLine` | 6 | including the one that matters: returning the all-declared line for a missing `provenance` |
| `savedViews` | 8 | including `parseInt` for `Number` (so `"3abc"` deletes the third view) and sharing by default |
| `drawPackage` | 6 | including a null IRR rendering as `0%` |
| `saml._cookie` | 1 | restore the pre-fix hyphenated helper — bites, with the diagnostic naming the real failure |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Saved views can be shared with the project, with clearer ownership labels and deletion warnings.
  - SAML single sign-on now appears as a sign-in option and works reliably.
  - Pro forma results show defaulted inputs, draw-package totals, and forecast returns.
  - Classification code entry displays division or crosswalk information and warns about unrecognized codes.
  - Sealed project files now display issuer and verification-key details when available.

- **Bug Fixes**
  - View deletion is limited to views the user can delete.
  - Fixed SAML session handling so sign-in completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->