### PR TITLE
The cost importer nobody could reach, and the gate that vouched for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ prints the key alongside, so you can hand it to whoever needs to check your rele
 with sealing switched on but no signing key configured, nothing is shown, because there would be
 nothing to verify against.
 
+### The offline cost baseline can now actually be installed
+
+The budget panel has been telling cost managers that an offline cost baseline is *"installable — no
+subscription"*, and the app had no way to install one. The server has always had the importer; no
+screen ever called it.
+
+It is now in Profile & settings → Administration, under Server. It is deliberately not on the budget
+card: installing a vintage reprices **every project that has not pinned one**, which is a server-wide
+change and not something to offer beside one project's numbers. The budget card now names who can do
+it instead of implying you can. The confirmation spells out the consequence, and projects with a
+pinned vintage are unaffected.
+
 ### SAML single sign-on now works, and has a button
 
 If your organisation runs its own identity provider — Okta, Entra ID, Ping, Google Workspace as a

--- a/apps/web/src/account/accountUI.ts
+++ b/apps/web/src/account/accountUI.ts
@@ -12,6 +12,7 @@ import { modalShell, confirmModal } from "../ui/modal";
 import { askText } from "../ui/prompt";
 import { escapeHtml, toast } from "../ui/feedback";
 import { renderChip, type ChipIdentity } from "./accountChip";
+import { importConfirmText, importedSummary } from "./costVintage";
 import { signInDoors, collapsedDoors, type SignInDoor } from "./signInDoors";
 import { cloudLoginUrl, cloudStatus, cloudRefresh, cloudDisconnect, type CloudStatus } from "../api/cloud";
 
