### PR TITLE
A regulator's data requirements, reachable at last — all five routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### An authority's data requirements can now be imported, applied and checked
+
+A **requirement pack** is a set of data requirements published by an authority for a jurisdiction —
+what a submitted model has to carry before it will be accepted. The whole mechanism was built and
+none of it could be reached from the app: not the shared library, not the import, not the delete,
+and not the two reads that apply a pack to a project and check the model against it.
+
+All of it is now under **CDE / Standards → Data requirements (jurisdiction)**. Packs resolve from
+the project's jurisdiction; a project with none is told so rather than given a default, because
+requirements from the wrong authority are a different answer that looks exactly like the right one.
+Every pack must carry its **authority, edition and source** before it can be stored, and every
+result says whose rules produced it — a compliance number detached from that is the kind that gets
+quoted at somebody. The built-in demonstration pack is labelled as one wherever its results appear,
+so it can never be mistaken for a finding. An import that is refused shows the server's own reason,
+which names the missing citation or the exact selector that would have silently matched nothing.
+
 ### The triangle census offered a saving you could not take
 
 Model QA → Standards has always measured where a model's triangle budget goes and told you what a

--- a/apps/web/src/api/codecheck.ts
+++ b/apps/web/src/api/codecheck.ts
@@ -14,11 +14,19 @@
  *  A mixin, so every call site resolves unchanged. `api/surface.test.ts` is what proves it.
  */
 import { HttpCore } from "./httpCore";
+import { withJurisdiction } from "./jurisdiction";
 
 type Ctor<T> = new (...args: any[]) => T;
 
