### PR TITLE
The buyout plan you could compute and could not keep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Buyout packages can be kept, and their RFQs sent
+
+**Budget → Buyout packages** has always grouped the model's priced quantities into packages, each
+with an RFQ scope. There was no way to keep them: the grouping vanished when you navigated away, and
+the buyout workflow it feeds — draft → RFQ sent → quotes in → awarded — could not be reached from the
+screen that produces its input.
+
+Keeping them now creates one **Buyout Packages** record per group, in draft, visible to the whole
+project and quotable by ref; each one then offers **Send RFQ**, which mints a Bid Solicitation
+carrying the package's name, trade and due date and moves the package to RFQ sent. The confirmation
+says what is being created before it is created, and re-grouping and keeping again is described as
+adding a second set rather than replacing the first, because that is what it does.
+
+Two refusals are reported rather than hidden. A grouping that produced nothing is reported as nothing
+kept, not as a save of zero. And because the server mints a solicitation whether or not the package
+was still in draft, a send that does **not** move the package says so and names the state it is
+actually in — so a second send cannot look like a first one.
+
 ### An authority's data requirements can now be imported, applied and checked
 
 A **requirement pack** is a set of data requirements published by an authority for a jurisdiction —

--- a/apps/web/src/api/procurement.ts
+++ b/apps/web/src/api/procurement.ts
@@ -40,6 +40,50 @@ export function withProcurement<TBase extends Ctor<HttpCore>>(Base: TBase) {
       `/projects/${pid}/procurement/buyout-packages`, { method: "POST", body: JSON.stringify({ qto_lines: qtoLines, by }) });
   }
   /**
+   * BUYOUT-KEEP — the write that turns a grouping into records somebody can work.
+   *
+   * `buyoutPackages` above computes the same grouping and returns it; this one PERSISTS each group
+   * as a `procurement_package` record in `draft`, which is what makes the buyout workflow
+   * (draft → rfq_sent → quotes_in → awarded) reachable at all. Until 2026-09-11 the screen could
+   * compute packages and had no way to keep them, so the entire downstream chain — this route and
+   * `sendPackageRfq` below — was unreachable from the product.
+   *
+   * Needs the **editor** role, because it writes records the whole project then sees.
+   */
+  saveBuyoutPackages(pid: string, qtoLines: Record<string, unknown>[], by = "trade",
+                     rfqDue?: string) {
+    return this.json<{
+      created: { id: string | number; ref: string; name: string; est_cost: number | null;
+                 line_count: number }[];
+      package_count: number;
+      note: string;
+    }>(`/projects/${pid}/procurement/packages/save`, {
+      method: "POST",
+      body: JSON.stringify({ qto_lines: qtoLines, by, ...(rfqDue ? { rfq_due: rfqDue } : {}) }),
+    });
+  }
+
+  /**
+   * BUYOUT-KEEP — mint a Bid Solicitation (ITB) from a stored package and advance it to `rfq_sent`.
+   *
+   * **`package_state` is the field that matters on the way back.** The server mints the
+   * solicitation unconditionally but only transitions a package that is still in `draft`; sending
+   * twice therefore produces a SECOND ITB and no state change. A client that reports "RFQ sent"
+   * from a resolved promise would hide exactly that, so the caller must read the state it returns
+   * rather than the fact that it returned.
+   */
+  sendPackageRfq(pid: string, rid: string, dueDate?: string) {
+    return this.json<{
+      solicitation: { id: string | number; ref: string };
+      package: string;
+      package_state: string | null;
+    }>(`/projects/${pid}/procurement/packages/${encodeURIComponent(rid)}/send-rfq`, {
+      method: "POST",
+      body: JSON.stringify(dueDate ? { due_date: dueDate } : {}),
+    });
+  }
+
+  /**
    * PROCURE-LEVEL — score returned quotes for ONE package against its RFQ scope.
    *
    * `scope` and `quotes` are typed to the shapes the route documents rather than to

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -4,6 +4,7 @@ import { confidenceSummary } from "../../ui/confidenceReading";
 import { confirmModal } from "../../ui/modal";
 import type { PanelContext } from "../panelContext";
 import { renderCostBrief } from "./costBrief";
+import { rfqConfirm, rfqGate, rfqSummary, saveConfirm, saveGate, saveSummary, type SavedPackage } from "./buyoutKeep";
 
 /**
  * GC GMP budget dashboard — the agreed GMP broken to every cost code & bid package plus GC/GR,
@@ -188,7 +189,93 @@ export async function renderBudget(ctx: PanelContext) {
         + `<th>Package</th><th style="text-align:right">Lines</th><th style="text-align:right">Est. cost</th>`
         + `<th>RFQ scope</th></tr></thead><tbody>${rows(pk)}</tbody></table></div>`
         + `<div class="meta" style="margin-top:4px">${esc(b.note || "")}</div>`);
+      // BUYOUT-KEEP — the grouping above is transient. Until 2026-09-11 that was the end of the
+      // road: `…/packages/save` and `…/packages/{rid}/send-rfq` had no client caller, so a user
+      // could produce a buyout plan and had no way to keep or act on it, and the whole
+      // draft -> rfq_sent -> quotes_in -> awarded workflow was unreachable from the screen that
+      // produces its input.
+      estDrawer.appendChild(keepRow(lines, b.packages, b.grouped_by));
     } catch (err) { fillEst(`<div class="meta">Buyout packaging failed: ${(err as Error).message}</div>`); }
+  };
+
+  /** The keep action, and — once kept — one send-RFQ button per stored package. */
+  const keepRow = (lines: Record<string, unknown>[],
+                   pkgs: { package: string; line_count: number; est_cost: number }[],
+                   groupedBy: string) => {
+    const wrap = document.createElement("div"); wrap.style.marginTop = "8px";
+    const gate = saveGate(pkgs.length);
+    if (!gate.can) {
+      wrap.innerHTML = `<span class="meta">Cannot keep these — ${esc(gate.why)}.</span>`;
+      return wrap;
+    }
+    const btn = document.createElement("button"); btn.className = "tool-btn";
+    btn.textContent = "💾 Keep these packages";
+    btn.title = "Store each group as a Buyout Packages record the project can track";
+    btn.onclick = async () => {
+      if (!(await confirmModal("Keep buyout packages", saveConfirm(pkgs, groupedBy), "Keep"))) return;
+      btn.disabled = true;
+      let saved;
+      try {
+        saved = await ctx.host.api.saveBuyoutPackages(pid, lines, groupedBy);
+      } catch (e) {
+        btn.disabled = false;
+        // The server's own text separates "not yours to write" (403) from a validation refusal.
+        ctx.host.setStatus(`could not keep the packages: ${(e as Error).message}`);
+        return;
+      }
+      // Pass the count the CONFIRMATION named: the server re-groups at write time from the lines it
+      // is sent, so these can differ, and saveSummary says so rather than reporting a clean success
+      // for a set the reader never agreed to.
+      ctx.host.setStatus(saveSummary(saved.created, pkgs.length));
+      wrap.replaceWith(sentRow(saved.created));
+    };
+    wrap.appendChild(btn);
+    return wrap;
+  };
+
+  /** One send-RFQ button per kept package, each carrying its own workflow state. */
+  const sentRow = (created: SavedPackage[]) => {
+    const wrap = document.createElement("div"); wrap.style.marginTop = "8px";
+    if (!created.length) {
+      wrap.innerHTML = `<span class="meta">${esc(saveSummary(created))}</span>`;
+      return wrap;
+    }
+    wrap.innerHTML = `<div class="meta" style="margin-bottom:4px">${esc(saveSummary(created))}</div>`;
+    for (const pkg of created) wrap.appendChild(rfqButton(pkg));
+    return wrap;
+  };
+
+  const rfqButton = (pkg: SavedPackage) => {
+    const row = document.createElement("div"); row.style.marginTop = "4px";
+    // A freshly-kept package is in `draft`; the gate still asks, because this same function redraws
+    // the row after a send and must then refuse the second one.
+    const gate = rfqGate({ id: pkg.id, state: (pkg as { state?: string }).state ?? "draft" });
+    if (!gate.can) {
+      row.innerHTML = `<span class="meta">${esc(pkg.ref)} — ${esc(gate.why)}.</span>`;
+      return row;
+    }
+    const btn = document.createElement("button"); btn.className = "tool-btn";
+    btn.textContent = `📨 Send RFQ — ${pkg.ref}`;
+    btn.onclick = async () => {
+      if (!(await confirmModal("Send RFQ", rfqConfirm(pkg), "Send"))) return;
+      btn.disabled = true;
+      let sent;
+      try {
+        sent = await ctx.host.api.sendPackageRfq(pid, String(pkg.id));
+      } catch (e) {
+        btn.disabled = false;
+        ctx.host.setStatus(`could not send the RFQ: ${(e as Error).message}`);
+        return;
+      }
+      // `package_state` is read rather than assumed. The server mints the solicitation
+      // unconditionally and transitions only a draft package, so a resolved promise does NOT mean
+      // the package moved -- and rfqSummary is what says which happened.
+      ctx.host.setStatus(rfqSummary(sent));
+      row.replaceWith(rfqButton({ ...pkg, ...{ state: sent.package_state ?? "rfq_sent" } } as
+        SavedPackage & { state: string }));
+    };
+    row.appendChild(btn);
+    return row;
   };
   // BUYOUT-SCHED — what must be ORDERED when, which is a different question from what to package.
   // Joins the model's priced quantities to their installing schedule activity and subtracts the

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -245,6 +245,15 @@ export async function renderBudget(ctx: PanelContext) {
     return wrap;
   };
 
