### PR TITLE
The eight dark routes, read — and two more the gate cannot see

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1752,6 +1752,27 @@ instances:
   claim about what an underwriting asserts, not a unit conversion, and it waits on the same domain
   call `/schedule/eot` does.
 
+- 📋 **FROZEN-TRIAGE — what the eight dark routes actually were** *(record, not a work item; 2026-09-11)*
+
+  UNREACHED-IMPORT froze eight newly-visible routes and said, correctly, that freezing is **not**
+  judging. All eight have now been read. **Only four are gaps, and one of those is already built** —
+  which is the point of writing this down: *an uncalled count is a list of questions, not a list of
+  missing features*, and treating 63 as 63 holes would send the next sprint to build duplicates.
+
+  | route | verdict |
+  |---|---|
+  | `/projects/{pid}/model/lod/proxy` | **GAP — built**, see LOD-PROXY below |
+  | `/projects/{pid}/georeference` | **DUPLICATE.** `/projects/{pid}/models/georeferencing` is wired and returns strictly more: a LoGeoRef level, its label, the map conversion, the CRS and the site. Wiring this adds a second answer to one question. |
+  | `/projects/{pid}/clash/coordinate` | **NO DEMAND.** The product's clash flow is `POST /projects/{pid}/clash/federated` with `coordinate=true`, which runs the same intelligence layer and IS wired. This route is the bring-your-own-results variant, for a single-model or external detection run — and the single-model path has no UI either. A button here would invent a workflow, not close a gap. |
+  | `/codes/seeded` | **COVERED.** `/codes/adoptions` is wired and already answers the sharper question per code family — `source: "seed"` or `"baseline"` — so a flat list of seeded jurisdictions adds a catalogue, not an answer. |
+  | `/projects/{pid}/documents/template` | **LARGELY COVERED.** The documents health read already reports required-folder coverage; the template is the static taxonomy behind it. Worth revisiting only if a "what folders should exist" screen is ever wanted on its own. |
+  | `/jurisdiction/packs` ×3 (list, import, delete) | **GENUINE GAP, and the largest left.** The whole import path for an authority's data requirements — no client at all, admin-gated, and the packs are used to fail other people's models. Same shape as PREFAB-DARK: a finished feature with no way in. |
+
+  **Two lessons, both about the gate rather than the routes.** A dark route can be a *duplicate*, and
+  the reachability rule structurally cannot tell that from a hole — only reading the handler can. And
+  a dark route can be an *integration surface* with no UI demand, which is not a defect at all. The
+  gate's job is to make them visible; deciding what they are is still a person's.
+
 - ✅ **LOD-PROXY — a saving quoted on screen with no way to take it**
   *(S — Lanes B/D; **CLOSED 2026-09-11**; gated by `services/api/test_route_reachability.py`)*
 
@@ -1776,10 +1797,12 @@ instances:
   one question. *A dark route can be a duplicate rather than a hole, and the gate cannot tell the
   difference — reading the handler is what tells them apart.*
 
-  Still frozen and still untriaged: `/codes/seeded`, the three `/jurisdiction/packs` routes,
-  `/projects/{pid}/clash/coordinate` and `/projects/{pid}/documents/template`. The clash one looks
-  like the highest value of those — it is the write that turns a detection run into tracked
-  coordination issues, the same transient-to-record shape as the prefab freeze.
+  The remaining four were triaged the same day — see FROZEN-TRIAGE above — and **the guess this
+  entry originally left here was wrong.** It named `/projects/{pid}/clash/coordinate` as the highest
+  value of the rest, on the transient-to-record shape alone; reading the handler showed the wired
+  `POST /projects/{pid}/clash/federated?coordinate=true` already runs that same write. The largest
+  genuine gap is `/jurisdiction/packs`. *A shape argument is a reason to go and read, never a verdict
+  on its own.*
 
 - ✅ ⭐ **PREFAB-DARK — an entire feature with no way in**
   *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `services/api/test_route_reachability.py` and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1766,12 +1766,25 @@ instances:
   | `/projects/{pid}/clash/coordinate` | **NO DEMAND.** The product's clash flow is `POST /projects/{pid}/clash/federated` with `coordinate=true`, which runs the same intelligence layer and IS wired. This route is the bring-your-own-results variant, for a single-model or external detection run — and the single-model path has no UI either. A button here would invent a workflow, not close a gap. |
   | `/codes/seeded` | **COVERED.** `/codes/adoptions` is wired and already answers the sharper question per code family — `source: "seed"` or `"baseline"` — so a flat list of seeded jurisdictions adds a catalogue, not an answer. |
   | `/projects/{pid}/documents/template` | **LARGELY COVERED.** The documents health read already reports required-folder coverage; the template is the static taxonomy behind it. Worth revisiting only if a "what folders should exist" screen is ever wanted on its own. |