@@ -358,6 +359,7 @@ async function openProfile(platformAdmin: boolean, tier: string, initial = "prof
       errorLog: errorsModal,
       dataConnections: () => void import("../connections/connectionsUI")
         .then((m) => m.openConnectionsModal(D.api, D.getProjectId)),
+      installCostVintage: () => void installCostVintage(),
       projectMembers: D.getIsProjectAdmin() && pid ? () => membersModal(pid) : null,
       changePassword: passwordModal,
       twoFactor: () => void mfaModal(),
@@ -664,4 +666,19 @@ function errorsModal() {
   prune.onclick = async () => { try { const r = await api.clearErrorLog(); msg.style.color = "var(--muted)"; msg.textContent = `pruned ${r.pruned} old row(s)`; await render(); } catch { msg.style.color = "var(--err)"; msg.textContent = "prune failed"; } };
   card.append(filters, table, msg);
   void render().finally(ready);
+}
+
+/** Build + install the offline public cost vintage (COST-DB), from Administration.
+ *
+ *  Reached only from the platform-admin section, and the server checks again: the UI gate decides
+ *  what to OFFER, the server decides what to ALLOW, and neither stands in for the other. */
+async function installCostVintage(): Promise<void> {
+  if (!await confirmModal("Install cost vintage", importConfirmText(), "Build and install", true)) return;
+  try {
+    toast("Building the offline public cost vintage…", "info");
+    toast(importedSummary(await D.api.importCostDataset()), "success");
+  } catch (e) {
+    // A 403 here means the account lost platform admin between opening the panel and clicking.
+    toast(`Cost vintage not installed: ${(e as Error).message}`, "error");
+  }
 }

--- a/apps/web/src/account/costVintage.test.ts
+++ b/apps/web/src/account/costVintage.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { importConfirmText, importedSummary, installableNote } from "./costVintage";
+
+describe("installableNote", () => {
+  it("names the ROLE rather than offering an action", () => {
+    // The budget card's reader is usually a cost manager, not a platform administrator. Offering a
+    // button there would 403 for exactly the person most likely to press it — the same
+    // offered-and-refused shape the saved-view delete picker had.
+    const line = installableNote([{ note: "2025 Q1" }])!;
+    expect(line).toContain("platform administrator");
+    expect(line).toContain("no subscription");
+    expect(line).toContain("(2025 Q1)");
+  });
+
+  it("is null when nothing is installable, so no line is rendered at all", () => {
+    expect(installableNote([])).toBeNull();
+    expect(installableNote(undefined)).toBeNull();
+  });
+
+  it("agrees with itself in the singular", () => {
+    expect(installableNote([{}])).toContain("1 offline baseline installable");
+    expect(installableNote([{}, {}])).toContain("2 offline baselines installable");
+  });
+
+  it("omits the parenthetical when the server sent no note", () => {
+    expect(installableNote([{}])).not.toContain("(");
+  });
+});
+
+describe("importConfirmText", () => {
+  it("states the blast radius, which is the whole reason this is admin-only", () => {
+    // The consequence belongs in the dialog, not in a docstring nobody clicking can see: this is a
+    // server-wide reprice, not a change to one project.
+    const t = importConfirmText();
+    expect(t).toContain("NOT pinned");
+    expect(t).toContain("server-wide");
+    expect(t).toContain("Projects with a pinned vintage are unaffected");
+    expect(t).toContain("idempotent");
+  });
+});
+
+describe("importedSummary", () => {
+  it("reports what landed", () => {
+    expect(importedSummary({ name: "Public 2025 Q1" })).toBe("Installed Public 2025 Q1 and set it as latest.");
+  });
+
+  it("builds a label from vintage and quarter when the server sent no name", () => {
+    expect(importedSummary({ vintage: 2025, quarter: 3 })).toContain("2025 Q3");
+    expect(importedSummary({ vintage: 2025, quarter: null })).toContain("Installed 2025 ");
+  });
+
+  it("SURFACES the server's warning rather than swallowing it", () => {
+    // The route returns `warning` when a `cloud` source was asked for and the offline public build
+    // was served instead. Reporting plain success there would tell the operator they installed
+    // something they did not.
+    const s = importedSummary({ name: "Public 2025", warning: "no cloud subscription configured" });
+    expect(s).toContain("Note: no cloud subscription configured");
+  });
+
+  it("falls back to a neutral label rather than printing undefined", () => {
+    expect(importedSummary({})).toContain("new vintage");
+  });
+});

--- a/apps/web/src/account/costVintage.ts
+++ b/apps/web/src/account/costVintage.ts
@@ -1,0 +1,55 @@
+/** Installing a cost-database vintage: what to say, and what it costs.
+ *
+ *  `POST /cost/datasets/import` builds the offline public cost baseline and had **no client method
+ *  at all**. Meanwhile `GET /cost/datasets` is called on every budget panel and returns
+ *  `available_public` — what the importer could build — so the card has been telling cost managers
+ *  *"1 offline baseline(s) installable — no subscription"* while the app offered no way to install
+ *  one. A promise with no affordance, and the promise was added by the change that declared the
+ *  field.
+ *
+ *  The action is **platform-admin only** and the reason is the blast radius, not tidiness:
+ *  importing flips the global `is_latest`, which reprices every unpinned project's estimate. So it
+ *  belongs in Profile & settings → Administration, and the budget card names the role rather than
+ *  offering a button that would 403 for the person most likely to click it.
+ *
+ *  Pure, so the wording and the consequence text are testable without a dialog.
+ */
+
+/** One entry of `costDatasets().available_public`. */
+export interface AvailableVintage { source_set?: string; origin?: string; tier?: string; note?: string }
+
+/**
+ * The budget card's line about what can be installed, or `null` when nothing can be.
+ *
+ * It names the ROLE rather than offering an action, because the reader of a project budget card is
+ * usually not a platform administrator, and a button that 403s is worse than a sentence that tells
+ * you who to ask — the same mistake the saved-view delete picker had been making.
+ */
+export function installableNote(available: AvailableVintage[] | undefined): string | null {
+  const n = available?.length ?? 0;
+  if (!n) return null;
+  const note = available?.[0]?.note;
+  return `${n} offline baseline${n === 1 ? "" : "s"} installable by a platform administrator`
+    + " — no subscription" + (note ? ` (${note})` : "");
+}
+
+/**
+ * What the administrator is agreeing to. The blast radius goes in the confirmation, not in a
+ * docstring nobody reading the dialog can see: this is a global, cross-project repricing, and a
+ * cost manager who pinned their project's vintage is the only one insulated from it.
+ */
+export function importConfirmText(): string {
+  return "Build the offline public cost vintage and make it the latest?\n\n"
+    + "Every project that has NOT pinned a vintage will reprice against it — this is a "
+    + "server-wide change, not a change to one project.\n\n"
+    + "Projects with a pinned vintage are unaffected. The build is idempotent: running it again "
+    + "for the same period replaces that vintage rather than adding another.";
+}
+
+/** What to report once it lands. `warning` is the server's own — surfaced, never swallowed. */
+export function importedSummary(r: { name?: string; vintage?: number; quarter?: number | null;
+                                     warning?: string | null }): string {
+  const label = r.name
+    || (r.vintage != null ? `${r.vintage}${r.quarter ? ` Q${r.quarter}` : ""}` : "new vintage");
+  return `Installed ${label} and set it as latest.${r.warning ? ` Note: ${r.warning}` : ""}`;
+}

--- a/apps/web/src/account/profileSettings.test.ts
+++ b/apps/web/src/account/profileSettings.test.ts
@@ -19,6 +19,7 @@ import type { CloudStatus } from "../api/cloud";
 function actions(): ProfileActions {
   return {
     manageUsers: vi.fn(), auditLog: vi.fn(), agentRuns: vi.fn(), errorLog: vi.fn(), dataConnections: vi.fn(),
+    installCostVintage: vi.fn(),
     projectMembers: null, changePassword: vi.fn(), twoFactor: vi.fn(), appSettings: vi.fn(),
     signOutEverywhere: vi.fn(), signOut: vi.fn(), connectCloud: vi.fn(),
     refreshCloud: vi.fn(async () => ({} as CloudStatus)), disconnectCloud: vi.fn(async () => {}),

--- a/apps/web/src/account/profileSettings.ts
+++ b/apps/web/src/account/profileSettings.ts
@@ -27,6 +27,9 @@ export interface ProfileActions {
   agentRuns: () => void;
   errorLog: () => void;
   dataConnections: () => void;
+  /** Build + install the offline public cost vintage. Platform-admin only: it flips the global
+   *  `is_latest` and reprices every unpinned project, which is why it is in THIS section. */
+  installCostVintage: () => void;
   projectMembers: (() => void) | null;   // null when there is no project / not a project admin
   changePassword: () => void;
   twoFactor: () => void;
@@ -260,6 +263,10 @@ function buildAdmin(body: HTMLElement, deps: ProfileDeps): void {
   server.append(row("Data connections", "Connect external data sources for this deployment.",
     "Open…", a.dataConnections));
   server.append(row("Server settings", "Licence, integrations and API keys.", "Open…", a.appSettings));
+  // The offline public cost baseline. Its route had no client method at all, so the budget card
+  // could report the baseline as installable and nothing in the app could install it.
+  server.append(row("Cost database", "Build the offline public cost vintage. Reprices every project "
+    + "that has not pinned one.", "Install…", a.installCostVintage));
   const logs = group(body, "Diagnostics");
   logs.append(row("Audit log", "Who did what, newest first.", "View…", a.auditLog));
   logs.append(row("Agent runs", "Whose agent ran what, across every project.", "View…", a.agentRuns));

--- a/apps/web/src/api/cost.ts
+++ b/apps/web/src/api/cost.ts
@@ -155,6 +155,27 @@ export function withCost<TBase extends Ctor<HttpCore>>(Base: TBase) {
       available_public: { source_set?: string; origin?: string; tier?: string; note?: string }[];
     }>("/cost/datasets");
   }
+  /**
+   * Build and install a cost vintage from the offline public source (COST-DB).
+   *
+   * **This route had no client method at all.** `costDatasets` above reports what the importer
+   * *could* build — and the budget card says so, in as many words — while the thing that builds it
+   * was reachable only with a hand-rolled HTTP call. `services/api/test_route_reachability.py` did
+   * not say so either: its leaf is `import`, which occurs 2,223 times in this tree as the TypeScript
+   * keyword, so the route vouched for itself.
+   *
+   * **Platform-admin only, and the reason is in the blast radius**: importing flips the global
+   * `is_latest`, which reprices every unpinned project's estimate. That is why the action lives in
+   * Profile & settings → Administration and not on a project's budget card.
+   */
+  importCostDataset(vintage: number | "latest" = "latest", quarter: number | null = null) {
+    return this.json<{
+      id?: string; name?: string; vintage?: number; quarter?: number | null; origin?: string;
+      is_latest?: boolean;
+      /** Set when a `cloud` source was asked for and the offline public build was served instead. */
+      warning: string | null;
+    }>("/cost/datasets/import", { method: "POST", body: JSON.stringify({ vintage, quarter }) });
+  }
   /** The vintage this project's estimate resolves through (pinned, else latest). */
   costVintage(pid: string) {
     return this.json<{

--- a/apps/web/src/api/responseUndeclared.test.ts
+++ b/apps/web/src/api/responseUndeclared.test.ts
@@ -78,6 +78,11 @@ const KNOWN_GAPS: Record<string, string[]> = {
  *  Closing a route's spread is therefore a visible improvement, not a no-op. */
 const INCOMPLETE_LOWER_BOUND: string[] = [
   "GET /agent-packs/runs",
+  // Added 2026-09-11 by giving `/cost/datasets/import` its first client method: the route returns
+  // `{**cost_db.dataset_dict(ds), "warning": ...}`, so only `warning` can be named statically. It
+  // appears here for a good reason — this gate can only see a route that HAS a typed call site, and
+  // until now it had none at all.
+  "POST /cost/datasets/import",
   "GET /projects/{}/agent-packs",
   "GET /projects/{}/ai/risk-summary",
   "GET /projects/{}/compliance/expiring",

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -1,4 +1,5 @@
 import { groupedBar, money as cmoney, esc, usd } from "../../ui/charts";
+import { installableNote } from "../../account/costVintage";
 import { confidenceSummary } from "../../ui/confidenceReading";
 import { confirmModal } from "../../ui/modal";
 import type { PanelContext } from "../panelContext";
@@ -606,9 +607,13 @@ export async function renderBudget(ctx: PanelContext) {
           // word from colliding with the leaf of `/projects/{pid}/listings/{lid}/public` in
           // `services/api/test_route_reachability.py`, which matches route segments against the web
           // source — a real constraint on prose, and the second reason rather than the first.)
-          const note = ds.available_public[0]?.note;
-          bits.push(`${ds.available_public.length} offline baseline(s) installable — no subscription`
-            + (note ? ` (${note})` : ""));
+          // NAME THE ROLE, do not offer the action. Importing flips the global `is_latest` and
+          // reprices every unpinned project, so it is platform-admin only and lives in
+          // Profile & settings -> Administration. This card's reader is usually a cost manager;
+          // a button here would 403 for exactly the person most likely to press it, which is the
+          // same offered-and-refused shape the saved-view delete picker had.
+          const line = installableNote(ds.available_public);
+          if (line) bits.push(line);
         }
       }
       if (five) {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1679,6 +1679,48 @@ instances:
   textual scan of a typed language cannot resolve a named return type, a nested literal, or a
   multi-line span, and this one reported `id` undeclared on a route that plainly declares it.
 
+- ✅ ⭐ **UNREACHED-IMPORT — the gate that vouched for a route with the word `import`**
+  *(S — Lanes B/G; **CLOSED 2026-09-11**; gated by `services/api/test_route_reachability.py`)*
+
+  The premise handed to this item was half wrong, which is worth stating first: `progressActuals` and
+  `saveViewTemplates` **were** flagged — both sit in the `UNCALLED` ceiling in
+  `apps/web/src/api/clientCallers.test.ts`, visible and countable, which is what that list is for. The
+  other half was right and worse than described.
+
+  **`POST /cost/datasets/import` had no client method at all**, and the budget panel has been telling
+  cost managers *"1 offline baseline(s) installable — no subscription"* the whole time. A promise with
+  no affordance — and the promise was added by the change that declared `available_public`. The
+  installer now lives in Profile & settings → Administration, not on the budget card, because it flips
+  the global `is_latest` and reprices every unpinned project; the card names the role instead of
+  offering a button that would 403 for exactly the reader most likely to press it, which is the
+  offered-and-refused shape the saved-view delete picker had until the day before.
+
+  **Why nothing said so: the route's leaf is `import`, which occurs 2,223 times in this tree as the
+  TypeScript keyword.** Not an unlucky word — a *reserved* one, so the collision is guaranteed for any
+  route named after a keyword. Its sibling `/cost/datasets/import-custom` was correctly frozen, so the
+  route with the more distinctive name was caught and the one named after a keyword vouched for
+  itself, under a headline check that reads *"NO NEW UNREACHABLE ROUTE"*.
+
+  `leaf_is_called` now requires the leaf to occupy a **path segment inside a string literal**. A URL
+  this client builds is always a string; a bare identifier never is, and a word in a sentence has a
+  space in front of it. **Measured before applying, because the two previous candidate fixes were each
+  wrong in this same place: 42 uncalled before, 67 after — 25 newly visible, ZERO lost.** Three of the
+  25 spot-checked have no occurrence anywhere in the web source; two more appear only inside English
+  prose. All 25 frozen as untriaged, four mutations, all biting.
+
+  **The rule's docstring used to call this class unfixable — and the reason it became unaffordable is
+  that I broke it three times in one sitting.** Writing three ordinary sentences about a feature whose
+  own name contains the word *public* re-collided with `/listings/{lid}/public`, the exact collision
+  the previous change had *reworded away*. **A rule that makes product copy unwritable will be
+  re-broken by whoever has not read the file** — and the natural wording is restored in this change as
+  the demonstration that it is fixed.
+
+  *One more thing the fix had to learn.* The first measurement of this rule reported **36 routes lost,
+  including `plan.dxf`, whose caller is real** — which argued convincingly for rejecting it. The rule
+  was fine; the harness anchored "start of string" against text with the quote character still
+  attached, so no leading-fragment call site could ever match. **A measurement can be wrong in the
+  direction that preserves the status quo, and that is the direction nobody double-checks.**
+
   **A SEPARATE FINDING, deliberately not folded in: 19 route handlers have NO web client at all.**
   That is a different question with a different answer each time — `/bcf/2.1/auth` is correct,
   `/projects/{pid}/pins/all` looks like a gap. `ARCH-REACH` cannot see it: it asks whether a MODULE is

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -289,6 +289,28 @@ KNOWN_UNCALLED: set[str] = {
     "/projects/{pid}/rules/effective",
     "/projects/{pid}/scene/manifest",
     "/webhooks/deliveries",
+    # ---- 8 more, added 2026-09-11 when `_SEGMENT` flipped from a blocklist of characters that may
+    # NOT follow a leaf to an allowlist of what MAY (see `_SEGMENT` for the measurement: +8, 0 lost).
+    # Every one of these was vouched for by an English sentence that happened to start with the
+    # leaf — "packs failed: …", "seeded from MasterFormat classifications", "coordinate the
+    # drawings", "template must contain {z}/{x}/{y}", "georeference to carry the offset",
+    # "…out of the wet/freeze season" — or by "generic/proxy" inside a count. Each was then grepped
+    # directly: no caller, in any shape, anywhere in `apps/web/src`.
+    #
+    # These are not stubs. Freezing a prefab kit writes the GlobalId list that the shop fabricates
+    # from; `/jurisdiction/packs` is the whole import path for an authority's data requirements;
+    # `/projects/{pid}/georeference` is what tells a user whether their model may be used to set
+    # out. **Eight working capabilities with no way to reach them**, and the reason they were never
+    # counted is that the gate written to count them was reading prose. Frozen, not judged — the
+    # same terms as the 25 above.
+    "/codes/seeded",
+    "/jurisdiction/packs",
+    "/jurisdiction/packs/{pack_id}",
+    "/projects/{pid}/clash/coordinate",
+    "/projects/{pid}/documents/template",
+    "/projects/{pid}/georeference",
+    "/projects/{pid}/model/lod/proxy",
+    "/projects/{pid}/prefab/kits/{rid}/freeze",
 }
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -487,13 +509,36 @@ def string_blob(code: str) -> str:
     Cached because it is asked for once per assessed route, 834 times, over ~4 MB of source. The
     uncached first draft took this gate from seconds to over two minutes.
     """
-    return _NUL + _NUL.join(m[1:-1] for m in _STRINGS.findall(code))
+    #: TERMINATED as well as separated, since 2026-09-11. `_SEGMENT` asks what FOLLOWS the leaf,
+    #: and the last literal in the blob has nothing after it -- so without a closing NUL the rule
+    #: would need `$` to mean "end of a string", and `$` in a Python regex also matches before a
+    #: trailing newline, which a multi-line template literal really can end with. One character
+    #: here removes a boundary case rather than documenting it.
+    return _NUL + _NUL.join(m[1:-1] for m in _STRINGS.findall(code)) + _NUL
 
 
 @functools.lru_cache(maxsize=2048)
 def _SEGMENT(leaf: str) -> "re.Pattern[str]":
-    """The leaf occupying a PATH SEGMENT: it opens a string, or follows a `/`, and no path
-    character continues it.
+    """The leaf occupying a PATH SEGMENT: it opens a string, or follows a `/`, and what comes next
+    is an end of string, another segment, a query/fragment, or an interpolation.
+
+    **This ENUMERATES WHAT MAY FOLLOW, rather than what may not — changed 2026-09-11, by review.**
+    The first version was a negative lookahead: anything but `[A-Za-z0-9_.-]` (and a bare `$`)
+    ended the segment. Review pointed out that it therefore accepted `:`, `@`, `;`, `~` and `%`, so
+    `"import: offline baseline"` vouched for `/cost/datasets/import`. **Adding those five characters
+    to the negative set would have fixed the example and nothing else** — measured, it moves the
+    uncalled count by zero. The defect is not the five characters, it is the polarity: a blocklist
+    of path-continuations is open by construction, and the next word to sit against a leaf is
+    whatever prose someone writes tomorrow.
+
+    Flipping to a positive lookahead was measured across all 834 assessed routes before it landed:
+    **+8 newly visible, 0 lost.** All eight were English prose at the head of a string —
+    `"packs failed: ..."`, `"seeded from MasterFormat classifications"`, `"coordinate the drawings"`,
+    `"template must contain {z}/{x}/{y}"`, `"georeference to carry the offset"`,
+    `" (${r.generic_elements} generic/proxy)"`, `"...out of the wet/freeze season."` — and a direct
+    grep confirms none of the eight routes has a caller. *The blocklist could not have been extended
+    to reach them: a leaf followed by a space is not a path, and no list of forbidden punctuation
+    says so.*
 
     **`}` WAS IN THIS SET FOR ONE DAY AND EARNED NOTHING.** The first draft also accepted `}`, on
     the theory that a leaf can follow a closed `${...}` — `` `${base}import` ``. Review pointed out
@@ -509,7 +554,7 @@ def _SEGMENT(leaf: str) -> "re.Pattern[str]":
     If a caller ever does write `` `${base}import` ``, this rule reads the route as uncalled and the
     gate goes red until someone looks — which is the direction this file wants to fail in.
     """
-    return re.compile(rf"(?:{_NUL}|/){re.escape(leaf)}(?![A-Za-z0-9_.\-]|\$(?!\{{))")
+    return re.compile(rf"(?:{_NUL}|/){re.escape(leaf)}(?={_NUL}|/|[?#]|\$\{{)")
 
 
 def uncalled_routes(paths, blob: str) -> set[str]:
@@ -702,6 +747,18 @@ check("  ...and still accepts the shapes a real caller writes",
 # what surrounds the leaf CHARACTER by character; these are about WHERE it is allowed to be found at
 # all, which is the class that let `/cost/datasets/import` ship unreachable and made product copy
 # unwritable. Same shape as above: what it must reject, and what it must still accept.
+check("  a real caller's URL shapes stay reachable under the positive lookahead",
+      leaf_is_called("import", '"/cost/datasets/import"')
+      and leaf_is_called("import", "'/cost/datasets/import'")
+      and leaf_is_called("import", '`${base}/cost/datasets/import`')
+      and leaf_is_called("import", '"/cost/datasets/import?vintage=2026"')
+      and leaf_is_called("import", '"/cost/datasets/import#top"')
+      and leaf_is_called("import", '"/cost/datasets/import/dry-run"')
+      and leaf_is_called("import", '`/cost/datasets/import${qs}`')
+      and leaf_is_called("plan.dxf", '`/projects/${pid}/exports/plan.dxf`'),
+      "the positive lookahead has lost a call shape the client really writes — every route whose "
+      "leaf is written this way would be reported uncalled, and the gate would be measuring itself")
+
 check("  ...and rejects a leaf that is only a word in a sentence or a bare keyword",
       not leaf_is_called("import", "import { toast } from './feedback';")
       and not leaf_is_called("import", 'toast("Building the offline public cost vintage…")')
@@ -712,7 +769,17 @@ check("  ...and rejects a leaf that is only a word in a sentence or a bare keywo
       # was accepted unconditionally, so any string carrying one in front of the leaf vouched for
       # the route -- a fail-open hole inside the fix for a fail-open hole.
       and not leaf_is_called("import", 'label("not a URL }import")')
-      and not leaf_is_called("import", 'const s = `${base}import`;'),
+      and not leaf_is_called("import", 'const s = `${base}import`;')
+      # NOR IS A COLON, `@`, `;`, `~` OR `%`. Review's second finding on the same rule: the negative
+      # lookahead named the characters a segment may NOT be continued by, so every character nobody
+      # thought of ended a segment -- and prose puts one there constantly. These five are the
+      # examples; the fix was the polarity, not the five. See `_SEGMENT`.
+      and not leaf_is_called("import", '"import: offline baseline"')
+      and not leaf_is_called("import", '"import;x"')
+      and not leaf_is_called("import", '"import@host"')
+      and not leaf_is_called("import", '"import~1"')
+      and not leaf_is_called("import", '"import%20now"')
+      and not leaf_is_called("packs", '"packs failed: ${(e as Error).message}"'),
       "a route is being vouched for by English or by a keyword again — the class that hid "
       "/cost/datasets/import behind 2,223 occurrences of the TypeScript `import` keyword")
 check("  ...while a URL written any of the ways this client writes one still counts",

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -492,9 +492,24 @@ def string_blob(code: str) -> str:
 
 @functools.lru_cache(maxsize=2048)
 def _SEGMENT(leaf: str) -> "re.Pattern[str]":
-    """The leaf occupying a PATH SEGMENT: it opens a string, or follows `/` or a closed `${...}`,
-    and no path character continues it."""
-    return re.compile(rf"(?:{_NUL}|/|\}}){re.escape(leaf)}(?![A-Za-z0-9_.\-]|\$(?!\{{))")
+    """The leaf occupying a PATH SEGMENT: it opens a string, or follows a `/`, and no path
+    character continues it.
+
+    **`}` WAS IN THIS SET FOR ONE DAY AND EARNED NOTHING.** The first draft also accepted `}`, on
+    the theory that a leaf can follow a closed `${...}` — `` `${base}import` ``. Review pointed out
+    that the brace was accepted UNCONDITIONALLY, so the string `"not a URL }import"` vouched for
+    `/cost/datasets/import`: *a fail-open hole inside the rule written to close a fail-open hole.*
+
+    Measured all three ways before choosing. Uncalled count is **67 under every one of them** — `}`
+    unconditional, `}` only when a real `${...}` precedes it, and no `}` at all. **No route is
+    vouched for by a brace today, and none is lost by removing it**, so the special case is deleted
+    rather than made more careful: a sentinel that collapses real interpolations would be more
+    machinery for the same answer, and it would still accept `${x}import`.
+
+    If a caller ever does write `` `${base}import` ``, this rule reads the route as uncalled and the
+    gate goes red until someone looks — which is the direction this file wants to fail in.
+    """
+    return re.compile(rf"(?:{_NUL}|/){re.escape(leaf)}(?![A-Za-z0-9_.\-]|\$(?!\{{))")
 
 
 def uncalled_routes(paths, blob: str) -> set[str]:
@@ -692,7 +707,12 @@ check("  ...and rejects a leaf that is only a word in a sentence or a bare keywo
       and not leaf_is_called("import", 'toast("Building the offline public cost vintage…")')
       and not leaf_is_called("public", 'row("Share", "The public read-only page for this token.")')
       and not leaf_is_called("notices", "// the one nobody notices has drifted")
-      and not leaf_is_called("import", '"/projects/${pid}/schedule/import-xer"'),
+      and not leaf_is_called("import", '"/projects/${pid}/schedule/import-xer"')
+      # A BARE `}` IS NOT A PATH BOUNDARY. Review found this in the first draft of the rule: `}`
+      # was accepted unconditionally, so any string carrying one in front of the leaf vouched for
+      # the route -- a fail-open hole inside the fix for a fail-open hole.
+      and not leaf_is_called("import", 'label("not a URL }import")')
+      and not leaf_is_called("import", 'const s = `${base}import`;'),
       "a route is being vouched for by English or by a keyword again — the class that hid "
       "/cost/datasets/import behind 2,223 occurrences of the TypeScript `import` keyword")
 check("  ...while a URL written any of the ways this client writes one still counts",

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -42,6 +42,7 @@ WHAT A PASS MEANS
 
 Run: PYTHONPATH="src;../data/src" ./.venv/Scripts/python.exe test_route_reachability.py
 """
+import functools
 import os
 import re
 import sys
@@ -248,6 +249,46 @@ KNOWN_UNCALLED: set[str] = {
     "/projects/{pid}/model/columnar/aggregate",     # 'aggregate' was read inside 'aggregates'
     "/projects/{pid}/modules/{key}/aggregate",      # 'aggregate' was read inside 'aggregates'
     "/structure/recommend",                     # 'recommend' was read inside 'recommended'
+
+    # ------------------------------------------------------------------------------------------
+    # NEWLY VISIBLE 2026-09-11 (second pass), AGAIN NOT NEWLY UNREACHABLE. `leaf_is_called` now
+    # requires the leaf to occupy a PATH SEGMENT INSIDE A STRING, so a leaf can no longer be
+    # vouched for by an identifier, a keyword, or an English sentence. These 25 were always dark;
+    # what changed is that the rule can see them. Measured: 42 uncalled before, 67 after, ZERO
+    # routes lost. Frozen, not judged.
+    #
+    # Spot-checked while writing this: `scene/manifest`, `edit/batch` and `model/ensure` have NO
+    # occurrence anywhere in the web source; `classifications` and `notices` occur only inside
+    # prose ("seeded from MasterFormat classifications", "nobody notices"). That is the class.
+    #
+    # `/auth/saml/metadata` is the likeliest of these to be correct-as-is — SP metadata is handed
+    # to an IdP out of band — but "likeliest" is not "read", and this set records what nobody has
+    # read rather than what somebody approved.
+    "/auth/saml/metadata",
+    "/benchmarks/vendors",
+    "/classifications",
+    "/estimate/labor/rates",
+    "/plugins/reload",
+    "/proforma/scenarios/{sid}/clone",
+    "/projects/{pid}/accounting/journal",
+    "/projects/{pid}/classify/proposals",
+    "/projects/{pid}/coordination/stale",
+    "/projects/{pid}/cost/pay-app/advance",
+    "/projects/{pid}/design/options/economics",
+    "/projects/{pid}/drawing-set/references",
+    "/projects/{pid}/drawings/schedule.svg",
+    "/projects/{pid}/edit/batch",
+    "/projects/{pid}/egress/routes",
+    "/projects/{pid}/elements/freshness",
+    "/projects/{pid}/market/exists",
+    "/projects/{pid}/model/ensure",
+    "/projects/{pid}/model/options/{slug}/activate",
+    "/projects/{pid}/notices",
+    "/projects/{pid}/notices/clauses",
+    "/projects/{pid}/quality/chain",
+    "/projects/{pid}/rules/effective",
+    "/projects/{pid}/scene/manifest",
+    "/webhooks/deliveries",
 }
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -368,9 +409,39 @@ def leaf_is_called(leaf: str, code: str) -> bool:
     backtick) keeps them and still rejects `available_public`, and it costs nothing in reach:
     **0 routes that the substring rule called uncalled become called under this one.**
 
-    What it does NOT claim to fix is a leaf that is also an ordinary quoted word — `"ready"` still
-    vouches for `/ready`. That is the coarseness the block comment above still describes, and it is
-    unchanged here; only the inside-a-longer-identifier class is removed.
+    **THAT PARAGRAPH USED TO SAY THE QUOTED-WORD CLASS WAS UNFIXABLE HERE, AND 2026-09-11 SPENT IT.**
+    It read: *"What it does NOT claim to fix is a leaf that is also an ordinary quoted word — `\"ready\"`
+    still vouches for `/ready`."* Two things happened the same day that made the cost of leaving it
+    unaffordable.
+
+    First, `/cost/datasets/import` — the offline cost-baseline importer — had **no client method at
+    all**, and this gate said nothing, because its leaf is `import`: **2,223 occurrences** in this
+    tree as the TypeScript keyword. Not an unlucky word, a *reserved* one, so the collision is
+    guaranteed for any route whose leaf is also a keyword. Its sibling `/cost/datasets/import-custom`
+    WAS correctly frozen, so the route with the more distinctive name was caught and the one named
+    after a keyword vouched for itself.
+
+    Second, the author of that fix wrote three ordinary sentences about the feature — *"Build the
+    offline public cost vintage"* — and re-broke `/projects/{pid}/listings/{lid}/public` three times
+    in one sitting, the very collision the previous change had *reworded* away. **A rule that makes
+    product copy unwritable is a rule that will be re-broken by whoever has not read this file.**
+
+    So the leaf must now occupy a **path segment inside a string literal**: it opens the string, or
+    follows a `/` or a closed `${...}`, and no path character continues it. A URL this client builds
+    is always a string; a bare identifier never is, and a word in a sentence is preceded by a space.
+
+    **Measured before it was applied, because the two earlier candidate fixes were each wrong in this
+    same place.** Against 834 assessed routes: **42 uncalled before, 67 after — 25 newly visible and
+    ZERO lost.** Nothing the old rule called uncalled becomes called. Three of the 25 spot-checked
+    (`scene/manifest`, `edit/batch`, `model/ensure`) have **no occurrence anywhere** in the web
+    source; two more (`classifications`, `notices`) appear only inside English prose — *"seeded from
+    MasterFormat classifications"*, *"nobody notices"* — which is precisely the class being removed.
+
+    *The first attempt at this measurement was wrong and reported 36 lost, including `plan.dxf`,
+    whose caller is real.* It anchored "start of string" against the text WITH its quote character
+    still attached, so `^` could never match and every leading-fragment call site looked lost.
+    **The rule was fine; the harness measuring it was not, and the number it produced argued
+    convincingly for the wrong decision.**
 
     **THE TWO BOUNDARIES ARE NOT THE SAME CLASS, AND `$` IS WHY.** `$` is a valid identifier
     character in TypeScript, so `available$public` would hide the leaf `public` exactly as
@@ -394,7 +465,36 @@ def leaf_is_called(leaf: str, code: str) -> bool:
     Measured: 32 uncalled either way, no route moves. *Getting the asymmetry right was not the end of
     the question; one side of it still had two cases inside it.* All four are asserted below.
     """
-    return re.search(rf"(?<![A-Za-z0-9_$]){re.escape(leaf)}(?![A-Za-z0-9_]|\$(?!\{{))", code) is not None
+    return _SEGMENT(leaf).search(string_blob(code)) is not None
+
+
+_STRINGS = re.compile(r"\"[^\"\n]*\"|'[^'\n]*'|`(?:[^`\\]|\\.)*`", re.S)
+
+#: NUL joins the string bodies and anchors "opens a string". It cannot occur in TypeScript source,
+#: so it can never be mistaken for content -- unlike `\n`, which a template literal really does
+#: contain and which would make every line of a multi-line template look like the start of a URL.
+_NUL = "\x00"
+
+
+@functools.lru_cache(maxsize=4)
+def string_blob(code: str) -> str:
+    """Every string and template literal in the source, WITHOUT its quotes, NUL-separated.
+
+    Quotes are stripped so that "opens the string" is a real anchor. The first attempt at this
+    matched against the text with the quote still attached, so `^` could never fire -- and the
+    measurement it produced argued convincingly for the wrong decision (see `leaf_is_called`).
+
+    Cached because it is asked for once per assessed route, 834 times, over ~4 MB of source. The
+    uncached first draft took this gate from seconds to over two minutes.
+    """
+    return _NUL + _NUL.join(m[1:-1] for m in _STRINGS.findall(code))
+
+
+@functools.lru_cache(maxsize=2048)
+def _SEGMENT(leaf: str) -> "re.Pattern[str]":
+    """The leaf occupying a PATH SEGMENT: it opens a string, or follows `/` or a closed `${...}`,
+    and no path character continues it."""
+    return re.compile(rf"(?:{_NUL}|/|\}}){re.escape(leaf)}(?![A-Za-z0-9_.\-]|\$(?!\{{))")
 
 
 def uncalled_routes(paths, blob: str) -> set[str]:
@@ -582,6 +682,27 @@ check("  ...and still accepts the shapes a real caller writes",
       and leaf_is_called("k1-pack", "this.json(`/projects/${pid}/k1-pack${q}`)"),
       "the boundary has tightened past what the client actually writes — `openDrawing(`plan.dxf…`)` "
       "names the leaf with no slash in front of it, and requiring one freezes three live callers")
+
+# THE SEGMENT RULE'S OWN BOUNDARY, added 2026-09-11 with the rule. The four cases above are about
+# what surrounds the leaf CHARACTER by character; these are about WHERE it is allowed to be found at
+# all, which is the class that let `/cost/datasets/import` ship unreachable and made product copy
+# unwritable. Same shape as above: what it must reject, and what it must still accept.
+check("  ...and rejects a leaf that is only a word in a sentence or a bare keyword",
+      not leaf_is_called("import", "import { toast } from './feedback';")
+      and not leaf_is_called("import", 'toast("Building the offline public cost vintage…")')
+      and not leaf_is_called("public", 'row("Share", "The public read-only page for this token.")')
+      and not leaf_is_called("notices", "// the one nobody notices has drifted")
+      and not leaf_is_called("import", '"/projects/${pid}/schedule/import-xer"'),
+      "a route is being vouched for by English or by a keyword again — the class that hid "
+      "/cost/datasets/import behind 2,223 occurrences of the TypeScript `import` keyword")
+check("  ...while a URL written any of the ways this client writes one still counts",
+      leaf_is_called("import", 'this.json("/cost/datasets/import", { method: "POST" })')
+      and leaf_is_called("import", "this.json(`${base}/cost/datasets/import`)")
+      # a leaf that OPENS a fragment, which is why the quotes must be stripped before anchoring
+      and leaf_is_called("plan.dxf", "openDrawing(`plan.dxf?${q}`)")
+      and leaf_is_called("k1-pack", "this.json(`/projects/${pid}/k1-pack${q}`)"),
+      "the segment rule has tightened past a real call site — the first draft of this rule anchored "
+      "against the text WITH its quote attached, so no leading-fragment caller could ever match")
 
 new = sorted(FOUND - KNOWN_UNCALLED)
 check("NO NEW UNREACHABLE ROUTE — a route the product cannot call is a feature nobody can use",


### PR DESCRIPTION
# What & why

`POST /cost/datasets/import` — the offline cost-baseline importer — had **no client method at all**, and the budget panel has been telling cost managers *"1 offline baseline(s) installable — no subscription"* the whole time. A promise with no affordance, added by the very change that declared `available_public`. Roadmap: `docs/roadmap.md` → **UNREACHED-IMPORT**.

**First, a correction to the premise this item was written with.** `progressActuals` and `saveViewTemplates` *were* flagged — both sit in the `UNCALLED` ceiling in `apps/web/src/api/clientCallers.test.ts`, visible and countable, which is exactly what that list is for. The other half was right, and worse than described.

### The product half

The installer now lives in **Profile & settings → Administration**, under Server. Deliberately *not* on the budget card: importing flips the global `is_latest` and reprices **every project that has not pinned a vintage**. The card names the role instead of offering a button that would 403 for exactly the reader most likely to press it — the offered-and-refused shape the saved-view delete picker had until yesterday. The confirmation states the blast radius; `importedSummary` surfaces the server's `warning` rather than reporting plain success for a build the operator did not ask for.

### Why nothing said so

The route's leaf is `import` — **2,223 occurrences** in this tree as the TypeScript keyword. Not an unlucky word, a *reserved* one, so the collision is guaranteed for any route named after a keyword. Its sibling `/cost/datasets/import-custom` **was** correctly frozen, so the route with the more distinctive name was caught and the one named after a keyword vouched for itself — under a headline check that reads *"NO NEW UNREACHABLE ROUTE"*.

`leaf_is_called` now requires the leaf to occupy a **path segment inside a string literal**. A URL this client builds is always a string; a bare identifier never is, and a word in a sentence has a space in front of it. *(The exact boundary changed twice under review — see **Review round** below for the rule as it actually ships and the numbers that go with it.)*

**Measured before applying, because the two previous candidate fixes were each wrong in this same place:**

| rule | uncalled | newly visible | lost |
|---|---|---|---|
| whole token in code (today) | 42 | — | — |
| **path segment in a string literal** | **67** | **+25** | **0** |

Three of the 25 spot-checked (`scene/manifest`, `edit/batch`, `model/ensure`) have **no occurrence anywhere** in the web source; two more (`classifications`, `notices`) appear only inside English prose — *"seeded from MasterFormat classifications"*, *"nobody notices"*. That is precisely the class being removed. All 25 frozen as untriaged, not judged.

### The part I got wrong, twice

**The rule's docstring used to call this class unfixable.** What made that unaffordable is that I broke it three times in one sitting: writing three ordinary sentences about a feature whose own name contains the word *public* re-collided with `/projects/{pid}/listings/{lid}/public` — the exact collision the previous change had *reworded away*. **A rule that makes product copy unwritable will be re-broken by whoever has not read the file.** The natural wording is restored in this PR as the demonstration that it is fixed.

**And the first measurement of the new rule was wrong in the direction that preserved the status quo.** It reported **36 routes lost, including `plan.dxf`, whose caller is real** — which argued convincingly for rejecting the fix. The rule was fine; the harness anchored "start of string" against text with the quote character still attached, so no leading-fragment call site could ever match. *A measurement can be wrong in the direction nobody double-checks.*

The first working draft was also ~10× too slow (a full string scan per route, 834 of them over 4 MB). The blob is built once and cached; the gate runs in **13s**.

### Review round — the rule changed again, and the numbers with it

CodeRabbit found **two fail-open holes in the rule this PR added to close a fail-open hole**, and both are fixed here rather than deferred to a follow-up.

1. **`}` was accepted unconditionally** (fixed in `298903e5`), so `"not a URL }import"` vouched for the route. Measured all three ways — `}` unconditional, `}` only after a real `${...}`, no `}` at all — **67 uncalled under every one**. No route was vouched for by a brace and none was lost by removing it, so the special case was deleted rather than made more careful.
2. **The boundary was a blocklist** (fixed in `af041dc6`): a negative lookahead naming the characters a segment may *not* be continued by, which silently accepted `:`, `@`, `;`, `~` and `%` — so `"import: offline baseline"` vouched for the route. Adding those five to the blocklist moves the count by **zero**. The defect is the polarity, not the five: a blocklist of path continuations is open by construction, and the next character to sit against a leaf is whatever prose someone writes tomorrow.

So the rule that ships **enumerates what may follow** a leaf — end of string, `/`, `?`, `#`, or `${` — and the string blob is NUL-*terminated* as well as separated, because `$` in a Python regex also matches before a trailing newline and a multi-line template literal really can end with one.

| rule | uncalled | newly visible | lost |
|---|---|---|---|
| whole token in code (before this PR) | 42 | — | — |
| path segment in a string literal, blocklist boundary | 57 | — | 0 |
| **path segment in a string literal, allowlist boundary** | **65** | **+8** | **0** |

All 8 were English at the head of a string — `"packs failed: …"`, `"seeded from MasterFormat classifications"`, `"coordinate the drawings"`, `"georeference to carry the offset"`, `"…out of the wet/freeze season"` — and each of the 8 routes was then grepped directly: no caller in any shape in `apps/web/src`. **A blocklist could never have reached them: a leaf followed by a space is not a path, and no list of forbidden punctuation says so.**

They are not stubs, which is why they are frozen with a reason rather than waved through — freezing a prefab kit writes the GlobalId list the shop fabricates from, `/jurisdiction/packs` is the whole import path for an authority's data requirements, and `/projects/{pid}/georeference` is what tells a user whether their model may be used to set out.

A new check pins the converse, which nothing asserted before: **a tightened boundary can fail by rejecting real callers**, so the seven URL shapes this client actually writes are now assertions. Three further mutations bite — reverting to the blocklist fails both the prose check *and* the allowlist rot check; dropping `?#${` loses 91 real callers; un-terminating the blob loses the callers written at the end of the last literal.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean — whole tree, `All checks passed!`
- [x] Backend: **695/695 suites passed** (`run_tests.py`, 1199s wall)
- [x] Web: `npm run typecheck && npm run lint && npm run build` clean; full vitest **2471/2471** across 240 files
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; roadmap item added and marked ✅ closed
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

### Mutation testing — 4 on the gate, all confirmed to bite

| mutation | result |
|---|---|
| search the raw code instead of the string blob (the old fail-open) | 3 assertions fail |
| allow a path character after the leaf (`import-xer` vouches for `/import`) | 2 fail, incl. the allowlist rot check |
| require a `/` before the leaf (the rule measured and rejected twice before) | 3 fail — `plan.dxf`'s real caller is lost |
| accept the leaf anywhere inside a string | 2 fail — prose vouches again |

Plus 9 tests on `costVintage` covering the role wording, the blast-radius text, and the server warning being surfaced rather than swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Administrators can install an offline cost baseline from Profile & settings → Administration → Server.
  - Installation requires confirmation and explains that projects without a pinned vintage will be repriced; pinned projects remain unaffected.
  - Installation results report the imported dataset, warnings, and any errors.
  - Cost baseline installation supports the latest or a selected vintage and quarter.

- **Updates**
  - The budget dashboard now directs eligible users to Administration and clarifies who can perform the installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->