### PR TITLE
The triangle census quoted a saving nobody could take

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### The triangle census offered a saving you could not take
+
+Model QA → Standards has always measured where a model's triangle budget goes and told you what a
+coarse stand-in would save — *"proxy would save 47%"*. There was no way to build it.
+
+There is now, in the same place the saving is quoted. It writes a **separate** file beside the
+model; the model itself is untouched, and every box in the proxy is stamped as a stand-in that must
+not be measured, scheduled or priced — a coarse shape mistaken for real geometry is worse than no
+coarse shape at all. When a model has nothing worth replacing, the button is absent and says why
+instead, and a build that stores nothing reports that plainly rather than as a success.
+
 ### Prefab kits are on the screen, and a released kit's scope can finally be written down
 
 The prefab-kit register was built and had no way in. Every kit, worst first, now appears under

--- a/apps/web/src/api/model.ts
+++ b/apps/web/src/api/model.ts
@@ -301,6 +301,25 @@ export function withModel<TBase extends Ctor<NeedsEditIfc>>(Base: TBase) {
         pct_saved?: number | null; reason?: string };
     }>(`/projects/${pid}/model/lod/census?max_elements=${maxElements}`);
   }
+  /**
+   * Build the coarse per-storey proxy `lodCensus` costs out, and store it beside the model.
+   *
+   * The census has always returned `plan.pct_saved` and the standards panel has always rendered it —
+   * *"proxy would save 47%"* — with **no way to act on it**. Wired 2026-09-11; the same
+   * promise-with-no-affordance shape as the budget card's "1 offline baseline installable".
+   *
+   * `classes` is a filter spent on this one call, not a stored collection. The server caps its
+   * length, refuses to store an empty result (`stored: false` with the reason rather than a 200 over
+   * silence), and stamps every box with an `AEC_LOD` pset saying it is not authored geometry and must
+   * not be measured, scheduled or priced.
+   */
+  lodProxy(pid: string, classes?: string[]) {
+    return this.json<{
+      written: boolean; stored: boolean; key?: string; next?: string;
+      elements_replaced?: number; storeys_proxied?: number; reason?: string;
+    }>(`/projects/${encodeURIComponent(pid)}/model/lod/proxy`,
+      { method: "POST", body: JSON.stringify({ classes: classes ?? null }) });
+  }
   /** LOD 500 handover as a work list (unverified / out of tolerance / thin information). */
   lodHandoverReadiness(pid: string) {
     return this.json<{

--- a/apps/web/src/api/responseUndeclared.test.ts
+++ b/apps/web/src/api/responseUndeclared.test.ts
@@ -83,6 +83,13 @@ const INCOMPLETE_LOWER_BOUND: string[] = [
   // appears here for a good reason — this gate can only see a route that HAS a typed call site, and
   // until now it had none at all.
   "POST /cost/datasets/import",
+  // Added 2026-09-11 with LOD-PROXY, the same shape one route over: the handler returns
+  // `{**report, "stored": ..., "key": ..., "next": ...}` on success and `{**report, "stored": False}`
+  // on a refusal, so only the four literal keys can be named. `report` comes from
+  // `lod.build_storey_proxy`, whose shape differs between those two branches — which is the
+  // reason the client types `elements_replaced`, `storeys_proxied` and `reason` as OPTIONAL
+  // rather than pretending one branch's keys are present in both.
+  "POST /projects/{}/model/lod/proxy",
   "GET /projects/{}/agent-packs",
   "GET /projects/{}/ai/risk-summary",
   "GET /projects/{}/compliance/expiring",

--- a/apps/web/src/portal/panels/lodProxy.test.ts
+++ b/apps/web/src/portal/panels/lodProxy.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { proxyOffer, proxyConfirm, proxySummary } from "./lodProxy";
+
+describe("proxyOffer — the button is absent with a reason, not offered-and-refused", () => {
+  it("offers when there is a real saving", () => {
+    expect(proxyOffer({ status: "ok", proxied: ["IfcWall"], pct_saved: 47 }).can).toBe(true);
+  });
+
+  it("declines with the server's OWN reason when the plan carries one", () => {
+    const g = proxyOffer({ status: "skip", reason: "no meshable geometry" });
+    expect(g.can).toBe(false);
+    expect(g.why).toBe("no meshable geometry");
+  });
+
+  it("declines when nothing is worth proxying", () => {
+    expect(proxyOffer({ status: "ok", proxied: [], pct_saved: 0 }).why).toContain("nothing in this model");
+  });
+
+  it("declines a ZERO or negative saving — a proxy that saves nothing costs more than it returns", () => {
+    // The server would refuse this anyway. Offering the button first is the shape this panel avoids.
+    expect(proxyOffer({ status: "ok", proxied: ["IfcWall"], pct_saved: 0 }).can).toBe(false);
+    expect(proxyOffer({ status: "ok", proxied: ["IfcWall"], pct_saved: null }).can).toBe(false);
+  });
+});
+
+describe("proxyConfirm", () => {
+  it("says the model is NOT changed, and that the boxes are stand-ins", () => {
+    // The server stamps every box with an AEC_LOD pset for exactly this reason: "a stand-in mistaken
+    // for real geometry is worse than no stand-in". The confirmation has to say so too, because the
+    // person clicking is the one who might later measure it.
+    const c = proxyConfirm({ status: "ok", proxied: ["IfcWall", "IfcSlab"], pct_saved: 47 });
+    expect(c).toContain("2 classes");
+    expect(c).toContain("47%");
+    expect(c).toContain("SEPARATE file");
+    expect(c).toContain("must not be measured");
+  });
+  it("singularises one class", () => {
+    expect(proxyConfirm({ status: "ok", proxied: ["IfcWall"], pct_saved: 5 })).toContain("1 class,");
+  });
+});
+
+describe("proxySummary", () => {
+  it("reports a REFUSAL as a refusal, with the reason and what was not written", () => {
+    // `stored: false` is a 200 from the server. Rendering it as success is precisely how "a
+    // successful export of nothing gets believed" — the server's own words.
+    const s = proxySummary({ written: false, stored: false, reason: "no storeys carry geometry" });
+    expect(s).toContain("No proxy was stored");
+    expect(s).toContain("no storeys carry geometry");
+    expect(s).toContain("Nothing was written");
+  });
+
+  it("reports a success with both counts and what still has to happen", () => {
+    const s = proxySummary({ written: true, stored: true, elements_replaced: 812, storeys_proxied: 6 });
+    expect(s).toContain("812 elements replaced across 6 storeys");
+    expect(s).toContain("needs converting");
+  });
+
+  it("falls back without inventing a number when the counts are absent", () => {
+    expect(proxySummary({ written: true, stored: true })).toContain("0 elements replaced across 0 storeys");
+  });
+});

--- a/apps/web/src/portal/panels/lodProxy.ts
+++ b/apps/web/src/portal/panels/lodProxy.ts
@@ -1,0 +1,59 @@
+/** The coarse-proxy action's wording — pure, so the rules can be tested without a DOM.
+ *
+ *  `lodCensus` has always returned `plan.pct_saved` and the standards panel has always rendered it —
+ *  *"proxy would save 47%"* — while `POST …/model/lod/proxy` had no client method at all. **A stated
+ *  benefit with no way to act on it**, which is the same shape as the budget card's "1 offline
+ *  baseline(s) installable" that PR #523 closed, and it was found the same way: the route surfaced
+ *  as newly-visible dark once the reachability gate stopped letting English vouch for a route.
+ */
+
+/** What `lodCensus().plan` says can be done, as the button and its explanation. */
+export interface ProxyPlan {
+  status: string;
+  proxied?: string[];
+  triangles_saved?: number | null;
+  pct_saved?: number | null;
+  reason?: string;
+}
+
+/** Whether building a proxy is worth offering, and — when it is not — the reason to show instead.
+ *
+ *  A plan with nothing to proxy is the common case on a small model, and the server refuses it
+ *  anyway (`stored: false` with a reason). Offering a button that will certainly be refused is the
+ *  offered-and-refused shape this codebase keeps removing, so the reason is shown in its place. */
+export function proxyOffer(plan: ProxyPlan): { can: boolean; why: string } {
+  if (plan.reason) return { can: false, why: plan.reason };
+  if (!plan.proxied?.length) {
+    return { can: false, why: "nothing in this model is worth replacing with a coarse stand-in" };
+  }
+  if (plan.pct_saved == null || plan.pct_saved <= 0) {
+    return { can: false, why: "the census measured no triangle saving, so a proxy would cost more than it returns" };
+  }
+  return { can: true, why: "" };
+}
+
+/** The confirmation. Names what the artefact IS, because a stand-in mistaken for real geometry is
+ *  the failure the server's own docstring says it stamps every box to prevent. */
+export function proxyConfirm(plan: ProxyPlan): string {
+  const cls = plan.proxied?.length ?? 0;
+  return `Build a coarse proxy for ${cls} class${cls === 1 ? "" : "es"}, saving about `
+    + `${plan.pct_saved}% of triangles?\n\nThis writes a SEPARATE file beside the model — it does not `
+    + "change the model. Every box is stamped as a stand-in that must not be measured, scheduled or "
+    + "priced, and the original geometry is untouched.";
+}
+
+/** What the build actually did. A refusal is reported as one, never as a quiet success. */
+export function proxySummary(r: {
+  written: boolean; stored: boolean; elements_replaced?: number; storeys_proxied?: number;
+  reason?: string;
+}): string {
+  if (!r.stored) {
+    return `No proxy was stored — ${r.reason || "the model had nothing to replace"}. `
+      + "Nothing was written beside the model.";
+  }
+  const n = r.elements_replaced ?? 0;
+  const s = r.storeys_proxied ?? 0;
+  return `Proxy stored: ${n} element${n === 1 ? "" : "s"} replaced across ${s} storey`
+    + `${s === 1 ? "" : "s"}. It is an ordinary IFC and needs converting before the viewer can serve `
+    + "it as a coarse tier.";
+}

--- a/apps/web/src/portal/panels/standards.ts
+++ b/apps/web/src/portal/panels/standards.ts
@@ -1,6 +1,7 @@
 import { destLabel, destTitle } from "../../shell/destinations";
 import { noProjectHtml } from "../../ui/empty";
 import { escapeHtml as esc, toast } from "../../ui/feedback";
+import { proxyConfirm, proxyOffer, proxySummary } from "./lodProxy";
 import type { PanelContext } from "../panelContext";
 
 /**
@@ -538,6 +539,30 @@ export async function renderModelAnalysis(ctx: PanelContext) {
           cen.appendChild(table(["Class", "Elements", "Triangles", "%"],
             c.by_class.slice(0, 12).map((r) => [r.ifc_class, r.elements, r.triangles, r.pct_triangles])));
         }
+        // The saving above was stated and could not be acted on: `plan.pct_saved` has been rendered
+        // here since the census shipped, while POST .../model/lod/proxy had no client method at all.
+        const offer = proxyOffer(c.plan);
+        const act = el("div"); act.style.marginTop = "6px";
+        if (!offer.can) {
+          act.innerHTML = `<span class="meta">No coarse proxy to build — ${esc(offer.why)}.</span>`;
+        } else {
+          const btn = el("button", "portal-btn") as HTMLButtonElement;
+          btn.textContent = "▣ Build the coarse proxy";
+          btn.onclick = async () => {
+            if (!window.confirm(proxyConfirm(c.plan))) return;
+            btn.disabled = true;
+            try {
+              // The server answers a refusal with `stored: false` and a reason, NOT an error, so the
+              // summary has to read the flag rather than assume a resolved promise means success.
+              ctx.host.setStatus(proxySummary(await ctx.host.api.lodProxy(pid)));
+            } catch (e) {
+              ctx.host.setStatus(`could not build the proxy: ${(e as Error).message}`);
+            }
+            btn.disabled = false;
+          };
+          act.appendChild(btn);
+        }
+        cen.appendChild(act);
     }).catch(fail(cen));
 
     const gt = section("🧵 Golden thread");

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1752,6 +1752,35 @@ instances:
   claim about what an underwriting asserts, not a unit conversion, and it waits on the same domain
   call `/schedule/eot` does.
 
+- ✅ **LOD-PROXY — a saving quoted on screen with no way to take it**
+  *(S — Lanes B/D; **CLOSED 2026-09-11**; gated by `services/api/test_route_reachability.py`)*
+
+  `lodCensus` returns `plan.pct_saved` and `apps/web/src/portal/panels/standards.ts` has rendered it
+  since the census shipped — *"proxy would save N%"* — while `POST /projects/{pid}/model/lod/proxy`
+  had no client method at all. **The same promise-with-no-affordance shape as the budget card's "1
+  offline baseline(s) installable"**, found the same way: newly visible once the reachability gate
+  stopped letting English vouch for a route.
+
+  The button now sits where the saving is quoted. `apps/web/src/portal/panels/lodProxy.ts` holds the
+  rules — 9 tests, four mutations all biting. Two of them are about refusals: the offer is **absent
+  with a reason** when a model has nothing worth proxying or the census measured no saving, and a
+  response with `stored: false` is reported as the refusal it is. That second one matters because the
+  server returns it as a **200** — its own comment says *"a 'successful' export of nothing gets
+  believed"* — so a client that treats a resolved promise as success would print the opposite of what
+  happened.
+
+  **TRIAGE FIRST, and it changed what got built.** Of the eight routes frozen by UNREACHED-IMPORT,
+  `/projects/{pid}/georeference` was read and **deliberately not wired**: `/projects/{pid}/models/
+  georeferencing` already has a caller and returns strictly more — a LoGeoRef level, its label, the
+  map conversion, the CRS and the site. Wiring the simpler one would have added a second answer to
+  one question. *A dark route can be a duplicate rather than a hole, and the gate cannot tell the
+  difference — reading the handler is what tells them apart.*
+
+  Still frozen and still untriaged: `/codes/seeded`, the three `/jurisdiction/packs` routes,
+  `/projects/{pid}/clash/coordinate` and `/projects/{pid}/documents/template`. The clash one looks
+  like the highest value of those — it is the write that turns a detection run into tracked
+  coordination issues, the same transient-to-record shape as the prefab freeze.
+
 - ✅ ⭐ **PREFAB-DARK — an entire feature with no way in**
   *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `services/api/test_route_reachability.py` and
   `apps/web/src/api/clientCallers.test.ts`)*

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -298,7 +298,7 @@ KNOWN_UNCALLED: set[str] = {
     "/projects/{pid}/rules/effective",
     "/projects/{pid}/scene/manifest",
     "/webhooks/deliveries",
-    # ---- 7 of 8, added 2026-09-11 when `_SEGMENT` flipped from a blocklist of characters that may
+    # ---- 6 of 8, added 2026-09-11 when `_SEGMENT` flipped from a blocklist of characters that may
     # NOT follow a leaf to an allowlist of what MAY (see `_SEGMENT` for the measurement: +8, 0 lost).
     # Every one of these was vouched for by an English sentence that happened to start with the
     # leaf — "packs failed: …", "seeded from MasterFormat classifications", "coordinate the
@@ -319,13 +319,23 @@ KNOWN_UNCALLED: set[str] = {
     # against -- so it was built rather than recorded. Its two siblings were never assessed at all
     # (leaf `kits`, under MIN_SEGMENT), and they now have callers too. *A frozen entry is a debt
     # with a name on it, which is why this one could be paid.*
+    #
+    # **A SECOND left the same day: `/projects/{pid}/model/lod/proxy`.** That one was not merely dark,
+    # it was dark beside a PROMISE — `lodCensus` returns `plan.pct_saved` and the standards panel has
+    # rendered *"proxy would save N%"* since the census shipped, with no way to act on it. Same shape
+    # as the budget card's "1 offline baseline(s) installable" that started this whole line of work.
+    #
+    # **Triage first, though: not every frozen route here is a gap.** `/projects/{pid}/georeference`
+    # was read and DELIBERATELY not wired — "/projects/{pid}/models/georeferencing" already has a
+    # caller and returns strictly more (a LoGeoRef level, its label, the map conversion, the CRS and
+    # the site), so wiring the simpler one would add a second answer to one question. *A dark route
+    # can be a duplicate rather than a hole, and the gate cannot tell the difference.*
     "/codes/seeded",
     "/jurisdiction/packs",
     "/jurisdiction/packs/{pack_id}",
     "/projects/{pid}/clash/coordinate",
     "/projects/{pid}/documents/template",
     "/projects/{pid}/georeference",
-    "/projects/{pid}/model/lod/proxy",
 }
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))


### PR DESCRIPTION
# What & why

`lodCensus` returns `plan.pct_saved`, and `apps/web/src/portal/panels/standards.ts` has rendered it since the census shipped — *"proxy would save N%"* — while `POST /projects/{pid}/model/lod/proxy` **had no client method at all**. Roadmap: `docs/roadmap.md` → **LOD-PROXY**.

**The same promise-with-no-affordance shape as the budget card's "1 offline baseline(s) installable"** that started this line of work in #523, and found the same way: the route surfaced as newly-visible dark once the reachability gate stopped letting English prose vouch for a route.

### Triage first, and it changed what got built

Of the eight routes frozen by UNREACHED-IMPORT, **`/projects/{pid}/georeference` was read and deliberately NOT wired.** `/projects/{pid}/models/georeferencing` already has a caller and returns strictly more — a LoGeoRef level, its label, the map conversion, the CRS and the site. Wiring the simpler one would have added a second answer to one question.

***A dark route can be a duplicate rather than a hole, and the gate cannot tell the difference.*** Reading the handler is what tells them apart. That distinction is recorded beside the frozen set so the next person triaging does not have to rediscover it.

### The build

The button sits where the saving is quoted. `apps/web/src/portal/panels/lodProxy.ts` holds the rules — 9 tests, four mutations all biting. **Two of them are about refusals:**

- The offer is **absent with a reason** when the model has nothing worth proxying, or the census measured no saving. The server would refuse either anyway; offering a button that will certainly be refused is the offered-and-refused shape this codebase keeps removing.
- A response with `stored: false` is reported **as a refusal**. This is the one that matters: the server returns it as a **200** — its own comment says *"a 'successful' export of nothing gets believed"* — so a client treating a resolved promise as success would print the opposite of what happened.

The confirmation states that the model is not changed and that every box is a stand-in that must not be measured, scheduled or priced. That is not decorum — the server stamps an `AEC_LOD` pset for exactly this reason, and the person clicking is the one who might later measure it.

### A gate caught the new call site immediately

`responseUndeclared` went red: the handler returns `{**report, …}` on **both** branches, so its key set is only a lower bound and is now tracked as one. The note records why `elements_replaced`, `storeys_proxied` and `reason` are typed **optional** — `report` differs between the success and refusal branches, and pretending one branch's keys are present in both is how a client reads a field that isn't there.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean — whole tree, `All checks passed!`
- [x] Backend: `test_route_reachability.py`, `test_file_sizes.py`, `test_claude_md_gates.py` pass
- [x] Web: `npm run typecheck && npm run lint && npm run build` clean; full vitest **2509/2509** across 243 files
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; roadmap item added and marked ✅ closed
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

### Mutation testing — four on the presentation rules, all confirmed to bite

| mutation | result |
|---|---|
| the offer ignores a zero or null saving | 1 fails |
| the offer ignores the server's own stated reason | 1 fails |
| the summary treats a **refusal** (`stored: false`) as a success | 1 fails |
| the confirmation drops the "must not be measured" warning | 1 fails |

**Route reachability: 64 → 63 uncalled**, the frozen entry removed because the allowlist's rot check demanded it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to build a coarse proxy model when meaningful savings are available.
  * Proxy models are saved as separate files, leaving the original model unchanged.
  * Confirmation messages explain savings, affected elements and storeys, and that proxy stand-ins must not be measured, scheduled, or priced.
  * Added clear status messages for successful storage, unavailable proxies, and refused builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->