-  | `/jurisdiction/packs` ×3 (list, import, delete) | **GENUINE GAP, and the largest left.** The whole import path for an authority's data requirements — no client at all, admin-gated, and the packs are used to fail other people's models. Same shape as PREFAB-DARK: a finished feature with no way in. |
+  | `/jurisdiction/packs` ×3 (list, import, delete) | **GENUINE GAP, and the largest left — and bigger than three.** The whole import path for an authority's data requirements: no client at all, admin-gated, and the packs are used to fail other people's models. Same shape as PREFAB-DARK, a finished feature with no way in. See below: the two routes that *consume* a pack are dark too, and the gate cannot see them. |
 
-  **Two lessons, both about the gate rather than the routes.** A dark route can be a *duplicate*, and
-  the reachability rule structurally cannot tell that from a hole — only reading the handler can. And
-  a dark route can be an *integration surface* with no UI demand, which is not a defect at all. The
+  **Three lessons, all about the gate rather than the routes.** A dark route can be a *duplicate*,
+  and the reachability rule structurally cannot tell that from a hole — only reading the handler can.
+  A dark route can be an *integration surface* with no UI demand, which is not a defect at all. The
   gate's job is to make them visible; deciding what they are is still a person's.
+
+  **And the count is wrong in BOTH directions, which is the third and the one worth keeping.**
+  Reading the jurisdiction handlers turned up two more dark routes the gate never flagged:
+  `/projects/{pid}/jurisdiction/requirements` and `/projects/{pid}/jurisdiction/check` — the two that
+  *consume* a pack. So R23-JURISDICTION-PACKS is unreachable in **five** routes, not three, and a
+  sprint that wired only the frozen three would have shipped an import path whose only consumers are
+  still dark. They hide for two different reasons, now asserted in
+  `services/api/test_route_reachability.py` beside the `/asset-rights/verify` precedent: `check`
+  collides with a **real sibling route** (`/projects/{pid}/standards/check` and `/rebar/check` are
+  genuinely called), and `requirements` collides with **unrelated text** (a TS union member in a
+  spec-PDF plugin). The first is the sharper one — the gate's stated blind spot is about coincidence
+  with prose, and this is a collision with another route. *A leaf is not a name.* Mutating only the
+  vouching text flags both immediately, which is how they were confirmed dark rather than assumed.
 
 - ✅ **LOD-PROXY — a saving quoted on screen with no way to take it**
   *(S — Lanes B/D; **CLOSED 2026-09-11**; gated by `services/api/test_route_reachability.py`)*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1752,7 +1752,7 @@ instances:
   claim about what an underwriting asserts, not a unit conversion, and it waits on the same domain
   call `/schedule/eot` does.
 
-- 📋 **FROZEN-TRIAGE — what the eight dark routes actually were** *(record, not a work item; 2026-09-11)*
+- ✅ **FROZEN-TRIAGE — what the eight dark routes actually were** *(record, not a work item; **CLOSED 2026-09-11**)*
 
   UNREACHED-IMPORT froze eight newly-visible routes and said, correctly, that freezing is **not**
   judging. All eight have now been read. **Only four are gaps, and one of those is already built** —

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -862,6 +862,37 @@ check("the ASSET-VERIFY blind spot is still a blind spot, not silent coverage",
       "if this now fails, the matcher changed — re-triage /asset-rights/verify rather than "
       "assuming the green tick above ever meant it was reachable")
 