+/**
+ * `withJurisdiction` is composed HERE rather than in `client.ts`'s top-level chain, and not for
+ * tidiness: that chain sits at TypeScript's instantiation ceiling, and a fifty-first `withX()` on it
+ * fails the build with TS2589 ("type instantiation is excessively deep"). `api/cost.ts` records the
+ * same remedy. It also belongs here on the merits — jurisdiction packs are a code-compliance answer
+ * about a place, which is what every other method in this file is.
+ */
 export function withCodeCheck<TBase extends Ctor<HttpCore>>(Base: TBase) {
-  return class CodeCheck extends Base {
+  return class CodeCheck extends withJurisdiction(Base) {
   // W9-2 computed occupancy load (IBC 1004) + egress capacity (IBC 1005) — pre-check assist
   codecheckEgress(pid: string) {
     return this.json<{

--- a/apps/web/src/api/jurisdiction.ts
+++ b/apps/web/src/api/jurisdiction.ts
@@ -1,0 +1,136 @@
+/** R23-JURISDICTION-PACKS — data requirements that belong to an authority, and the client that
+ *  could not reach any of them.
+ *
+ *  Added 2026-09-11. All **five** routes of this feature had no client caller: the library, the
+ *  import and the delete (admin-gated), and the two that CONSUME a pack —
+ *  `/projects/{pid}/jurisdiction/requirements` and `/projects/{pid}/jurisdiction/check`. The server
+ *  side has been complete since R23: validation that refuses an uncited pack, selector parsing with
+ *  the same parser that evaluates it, and a check that carries its own attribution.
+ *
+ *  The frozen three were visible to `services/api/test_route_reachability.py`. The two consumers
+ *  were not, for two different reasons recorded in that file: `check` shares its last segment with
+ *  `/projects/{pid}/standards/check`, which the client genuinely calls, and `requirements` collides
+ *  with unrelated text. **A leaf is not a name** — which is why the feature read as three-fifths
+ *  dark rather than dark.
+ */
+import { HttpCore } from "./httpCore";
+
+type Ctor<T> = new (...args: any[]) => T;
+
+/** One requirement inside a pack — `rule_library`-shaped, and evaluated by that same engine. */
+export interface PackRequirement {
+  id: string;
+  name: string;
+  /** Which elements the requirement is about. */
+  scope: string;
+  /** What must hold for them. */
+  require: string;
+  severity: string;
+}
+
+/**
+ * A data-requirement pack: a named, versioned, ATTRIBUTED set of requirements keyed to a place.
+ *
+ * `authority`, `edition` and `source` are required by the server, and the reason is the whole point
+ * of the feature: this pack will be used to fail somebody else's model, and they have to be able to
+ * go and read the rule. A requirement nobody can trace is a house rule wearing a regulator's name.
+ */
+export interface JurisdictionPack {
+  id: string;
+  jurisdiction: string;
+  authority: string;
+  name: string;
+  edition: string;
+  source: string;
+  /** True only for the built-in `example`, which asserts nothing about any real place. */
+  is_example?: boolean;
+  requirements: PackRequirement[];
+}
+
+/** The library: every pack available, optionally narrowed to one jurisdiction. */
+export interface PackLibrary { packs: JurisdictionPack[]; count: number; note?: string }
+
+/** Which packs apply to a project, and — when none do — why. */
+export interface ProjectRequirements {
+  jurisdiction: string | null;
+  packs: JurisdictionPack[];
+  adopted: boolean;
+  /** Set when nothing applies. Null when packs resolved normally. */
+  why?: string | null;
+  /** True when a pack was applied by id rather than resolved from the project's jurisdiction. */
+  explicit?: boolean;
+  note?: string;
+}
+
+/** One pack's result, carrying the authority whose rules produced the number. */
+export interface PackResult {
+  id: string | null;
+  name: string | null;
+  authority: string | null;
+  edition: string | null;
+  source: string | null;
+  is_example: boolean;
+  total_rules: number;
+  failing_rules: number;
+  total_violations: number;
+  rules?: { id: string; name?: string; severity?: string; matched?: number; violations?: number }[];
+}
+
+/**
+ * The check. `model_scored` false means no model was loaded — every figure below is then absent,
+ * not zero, and a client that renders 0/0 as "compliant" says the opposite of what happened.
+ */
+export interface JurisdictionCheck {
+  jurisdiction: string | null;
+  adopted?: boolean;
+  why?: string | null;
+  explicit?: boolean;
+  model_scored: boolean;
+  packs: PackResult[];
+  total_requirements: number;
+  failing_requirements?: number;
+  total_violations?: number;
+  satisfied?: boolean;
+  attribution?: { pack: string | null; authority: string | null; edition: string | null;
+                  is_example: boolean }[];
+  note?: string;
+}
+
+/** What a delete removed. */
+export interface PackDeleted { deleted: string }
+
+export function withJurisdiction<TBase extends Ctor<HttpCore>>(Base: TBase) {
+  return class extends Base {
+    /** Every data-requirement pack available, optionally filtered to one jurisdiction. */
+    jurisdictionPacks(jurisdiction?: string) {
+      const q = jurisdiction ? `?jurisdiction=${encodeURIComponent(jurisdiction)}` : "";
+      return this.json<PackLibrary>(`/jurisdiction/packs${q}`);
+    }
+    /**
+     * Import a pack from an authority. Admin-only, and refused with a 422 whose `detail` names the
+     * missing citation field or the unparseable selector — surface it verbatim rather than a
+     * generic failure, because the refusal is the instruction.
+     */
+    jurisdictionImportPack(pack: unknown) {
+      return this.json<JurisdictionPack>("/jurisdiction/packs",
+        { method: "POST", body: JSON.stringify(pack) });
+    }
+    /** Remove an imported pack. The built-in example cannot be deleted (404). */
+    jurisdictionDeletePack(packId: string) {
+      return this.json<PackDeleted>(`/jurisdiction/packs/${encodeURIComponent(packId)}`,
+        { method: "DELETE" });
+    }
+    /** The packs that apply to this project — resolved from its jurisdiction, or one by id. */
+    projectRequirements(pid: string, pack?: string) {
+      const q = pack ? `?pack=${encodeURIComponent(pack)}` : "";
+      return this.json<ProjectRequirements>(
+        `/projects/${encodeURIComponent(pid)}/jurisdiction/requirements${q}`);
+    }
+    /** Check the project's model against those requirements. */
+    jurisdictionCheck(pid: string, pack?: string) {
+      const q = pack ? `?pack=${encodeURIComponent(pack)}` : "";
+      return this.json<JurisdictionCheck>(
+        `/projects/${encodeURIComponent(pid)}/jurisdiction/check${q}`);
+    }
+  };
+}

--- a/apps/web/src/portal/panels/jurisdictionPacks.test.ts
+++ b/apps/web/src/portal/panels/jurisdictionPacks.test.ts
@@ -61,6 +61,48 @@ describe("the example pack can never read as a compliance finding", () => {
     expect(attributionLine([REAL])).not.toContain("demonstration");
   });
 
+  it("NEVER emits the word Satisfied for an example-only run", () => {
+    // Found in review on PR #527. The attribution clause already named it a demonstration pack, and
+    // that is not enough: "Satisfied" is the word that gets read and quoted, and a qualifier after
+    // it is read second or not at all.
+    const s = checkSummary({
+      model_scored: true, packs: [EXAMPLE], total_requirements: 2,
+      failing_requirements: 0, total_violations: 0, satisfied: true,
+    });
+    expect(s).not.toContain("Satisfied");
+    expect(s).toContain("Demonstration result");
+    expect(s).toContain("no real requirement was evaluated");
+  });
+
+  it("withholds it for a MIXED run too — a summed total cannot be partly valid", () => {
+    const s = checkSummary({
+      model_scored: true, packs: [REAL, EXAMPLE], total_requirements: 6,
+      failing_requirements: 0, total_violations: 0, satisfied: true,
+    });
+    expect(s).not.toContain("Satisfied");
+    expect(s).toContain("Demonstration result");
+    expect(s).toContain("City of Austin DSD");
+  });
+
+  it("withholds the verdict on FAILURES as well — the lie runs both ways", () => {
+    // An example pack reporting failures says a model breaks rules nobody imposed.
+    const s = checkSummary({
+      model_scored: true, packs: [{ ...EXAMPLE, failing_rules: 1, total_violations: 3 }],
+      total_requirements: 2, failing_requirements: 1, total_violations: 3,
+    });
+    expect(s).toContain("Demonstration result");
+    expect(s).toContain("1 of 2");
+  });
+
+  it("still says Satisfied when every pack is real — the caveat must not swallow the verdict", () => {
+    const s = checkSummary({
+      model_scored: true, packs: [REAL], total_requirements: 4,
+      failing_requirements: 0, total_violations: 0, satisfied: true,
+    });
+    expect(s).toContain("Satisfied");
+    expect(s).not.toContain("Demonstration");
+  });
+
   it("still marks it when a real pack ran alongside — a mixed run is not a real run", () => {
     const line = attributionLine([REAL, EXAMPLE]);
     expect(line).toContain("City of Austin DSD");

--- a/apps/web/src/portal/panels/jurisdictionPacks.test.ts
+++ b/apps/web/src/portal/panels/jurisdictionPacks.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "vitest";
+import {
+  packHeadline, exampleCaveat, adoptionLine, checkGate, checkSummary, attributionLine,
+  outcomeLine, deleteConfirm, importRefusal,
+  type PackHeader, type Applicability, type CheckOutcome, type PackOutcome,
+} from "./jurisdictionPacks";
+
+const PACK: PackHeader = {
+  id: "tx-austin-2026", jurisdiction: "TX", authority: "City of Austin DSD",
+  name: "Austin submittal data requirements", edition: "2026.1",
+  source: "https://example.invalid/ordinance", requirements: [{ id: "r0" }, { id: "r1" }],
+};
+
+const REAL: PackOutcome = {
+  id: "tx-austin-2026", name: "Austin submittal data requirements",
+  authority: "City of Austin DSD", edition: "2026.1", is_example: false,
+  total_rules: 4, failing_rules: 0, total_violations: 0,
+};
+
+const EXAMPLE: PackOutcome = {
+  id: "example", name: "Example pack", authority: "", edition: "",
+  is_example: true, total_rules: 2, failing_rules: 0, total_violations: 0,
+};
+
+describe("a pack is citable at a glance", () => {
+  it("names the authority and the edition, not just the pack", () => {
+    const line = packHeadline(PACK);
+    expect(line).toContain("City of Austin DSD");
+    expect(line).toContain("2026.1");
+    expect(line).toContain("TX");
+    expect(line).toContain("2 requirements");
+  });
+
+  it("counts one requirement in the singular", () => {
+    expect(packHeadline({ ...PACK, requirements: [{ id: "r0" }] })).toContain("1 requirement");
+    expect(packHeadline({ ...PACK, requirements: [{ id: "r0" }] })).not.toContain("1 requirements");
+  });
+
+  it("survives a pack whose requirements were not expanded in the list response", () => {
+    expect(packHeadline({ ...PACK, requirements: undefined })).toContain("0 requirements");
+  });
+});
+
+describe("the example pack can never read as a compliance finding", () => {
+  // The load-bearing test of this file. `example` is the ONLY pack present before anything is
+  // imported, so it is the one a first-time user runs. A result from it that looks like a verdict
+  // tells somebody their model satisfies rules that do not exist anywhere.
+  it("carries a caveat that says it asserts nothing about any real place", () => {
+    const c = exampleCaveat({ is_example: true });
+    expect(c).toContain("DEMONSTRATION");
+    expect(c.toLowerCase()).toContain("not a compliance finding");
+  });
+
+  it("says NOTHING for a real pack — a caveat on every result is a caveat nobody reads", () => {
+    expect(exampleCaveat({ is_example: false })).toBe("");
+    expect(exampleCaveat({})).toBe("");
+  });
+
+  it("marks the demonstration pack inside the attribution line itself, not in a footnote", () => {
+    expect(attributionLine([EXAMPLE])).toContain("demonstration pack");
+    expect(attributionLine([REAL])).not.toContain("demonstration");
+  });
+
+  it("still marks it when a real pack ran alongside — a mixed run is not a real run", () => {
+    const line = attributionLine([REAL, EXAMPLE]);
+    expect(line).toContain("City of Austin DSD");
+    expect(line).toContain("demonstration pack");
+  });
+});
+
+describe("attribution is never dropped", () => {
+  it("names whose rules produced the figure, in the same sentence as the figure", () => {
+    const r: CheckOutcome = {
+      model_scored: true, packs: [REAL], total_requirements: 4,
+      failing_requirements: 0, total_violations: 0, satisfied: true,
+    };
+    const s = checkSummary(r);
+    expect(s).toContain("Satisfied");
+    expect(s).toContain("City of Austin DSD");
+  });
+
+  it("says 'an unattributed source' rather than printing a bare number", () => {
+    expect(attributionLine([{ ...REAL, authority: null, edition: null }]))
+      .toContain("an unattributed source");
+  });
+
+  it("reports failures with both the count and the violations", () => {
+    const s = checkSummary({
+      model_scored: true, packs: [{ ...REAL, failing_rules: 2, total_violations: 7 }],
+      total_requirements: 4, failing_requirements: 2, total_violations: 7,
+    });
+    expect(s).toContain("2 of 4");
+    expect(s).toContain("7 violations");
+    expect(s).toContain("City of Austin DSD");
+  });
+});
+
+describe("an absent result is never a pass", () => {
+  it("reports an unscored model as the absence it is", () => {
+    const s = checkSummary({ model_scored: false, packs: [], total_requirements: 0,
+                             note: "no model index loaded" });
+    expect(s).toContain("no model index loaded");
+    expect(s).not.toContain("Satisfied");
+  });
+
+  it("refuses to call zero requirements a pass", () => {
+    const s = checkSummary({ model_scored: true, packs: [], total_requirements: 0 });
+    expect(s).toContain("nothing to report");
+    expect(s).toContain("not a pass");
+    expect(s).not.toContain("Satisfied");
+  });
+
+  it("falls back to its own wording when the server sent no note", () => {
+    const s = checkSummary({ model_scored: false, packs: [], total_requirements: 0 });
+    expect(s).toContain("not a pass");
+  });
+});
+
+describe("the two refusals are told apart", () => {
+  // Collapsing them would tell somebody to import a pack when what they need is to upload a model.
+  const applies: Applicability = { jurisdiction: "TX", packs: [{ id: "tx-austin-2026" }],
+                                   adopted: true };
+
+  it("refuses for want of a pack when nothing applies", () => {
+    const g = checkGate({ jurisdiction: "TX", packs: [], adopted: false,
+                          why: "no pack has been imported for TX" }, true);
+    expect(g.can).toBe(false);
+    expect(g.why).toContain("no pack has been imported");
+  });
+
+  it("refuses for want of a MODEL when packs do apply", () => {
+    const g = checkGate(applies, false);
+    expect(g.can).toBe(false);
+    expect(g.why).toContain("No model is loaded");
+    expect(g.why).not.toContain("pack has been imported");
+  });
+
+  it("offers the check when a pack applies and a model is loaded", () => {
+    expect(checkGate(applies, true)).toEqual({ can: true, why: "" });
+  });
+
+  it("offers it for an explicit pack even when the project's jurisdiction resolves nothing", () => {
+    const g = checkGate({ jurisdiction: null, packs: [{ id: "example" }], adopted: false,
+                          explicit: true }, true);
+    expect(g.can).toBe(true);
+  });
+});
+
+describe("a project with no jurisdiction is told so, and never given a default", () => {
+  it("passes the server's reason through rather than inventing one", () => {
+    const line = adoptionLine({ jurisdiction: null, packs: [], adopted: false,
+                                why: "this project has no jurisdiction set" });
+    expect(line).toBe("this project has no jurisdiction set");
+  });
+
+  it("has its own wording when the server sent none", () => {
+    expect(adoptionLine({ jurisdiction: null, packs: [], adopted: false }))
+      .toContain("no jurisdiction set");
+  });
+
+  it("distinguishes 'no jurisdiction' from 'jurisdiction with no packs'", () => {
+    expect(adoptionLine({ jurisdiction: "TX", packs: [], adopted: false })).toContain("TX");
+  });
+
+  it("says how many apply when they do", () => {
+    expect(adoptionLine({ jurisdiction: "TX", packs: [{ id: "a" }, { id: "b" }], adopted: true }))
+      .toContain("2 packs apply in TX");
+  });
+
+  it("says an explicit pack was NOT resolved from the project", () => {
+    const line = adoptionLine({ jurisdiction: null, packs: [{ id: "example" }], adopted: true,
+                                explicit: true });
+    expect(line).toContain("not resolved");
+  });
+});
+
+describe("one pack's row", () => {
+  it("reports met/total and violations", () => {
+    expect(outcomeLine({ ...REAL, failing_rules: 1, total_violations: 3 }))
+      .toContain("3/4 met, 3 violations");
+  });
+
+  it("says so when a pack carries no requirements rather than printing 0/0", () => {
+    expect(outcomeLine({ ...REAL, total_rules: 0, failing_rules: 0, total_violations: 0 }))
+      .toContain("no requirements");
+  });
+});
+
+describe("deleting names the blast radius", () => {
+  it("says the library is shared, not per-project", () => {
+    const c = deleteConfirm(PACK);
+    expect(c).toContain("SHARED");
+    expect(c).toContain("TX");
+    expect(c).toContain("re-imported");
+  });
+});
+
+describe("an import refusal is the instruction, so it is shown verbatim", () => {
+  it("passes the server's detail through", () => {
+    const msg = "requirement 0's scope contains 'Pset_WallCommon.FireRating' — property paths use "
+      + "TWO colons";
+    expect(importRefusal(msg)).toContain("Pset_WallCommon.FireRating");
+    expect(importRefusal(msg)).toContain("TWO colons");
+  });
+
+  it("says the server gave no reason rather than printing an empty refusal", () => {
+    expect(importRefusal("")).toContain("no reason");
+    expect(importRefusal("   ")).toContain("no reason");
+  });
+});

--- a/apps/web/src/portal/panels/jurisdictionPacks.ts
+++ b/apps/web/src/portal/panels/jurisdictionPacks.ts
@@ -1,0 +1,190 @@
+/** R23-JURISDICTION-PACKS — the wording for a compliance answer that belongs to somebody.
+ *
+ *  Pure, so the rules can be tested without a DOM. The rules that matter here are all about
+ *  ATTRIBUTION, because that is what this feature is for: a pack is a set of data requirements
+ *  published by an authority, and the number it produces will be quoted at the party whose model
+ *  failed. **A compliance figure detached from whose rules it measured is the thing the server's own
+ *  docstring refuses to emit** — so nothing in this file renders one either.
+ *
+ *  The load-bearing case is the built-in `example` pack. It asserts nothing about any real place and
+ *  is attributed to nobody, and it is the pack a first-time user will run, because it is the only
+ *  one there before anything is imported. A result from it that reads like a compliance verdict is
+ *  worse than no feature: it tells somebody their model passes rules that do not exist.
+ */
+
+/** One requirement's result inside a pack. */
+export interface PackRuleResult {
+  id: string;
+  name?: string;
+  severity?: string;
+  matched?: number;
+  violations?: number;
+}
+
+/** What one pack said about the model, with the authority that said it. */
+export interface PackOutcome {
+  id: string | null;
+  name: string | null;
+  authority: string | null;
+  edition: string | null;
+  is_example: boolean;
+  total_rules: number;
+  failing_rules: number;
+  total_violations: number;
+  rules?: PackRuleResult[];
+}
+
+/** A pack as the library lists it. */
+export interface PackHeader {
+  id: string;
+  jurisdiction: string;
+  authority: string;
+  name: string;
+  edition: string;
+  source: string;
+  is_example?: boolean;
+  requirements?: { id: string }[];
+}
+
+/** Which packs apply to a project, and — when none do — why not. */
+export interface Applicability {
+  jurisdiction: string | null;
+  packs: { id: string }[];
+  adopted: boolean;
+  why?: string | null;
+  explicit?: boolean;
+}
+
+/** The check result. `model_scored` false means the figures are ABSENT, not zero. */
+export interface CheckOutcome {
+  model_scored: boolean;
+  packs: PackOutcome[];
+  total_requirements: number;
+  failing_requirements?: number;
+  total_violations?: number;
+  satisfied?: boolean;
+  note?: string;
+}
+
+/** `AUTHORITY · edition` — the line that makes a pack citable at a glance. */
+export function packHeadline(p: PackHeader): string {
+  const n = p.requirements?.length ?? 0;
+  return `${p.name} — ${p.authority}, ${p.edition} · ${p.jurisdiction} · `
+    + `${n} requirement${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * The caveat that must ride along with anything the example pack produced.
+ *
+ * Empty string for a real pack — a caveat printed on every result trains the reader to skip it, and
+ * then it is not there when it matters.
+ */
+export function exampleCaveat(p: { is_example?: boolean }): string {
+  return p.is_example
+    ? "DEMONSTRATION PACK — attributed to nobody and asserting nothing about any real jurisdiction. "
+      + "A result from it is not a compliance finding and must not be reported as one."
+    : "";
+}
+
+/**
+ * Whether this project has requirements at all, and the reason when it does not.
+ *
+ * A project with no jurisdiction gets the server's own reason rather than a default pack: a
+ * requirement set from the wrong authority is not a conservative approximation of the right one, it
+ * is a different answer that looks exactly the same.
+ */
+export function adoptionLine(a: Applicability): string {
+  if (a.explicit) {
+    return `Applying 1 pack by id — chosen explicitly, not resolved from this project's jurisdiction.`;
+  }
+  if (!a.jurisdiction) {
+    return a.why || "This project has no jurisdiction set, so no data requirements can be resolved.";
+  }
+  if (!a.adopted) return a.why || `No pack has been imported for ${a.jurisdiction}.`;
+  const n = a.packs.length;
+  return `${n} pack${n === 1 ? "" : "s"} apply in ${a.jurisdiction}.`;
+}
+
+/**
+ * Whether a check can be offered, and the reason when it cannot.
+ *
+ * Two refusals, and they are different: nothing applies (no jurisdiction, or no pack imported for
+ * it), versus packs apply but no model is loaded to check them against. Collapsing them would tell
+ * somebody to import a pack when what they need is to upload a model.
+ */
+export function checkGate(a: Applicability, modelLoaded: boolean): { can: boolean; why: string } {
+  if (!a.adopted && !a.explicit) {
+    return { can: false, why: adoptionLine(a) };
+  }
+  if (!modelLoaded) {
+    return { can: false,
+             why: "No model is loaded, and a data-requirement check needs a model to check." };
+  }
+  return { can: true, why: "" };
+}
+
+/**
+ * What the check found — and never a bare number.
+ *
+ * `model_scored` false is reported as the absence it is. Every figure is followed by whose rules
+ * produced it, and an example-pack run says so in the same breath rather than in a footnote.
+ */
+export function checkSummary(r: CheckOutcome): string {
+  if (!r.model_scored) {
+    return r.note || "No model was scored, so there is no result — this is not a pass.";
+  }
+  if (!r.packs.length || r.total_requirements === 0) {
+    return "No requirements were evaluated, so there is nothing to report — this is not a pass.";
+  }
+  const failing = r.failing_requirements ?? 0;
+  const verdict = failing === 0
+    ? `Satisfied: ${r.total_requirements} requirement${r.total_requirements === 1 ? "" : "s"} met`
+    : `${failing} of ${r.total_requirements} requirement${r.total_requirements === 1 ? "" : "s"} `
+      + `failing (${r.total_violations ?? 0} violation${(r.total_violations ?? 0) === 1 ? "" : "s"})`;
+  return `${verdict}, against ${attributionLine(r.packs)}.`;
+}
+
+/** Whose rules these were. Always plural-safe, and always names the example pack as an example. */
+export function attributionLine(packs: PackOutcome[]): string {
+  if (!packs.length) return "no pack";
+  return packs
+    .map((p) => `${p.authority || "an unattributed source"} ${p.edition || ""}`.trim()
+      + (p.is_example ? " (demonstration pack — not a real requirement)" : ""))
+    .join("; ");
+}
+
+/** One pack's row in the results table, worst first is the caller's job. */
+export function outcomeLine(p: PackOutcome): string {
+  const head = `${p.name || p.id || "pack"} — ${p.authority || "unattributed"} ${p.edition || ""}`.trim();
+  if (p.total_rules === 0) return `${head}: no requirements`;
+  const ok = p.total_rules - p.failing_rules;
+  return `${head}: ${ok}/${p.total_rules} met, ${p.total_violations} violation`
+    + `${p.total_violations === 1 ? "" : "s"}`;
+}
+
+/**
+ * The confirmation before removing a pack from the shared library.
+ *
+ * Names the blast radius, because the library is global: deleting is not a per-project action and
+ * every project resolving that jurisdiction loses the requirements.
+ */
+export function deleteConfirm(p: PackHeader): string {
+  return `Delete the pack "${p.name}" (${p.authority}, ${p.edition})?\n\n`
+    + `The pack library is SHARED — every project in ${p.jurisdiction} stops resolving these `
+    + "requirements, not just this one. Imported packs can be re-imported from their source.";
+}
+
+/**
+ * The import refusal, shown verbatim.
+ *
+ * The server's 422 `detail` names the missing citation field or the exact dotted property path that
+ * would have made a requirement silently pass forever. **That text is the instruction**, so a
+ * generic "import failed" throws away the only thing that tells the user what to fix — which is
+ * also why `httpCore.json()` was taught to carry `detail` through in the first place.
+ */
+export function importRefusal(message: string): string {
+  const m = (message || "").trim();
+  return m
+    ? `The pack was refused: ${m}`
+    : "The pack was refused and the server gave no reason — nothing was stored.";
+}

--- a/apps/web/src/portal/panels/jurisdictionPacks.ts
+++ b/apps/web/src/portal/panels/jurisdictionPacks.ts
@@ -137,10 +137,19 @@ export function checkSummary(r: CheckOutcome): string {
     return "No requirements were evaluated, so there is nothing to report — this is not a pass.";
   }
   const failing = r.failing_requirements ?? 0;
-  const verdict = failing === 0
-    ? `Satisfied: ${r.total_requirements} requirement${r.total_requirements === 1 ? "" : "s"} met`
+  const counted = failing === 0
+    ? `${r.total_requirements} requirement${r.total_requirements === 1 ? "" : "s"} met`
     : `${failing} of ${r.total_requirements} requirement${r.total_requirements === 1 ? "" : "s"} `
       + `failing (${r.total_violations ?? 0} violation${(r.total_violations ?? 0) === 1 ? "" : "s"})`;
+  // **The verdict WORD is withheld the moment a demonstration pack took part**, and the attribution
+  // clause is not enough on its own: "Satisfied" is what gets read, screenshotted and quoted, and a
+  // qualifier trailing it is read second or not at all. This applies to the failing branch too --
+  // an example pack reporting failures says a model breaks rules that do not exist, which is the
+  // same lie in the other direction. A mixed run is contaminated rather than partly valid: the
+  // totals are summed across packs, so no honest verdict can be recovered from the aggregate.
+  const verdict = r.packs.some((p) => p.is_example)
+    ? `Demonstration result — ${counted}; no real requirement was evaluated`
+    : failing === 0 ? `Satisfied: ${counted}` : counted;
   return `${verdict}, against ${attributionLine(r.packs)}.`;
 }
 

--- a/apps/web/src/portal/panels/jurisdictionPanel.ts
+++ b/apps/web/src/portal/panels/jurisdictionPanel.ts
@@ -1,0 +1,202 @@
+import { noProjectHtml } from "../../ui/empty";
+import { escapeHtml as esc } from "../../ui/feedback";
+import type { PanelContext } from "../panelContext";
+import type { JurisdictionPack, JurisdictionCheck, ProjectRequirements } from "../../api/jurisdiction";
+import {
+  adoptionLine, attributionLine, checkGate, checkSummary, deleteConfirm, exampleCaveat,
+  importRefusal, outcomeLine, packHeadline,
+} from "./jurisdictionPacks";
+
+/**
+ * R23-JURISDICTION-PACKS — data requirements published by an authority, and the screen that reaches
+ * them. All five of this feature's routes had no client caller until this panel existed.
+ *
+ * The presentation rules live in `jurisdictionPacks.ts` and are tested there; this file is the DOM
+ * and the five network calls. Three sections, in the order a person needs them: what applies here,
+ * what the model does against it, and the shared library the packs come from.
+ */
+export async function renderJurisdiction(ctx: PanelContext) {
+  const root = ctx.root; root.innerHTML = "";
+  const el = (t: string, c = "") => { const e = document.createElement(t); if (c) e.className = c; return e; };
+  root.appendChild(ctx.bar("⚖️ Data Requirements", () => {
+    ctx.activeKey = null; void ctx.renderHome(); ctx.buildNav();
+  }));
+  const pid = ctx.host.projectId();
+  if (!pid) { root.insertAdjacentHTML("beforeend", noProjectHtml("Data Requirements")); return; }
+
+  const intro = el("div", "meta"); intro.style.marginBottom = "8px";
+  intro.innerHTML = "A <b>pack</b> is a set of data requirements published by an authority for a "
+    + "jurisdiction, and it is used to fail a submitted model — so every pack must carry its "
+    + "<b>authority, edition and source</b>, and every result says whose rules produced it. Packs "
+    + "resolve from this project's jurisdiction; a project with none gets no requirements rather "
+    + "than a default, because requirements from the wrong authority are a different answer that "
+    + "looks exactly like the right one. Importing and deleting need <b>admin</b>.";
+  root.appendChild(intro);
+
+  const applies = el("div"); applies.style.marginTop = "8px"; applies.textContent = "loading…";
+  const results = el("div"); results.style.marginTop = "12px";
+  const library = el("div"); library.style.marginTop = "16px";
+  root.append(applies, results, library);
+
+  /** Section 1 + 2: what applies here, and what the model does against it. */
+  const drawProject = async () => {
+    applies.textContent = "loading…"; results.innerHTML = "";
+    let req: ProjectRequirements;
+    try { req = await ctx.host.api.projectRequirements(pid); }
+    catch (e) { applies.textContent = `requirements failed: ${(e as Error).message}`; return; }
+
+    applies.innerHTML = `<div><b>${esc(adoptionLine(req))}</b></div>`;
+    for (const p of req.packs) {
+      const card = el("div", "dash-card"); card.style.cssText = "margin-top:6px";
+      card.innerHTML = `<div>${esc(packHeadline(p))}</div>`
+        + `<div class="meta" style="margin-top:2px">source: ${esc(p.source)}</div>`;
+      const caveat = exampleCaveat(p);
+      if (caveat) {
+        card.style.borderLeft = "3px solid var(--status-warn)";
+        card.insertAdjacentHTML("beforeend",
+          `<div class="meta" style="margin-top:4px">${esc(caveat)}</div>`);
+      }
+      applies.appendChild(card);
+    }
+    if (!req.adopted && !req.explicit) return;    // nothing to check against
+
+    await drawCheck(req);
+  };
+
+  const drawCheck = async (req: ProjectRequirements) => {
+    results.innerHTML = "<span class='meta'>checking the model…</span>";
+    let r: JurisdictionCheck;
+    try { r = await ctx.host.api.jurisdictionCheck(pid); }
+    catch (e) { results.textContent = `check failed: ${(e as Error).message}`; return; }
+    results.innerHTML = "";
+
+    const head = el("div");
+    head.innerHTML = `<b>${esc(checkSummary(r))}</b>`;
+    results.appendChild(head);
+
+    // The example pack's caveat rides with the RESULT, not only with the pack above: a reader who
+    // scrolled to the number is the one who needs it.
+    if (r.packs.some((p) => p.is_example)) {
+      const c = el("div", "dash-card");
+      c.style.cssText = "margin-top:6px;border-left:3px solid var(--status-warn)";
+      c.innerHTML = `<span class="meta">${esc(exampleCaveat({ is_example: true }))}</span>`;
+      results.appendChild(c);
+    }
+
+    for (const p of r.packs) {
+      const row = el("div", "meta"); row.style.marginTop = "4px";
+      row.textContent = outcomeLine(p);
+      results.appendChild(row);
+    }
+    if (r.packs.length) {
+      const attr = el("div", "meta"); attr.style.marginTop = "6px";
+      attr.textContent = `Measured against: ${attributionLine(r.packs)}`;
+      results.appendChild(attr);
+    }
+
+    // `model_scored` from the run we just did is what says whether a re-run can mean anything --
+    // the same reason `checkGate` takes it rather than assuming. A button that will certainly come
+    // back empty is the offered-and-refused shape this codebase keeps removing.
+    const gate = checkGate(req, r.model_scored);
+    const act = el("div"); act.style.marginTop = "8px";
+    if (gate.can) {
+      const btn = el("button", "mini-btn") as HTMLButtonElement;
+      btn.textContent = "↻ Re-check the model";
+      btn.onclick = () => { void drawCheck(req); };
+      act.appendChild(btn);
+    } else {
+      act.innerHTML = `<span class="meta">Cannot check — ${esc(gate.why)}</span>`;
+    }
+    results.appendChild(act);
+  };
+
+  /** Section 3: the shared library, and the two writes that maintain it. */
+  const drawLibrary = async () => {
+    library.innerHTML = "<span class='meta'>loading the pack library…</span>";
+    let lib;
+    try { lib = await ctx.host.api.jurisdictionPacks(); }
+    catch (e) { library.textContent = `library failed: ${(e as Error).message}`; return; }
+    library.innerHTML = `<div style="margin-bottom:6px"><b>Pack library — ${lib.count} pack`
+      + `${lib.count === 1 ? "" : "s"}</b> <span class="meta">shared across every project</span></div>`;
+
+    for (const p of lib.packs) library.appendChild(libraryRow(p));
+    library.appendChild(importBox());
+  };
+
+  const libraryRow = (p: JurisdictionPack) => {
+    const card = el("div", "dash-card"); card.style.cssText = "margin-bottom:6px";
+    card.innerHTML = `<div>${esc(packHeadline(p))}</div>`
+      + `<div class="meta" style="margin-top:2px">source: ${esc(p.source)}</div>`;
+    if (p.is_example) {
+      card.style.borderLeft = "3px solid var(--status-warn)";
+      card.insertAdjacentHTML("beforeend",
+        `<div class="meta" style="margin-top:4px">${esc(exampleCaveat(p))} It cannot be deleted.`
+        + `</div>`);
+      return card;
+    }
+    const btn = el("button", "mini-btn") as HTMLButtonElement;
+    btn.textContent = "🗑 Delete"; btn.style.marginTop = "6px";
+    btn.onclick = async () => {
+      if (!window.confirm(deleteConfirm(p))) return;
+      btn.disabled = true;
+      try { await ctx.host.api.jurisdictionDeletePack(p.id); }
+      catch (e) {
+        btn.disabled = false;
+        // The server's own text distinguishes "not yours to delete" (403) from "no such imported
+        // pack" (404) -- a generic failure would hide which.
+        ctx.host.setStatus(`could not delete the pack: ${(e as Error).message}`);
+        return;
+      }
+      ctx.host.setStatus(`Deleted the pack "${p.name}".`);
+      // Deleting changes what resolves for this project too, so both halves are re-read. They are
+      // separate awaits from the delete above on purpose: a failed refresh must not report a
+      // failed delete.
+      void drawLibrary(); void drawProject();
+    };
+    card.appendChild(btn);
+    return card;
+  };
+
+  const importBox = () => {
+    const box = el("div", "dash-card"); box.style.marginTop = "10px";
+    box.innerHTML = "<div><b>Import a pack</b></div>"
+      + `<div class="meta" style="margin-top:2px">Paste the pack JSON from the authority. It is `
+      + `refused unless it carries an <b>id, jurisdiction, authority, name, edition and source</b>, `
+      + `and every selector is parsed with the engine that will evaluate it — so a rule that would `
+      + `silently match nothing is refused rather than stored.</div>`;
+    const ta = el("textarea", "portal-filter") as HTMLTextAreaElement;
+    ta.rows = 6; ta.style.cssText = "width:100%;margin-top:6px;font-family:monospace;font-size:12px";
+    ta.placeholder = '{"id": "tx-austin-2026", "jurisdiction": "TX", "authority": "…", '
+      + '"name": "…", "edition": "…", "source": "…", "requirements": [{"scope": "…", "require": "…"}]}';
+    const btn = el("button", "mini-btn") as HTMLButtonElement;
+    btn.textContent = "⬆ Import"; btn.style.marginTop = "6px";
+    btn.onclick = async () => {
+      let parsed: unknown;
+      // A malformed paste is the USER's error and gets its own message: `importRefusal` is for what
+      // the server said, and attributing a JSON syntax error to the server would send the reader to
+      // look at their requirements when the problem is a missing brace.
+      try { parsed = JSON.parse(ta.value); }
+      catch (e) {
+        ctx.host.setStatus(`That is not valid JSON: ${(e as Error).message}`);
+        return;
+      }
+      btn.disabled = true;
+      let stored;
+      try { stored = await ctx.host.api.jurisdictionImportPack(parsed); }
+      catch (e) {
+        btn.disabled = false;
+        ctx.host.setStatus(importRefusal((e as Error).message));
+        return;
+      }
+      btn.disabled = false; ta.value = "";
+      ctx.host.setStatus(`Imported "${stored.name}" (${stored.authority}, ${stored.edition}) for `
+        + `${stored.jurisdiction}.`);
+      void drawLibrary(); void drawProject();
+    };
+    box.append(ta, btn);
+    return box;
+  };
+
+  await drawProject();
+  await drawLibrary();
+}

--- a/apps/web/src/portal/panels/jurisdictionPanel.ts
+++ b/apps/web/src/portal/panels/jurisdictionPanel.ts
@@ -197,6 +197,9 @@ export async function renderJurisdiction(ctx: PanelContext) {
     return box;
   };
 
-  await drawProject();
-  await drawLibrary();
+  // Concurrent, not sequential: the two sections share no state, and `drawProject` waits on a model
+  // check that can take seconds. Awaiting it first left the pack library -- and the import box, the
+  // only way to fix "no pack has been imported for TX" -- blank until that check settled. Found in
+  // review on PR #527. Each half already catches its own failure, so neither can reject here.
+  await Promise.all([drawProject(), drawLibrary()]);
 }

--- a/apps/web/src/portal/panels/standards.ts
+++ b/apps/web/src/portal/panels/standards.ts
@@ -164,6 +164,21 @@ export async function renderStandards(ctx: PanelContext) {
       }
     })();
     root.appendChild(bepCard);
+    // R23-JURISDICTION-PACKS — the authority's data requirements, which are information
+    // requirements for a PLACE rather than for this appointment. It sits here because the EIR/BEP
+    // above is the same question asked by the client instead of by the regulator, and a submitter
+    // needs both answers before a submittal. Its own panel; this is the way in.
+    const jurCard = el("div", "dash-card"); jurCard.style.marginBottom = "8px";
+    jurCard.innerHTML = `<div><b>⚖️ Data requirements (jurisdiction)</b></div>`
+      + `<div class="meta" style="margin-top:2px">Requirement packs published by an authority for a `
+      + `jurisdiction, each carrying its authority, edition and source — and this model checked `
+      + `against the ones that apply here.</div>`;
+    const jurBtn = el("button"); jurBtn.className = "mini-btn on"; jurBtn.textContent = "Open";
+    jurBtn.style.marginTop = "6px";
+    jurBtn.onclick = () => void (async () => {
+      await (await import("./jurisdictionPanel")).renderJurisdiction(ctx);
+    })();
+    jurCard.append(jurBtn); root.appendChild(jurCard);
     // AI / data-readiness — "can an agent act on this project's data yet?"
     void ctx.host.api.aiReadiness(pid).then((ai) => {
       const col = ai.verdict === "ready" ? "--status-good" : ai.verdict === "partial" ? "--status-warn" : "--status-crit";

--- a/apps/web/src/portal/panels/standards.ts
+++ b/apps/web/src/portal/panels/standards.ts
@@ -180,7 +180,16 @@ export async function renderStandards(ctx: PanelContext) {
     })();
     jurCard.append(jurBtn); root.appendChild(jurCard);
     // AI / data-readiness — "can an agent act on this project's data yet?"
+    //
+    // The card lands in a SLOT appended now rather than straight onto `root` when the read returns.
+    // `root` is shared by every panel and is cleared by whoever renders next, so a late `.then` was
+    // appending this card into a different screen -- visible since the jurisdiction button above
+    // gives the reader something to navigate to while this is still in flight. An empty div has no
+    // visual footprint, and `isConnected` goes false the moment `root.innerHTML` is cleared, which
+    // is the cheapest liveness check there is. Found in review on PR #527.
+    const aiSlot = el("div"); root.appendChild(aiSlot);
     void ctx.host.api.aiReadiness(pid).then((ai) => {
+      if (!aiSlot.isConnected) return;    // the reader moved on; this panel is gone
       const col = ai.verdict === "ready" ? "--status-good" : ai.verdict === "partial" ? "--status-warn" : "--status-crit";
       const ac = el("div", "dash-card"); ac.style.cssText = `border-left:3px solid var(${col});margin-bottom:8px`;
       const dim = (label: string, k: keyof typeof ai.dimensions) => {
@@ -192,7 +201,7 @@ export async function renderStandards(ctx: PanelContext) {
         + `<table class="fin-table" style="width:100%;font-size:12px;margin-top:4px">`
         + dim("Single source of truth", "single_source_of_truth") + dim("Information completeness", "information_completeness")
         + dim("Model integrity", "model_integrity") + dim("Governance", "governance") + `</table>`;
-      root.appendChild(ac);
+      aiSlot.appendChild(ac);
     }).catch(() => { /* best-effort */ });
     const body = el("div"); body.textContent = "loading…"; root.appendChild(body);
     let st; let reg;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1752,6 +1752,39 @@ instances:
   claim about what an underwriting asserts, not a unit conversion, and it waits on the same domain
   call `/schedule/eot` does.
 
+- ✅ ⭐ **JURISDICTION-PACKS — a regulator's data requirements, and no way to reach any of them**
+  *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts` and
+  `apps/web/src/portal/panels/jurisdictionPacks.test.ts`)*
+
+  R23 built the whole thing server-side: a pack is a **named, versioned, attributed** set of data
+  requirements keyed to a jurisdiction, validated by a rule that refuses an uncited pack, with
+  selectors parsed by the same engine that evaluates them. **All five of its routes had no client
+  caller.** The library, the import and the delete were frozen by UNREACHED-IMPORT; the two that
+  *consume* a pack — `/projects/{pid}/jurisdiction/requirements` and `/projects/{pid}/jurisdiction/check`
+  — were invisible to the gate entirely, so the feature read as three-fifths dark rather than dark.
+
+  `apps/web/src/api/jurisdiction.ts` carries the five methods and
+  `apps/web/src/portal/panels/jurisdictionPanel.ts` the screen, reached from CDE / Standards because
+  a pack is an information requirement for a **place** where the EIR beside it is one for an
+  appointment — a submitter needs both before a submittal. The rules are in
+  `apps/web/src/portal/panels/jurisdictionPacks.ts`: 27 tests, four mutations all biting.
+
+  **The rules are all about attribution, because that is what the feature is for.** The built-in
+  `example` pack is attributed to nobody and asserts nothing about any real place — and it is the
+  only pack present before anything is imported, so it is the one a first-time user runs. A result
+  from it that reads like a verdict tells somebody their model satisfies rules that do not exist.
+  So the caveat rides with the *result* and inside the attribution line itself, not in a footnote,
+  and `exampleCaveat` is deliberately **empty for a real pack** — a caveat printed on everything is
+  one nobody reads, and then it is absent when it matters. Two refusals are also kept apart: nothing
+  applies, versus packs apply but no model is loaded. Collapsing them would tell somebody to import a
+  pack when what they need is to upload a model.
+
+  **The count of dark routes was a floor, not the debt.** The frozen set said three; reading the
+  handlers said five. *A ratchet undercounts by exactly the size of the blind spot in the rule that
+  fills it* — which is why the two invisible ones are now asserted in
+  `services/api/test_route_reachability.py` as blind spots that stay blind: they have callers today
+  and that gate still has no opinion about them, so its two green ticks must not be read as coverage.
+
 - ✅ **FROZEN-TRIAGE — what the eight dark routes actually were** *(record, not a work item; **CLOSED 2026-09-11**)*
 
   UNREACHED-IMPORT froze eight newly-visible routes and said, correctly, that freezing is **not**

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -330,9 +330,15 @@ KNOWN_UNCALLED: set[str] = {
     # caller and returns strictly more (a LoGeoRef level, its label, the map conversion, the CRS and
     # the site), so wiring the simpler one would add a second answer to one question. *A dark route
     # can be a duplicate rather than a hole, and the gate cannot tell the difference.*
+    #
+    # **A THIRD and FOURTH left on 2026-09-11: both `/jurisdiction/packs` entries.** That was the
+    # largest genuine gap of the eight and it was bigger than this set could say -- the two routes
+    # that CONSUME a pack are dark too and are invisible here, for the two reasons recorded further
+    # down beside the `/asset-rights/verify` blind spot. So the feature was wired end to end rather
+    # than in the three-fifths this list could see: `apps/web/src/api/jurisdiction.ts` and the panel
+    # in `apps/web/src/portal/panels/jurisdictionPanel.ts`. *A frozen entry undercounts whenever the
+    # rule that produced it has a blind spot -- the list is a floor on the debt, never the debt.*
     "/codes/seeded",
-    "/jurisdiction/packs",
-    "/jurisdiction/packs/{pack_id}",
     "/projects/{pid}/clash/coordinate",
     "/projects/{pid}/documents/template",
     "/projects/{pid}/georeference",
@@ -885,8 +891,15 @@ check("the ASSET-VERIFY blind spot is still a blind spot, not silent coverage",
 #
 # Neither can be frozen in KNOWN_UNCALLED -- the rot check above would immediately report them as
 # "quietly become called" -- so, exactly as with `/asset-rights/verify`, the honest instrument is to
-# assert that they remain outside both sets. Unlike that route, these two SHOULD gain callers: the
-# whole feature is finished server-side and unreachable from the product.
+# assert that they remain outside both sets.
+#
+# **BOTH NOW HAVE CALLERS** (`apps/web/src/api/jurisdiction.ts`, called from
+# `apps/web/src/portal/panels/jurisdictionPanel.ts`), and the assertions below still pass unchanged
+# -- which is exactly what makes the point worth leaving here. The gate could not see these routes
+# dark and cannot see them wired either; its verdict on them was, and remains, no verdict. Do not
+# read the two PASSes below as coverage of this feature. What proves the wiring is
+# `apps/web/src/api/clientCallers.test.ts`, which refuses an unused client method, plus the panel
+# tests -- not this file.
 for _r in ("/projects/{pid}/jurisdiction/requirements", "/projects/{pid}/jurisdiction/check"):
     check(f"the R23-JURISDICTION-PACKS blind spot is still a blind spot: {_r}",
           _r not in FOUND and _r not in KNOWN_UNCALLED,


### PR DESCRIPTION
# What & why

**R23-JURISDICTION-PACKS was complete server-side and unreachable from the product.** A pack is a named, versioned, **attributed** set of data requirements keyed to a jurisdiction — what a submitted model must carry before an authority will accept it. `validate()` refuses a pack without an authority, edition and source, and parses every selector with the same engine that evaluates it, so a rule that would silently match nothing is refused rather than stored. None of that had a client caller.

Five routes, now all wired:

| route | what it does |
|---|---|
| `GET /jurisdiction/packs` | the shared library |
| `POST /jurisdiction/packs` | import from an authority (admin) |
| `DELETE /jurisdiction/packs/{pack_id}` | remove an imported pack (admin) |
| `GET /projects/{pid}/jurisdiction/requirements` | which packs apply here, and why not when none do |
| `GET /projects/{pid}/jurisdiction/check` | this model against them |

The frozen set in `services/api/test_route_reachability.py` said **three**. Reading the handlers said **five** — the two *consumers* are invisible to that gate (`check` collides with `/standards/check`, which the client genuinely calls; `requirements` with unrelated text). So the feature is wired end to end rather than in the three-fifths the list could see. **A ratchet undercounts by exactly the size of the blind spot in the rule that fills it.**

## The rules are about attribution, because that is what the feature is for

`apps/web/src/portal/panels/jurisdictionPacks.ts` — 27 tests, **four mutations all biting**.

The load-bearing case is the built-in `example` pack: attributed to nobody, asserting nothing about any real place, and the **only** pack present before anything is imported — so it is the one a first-time user runs. A result from it that reads like a verdict tells somebody their model satisfies rules that do not exist. Its caveat therefore rides with the **result** and inside the attribution line itself, not in a footnote. `exampleCaveat` returns **empty for a real pack** on purpose: a caveat printed on everything is one nobody reads, and then it is absent when it matters.

Two refusals are kept apart: *nothing applies* versus *packs apply but no model is loaded*. Collapsing them would tell somebody to import a pack when what they need is to upload a model. An unscored model and a zero-requirement run are both reported as the absences they are — **never as a pass**. An import refusal is shown verbatim, because the server's `detail` names the missing citation or the exact dotted property path that would have silently passed forever; that is the instruction, and carrying it through is what #524 taught `httpCore.json()` to do.

`withJurisdiction` is composed **inside** `withCodeCheck` rather than added to `client.ts`'s top-level chain, which sits at TypeScript's instantiation ceiling — a 51st `withX()` fails the build with TS2589. `api/cost.ts` records the same remedy.

## Noticed and deliberately not fixed here

**`.portal-btn` is defined in no stylesheet**, yet nine panels under `portal/panels/` use it, so those buttons fall back to default browser styling. This panel uses `.mini-btn` and `.portal-filter`, which are real. Queued as a separate task: it wants a derivation across every `className` literal, not a one-line patch, and widening this PR to chase it would bury the feature.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` → "All checks passed!"
- [x] Backend: `test_route_reachability.py`, `test_claude_md_gates.py`, `test_file_sizes.py`, `test_changelog_current.py`, `test_no_comparative_names.py` all green; the full suite was still running at push time and its result is reported on the PR
- [x] Web: `npm run typecheck && npm run lint && npm run build` clean; `npx vitest run` → 244 files / 2536 tests passing
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; `docs/roadmap.md` gains the JURISDICTION-PACKS entry
- [x] No version bump (not a release PR)
- [x] No secrets; no competitor names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added jurisdiction-based data requirement packs under **CDE / Standards → Data requirements (jurisdiction)**.
  - View applicable requirements, run checks, and see results attributed to the governing authority, edition, and source.
  - Browse shared packs, import validated packs, and delete eligible packs.
  - Demonstration-pack results are clearly labeled and excluded from compliance findings.
  - Projects without a jurisdiction receive an explicit explanation instead of default requirements.
  - Import rejections display the server-provided reason, including missing citations or unmatched selectors.

- **Documentation**
  - Added guidance covering pack management, applicability, attribution, and import rejection messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->