+  /**
+   * One package's send-RFQ control, which REDRAWS ITSELF with the state the send reported.
+   *
+   * That is the whole reason it is a function rather than inline: after a send it replaces its own
+   * row by calling itself with the returned `package_state`, so the second pass hits `rfqGate` with
+   * the real state and refuses. Without the redraw the button would stay live and a second click
+   * would mint a duplicate solicitation — the server transitions only a `draft` package but mints
+   * unconditionally.
+   */
   const rfqButton = (pkg: SavedPackage) => {
     const row = document.createElement("div"); row.style.marginTop = "4px";
     // A freshly-kept package is in `draft`; the gate still asks, because this same function redraws

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -212,8 +212,14 @@ export async function renderBudget(ctx: PanelContext) {
     btn.textContent = "💾 Keep these packages";
     btn.title = "Store each group as a Buyout Packages record the project can track";
     btn.onclick = async () => {
-      if (!(await confirmModal("Keep buyout packages", saveConfirm(pkgs, groupedBy), "Keep"))) return;
+      // Disabled BEFORE the await, not after the confirmation. The modal's backdrop stops a mouse
+      // reaching this button, but focus only moves into the dialog on the next macrotask, so a held
+      // Enter can fire this handler twice and open two dialogs -- and neither endpoint is
+      // idempotent: save creates records on every request. Restored on cancel, and on failure below.
       btn.disabled = true;
+      if (!(await confirmModal("Keep buyout packages", saveConfirm(pkgs, groupedBy), "Keep"))) {
+        btn.disabled = false; return;
+      }
       let saved;
       try {
         saved = await ctx.host.api.saveBuyoutPackages(pid, lines, groupedBy);
@@ -266,8 +272,8 @@ export async function renderBudget(ctx: PanelContext) {
     const btn = document.createElement("button"); btn.className = "tool-btn";
     btn.textContent = `📨 Send RFQ — ${pkg.ref}`;
     btn.onclick = async () => {
-      if (!(await confirmModal("Send RFQ", rfqConfirm(pkg), "Send"))) return;
-      btn.disabled = true;
+      btn.disabled = true;                 // same reason as the keep button above
+      if (!(await confirmModal("Send RFQ", rfqConfirm(pkg), "Send"))) { btn.disabled = false; return; }
       let sent;
       try {
         sent = await ctx.host.api.sendPackageRfq(pid, String(pkg.id));
@@ -280,7 +286,10 @@ export async function renderBudget(ctx: PanelContext) {
       // unconditionally and transitions only a draft package, so a resolved promise does NOT mean
       // the package moved -- and rfqSummary is what says which happened.
       ctx.host.setStatus(rfqSummary(sent));
-      row.replaceWith(rfqButton({ ...pkg, ...{ state: sent.package_state ?? "rfq_sent" } } as
+      // NOT `?? "rfq_sent"`. When the server reports no state, rfqSummary above has just told the
+      // reader the package did NOT move -- redrawing it as sent would contradict that in the same
+      // breath. `unknown` is carried through instead, and rfqGate refuses on it with its own reason.
+      row.replaceWith(rfqButton({ ...pkg, ...{ state: sent.package_state || "unknown" } } as
         SavedPackage & { state: string }));
     };
     row.appendChild(btn);

--- a/apps/web/src/portal/panels/buyoutKeep.test.ts
+++ b/apps/web/src/portal/panels/buyoutKeep.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  saveGate, saveConfirm, saveSummary, rfqGate, rfqConfirm, rfqSummary,
+  type GroupedPackage, type SavedPackage,
+} from "./buyoutKeep";
+
+const GROUPED: GroupedPackage[] = [
+  { package: "Concrete", line_count: 12, est_cost: 480_000 },
+  { package: "Steel", line_count: 7, est_cost: 1_250_500 },
+];
+
+const SAVED: SavedPackage[] = [
+  { id: 41, ref: "PKG-0001", name: "Concrete", est_cost: 480_000, line_count: 12 },
+  { id: 42, ref: "PKG-0002", name: "Steel", est_cost: 1_250_500, line_count: 7 },
+];
+
+describe("keeping nothing is refused, not reported as a save", () => {
+  it("refuses an empty grouping with the reason", () => {
+    const g = saveGate(0);
+    expect(g.can).toBe(false);
+    expect(g.why).toContain("no packages to keep");
+  });
+
+  it("offers the save when there is something to keep", () => {
+    expect(saveGate(2)).toEqual({ can: true, why: "" });
+  });
+});
+
+describe("the confirmation names the blast radius, not the mechanics", () => {
+  it("says these become project-wide records, not a browser draft", () => {
+    const c = saveConfirm(GROUPED, "trade");
+    expect(c).toContain("RECORD");
+    expect(c).toContain("whole project");
+    expect(c).toContain("not a draft in");
+  });
+
+  it("states the count and the money so a mis-grouping is caught before twelve records exist", () => {
+    const c = saveConfirm(GROUPED, "trade");
+    expect(c).toContain("2 buyout packages");
+    expect(c).toContain("$1,730,500");
+    expect(c).toContain("trade");
+  });
+
+  it("warns that keeping again ADDS a set rather than replacing one", () => {
+    expect(saveConfirm(GROUPED, "trade")).toContain("SECOND set");
+  });
+
+  it("counts one package in the singular", () => {
+    const c = saveConfirm([GROUPED[0]!], "trade");
+    expect(c).toContain("1 buyout package");
+    expect(c).not.toContain("1 buyout packages");
+  });
+});
+
+describe("the save summary reports what was created", () => {
+  it("names the refs, because a ref is what somebody quotes later", () => {
+    const s = saveSummary(SAVED);
+    expect(s).toContain("PKG-0001");
+    expect(s).toContain("PKG-0002");
+    expect(s).toContain("Kept 2 buyout packages");
+  });
+
+  it("reports an empty write as nothing kept — the server answers 200 for it", () => {
+    const s = saveSummary([]);
+    expect(s).toContain("Nothing was kept");
+    expect(s).not.toContain("Kept");
+  });
+
+  it("flags a count that differs from the one the confirmation named", () => {
+    const s = saveSummary(SAVED, 3);
+    expect(s).toContain("3 packages were offered and 2 were created");
+    expect(s).toContain("re-grouped at write time");
+  });
+
+  it("says nothing extra when the count matches", () => {
+    expect(saveSummary(SAVED, 2)).not.toContain("NOTE");
+  });
+
+  it("truncates a long list rather than printing forty refs", () => {
+    const many = Array.from({ length: 9 }, (_, i) => ({
+      ...SAVED[0]!, id: i, ref: `PKG-000${i}`,
+    }));
+    expect(saveSummary(many)).toContain("+5 more");
+  });
+});
+
+describe("an RFQ cannot be sent for a package that was never kept", () => {
+  it("refuses when the record has no id — the route is keyed on it and would 404", () => {
+    const g = rfqGate({ id: null, state: "draft" });
+    expect(g.can).toBe(false);
+    expect(g.why).toContain("not been kept");
+  });
+
+  it("refuses an empty-string id the same way", () => {
+    expect(rfqGate({ id: "", state: "draft" }).can).toBe(false);
+  });
+
+  it("allows it for a kept package still in draft", () => {
+    expect(rfqGate({ id: 41, state: "draft" })).toEqual({ can: true, why: "" });
+  });
+
+  it("treats a missing state as draft rather than blocking a fresh record", () => {
+    expect(rfqGate({ id: 41 }).can).toBe(true);
+  });
+});
+
+describe("the double-send trap", () => {
+  // THE load-bearing rule. The server mints the solicitation UNCONDITIONALLY and transitions only a
+  // draft package. So a second send produces a second ITB and no state change, and a client that
+  // reports success from a resolved promise hides a duplicate solicitation nobody asked for.
+  it("refuses a package whose RFQ has already gone out, and says which state it is in", () => {
+    const g = rfqGate({ id: 41, state: "rfq_sent" });
+    expect(g.can).toBe(false);
+    expect(g.why).toContain("rfq sent");
+  });
+
+  it("refuses an awarded package too — every state past draft", () => {
+    expect(rfqGate({ id: 41, state: "awarded" }).can).toBe(false);
+  });
+
+  it("reports a successful send as the move it made", () => {
+    const s = rfqSummary({ solicitation: { id: 7, ref: "ITB-0007" }, package: "PKG-0001",
+                           package_state: "rfq_sent" });
+    expect(s).toContain("ITB-0007");
+    expect(s).toContain("moved to RFQ sent");
+    expect(s).not.toContain("did NOT");
+  });
+
+  it("reports a send that did NOT move the package as the half-success it is", () => {
+    const s = rfqSummary({ solicitation: { id: 8, ref: "ITB-0008" }, package: "PKG-0001",
+                           package_state: "quotes_in" });
+    expect(s).toContain("did NOT move");
+    expect(s).toContain("quotes in");
+    expect(s).toContain("minted anyway");
+  });
+
+  it("handles an unreported state without claiming the move happened", () => {
+    const s = rfqSummary({ solicitation: { id: 9, ref: "ITB-0009" }, package: "PKG-0001",
+                           package_state: null });
+    expect(s).toContain("did NOT move");
+    expect(s).not.toContain("moved to RFQ sent.");
+  });
+});
+
+describe("the RFQ confirmation names BOTH writes", () => {
+  it("says a solicitation is minted and the package moves", () => {
+    const c = rfqConfirm(SAVED[0]!);
+    expect(c).toContain("Bid Solicitation");
+    expect(c).toContain("draft to RFQ sent");
+    expect(c).toContain("PKG-0001");
+  });
+
+  it("carries the due date when one was given", () => {
+    expect(rfqConfirm(SAVED[0]!, "2026-10-01")).toContain("due 2026-10-01");
+  });
+});

--- a/apps/web/src/portal/panels/buyoutKeep.test.ts
+++ b/apps/web/src/portal/panels/buyoutKeep.test.ts
@@ -118,6 +118,17 @@ describe("the double-send trap", () => {
     expect(rfqGate({ id: 41, state: "awarded" }).can).toBe(false);
   });
 
+  it("refuses an UNKNOWN state with its own reason, not 'already sent'", () => {
+    // Found in review on PR #528. The panel carries `unknown` through when the server answered
+    // without a state; saying "its RFQ has gone out" would assert the one thing that response
+    // failed to establish.
+    const g = rfqGate({ id: 41, state: "unknown" });
+    expect(g.can).toBe(false);
+    expect(g.why).toContain("did not report");
+    expect(g.why).toContain("reload");
+    expect(g.why).not.toContain("gone out");
+  });
+
   it("reports a successful send as the move it made", () => {
     const s = rfqSummary({ solicitation: { id: 7, ref: "ITB-0007" }, package: "PKG-0001",
                            package_state: "rfq_sent" });

--- a/apps/web/src/portal/panels/buyoutKeep.ts
+++ b/apps/web/src/portal/panels/buyoutKeep.ts
@@ -1,0 +1,142 @@
+/** BUYOUT-KEEP — the wording for turning a computed grouping into records somebody can work.
+ *
+ *  Pure, so the rules can be tested without a DOM.
+ *
+ *  The buyout screen has always been able to GROUP the model's priced quantities into packages and
+ *  render them — `POST …/procurement/buyout-packages` is wired and has been since PROCURE-LEVEL.
+ *  **Keeping them was not.** `…/packages/save`, which persists each group as a `procurement_package`
+ *  in `draft`, and `…/packages/{rid}/send-rfq`, which mints the Bid Solicitation and advances the
+ *  workflow, both had no client caller — so a user could produce a buyout plan and had no way to act
+ *  on it, and the whole draft → rfq_sent → quotes_in → awarded workflow was unreachable from the
+ *  screen that produces its input. Same transient-to-record shape as the prefab freeze, on money.
+ */
+
+/** One package as the grouping returns it, before anything is stored. */
+export interface GroupedPackage {
+  package: string;
+  line_count: number;
+  est_cost: number;
+}
+
+/** One package as the SAVE returns it — now a record, with a ref somebody can quote. */
+export interface SavedPackage {
+  id: string | number;
+  ref: string;
+  name: string;
+  est_cost: number | null;
+  line_count: number;
+}
+
+/** What `sendPackageRfq` answered. `package_state` is the half that can disappoint. */
+export interface RfqResult {
+  solicitation: { id: string | number; ref: string };
+  package: string;
+  package_state: string | null;
+}
+
+/**
+ * Whether the grouping is worth keeping, and the reason when it is not.
+ *
+ * Saving nothing would create nothing and report a cheerful count of zero, which reads as success.
+ */
+export function saveGate(packageCount: number): { can: boolean; why: string } {
+  if (packageCount <= 0) {
+    return { can: false,
+             why: "there are no packages to keep — group the quantities first" };
+  }
+  return { can: true, why: "" };
+}
+
+/**
+ * The confirmation before writing.
+ *
+ * Names the blast radius rather than the mechanics: these become records the whole project can see
+ * and work, not a private draft in this browser, and the count is stated so a mis-grouping is
+ * caught before it becomes twelve records somebody has to delete one at a time.
+ */
+export function saveConfirm(pkgs: GroupedPackage[], groupedBy: string): string {
+  const n = pkgs.length;
+  const total = pkgs.reduce((sum, p) => sum + (p.est_cost || 0), 0);
+  return `Keep ${n} buyout package${n === 1 ? "" : "s"} (grouped by ${groupedBy}, `
+    + `about ${fmtUsd(total)} estimated)?\n\n`
+    + "Each one becomes a Buyout Packages RECORD in draft — visible to the whole project, trackable "
+    + "through draft → RFQ sent → quotes in → awarded, and quotable by ref. This is not a draft in "
+    + "your browser. Re-grouping and keeping again creates a SECOND set; it does not replace this one.";
+}
+
+/**
+ * What the save actually created.
+ *
+ * A zero-length `created` is reported as the nothing it is: the server answers 200 with an empty
+ * list when the grouping produced no packages, and a client that trusts the resolved promise would
+ * print "saved" over an empty write.
+ */
+export function saveSummary(created: SavedPackage[], expected?: number): string {
+  if (!created.length) {
+    return "Nothing was kept — the grouping produced no packages, so no record was created.";
+  }
+  const n = created.length;
+  const refs = created.slice(0, 4).map((p) => p.ref).join(", ");
+  const more = n > 4 ? ` +${n - 4} more` : "";
+  const head = `Kept ${n} buyout package${n === 1 ? "" : "s"}: ${refs}${more}.`;
+  // The count the CONFIRMATION named, versus what came back. The server re-groups at write time
+  // from the lines it is sent, so these can differ; saying so beats reporting a clean success for a
+  // set the reader never agreed to.
+  return expected != null && expected !== n
+    ? `${head} NOTE: ${expected} package${expected === 1 ? " was" : "s were"} offered and ${n} `
+      + `${n === 1 ? "was" : "were"} created — the server re-grouped at write time.`
+    : head;
+}
+
+/**
+ * Whether an RFQ can be sent for this package, and why not when it cannot.
+ *
+ * Two distinct refusals. A package with no record id was never stored — the route is keyed on the
+ * record id and would 404 indistinguishably from a refusal on the merits. A package past `draft`
+ * has already had its RFQ sent, and sending again is the double-send trap below.
+ */
+export function rfqGate(pkg: { id?: string | number | null; state?: string | null }):
+    { can: boolean; why: string } {
+  if (pkg.id == null || pkg.id === "") {
+    return { can: false, why: "this package has not been kept yet, so there is nothing to send" };
+  }
+  const state = (pkg.state || "draft").toLowerCase();
+  if (state !== "draft") {
+    return { can: false,
+             why: `this package is already ${state.replace(/_/g, " ")} — its RFQ has gone out` };
+  }
+  return { can: true, why: "" };
+}
+
+/** The confirmation before minting a solicitation. Names both writes, because there are two. */
+export function rfqConfirm(pkg: SavedPackage, due?: string): string {
+  return `Send an RFQ for ${pkg.ref} (${pkg.name})?\n\n`
+    + "This mints a Bid Solicitation record carrying the package's name, trade and due date, and "
+    + `moves the package from draft to RFQ sent${due ? `, due ${due}` : ""}. Both are records the `
+    + "project can see.";
+}
+
+/**
+ * What the send actually did — and this is the load-bearing rule of this file.
+ *
+ * **The server mints the solicitation unconditionally and transitions only a `draft` package.** So a
+ * second send produces a second ITB and leaves the state exactly where it was, and a client that
+ * says "RFQ sent" because the promise resolved would report a clean success for a duplicate
+ * solicitation nobody asked for. When the state did not reach `rfq_sent`, say so and say what the
+ * state actually is.
+ */
+export function rfqSummary(r: RfqResult): string {
+  const ref = r.solicitation?.ref || "(unnamed)";
+  const state = (r.package_state || "").toLowerCase();
+  if (state === "rfq_sent") {
+    return `RFQ ${ref} created and ${r.package} moved to RFQ sent.`;
+  }
+  return `RFQ ${ref} was created, but ${r.package} did NOT move to RFQ sent — it is `
+    + `${state ? state.replace(/_/g, " ") : "in an unreported state"}. A solicitation has been `
+    + "minted anyway, so check whether this package already had one before sending another.";
+}
+
+/** Money, in whole dollars — the estimating figures here are never cent-precise. */
+function fmtUsd(n: number): string {
+  return `$${Math.round(n).toLocaleString("en-US")}`;
+}

--- a/apps/web/src/portal/panels/buyoutKeep.ts
+++ b/apps/web/src/portal/panels/buyoutKeep.ts
@@ -101,6 +101,14 @@ export function rfqGate(pkg: { id?: string | number | null; state?: string | nul
     return { can: false, why: "this package has not been kept yet, so there is nothing to send" };
   }
   const state = (pkg.state || "draft").toLowerCase();
+  // An explicit `unknown` is NOT "already sent": the server answered without a state, so what the
+  // package is now is exactly what nobody knows. Saying "its RFQ has gone out" would assert the one
+  // thing the response failed to establish, so it gets its own refusal pointing at a reload.
+  if (state === "unknown") {
+    return { can: false,
+             why: "the server did not report this package's state after the last send — reload the "
+                  + "register before sending again" };
+  }
   if (state !== "draft") {
     return { can: false,
              why: `this package is already ${state.replace(/_/g, " ")} — its RFQ has gone out` };

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1752,6 +1752,38 @@ instances:
   claim about what an underwriting asserts, not a unit conversion, and it waits on the same domain
   call `/schedule/eot` does.
 
+- ✅ ⭐ **BUYOUT-KEEP — the buyout plan you could compute and could not keep**
+  *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts` and
+  `apps/web/src/portal/panels/buyoutKeep.test.ts`)*
+
+  Budget → **📦 Buyout packages** has grouped the model's priced quantities into packages with RFQ
+  scopes since PROCURE-LEVEL, and `POST …/procurement/buyout-packages` has a caller. **Keeping them
+  did not.** `…/packages/save`, which persists each group as a `procurement_package` in `draft`, and
+  `…/packages/{rid}/send-rfq`, which mints the Bid Solicitation and advances the workflow, both had
+  no client caller — so a user could produce a buyout plan and had no way to act on it, and the whole
+  draft → rfq_sent → quotes_in → awarded workflow was unreachable from the screen that produces its
+  input. Same transient-to-record shape as the prefab freeze, on money.
+
+  **The two were dark for different reasons, and the second one is the finding.** `send-rfq` was
+  frozen in `services/api/test_route_reachability.py` and could have been read any day; `save` has a
+  four-character leaf and the gate never assessed it at all. But wiring `send-rfq` alone was never
+  possible: **it is keyed on a stored package's record id, and `save` is the only thing that creates
+  one.** *A dark route can be dark because the route that feeds it is* — so a frozen entry is not
+  always a unit of work, and reading one without its neighbours can make a feature look
+  one-button-away when the button has nothing to act on.
+
+  `apps/web/src/portal/panels/buyoutKeep.ts` holds the rules — 22 tests, five mutations all biting.
+  **The load-bearing one is the double-send trap.** The server mints the solicitation
+  *unconditionally* and transitions only a `draft` package, so a second send produces a second ITB
+  and no state change. A client that reported success from a resolved promise would hide a duplicate
+  solicitation nobody asked for, so `rfqSummary` reads `package_state` and says plainly when the
+  package did **not** move, and `rfqGate` refuses a package already past draft. An empty save is
+  reported as nothing kept rather than a cheerful zero, and the summary flags a created count that
+  differs from the one the confirmation named, because the server re-groups at write time.
+
+  Uncalled routes **61 → 60**, and the never-assessed dark set **9 → 8** — two different counters,
+  because the two routes sat one on each side of `MIN_SEGMENT`.
+
 - ✅ ⭐ **JURISDICTION-PACKS — a regulator's data requirements, and no way to reach any of them**
   *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts` and
   `apps/web/src/portal/panels/jurisdictionPacks.test.ts`)*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1752,6 +1752,33 @@ instances:
   claim about what an underwriting asserts, not a unit conversion, and it waits on the same domain
   call `/schedule/eot` does.
 
+- 🟡 **RFQ-IDEMPOTENT — `send_rfq` mints before it checks, so a second send duplicates**
+  *(S — Lane G; **OPEN**, raised in review on PR #528 2026-09-11; needs a contract decision)*
+
+  `services/api/src/aec_api/routers/procurement.py`'s `send_rfq` calls `me.create_record` — which
+  commits by default — and only *then* looks at `workflow_state`. A second request therefore persists
+  **another** `bid_solicitation` while skipping the package transition, and even the first request
+  commits the solicitation separately from the transition, so a failure between them leaves an ITB
+  with no state change behind it. BUYOUT-KEEP's client refuses the second send (`rfqGate`) and reports
+  a non-move honestly (`rfqSummary`), but **that is UI feedback, not enforcement**: a second tab, a
+  retry, or a direct API call still duplicates.
+
+  **Not fixed in #528 because the fix requires deciding what a second send MEANS**, and that is a
+  product call rather than a cleanup:
+
+  * **409 Conflict** — a package past `draft` cannot be re-solicited. Simplest, and wrong if a second
+    bid round is a real workflow.
+  * **Idempotent no-op** — return the existing solicitation. Safe, but silently ignores an operator
+    who meant to re-solicit.
+  * **Deliberate re-solicitation** — mint a new ITB *on purpose*, with its own round number, and say
+    so. This is what the current behaviour accidentally approximates.
+
+  The mechanical part is the same under all three: one transaction, a conditional `draft → rfq_sent`
+  update, create the solicitation only when that update changes exactly one row. *The transaction is
+  the easy half; what to do when it changes zero rows is the decision.* Same shape as
+  PREFAB-FREEZE-RACE, and filed the same way rather than left in a review thread — **a follow-up held
+  only in a thread closes by default when the PR merges.**
+
 - ✅ ⭐ **BUYOUT-KEEP — the buyout plan you could compute and could not keep**
   *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts` and
   `apps/web/src/portal/panels/buyoutKeep.test.ts`)*
@@ -3011,7 +3038,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* *(**UX-3 left this cell 2026-09-06: all five of its items now ship** — see its entry. The cell had pointed at `apps/web/src/viewer/tools/authoringSection.ts`, which is a real file and the WRONG one: every one of the five landed under `apps/web/src/viewer/draft/`. Lanes are assigned by directory, so a pointer that resolves is not the same as a pointer that is right — a tracked-path gate cannot catch this, and did not)* |
 | **F · Docs & demo** | `README.md`, `docs/`, `apps/web/src/demo/` | keep the shipped surface honest (below) — no coded items. **`demoData.test.ts` now gates the shell's startup endpoints**; re-run `build_demo_data.py` and that test after adding one |
-| **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | no standalone items: **every lane routes its own work**, which is why this is a lane rather than a shared file |
+| **G · API surface** | `services/api/src/aec_api/routers/`, `main.py` | RFQ-IDEMPOTENT *(the first standalone item this lane has carried, and it earns one: the fix is entirely inside a router's transaction boundary — mint-after-check in one transaction — and belongs to no feature lane. **The sentence below was true until 2026-09-11 and is kept because it still explains the lane's shape**: every lane normally routes its own work, which is why this is a lane rather than a shared file)* |
 | **H · Registers** | `services/api/modules/*/module.json` | — |
 | **I · API client** | `apps/web/src/api/` | RESPONSE-UNDECLARED *(**CLOSED 2026-09-11** — all 15 gaps declared and rendered, `KNOWN_GAPS` is empty and asserted empty. The finding came from `services/api/src/aec_api/routers/`, which is Lane G's, but the WORK is declaring the field on the client interface so something can read it — lanes go by the directory the work touches, the correction Lane E's cell already had to make. Rendering the newly-declared field afterwards is Lane B's)* · SCALE-SEAM *(the only open slice; ②–⓾ plus (81)–(91) have shipped. **Deliberately carries NO mark**: ⓾ is the last glyph in `MARKS` and the double-circled range it closes has no successor, so the next slice cannot be numbered at all — writing a mark the parser does not know would drop the item out of this table's own population.)* *(this cell said (81)–(87) until 2026-09-04, four slices after (88) landed — the same drift its own history below records, in the same cell, for the third time. It named ⓽ until 2026-09-03; ②–⓼ had shipped. This cell named ⑬–⑳ until 2026-08-24 — eight slices whose extractions had already landed — because the item regex could not see `㉒` at all, so nothing required this row to be right)* |
 | **J · Build & tooling** | `apps/web/scripts/`, `apps/web/vite.config.ts`, `apps/web/src/style.css`, `apps/web/src/tooling/`, `services/api/test_file_sizes.py`, `services/api/run_tests.py` | R39-TSC-CACHE *(local typecheck once diverged from CI; cause unknown, prior explanation retracted — an OBSERVATION, not a defect with a known fix. Read the entry before "fixing" it: the proposed fix is named there and rejected)*  · DESKTOP-CONVERT-TIMEOUT *(the Python converter runs in-process and cannot be interrupted, so `edit_preview`'s 120 s deadline is unenforceable on the desktop path. Filed here rather than Lane C because the fix is process/packaging shape — killable child under PyInstaller, where spawn re-execs the frozen app — the same derived-here-fixed-there split as DESKTOP-SMOKE above)* |

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -239,7 +239,11 @@ KNOWN_UNCALLED: set[str] = {
     # `/drawings/schedule.csv`, `/opendata/permits.geojson`, `/modules/{key}/log.pdf`,
     # `/view-templates/{tid}/graphics` left here in v0.3.1138.
     "/projects/{pid}/modules/backfill-references",
-    "/projects/{pid}/procurement/packages/{rid}/send-rfq",
+    # `/procurement/packages/{rid}/send-rfq` left here in v0.3.1144 — BUYOUT-KEEP. It could not be
+    # wired before, and not for a UI reason: the route is keyed on a STORED package's record id, and
+    # `/procurement/packages/save` -- the only thing that creates one -- had no caller either. A
+    # send-RFQ button on a transient grouping would have had nothing to send for. *A dark route can
+    # be dark because the route that feeds it is.*
     # `/project-package.pdf` left here in v0.3.1137 — Exports opens `projectPackagePdfUrl`.
     "/projects/{pid}/provenance/admissibility",
     "/projects/{pid}/recipes/replay-plan",


### PR DESCRIPTION
# What & why

**Budget → 📦 Buyout packages** has grouped the model's priced quantities into packages with RFQ scopes since PROCURE-LEVEL, and that grouping route has a caller. **Keeping them did not.**

| route | state before |
|---|---|
| `POST …/procurement/buyout-packages` | wired — computes the grouping, renders the table |
| `POST …/procurement/packages/save` | **dark** — persists each group as a `procurement_package` in `draft` |
| `POST …/procurement/packages/{rid}/send-rfq` | **dark** — mints the Bid Solicitation, advances draft → rfq_sent |

So a user could produce a buyout plan and had no way to act on it, and the entire draft → rfq_sent → quotes_in → awarded workflow was unreachable from the screen that produces its input. Same transient-to-record shape as the prefab freeze, on money this time.

## The two were dark for different reasons, and the second one is the finding

`send-rfq` was **frozen** in `services/api/test_route_reachability.py` and could have been read any day since. `save` has a four-character leaf, so `MIN_SEGMENT` meant the gate never assessed it at all.

But wiring `send-rfq` alone was never possible: **it is keyed on a stored package's record id, and `save` is the only thing that creates one.** A send-RFQ button on a transient grouping would have had nothing to send for.

***A dark route can be dark because the route that feeds it is.*** A frozen entry is therefore not always a unit of work, and reading one without its neighbours can make a feature look one-button-away when the button has nothing to act on.

## The double-send trap

`apps/web/src/portal/panels/buyoutKeep.ts` — 22 tests, **five mutations all biting**.

The server **mints the solicitation unconditionally** and transitions only a package still in `draft`. A second send therefore produces a second ITB and leaves the state where it was. A client reporting success from a resolved promise would hide a duplicate solicitation nobody asked for — so `rfqSummary` reads `package_state` and says plainly when the package did **not** move, naming the state it is actually in, and `rfqGate` refuses a package already past draft.

Two more refusals are reported rather than hidden: an empty save is "nothing was kept", not a cheerful zero (the server answers 200 for it), and the summary flags a created count that differs from the one the confirmation named, because the server re-groups at write time.

One mutation deserves a note: my **first** attempt at the fifth only changed a label word and survived, which proved nothing. Re-done against the actual branch, it fails. *A mutation that edits a string is not a mutation of the rule.*

## Counts

Uncalled routes **61 → 60**, and the never-assessed dark set **9 → 8** — two different counters, because the two routes sat one on each side of `MIN_SEGMENT`. Both measured with the gate's own `leaf_is_called`, never a re-implementation.

## Noticed and deliberately not fixed here

The import added to `budget.ts` is **single-line on purpose**. A multi-line import makes DOC-STRAND's `isFileHeader` stop recognising that file's header — it only skips lines starting with `import `, so a continuation line ends the scan — which reds the build on correct code and breaks the gate's own `headers.length === 1` control. That file's other imports are single-line anyway, so this was the consistent choice; the gate limitation is queued as a separate task rather than widened here.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` → "All checks passed!"
- [x] Backend: `test_route_reachability.py` (rot check fired correctly and was resolved by unfreezing), `test_claude_md_gates.py`, `test_changelog_current.py` green; full suite running, result reported on the PR
- [x] Web: `npm run typecheck && npm run lint && npm run build` clean; `npx vitest run` → 245 files / 2562 tests passing
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added; `docs/roadmap.md` gains the BUYOUT-KEEP entry
- [x] No version bump (not a release PR)
- [x] No secrets; no competitor names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Budget buyout packages can be saved as project-wide draft records.
  * Saved packages can be quoted by reference and sent as RFQs.
  * RFQs carry the package name, trade, and due date.
  * Confirmation dialogs explain the records and solicitations that will be created.
  * Re-grouping and saving adds another package set without replacing existing records.
* **Bug Fixes**
  * Clear feedback is shown when no packages are saved.
  * RFQ results distinguish successful state changes from solicitations created without moving the package.
  * Duplicate actions are prevented while requests are processing, with accurate package-state feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->