+# A THIRD AND FOURTH INSTANCE, measured 2026-09-11 while triaging the eight routes UNREACHED-IMPORT
+# froze. R23-JURISDICTION-PACKS is dark in **five** routes, not the three this file freezes. The
+# library, import and delete routes are in KNOWN_UNCALLED above; the two that CONSUME a pack --
+# `/projects/{pid}/jurisdiction/requirements` and `/projects/{pid}/jurisdiction/check` -- have no
+# client caller either, and this rule reads both as reachable. So the frozen list does not merely
+# fail to judge what it holds; on this feature it also UNDERCOUNTS it, and a reader taking the three
+# as the extent of the gap would wire an import path whose only consumers are still unreachable.
+#
+# They are invisible for two DIFFERENT reasons, which is why both are recorded rather than one
+# standing for the pair:
+#   * `check` collides with a REAL SIBLING ROUTE. `apps/web/src/api/model.ts` builds
+#     `/projects/${pid}/standards/check` and `/projects/${pid}/rebar/check`, so the leaf is genuinely
+#     called -- by something else. No prose is involved and no amount of tidying the source removes
+#     it: two routes sharing a last segment is a normal thing for an API to do.
+#   * `requirements` collides with UNRELATED TEXT -- a TypeScript union member `"requirements"` in
+#     `apps/web/src/vendor/massingpdf/plugins/specs.ts`, which is a spec-PDF view mode and has
+#     nothing to do with jurisdictions. That is the `/proforma/renovation` shape asserted below,
+#     found a second time.
+# The first is the more interesting of the two, because the docstring's stated blind spot is about
+# coincidence with *text*, and this one is a collision with a *route*. A leaf is not a name.
+#
+# Neither can be frozen in KNOWN_UNCALLED -- the rot check above would immediately report them as
+# "quietly become called" -- so, exactly as with `/asset-rights/verify`, the honest instrument is to
+# assert that they remain outside both sets. Unlike that route, these two SHOULD gain callers: the
+# whole feature is finished server-side and unreachable from the product.
+for _r in ("/projects/{pid}/jurisdiction/requirements", "/projects/{pid}/jurisdiction/check"):
+    check(f"the R23-JURISDICTION-PACKS blind spot is still a blind spot: {_r}",
+          _r not in FOUND and _r not in KNOWN_UNCALLED,
+          "if this fails the matcher changed or the vouching text moved -- re-triage the route "
+          "rather than assuming this gate ever had an opinion about it")
+
 # The stated blind spot, asserted so it cannot be quietly forgotten.
 check("the rule's known FALSE NEGATIVE still holds: /proforma/renovation is NOT flagged",
       "/projects/{pid}/proforma/renovation" not in FOUND,


### PR DESCRIPTION
# What & why

UNREACHED-IMPORT (#523) sharpened the reachability gate and froze eight newly-visible routes, correctly declining to judge them at the time. All eight have now been read. The verdicts go into `docs/roadmap.md` as **FROZEN-TRIAGE**, because they change what the uncalled count *means*: **an uncalled count is a list of questions, not a list of missing features.**

| route | verdict |
|---|---|
| `/projects/{pid}/model/lod/proxy` | **GAP — built** (#525) |
| `/projects/{pid}/georeference` | **DUPLICATE** — `/projects/{pid}/models/georeferencing` is wired and returns strictly more |
| `/projects/{pid}/clash/coordinate` | **NO DEMAND** — `POST /clash/federated?coordinate=true` runs the same write and is wired |
| `/codes/seeded` | **COVERED** — `/codes/adoptions` already answers the sharper question per code family |
| `/projects/{pid}/documents/template` | **LARGELY COVERED** — documents health already reports required-folder coverage |
| `/jurisdiction/packs` ×3 | **GENUINE GAP, the largest left** — and bigger than three, see below |

## The count is wrong in both directions

Reading the jurisdiction handlers turned up **two more dark routes the gate never flagged** — the two that *consume* a pack: `/projects/{pid}/jurisdiction/requirements` and `/projects/{pid}/jurisdiction/check`. Neither has a client caller, so **R23-JURISDICTION-PACKS is unreachable end to end, in five routes rather than three.** A sprint that wired only the frozen three would have shipped an import path whose only consumers are still dark.

They hide for two *different* reasons, now recorded and asserted in `services/api/test_route_reachability.py` beside the `/asset-rights/verify` precedent:

- **`check` collides with a real sibling route.** `apps/web/src/api/model.ts` genuinely calls `/projects/${pid}/standards/check` and `/rebar/check`. No prose is involved and no tidying of the source removes it — two routes sharing a last segment is a normal thing for an API to do. This is the sharper of the two: the gate's stated blind spot is about coincidence with *text*, and this is a collision with a *route*. **A leaf is not a name.**
- **`requirements` collides with unrelated text** — a TypeScript union member `"requirements"` in a spec-PDF plugin. That is the `/proforma/renovation` shape, found a second time.

Confirmed by **mutation, not assumption**: neutralising only the vouching text flags both routes immediately. Like `/asset-rights/verify`, neither can be frozen in `KNOWN_UNCALLED` — the rot check would report them as "quietly become called" — so the honest instrument is an assertion that they stay outside both sets, which fails the day the matcher or the vouching text changes.

## Two corrections, both landed in the same edit rather than promised

- The **LOD-PROXY** entry closed with a guess: it named `/projects/{pid}/clash/coordinate` the highest-value route of the untriaged rest, from the transient-to-record *shape* alone. Reading the handler showed the wired `/clash/federated?coordinate=true` already performs that write. *A shape argument is a reason to go and read, never a verdict on its own.*
- The **FROZEN-TRIAGE** row for `/jurisdiction/packs` said ×3; the second commit corrects it to five in the same edit that establishes the number, rather than leaving a follow-up that closes by default when this merges.

No behaviour changes. One test file gains two assertions; the rest is record.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` → "All checks passed!"
- [x] Backend: `test_route_reachability.py` passes with the two new assertions; `test_claude_md_gates.py`, `test_file_sizes.py`, `test_changelog_current.py` all green
- [x] Web: `apps/web/src/shell/roadmapLanes.test.ts` passes (17/17) — the new roadmap entry is a record and claims no lane or files
- [x] No import cycles introduced (no source modules changed)
- [x] Roadmap item updated — this PR *is* the roadmap update. No `CHANGELOG.md` entry: nothing ships, and the changelog records released behaviour
- [x] No version bump (not a release PR)
- [x] No secrets; no competitor names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA