### PR TITLE
A wind answer at the only stage that can act on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Pedestrian wind comfort, screened from the massing
+
+**📐 Design Metrics** now carries a **pedestrian wind comfort** screen. Give it a height, width and
+depth — or leave them blank and they come off the model's bounding box — plus the site's mean
+pedestrian-level wind, and it grades corner acceleration, downwash and channelling against the
+**Lawson comfort categories**, lists the zone speeds, and names the standard mitigations: corner
+chamfers, a podium, an entrance canopy, porous screens in a passage.
+
+It runs offline and in a second, which is the point: massing decides most pedestrian wind outcomes,
+and a wind-tunnel study arrives long after the massing is fixed. **It is a screening heuristic, not
+CFD and not a wind study**, and it says so on every result.
+
+Three things it will not do. It will not call a result acceptable when a check did not run —
+channelling is only looked at if you give it the gap to the neighbouring building, and without that
+the screen says plainly that it is partial. It will not let the default site wind pass as a
+measurement, because every speed on the screen scales directly with it. And when the dimensions came
+off the model it says so, since a bounding box spans the site and context geometry as well as the
+building.
+
 ### Buyout packages can be kept, and their RFQs sent
 
 **Budget → Buyout packages** has always grouped the model's priced quantities into packages, each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ pedestrian-level wind, and it grades corner acceleration, downwash and channelli
 **Lawson comfort categories**, lists the zone speeds, and names the standard mitigations: corner
 chamfers, a podium, an entrance canopy, porous screens in a passage.
 
-It runs offline and in a second, which is the point: massing decides most pedestrian wind outcomes,
-and a wind-tunnel study arrives long after the massing is fixed. **It is a screening heuristic, not
-CFD and not a wind study**, and it says so on every result.
+It answers in a second, which is the point: massing decides most pedestrian wind outcomes, and a
+wind-tunnel study arrives long after the massing is fixed. **It is a screening heuristic, not CFD
+and not a wind study** — no external service, no simulation licence, no weeks of turnaround — and it
+says so on every result.
 
 Three things it will not do. It will not call a result acceptable when a check did not run —
 channelling is only looked at if you give it the gap to the neighbouring building, and without that

--- a/apps/web/src/api/designPerformance.ts
+++ b/apps/web/src/api/designPerformance.ts
@@ -23,6 +23,29 @@ import type { EnergyResult } from "./types";
 
 import { HttpCore } from "./httpCore";
 
+/** One graded zone as the screen returns it. */
+export interface WindZone {
+  zone: string;
+  factor: number;
+  speed_ms: number;
+  lawson: string;
+  comfort: string;
+}
+
+/** The screen's full answer. `inputs` echoes what was actually used — including derived dimensions. */
+export interface WindResult {
+  inputs: {
+    height_m: number; width_m: number; depth_m: number; wind_ms: number;
+    gap_m: number | null; podium_height_m: number;
+  };
+  zones: WindZone[];
+  worst: { zone: string; lawson: string; speed_ms: number };
+  acceptable_for_entrances: boolean;
+  mitigations: string[];
+  disclaimer: string;
+}
+
+
 type Ctor<T> = new (...args: any[]) => T;
 
 export function withDesignPerformance<TBase extends Ctor<HttpCore>>(Base: TBase) {
@@ -58,6 +81,16 @@ export function withDesignPerformance<TBase extends Ctor<HttpCore>>(Base: TBase)
                    passing: number; failing: number };
       leed_inventory: { total_tco2e: number; items: { category: string; kgco2e: number; share_pct: number }[] };
     }>(`/projects/${pid}/carbon/compliance`);
+  }
+
+  /** ENV-1 — the pedestrian wind-comfort screen. Omit the dims and the mass comes off the model's
+   *  bounding box; 409 when there is neither a full set of dims nor a source model. NOT CFD. */
+  envWindScreen(pid: string, body: { height_m?: number | null; width_m?: number | null;
+                                     depth_m?: number | null; wind_ms?: number | null;
+                                     gap_m?: number | null; podium_height_m?: number | null }) {
+    return this.json<WindResult>(`/projects/${pid}/env/wind`, {
+      method: "POST", body: JSON.stringify(body),
+    });
   }
 
   projectCarbon(pid: string) {

--- a/apps/web/src/portal/panels/designMetrics.ts
+++ b/apps/web/src/portal/panels/designMetrics.ts
@@ -22,8 +22,15 @@ export async function renderDesignMetrics(ctx: PanelContext) {
     `<div style="min-width:104px"><div style="font-size:20px;font-weight:800;font-variant-numeric:tabular-nums">${esc(value)}</div>`
     + `<div class="meta" style="margin:0">${esc(label)}${sub ? ` <span style="opacity:.7">${esc(sub)}</span>` : ""}</div></div>`;
 
+  // The wind screen lives outside the metrics try/catch on purpose: it can run on typed dimensions
+  // with no model at all, so a 409 on the metrics must not take it down with them.
+  const windHost = document.createElement("div");
+  ctx.root.appendChild(windHost);
+  let hasModel = false;
+
   try {
     const r = await ctx.host.api.modelDesignMetrics(pid);
+    hasModel = true;
     body.replaceChildren();
 
     const head = document.createElement("div"); head.className = "dash-card"; head.style.marginBottom = "10px";
@@ -75,4 +82,81 @@ export async function renderDesignMetrics(ctx: PanelContext) {
       ? `<div class="meta">Design metrics need a source IFC. Convert or upload a model, then reopen this panel.</div>`
       : `<div class="meta">Design metrics unavailable: ${esc(msg)}</div>`;
   }
+
+  await renderWindScreen(ctx, windHost, pid, hasModel);
+}
+
+/**
+ * ENV-WIND — the pedestrian wind-comfort screen, drawn under the metrics it shares a stage with.
+ *
+ * A form, because the screen's three most misreadable inputs are all optional: the dimensions (blank
+ * ⇒ taken off the model's bounding box), the site wind (blank ⇒ a default that scales every number),
+ * and the gap to a neighbouring mass (blank ⇒ channelling is never checked at all). `envWind.ts`
+ * holds the wording for all three; this function only draws it.
+ */
+async function renderWindScreen(ctx: PanelContext, host: HTMLElement, pid: string, hasModel: boolean) {
+  const W = await import("./envWind");
+  const card = document.createElement("div"); card.className = "dash-card";
+  const num = (id: string, label: string, ph: string) =>
+    `<label style="display:flex;flex-direction:column;gap:2px;font-size:11px;color:var(--muted)">${esc(label)}`
+    + `<input class="portal-filter" data-w="${id}" type="number" min="0" step="0.1" placeholder="${esc(ph)}" style="width:96px"></label>`;
+  card.innerHTML = `<div class="section-title" style="margin:0 0 8px">Pedestrian wind comfort `
+    + `<span style="opacity:.6;font-weight:500;font-size:11px">(massing screen — not CFD)</span></div>`
+    + `<div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end">`
+    + num("height_m", "Height (m)", hasModel ? "from model" : "required")
+    + num("width_m", "Width (m)", hasModel ? "from model" : "required")
+    + num("depth_m", "Depth (m)", hasModel ? "from model" : "required")
+    + num("wind_ms", "Site wind (m/s)", "default 5")
+    + num("gap_m", "Gap to neighbour (m)", "not checked")
+    + num("podium_height_m", "Podium height (m)", "none")
+    + `<button class="mini-btn" data-w-run type="button">Screen</button></div>`
+    + `<div data-w-out style="margin-top:10px"></div>`;
+  host.appendChild(card);
+
+  const out = card.querySelector<HTMLElement>("[data-w-out]")!;
+  const btn = card.querySelector<HTMLButtonElement>("[data-w-run]")!;
+  const read = (): import("./envWind").WindForm => {
+    const f: Record<string, number | null> = {};
+    card.querySelectorAll<HTMLInputElement>("input[data-w]").forEach((i) => {
+      const v = i.value.trim();
+      f[i.dataset.w!] = v === "" ? null : Number(v);
+    });
+    return f as import("./envWind").WindForm;
+  };
+
+  btn.addEventListener("click", async () => {
+    const form = read();
+    const gate = W.screenGate(form, hasModel);
+    if (!gate.can) { out.innerHTML = `<div class="meta">Cannot screen — ${esc(gate.why)}.</div>`; return; }
+    btn.disabled = true;
+    out.innerHTML = `<div class="meta">Screening…</div>`;
+    try {
+      const r = await ctx.host.api.envWindScreen(pid, form);
+      const gaps = W.unassessed(r);
+      const bad = !r.acceptable_for_entrances || r.worst.lawson === "S";
+      out.innerHTML =
+        `<div style="font-weight:700;color:${bad ? "#b42318" : gaps.length ? "#9a6700" : "#1a7f37"}">`
+        + `${esc(W.verdict(r))}</div>`
+        + gaps.map((g) => `<div class="meta" style="margin-top:6px;color:#9a6700">⚠ ${esc(g)}</div>`).join("")
+        + `<div class="meta" style="margin-top:6px">${esc(W.dimensionBasis(r, form))}</div>`
+        + `<div class="meta" style="margin-top:2px">${esc(W.windBasis(form.wind_ms, r.inputs.wind_ms))}</div>`
+        + `<table class="portal-table" style="margin-top:8px"><thead><tr>`
+        + `<th scope="col">Zone</th><th scope="col" style="text-align:right">Factor</th>`
+        + `<th scope="col" style="text-align:right">Speed (m/s)</th><th scope="col">Lawson</th></tr></thead><tbody>`
+        + r.zones.map((z) => `<tr><td>${esc(z.zone)}</td>`
+          + `<td style="text-align:right;font-variant-numeric:tabular-nums">×${z.factor}</td>`
+          + `<td style="text-align:right;font-variant-numeric:tabular-nums">${z.speed_ms}</td>`
+          + `<td>${esc(W.comfortLabel(z))}</td></tr>`).join("")
+        + `</tbody></table>`
+        + `<div class="section-title" style="margin:10px 0 4px">Mitigations</div>`
+        + `<ul style="margin:0;padding-left:18px;font-size:12px">`
+        + W.mitigationLines(r).map((m) => `<li>${esc(m)}</li>`).join("") + `</ul>`
+        + `<div class="meta" style="margin-top:8px;opacity:.8">${esc(r.disclaimer)}</div>`;
+    } catch (e) {
+      const msg = (e as Error).message || "";
+      out.innerHTML = `<div class="meta">Wind screen unavailable: ${esc(msg)}</div>`;
+    } finally {
+      btn.disabled = false;
+    }
+  });
 }

--- a/apps/web/src/portal/panels/designMetrics.ts
+++ b/apps/web/src/portal/panels/designMetrics.ts
@@ -26,11 +26,14 @@ export async function renderDesignMetrics(ctx: PanelContext) {
   // with no model at all, so a 409 on the metrics must not take it down with them.
   const windHost = document.createElement("div");
   ctx.root.appendChild(windHost);
-  let hasModel = false;
+  // Three states, not a boolean. Only a 409 here is evidence there is no model — it is the same
+  // `open_source_ifc` refusal the wind route makes. Any OTHER failure says nothing about that, and
+  // refusing the wind screen on it would invent a refusal. Found in review on PR #529.
+  let model: import("./envWind").ModelPresence = "unknown";
 
   try {
     const r = await ctx.host.api.modelDesignMetrics(pid);
-    hasModel = true;
+    model = "present";
     body.replaceChildren();
 
     const head = document.createElement("div"); head.className = "dash-card"; head.style.marginBottom = "10px";
@@ -78,12 +81,14 @@ export async function renderDesignMetrics(ctx: PanelContext) {
     }
   } catch (e) {
     const msg = (e as Error).message || "";
-    body.innerHTML = /409/.test(msg)
+    const noModel = /409/.test(msg);
+    if (noModel) model = "absent";
+    body.innerHTML = noModel
       ? `<div class="meta">Design metrics need a source IFC. Convert or upload a model, then reopen this panel.</div>`
       : `<div class="meta">Design metrics unavailable: ${esc(msg)}</div>`;
   }
 
-  await renderWindScreen(ctx, windHost, pid, hasModel);
+  await renderWindScreen(ctx, windHost, pid, model);
 }
 
 /**
@@ -94,7 +99,8 @@ export async function renderDesignMetrics(ctx: PanelContext) {
  * and the gap to a neighbouring mass (blank ⇒ channelling is never checked at all). `envWind.ts`
  * holds the wording for all three; this function only draws it.
  */
-async function renderWindScreen(ctx: PanelContext, host: HTMLElement, pid: string, hasModel: boolean) {
+async function renderWindScreen(ctx: PanelContext, host: HTMLElement, pid: string,
+                                model: import("./envWind").ModelPresence) {
   const W = await import("./envWind");
   const card = document.createElement("div"); card.className = "dash-card";
   const num = (id: string, label: string, ph: string) =>
@@ -103,9 +109,9 @@ async function renderWindScreen(ctx: PanelContext, host: HTMLElement, pid: strin
   card.innerHTML = `<div class="section-title" style="margin:0 0 8px">Pedestrian wind comfort `
     + `<span style="opacity:.6;font-weight:500;font-size:11px">(massing screen — not CFD)</span></div>`
     + `<div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end">`
-    + num("height_m", "Height (m)", hasModel ? "from model" : "required")
-    + num("width_m", "Width (m)", hasModel ? "from model" : "required")
-    + num("depth_m", "Depth (m)", hasModel ? "from model" : "required")
+    + num("height_m", "Height (m)", model === "absent" ? "required" : "from model")
+    + num("width_m", "Width (m)", model === "absent" ? "required" : "from model")
+    + num("depth_m", "Depth (m)", model === "absent" ? "required" : "from model")
     + num("wind_ms", "Site wind (m/s)", "default 5")
     + num("gap_m", "Gap to neighbour (m)", "not checked")
     + num("podium_height_m", "Podium height (m)", "none")
@@ -126,7 +132,7 @@ async function renderWindScreen(ctx: PanelContext, host: HTMLElement, pid: strin
 
   btn.addEventListener("click", async () => {
     const form = read();
-    const gate = W.screenGate(form, hasModel);
+    const gate = W.screenGate(form, model);
     if (!gate.can) { out.innerHTML = `<div class="meta">Cannot screen — ${esc(gate.why)}.</div>`; return; }
     btn.disabled = true;
     out.innerHTML = `<div class="meta">Screening…</div>`;
@@ -153,8 +159,12 @@ async function renderWindScreen(ctx: PanelContext, host: HTMLElement, pid: strin
         + W.mitigationLines(r).map((m) => `<li>${esc(m)}</li>`).join("") + `</ul>`
         + `<div class="meta" style="margin-top:8px;opacity:.8">${esc(r.disclaimer)}</div>`;
     } catch (e) {
+      // A 409 here is the server's own instruction ("pass height_m/width_m/depth_m, or load a
+      // source IFC"), not a failure — show it as the instruction it is.
       const msg = (e as Error).message || "";
-      out.innerHTML = `<div class="meta">Wind screen unavailable: ${esc(msg)}</div>`;
+      out.innerHTML = /409/.test(msg)
+        ? `<div class="meta">Cannot screen — ${esc(msg.replace(/^\s*409[:\s-]*/, ""))}</div>`
+        : `<div class="meta">Wind screen unavailable: ${esc(msg)}</div>`;
     } finally {
       btn.disabled = false;
     }

--- a/apps/web/src/portal/panels/envWind.test.ts
+++ b/apps/web/src/portal/panels/envWind.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import {
+  screenGate, unassessed, verdict, dimensionBasis, windBasis, mitigationLines, comfortLabel,
+} from "./envWind";
+import type { WindResult } from "../../api/designPerformance";
+
+/** A 120 m tower on a 6 m/s site with a gap supplied — every mechanism looked at. */
+const TOWER: WindResult = {
+  inputs: { height_m: 120, width_m: 40, depth_m: 30, wind_ms: 6, gap_m: 20, podium_height_m: 0 },
+  zones: [
+    { zone: "open site (baseline)", factor: 1, speed_ms: 6, lawson: "B", comfort: "standing" },
+    { zone: "corners", factor: 1.6, speed_ms: 9.6, lawson: "D", comfort: "brisk walking" },
+    { zone: "base (downwash)", factor: 1.48, speed_ms: 8.9, lawson: "D", comfort: "brisk walking" },
+    { zone: "passage (20 m gap)", factor: 1.33, speed_ms: 8, lawson: "D", comfort: "brisk walking" },
+  ],
+  worst: { zone: "corners", lawson: "D", speed_ms: 9.6 },
+  acceptable_for_entrances: false,
+  mitigations: ["chamfer/round the windward corners or add corner canopies"],
+  disclaimer: "Approximate massing-stage screen … NOT CFD or a wind-tunnel study.",
+};
+
+/** A low calm building, screened with NO gap — the partial-screen case. */
+const LOW: WindResult = {
+  inputs: { height_m: 9, width_m: 20, depth_m: 15, wind_ms: 3, gap_m: null, podium_height_m: 0 },
+  zones: [
+    { zone: "open site (baseline)", factor: 1, speed_ms: 3, lawson: "A", comfort: "sitting" },
+    { zone: "corners", factor: 1.24, speed_ms: 3.7, lawson: "A", comfort: "sitting" },
+  ],
+  worst: { zone: "corners", lawson: "A", speed_ms: 3.7 },
+  acceptable_for_entrances: true,
+  mitigations: [],
+  disclaimer: "Approximate massing-stage screen … NOT CFD or a wind-tunnel study.",
+};
+
+describe("the screen refuses to run rather than surfacing a 409", () => {
+  it("needs dimensions or a model", () => {
+    const g = screenGate({}, false);
+    expect(g.can).toBe(false);
+    expect(g.why).toContain("height, width and depth");
+    expect(g.why).toContain("bounding box");
+  });
+
+  it("runs on a model alone — the dims get derived", () => {
+    expect(screenGate({}, true)).toEqual({ can: true, why: "" });
+  });
+
+  it("runs on a full set of dimensions with no model at all", () => {
+    expect(screenGate({ height_m: 30, width_m: 20, depth_m: 15 }, false).can).toBe(true);
+  });
+
+  it("refuses a PARTIAL set with no model — the server 409s on exactly this", () => {
+    expect(screenGate({ height_m: 30, width_m: 20 }, false).can).toBe(false);
+  });
+
+  it("does not count a zero or negative dimension as given", () => {
+    expect(screenGate({ height_m: 30, width_m: 0, depth_m: 15 }, false).can).toBe(false);
+    expect(screenGate({ height_m: 30, width_m: -4, depth_m: 15 }, false).can).toBe(false);
+  });
+});
+
+describe("a check that did not run is never reported as a pass", () => {
+  // THE load-bearing rule. Channelling is raised only when a gap is supplied, so a blank gap gives
+  // `acceptable_for_entrances: true` having never looked at the passage — which is where pedestrian
+  // wind complaints actually come from.
+  it("names channelling as unchecked when no gap was given", () => {
+    const u = unassessed(LOW);
+    expect(u).toHaveLength(1);
+    expect(u[0]).toContain("NOT checked");
+    expect(u[0]).toContain("gap");
+  });
+
+  it("withholds the word 'acceptable' from a partial screen the server called acceptable", () => {
+    expect(LOW.acceptable_for_entrances).toBe(true);
+    const v = verdict(LOW);
+    expect(v).not.toContain("Acceptable for entrances");
+    expect(v).toContain("PARTIAL");
+    expect(v).toContain("not a pass");
+  });
+
+  it("reports nothing unchecked once a passage zone is in the answer", () => {
+    expect(unassessed(TOWER)).toEqual([]);
+  });
+
+  it("reports nothing unchecked when a gap was given and raised no passage zone", () => {
+    // A wide gap does not channel. That is a mechanism LOOKED AT and found not to apply — a finding,
+    // not a hole, and listing it would train the reader to skip the list.
+    const wide = { ...LOW, inputs: { ...LOW.inputs, gap_m: 60 } };
+    expect(unassessed(wide)).toEqual([]);
+  });
+
+  it("reads the ANSWER rather than re-deriving the server's applicability rule", () => {
+    // A passage zone present with gap_m somehow absent is still an assessed channelling check. A
+    // second copy of `gap < h/2 and h > 10` here would measure the copy, not the screen.
+    const odd = { ...TOWER, inputs: { ...TOWER.inputs, gap_m: null } };
+    expect(unassessed(odd)).toEqual([]);
+  });
+
+  it("says 'acceptable' plainly when every mechanism ran and none failed", () => {
+    const full = { ...LOW, inputs: { ...LOW.inputs, gap_m: 60 } };
+    const v = verdict(full);
+    expect(v).toContain("Acceptable for entrances");
+    expect(v).not.toContain("PARTIAL");
+  });
+});
+
+describe("the verdict distinguishes discomfort from danger", () => {
+  it("reports a failing comfort screen as a comfort failure", () => {
+    const v = verdict(TOWER);
+    expect(v).toContain("NOT acceptable");
+    expect(v).toContain("9.6 m/s");
+    expect(v).toContain("Lawson D");
+    expect(v).not.toContain("UNSAFE");
+  });
+
+  it("calls the S grade a SAFETY threshold, not a worse comfort grade", () => {
+    const gale: WindResult = { ...TOWER, worst: { zone: "corners", lawson: "S", speed_ms: 17.6 } };
+    const v = verdict(gale);
+    expect(v).toContain("UNSAFE");
+    expect(v).toContain("15 m/s safety criterion");
+    expect(v).toContain("not a comfort grade");
+  });
+
+  it("labels an S zone row the same way", () => {
+    expect(comfortLabel({ zone: "corners", factor: 1.6, speed_ms: 17.6, lawson: "S",
+                          comfort: "unsafe — exceeds the 15 m/s safety criterion" }))
+      .toContain("safety criterion");
+    expect(comfortLabel(TOWER.zones[1]!)).toBe("D · brisk walking");
+  });
+});
+
+describe("a bounding box is not a building", () => {
+  it("says so when every dimension was derived", () => {
+    const b = dimensionBasis(TOWER, {});
+    expect(b).toContain("BOUNDING BOX");
+    expect(b).toContain("All three dimensions were");
+    expect(b).toContain("site and context geometry");
+  });
+
+  it("names WHICH ones were derived on a partial form", () => {
+    const b = dimensionBasis(TOWER, { height_m: 120 });
+    expect(b).toContain("width and depth were");
+    expect(b).toContain("BOUNDING BOX");
+  });
+
+  it("uses the singular for one derived dimension", () => {
+    const b = dimensionBasis(TOWER, { height_m: 120, width_m: 40 });
+    expect(b).toContain("depth was");
+  });
+
+  it("claims nothing about a bounding box when all three were typed in", () => {
+    const b = dimensionBasis(TOWER, { height_m: 120, width_m: 40, depth_m: 30 });
+    expect(b).toContain("the dimensions you gave");
+    expect(b).not.toContain("BOUNDING BOX");
+  });
+
+  it("prints what was actually screened, so a context-inflated box is visible", () => {
+    const wide = { ...TOWER, inputs: { ...TOWER.inputs, width_m: 412.5 } };
+    expect(dimensionBasis(wide, {})).toContain("412.5");
+  });
+});
+
+describe("the site wind is the multiplier, so its provenance is stated", () => {
+  it("flags the default as a default, not a measurement", () => {
+    const w = windBasis(null, 5);
+    expect(w).toContain("DEFAULT");
+    expect(w).toContain("not a measurement");
+    expect(w).toContain("scales directly");
+  });
+
+  it("does not cry default when a figure was supplied", () => {
+    const w = windBasis(6, 6);
+    expect(w).not.toContain("DEFAULT");
+    expect(w).toContain("6 m/s");
+  });
+
+  it("treats a zero as not supplied — the server substitutes its own floor for it", () => {
+    expect(windBasis(0, 5)).toContain("DEFAULT");
+  });
+});
+
+describe("mitigations are never rendered as a silent blank", () => {
+  it("passes the server's list through", () => {
+    expect(mitigationLines(TOWER)).toEqual(TOWER.mitigations);
+  });
+
+  it("says none is called for when the screen is clean", () => {
+    expect(mitigationLines(LOW)[0]).toContain("No mitigation is called for");
+  });
+
+  it("flags an EMPTY list on a FAILING screen rather than showing nothing", () => {
+    const odd = { ...TOWER, mitigations: [] };
+    expect(mitigationLines(odd)[0]).toContain("unexpected");
+    expect(mitigationLines(odd)[0]).toContain("wind consultant");
+  });
+});

--- a/apps/web/src/portal/panels/envWind.test.ts
+++ b/apps/web/src/portal/panels/envWind.test.ts
@@ -34,27 +34,42 @@ const LOW: WindResult = {
 
 describe("the screen refuses to run rather than surfacing a 409", () => {
   it("needs dimensions or a model", () => {
-    const g = screenGate({}, false);
+    const g = screenGate({}, "absent");
     expect(g.can).toBe(false);
     expect(g.why).toContain("height, width and depth");
     expect(g.why).toContain("bounding box");
   });
 
   it("runs on a model alone — the dims get derived", () => {
-    expect(screenGate({}, true)).toEqual({ can: true, why: "" });
+    expect(screenGate({}, "present")).toEqual({ can: true, why: "" });
   });
 
   it("runs on a full set of dimensions with no model at all", () => {
-    expect(screenGate({ height_m: 30, width_m: 20, depth_m: 15 }, false).can).toBe(true);
+    expect(screenGate({ height_m: 30, width_m: 20, depth_m: 15 }, "absent").can).toBe(true);
   });
 
-  it("refuses a PARTIAL set with no model — the server 409s on exactly this", () => {
-    expect(screenGate({ height_m: 30, width_m: 20 }, false).can).toBe(false);
+  it("refuses a PARTIAL set with a CONFIRMED absent model — the server 409s on exactly this", () => {
+    expect(screenGate({ height_m: 30, width_m: 20 }, "absent").can).toBe(false);
   });
 
   it("does not count a zero or negative dimension as given", () => {
-    expect(screenGate({ height_m: 30, width_m: 0, depth_m: 15 }, false).can).toBe(false);
-    expect(screenGate({ height_m: 30, width_m: -4, depth_m: 15 }, false).can).toBe(false);
+    expect(screenGate({ height_m: 30, width_m: 0, depth_m: 15 }, "absent").can).toBe(false);
+    expect(screenGate({ height_m: 30, width_m: -4, depth_m: 15 }, "absent").can).toBe(false);
+  });
+});
+
+describe("a gate that exists to relay a 409 must not invent one", () => {
+  // Found in review on PR #529. The panel learns about the model from the design-metrics read, and
+  // only its 409 is evidence there is NO model — that is the same `open_source_ifc` refusal the wind
+  // route makes. A 500 in the daylight computation says nothing about it. Collapsing both into one
+  // boolean refused the screen on a project that has a perfectly good model.
+  it("lets an UNKNOWN model reach the server, which is the thing that knows", () => {
+    expect(screenGate({}, "unknown").can).toBe(true);
+    expect(screenGate({ height_m: 30 }, "unknown").can).toBe(true);
+  });
+
+  it("refuses only on a CONFIRMED absence", () => {
+    expect(screenGate({}, "absent").can).toBe(false);
   });
 });
 
@@ -183,8 +198,22 @@ describe("mitigations are never rendered as a silent blank", () => {
     expect(mitigationLines(TOWER)).toEqual(TOWER.mitigations);
   });
 
-  it("says none is called for when the screen is clean", () => {
-    expect(mitigationLines(LOW)[0]).toContain("No mitigation is called for");
+  it("says none is called for when the screen is clean AND complete", () => {
+    const full = { ...LOW, inputs: { ...LOW.inputs, gap_m: 60 } };
+    expect(mitigationLines(full)[0]).toContain("No mitigation is called for by this screen");
+    expect(mitigationLines(full)[0]).toContain("every zone graded");
+  });
+
+  it("does NOT report a clean bill over a partial screen", () => {
+    // Found in review on PR #529, and it is the file's own load-bearing rule failing one function
+    // down: `verdict()` had just called this same result a PARTIAL screen, while this said no
+    // mitigation was called for. "Every zone graded A–C" is false on its own terms too — a zone
+    // that was never computed was never graded.
+    const m = mitigationLines(LOW)[0]!;
+    expect(unassessed(LOW)).toHaveLength(1);
+    expect(m).toContain("mechanisms this screen DID check");
+    expect(m).toContain("did not check");
+    expect(m).not.toContain("every zone graded");
   });
 
   it("flags an EMPTY list on a FAILING screen rather than showing nothing", () => {

--- a/apps/web/src/portal/panels/envWind.ts
+++ b/apps/web/src/portal/panels/envWind.ts
@@ -1,0 +1,157 @@
+/** ENV-WIND — the wording for the pedestrian wind-comfort screen at massing stage.
+ *
+ *  Pure, so the rules can be tested without a DOM.
+ *
+ *  `POST …/env/wind` has graded corner acceleration, downwash and channelling on the Lawson comfort
+ *  categories since ENV-1, offline and deterministic, deriving the mass from the model's bounding box
+ *  when no dimensions are given. **Nothing called it.** A massing-stage wind answer that only a
+ *  `curl` can reach is not an answer the design has.
+ *
+ *  Three things about this screen will be misread if the panel does not say them, and each has its
+ *  own function below because each is a different lie:
+ *
+ *  1. **A check that did not run is not a check that passed.** Channelling is raised only when a gap
+ *     to a neighbouring mass is supplied. Leave the gap blank and `acceptable_for_entrances` can come
+ *     back `true` having never looked at the passage — which is where pedestrian wind complaints
+ *     actually come from. `unassessed()` names what was skipped, and `verdict()` refuses the word
+ *     "acceptable" while anything is on that list.
+ *  2. **Every speed here is the site wind times a factor.** `wind_ms` scales the whole result
+ *     linearly, and it defaults. A screen run on the default and read as a site answer is wrong by
+ *     exactly the ratio of the two. `windBasis()` says which one produced the numbers.
+ *  3. **A bounding box is not a building.** With no dimensions the server takes the model's world
+ *     bounds, which span site and context geometry too. `dimensionBasis()` prints what was actually
+ *     screened so a 400 m "width" is visible rather than silently believed.
+ *
+ *  And under all three: this is a screening heuristic, not CFD and not a wind tunnel. The server says
+ *  so in `disclaimer`; the panel shows it rather than filing it.
+ */
+
+import type { WindResult, WindZone } from "../../api/designPerformance";
+
+/** What the form holds. Every field optional — the server derives the mass when the dims are blank. */
+export interface WindForm {
+  height_m?: number | null;
+  width_m?: number | null;
+  depth_m?: number | null;
+  wind_ms?: number | null;
+  gap_m?: number | null;
+  podium_height_m?: number | null;
+}
+
+/**
+ * Whether the screen can run at all, and why not when it cannot.
+ *
+ * The server needs a full set of dimensions OR a source model to derive the missing ones from, and
+ * answers 409 otherwise. Saying that here beats letting a 409 surface as "request failed".
+ */
+export function screenGate(form: WindForm, hasModel: boolean): { can: boolean; why: string } {
+  const complete = [form.height_m, form.width_m, form.depth_m]
+    .every((v) => typeof v === "number" && Number.isFinite(v) && v > 0);
+  if (complete || hasModel) return { can: true, why: "" };
+  return { can: false,
+           why: "give a height, width and depth — or load a source model and they will be derived "
+                + "from its bounding box" };
+}
+
+/**
+ * The checks this screen did NOT run. **The load-bearing function of this file.**
+ *
+ * Read off the RESPONSE, never re-derived from the inputs: the server decides when a mechanism
+ * applies, and a second copy of that rule here would be measuring the copy. A `passage (…)` zone in
+ * the answer means channelling was looked at; no passage zone and no gap supplied means it was not.
+ *
+ * Downwash is deliberately absent from this list. Below about 25 m it does not apply — that is a
+ * mechanism ruled out, which is a finding, not a hole.
+ */
+export function unassessed(r: WindResult): string[] {
+  const gaps: string[] = [];
+  const hasPassage = r.zones.some((z) => z.zone.startsWith("passage"));
+  if (!hasPassage && (r.inputs.gap_m == null || r.inputs.gap_m <= 0)) {
+    gaps.push("Channelling between buildings was NOT checked — no gap to a neighbouring mass was "
+              + "given. A narrow passage is the commonest source of a pedestrian wind complaint, and "
+              + "it is not in the figure above.");
+  }
+  return gaps;
+}
+
+/**
+ * The headline.
+ *
+ * While anything is on the `unassessed` list the word "acceptable" is withheld, whatever
+ * `acceptable_for_entrances` says: a partial screen that reads as a pass is how a scheme goes to
+ * planning on a check nobody ran. `S` is the 15 m/s SAFETY criterion, not a comfort grade, and is
+ * called out as such.
+ */
+export function verdict(r: WindResult): string {
+  const w = r.worst;
+  const gaps = unassessed(r);
+  if (w.lawson === "S") {
+    return `UNSAFE — ${w.zone} screens at ${w.speed_ms} m/s, past the 15 m/s safety criterion. `
+      + "This is a safety threshold, not a comfort grade; a wind consultant is not optional here.";
+  }
+  if (!r.acceptable_for_entrances) {
+    return `NOT acceptable for entrances or seating — ${w.zone} screens at ${w.speed_ms} m/s `
+      + `(Lawson ${w.lawson}). Lawson A–C is the range an entrance wants.`;
+  }
+  if (gaps.length) {
+    return `No comfort problem in the checks that RAN — worst was ${w.zone} at ${w.speed_ms} m/s `
+      + `(Lawson ${w.lawson}). This is a PARTIAL screen: ${gaps.length} mechanism was not checked, `
+      + "so it is not a pass.";
+  }
+  return `Acceptable for entrances on this screen — worst zone ${w.zone} at ${w.speed_ms} m/s `
+    + `(Lawson ${w.lawson}).`;
+}
+
+/**
+ * Where the dimensions came from.
+ *
+ * `supplied` is what the form sent. When it sent nothing the server took the model's world bounds,
+ * and a bounding box spans every piece of geometry in the file — site, context, a survey point left
+ * at the origin. Printing what was screened is what makes a 400 m "width" visible.
+ */
+export function dimensionBasis(r: WindResult, supplied: WindForm): string {
+  const dims = `${fmt(r.inputs.height_m)} m tall × ${fmt(r.inputs.width_m)} m × ${fmt(r.inputs.depth_m)} m`;
+  const gave = (v: unknown) => typeof v === "number" && Number.isFinite(v) && v > 0;
+  const derived = (["height_m", "width_m", "depth_m"] as const).filter((k) => !gave(supplied[k]));
+  if (!derived.length) return `Screened at ${dims} — the dimensions you gave.`;
+  const which = derived.length === 3 ? "All three dimensions were"
+    : `${derived.map((k) => k.replace("_m", "")).join(" and ")} ${derived.length === 1 ? "was" : "were"}`;
+  return `Screened at ${dims}. ${which} derived from the model's BOUNDING BOX, which spans site and `
+    + "context geometry as well as the building — override any that do not look like the mass you "
+    + "meant to screen.";
+}
+
+/**
+ * Which site wind produced these numbers.
+ *
+ * Every speed in the result is this figure times a zone factor, so reading a default-run screen as a
+ * site answer is wrong by the ratio of the two. 5 m/s is the server's default, not a measurement.
+ */
+export function windBasis(supplied: number | null | undefined, used: number): string {
+  const gave = typeof supplied === "number" && Number.isFinite(supplied) && supplied > 0;
+  if (gave) {
+    return `Site wind ${fmt(used)} m/s — every speed below is this times a zone factor.`;
+  }
+  return `Site wind ${fmt(used)} m/s — the DEFAULT, not a measurement for this site. Every speed `
+    + "below scales directly with it, so put in the local mean pedestrian-level wind before quoting "
+    + "any of these figures.";
+}
+
+/** The mitigations, or an explicit nothing — an empty list rendered as blank reads as "none needed". */
+export function mitigationLines(r: WindResult): string[] {
+  if (r.mitigations.length) return r.mitigations;
+  return r.acceptable_for_entrances
+    ? ["No mitigation is called for by this screen — every zone graded Lawson A–C."]
+    : ["This screen raised no mitigation, which is unexpected for a failing result — treat the "
+       + "zone table as the finding and take it to a wind consultant."];
+}
+
+/** One zone row's comfort phrase, with the safety grade called out rather than listed alongside. */
+export function comfortLabel(z: WindZone): string {
+  return z.lawson === "S" ? "unsafe — past the 15 m/s safety criterion" : `${z.lawson} · ${z.comfort}`;
+}
+
+/** Metres, trimmed — the screen's precision is nowhere near a decimal place on a 120 m tower. */
+function fmt(n: number): string {
+  return Number.isFinite(n) ? String(Math.round(n * 10) / 10) : "?";
+}

--- a/apps/web/src/portal/panels/envWind.ts
+++ b/apps/web/src/portal/panels/envWind.ts
@@ -28,6 +28,16 @@
 
 import type { WindResult, WindZone } from "../../api/designPerformance";
 
+/**
+ * What the panel knows about a source model.
+ *
+ * Three states, not a boolean. `absent` is a CONFIRMED no-model — the metrics read 409'd, which is
+ * the same `open_source_ifc` refusal the wind route makes. `unknown` is any other failure: a 500 in
+ * the daylight computation says nothing about whether a model exists, and refusing the screen on it
+ * would manufacture a refusal out of evidence that does not establish one.
+ */
+export type ModelPresence = "present" | "absent" | "unknown";
+
 /** What the form holds. Every field optional — the server derives the mass when the dims are blank. */
 export interface WindForm {
   height_m?: number | null;
@@ -43,11 +53,15 @@ export interface WindForm {
  *
  * The server needs a full set of dimensions OR a source model to derive the missing ones from, and
  * answers 409 otherwise. Saying that here beats letting a 409 surface as "request failed".
+ *
+ * Only a CONFIRMED `absent` refuses. This gate exists so the server's 409 arrives as an instruction
+ * rather than a failure — it must not become a way of inventing one: on `unknown` the request goes
+ * out and the server answers, because the server is the thing that knows.
  */
-export function screenGate(form: WindForm, hasModel: boolean): { can: boolean; why: string } {
+export function screenGate(form: WindForm, model: ModelPresence): { can: boolean; why: string } {
   const complete = [form.height_m, form.width_m, form.depth_m]
     .every((v) => typeof v === "number" && Number.isFinite(v) && v > 0);
-  if (complete || hasModel) return { can: true, why: "" };
+  if (complete || model !== "absent") return { can: true, why: "" };
   return { can: false,
            why: "give a height, width and depth — or load a source model and they will be derived "
                 + "from its bounding box" };
@@ -137,9 +151,23 @@ export function windBasis(supplied: number | null | undefined, used: number): st
     + "any of these figures.";
 }
 
-/** The mitigations, or an explicit nothing — an empty list rendered as blank reads as "none needed". */
+/**
+ * The mitigations, or an explicit nothing — an empty list rendered as blank reads as "none needed".
+ *
+ * **A clean list over a PARTIAL screen is the same lie `verdict()` refuses**, one function down, and
+ * it was in the first draft of this file: "no mitigation is called for … every zone graded A–C" was
+ * returned for a result whose channelling was never looked at, contradicting the partial-screen
+ * warning printed directly above it. "Every zone" is false on its own terms too — a zone that was
+ * never computed was never graded. Found in review on PR #529.
+ */
 export function mitigationLines(r: WindResult): string[] {
   if (r.mitigations.length) return r.mitigations;
+  const gaps = unassessed(r);
+  if (gaps.length) {
+    return ["No mitigation is called for by the mechanisms this screen DID check. It did not check "
+            + `${gaps.length === 1 ? "one of them" : `${gaps.length} of them`}, and an unchecked `
+            + "mechanism can need mitigation as readily as a checked one."];
+  }
   return r.acceptable_for_entrances
     ? ["No mitigation is called for by this screen — every zone graded Lawson A–C."]
     : ["This screen raised no mitigation, which is unexpected for a failing result — treat the "

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1779,6 +1779,41 @@ instances:
   PREFAB-FREEZE-RACE, and filed the same way rather than left in a review thread — **a follow-up held
   only in a thread closes by default when the PR merges.**
 
+- ✅ ⭐ **ENV-WIND — a wind answer at the only stage that can act on it**
+  *(S — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts`,
+  `apps/web/src/portal/panels/envWind.test.ts` and `services/api/test_route_reachability.py`)*
+
+  `POST …/env/wind` has graded pedestrian wind comfort since ENV-1 — corner acceleration, downwash
+  and channelling against the Lawson categories, offline and deterministic, deriving the mass from
+  the model's bounding box when no dimensions are given. **Nothing called it.** Massing decides most
+  pedestrian wind outcomes and CFD arrives far too late to steer them; an answer only `curl` can
+  reach is not an answer the design has. It now draws under **📐 Design Metrics**, which is the panel
+  that already answers "what is this massing doing" off the same model.
+
+  **Three things about this screen are misread unless the panel says them, and each is a different
+  lie**, so each has its own rule in `apps/web/src/portal/panels/envWind.ts` (25 tests, four
+  mutations all biting):
+
+  * **A check that did not run is not a check that passed.** Channelling is raised only when a gap to
+    a neighbouring mass is supplied. Leave it blank and `acceptable_for_entrances` comes back `true`
+    having never looked at the passage — which is where pedestrian wind complaints actually come
+    from. `unassessed()` names what was skipped and `verdict()` withholds the word *acceptable* while
+    anything is on that list. It reads the **answer** rather than re-deriving the server's
+    applicability rule, because a second copy of that rule would be measuring the copy.
+  * **Every speed is the site wind times a factor**, and the site wind defaults. A screen run on the
+    default and read as a site answer is wrong by exactly the ratio of the two.
+  * **A bounding box is not a building.** With the dimensions blank the server takes the model's
+    world bounds, which span site and context geometry too, so what was actually screened is printed.
+
+  **The gate could not see this route in either direction, for a THIRD new reason.** `wind` is four
+  characters and `MIN_SEGMENT` is five, so it was never in the reachability gate's population at
+  all — not flaggable, not freezable, not in `FOUND`. That file's own note said the sub-threshold
+  routes were "otherwise still unmeasured" and asked for a re-derivation rather than trust; this is
+  that re-derivation, and **one half of it is sound**. 115 of 949 routes fall below the threshold and
+  for 108 the leaf occurs somewhere in the web source, which means nothing — but the coarseness runs
+  in one direction only: *a leaf that appears nowhere cannot be being called, however short it is.*
+  Those seven are now a ratchet that may shrink and never grow. It held **eight** until this item.
+
 - ✅ ⭐ **BUYOUT-KEEP — the buyout plan you could compute and could not keep**
   *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts` and
   `apps/web/src/portal/panels/buyoutKeep.test.ts`)*

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -910,6 +910,60 @@ for _r in ("/projects/{pid}/jurisdiction/requirements", "/projects/{pid}/jurisdi
           "if this fails the matcher changed or the vouching text moved -- re-triage the route "
           "rather than assuming this gate ever had an opinion about it")
 
+# A FIFTH INSTANCE, measured 2026-09-11 while wiring ENV-WIND, and it is invisible for a THIRD
+# reason again -- not a collision with text (`requirements`), not a collision with a sibling route
+# (`check`), but a leaf too SHORT to be looked at. `MIN_SEGMENT = 5` above drops any route whose last
+# static segment is under five characters, and `wind` is four. `/projects/{pid}/env/wind` was
+# therefore never in this gate's population at all: not in FOUND, not flaggable, not freezable.
+#
+# The paragraph at `MIN_SEGMENT` says those routes are "otherwise still unmeasured" and asks for a
+# re-derivation rather than trust. **This is that re-derivation, and it holds one sound half.**
+#
+# 115 of 949 routes fall below the threshold. For 108 of them the leaf DOES occur somewhere in the
+# web source -- and that means nothing: `due`, `acs`, `eot` are ordinary words, which is the whole
+# reason the threshold exists. But the rule's coarseness runs in ONE direction only. A leaf that
+# appears NOWHERE cannot be being called, however short it is; absence is conclusive where presence
+# is not. So the seven below are not "probably dark" -- they are dark on the same evidence the main
+# rule uses, and freezing them is a real ratchet rather than a number to look at.
+#
+# It may SHRINK and never grow. A wired route leaves the set by putting its leaf into the source,
+# which is what ENV-WIND just did: this list held eight until `envWindScreen`
+# (`apps/web/src/api/designPerformance.ts`) landed, called from the wind section of
+# `apps/web/src/portal/panels/designMetrics.ts`.
+#
+# What it does NOT claim: that the other 108 are reachable. This gate has no opinion about them and
+# neither does this check. *A sound half of a coarse rule is worth extracting; announcing the other
+# half as covered is how a green tick comes to mean nothing.*
+CONFIRMED_DARK_SHORT_LEAF = {
+    #: The SAML assertion-consumer endpoint. Must have no web caller -- the IdP POSTs the assertion
+    #: here, exactly like `/auth/cloud/callback` above. Not parked work.
+    "/auth/saml/acs",
+    #: Scheduler polls. `/routines/due` and its per-project sibling are read by the server-side
+    #: runner, not by a browser.
+    "/routines/due", "/projects/{pid}/routines/due",
+    #: JSON siblings of the AIA G702/G703 PDF routes, which ARE called
+    #: (`apps/web/src/api/downloadPdf.ts`). A screen that renders the payment application from data
+    #: rather than downloading it would use these; none exists yet.
+    "/projects/{pid}/cost/g702", "/projects/{pid}/cost/g703",
+    #: Extension-of-time claim assembly, and the ERP entity bridge. Both are finished server-side
+    #: and have no screen. Candidates for the next wiring sprint, in that order.
+    "/projects/{pid}/schedule/eot", "/connections/{cid}/erp/{entity}",
+}
+_SHORT = {r for r in PATHS if len(_leaf(r)) < MIN_SEGMENT}
+_SHORT_DARK = {r for r in _SHORT if not leaf_is_called(_leaf(r), _CODE)}
+check("the sub-MIN_SEGMENT population is bounded and known, not an unexamined remainder",
+      len(_SHORT) <= 130,
+      f"{len(_SHORT)} of {len(PATHS)} routes now have a leaf under {MIN_SEGMENT} characters — if the "
+      "threshold moved or a family of short-leaf routes landed, re-derive the dark subset below "
+      "rather than widening this bound")
+check("  no NEW route is confirmed-dark by absence — this ratchet only comes down",
+      not (_SHORT_DARK - CONFIRMED_DARK_SHORT_LEAF),
+      f"newly dark: {sorted(_SHORT_DARK - CONFIRMED_DARK_SHORT_LEAF)} — a short leaf hides a route "
+      "from the main rule, so wire it or record here why it must stay callerless")
+_LEFT = sorted(CONFIRMED_DARK_SHORT_LEAF - _SHORT_DARK)
+if _LEFT:
+    print(f"  (ratchet down: {_LEFT} left the confirmed-dark set — delete the entries above)")
+
 # The stated blind spot, asserted so it cannot be quietly forgotten.
 check("the rule's known FALSE NEGATIVE still holds: /proforma/renovation is NOT flagged",
       "/projects/{pid}/proforma/renovation" not in FOUND,


### PR DESCRIPTION
`POST …/env/wind` has graded pedestrian wind comfort since ENV-1 — corner acceleration, downwash and channelling against the **Lawson comfort categories**, offline and deterministic, deriving the mass from the model's bounding box when no dimensions are given. **Nothing called it.**

Massing decides most pedestrian wind outcomes and CFD arrives far too late to steer them, so an answer only `curl` can reach is not an answer the design has. It now draws under **📐 Design Metrics** — the panel that already answers "what is this massing doing" off the same model — as a form, because the screen's three most misreadable inputs are all optional.

## Three rules, because there are three different lies

Each has its own function in `apps/web/src/portal/panels/envWind.ts`.

**1. A check that did not run is not a check that passed.** Channelling is raised only when a gap to a neighbouring mass is supplied. Leave it blank and `acceptable_for_entrances` comes back `true` having never looked at the passage — which is where pedestrian wind complaints actually come from. `unassessed()` names what was skipped and `verdict()` withholds the word *acceptable* while anything is on that list.

It reads the **answer** rather than re-deriving the server's applicability rule: a second copy of `gap < h/2 and h > 10` here would be measuring the copy. A wide gap that raises no passage zone is a mechanism *looked at and found not to apply* — a finding, not a hole, and listing it would train the reader to skip the list.

**2. Every speed is the site wind times a zone factor**, and the site wind defaults to 5 m/s. A screen run on the default and read as a site answer is wrong by exactly the ratio of the two.

**3. A bounding box is not a building.** With the dimensions blank the server takes the model's world bounds, which span site and context geometry as well, so what was actually screened is printed and which dimensions were derived is named.

The Lawson `S` grade is the 15 m/s **safety** criterion, not a worse comfort grade, and the verdict says so separately.

25 tests, four mutations all biting.

## The gate could not see this route in either direction — for a third new reason

Not a collision with text (`requirements`), not a collision with a sibling route (`check`), but **a leaf too short to be looked at**. `wind` is four characters and `MIN_SEGMENT` is five, so the route was never in `test_route_reachability.py`'s population: not in `FOUND`, not flaggable, not freezable.

That file's own note said the sub-threshold routes were "otherwise still unmeasured" and asked for a re-derivation rather than trust. This is that re-derivation, and **one half of it is sound**:

- **115 of 949** routes fall below the threshold.
- For **108** the leaf occurs somewhere in the web source — which means nothing, because `due`, `acs` and `eot` are ordinary words. That is the whole reason the threshold exists.
- But the coarseness runs in **one direction only**: a leaf that appears *nowhere* cannot be being called, however short it is. Those **7** are dark on the same evidence the main rule uses.

They are now a ratchet that may shrink and never grow. It held **eight** until this PR. Unwiring the route makes the ratchet name it — that is the mutation that was run.

The check explicitly does **not** claim the other 108 are reachable. Announcing that would be how a green tick comes to mean nothing.

## Verification

- `services/api/test_route_reachability.py`, `test_claude_md_gates.py`, `test_roadmap_status.py`, `test_changelog_current.py` — all green
- `ruff check` over the whole tree — clean
- Web: **246 files / 2588 tests**, typecheck, lint, build
- Re-run on the resynced base after #528 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pedestrian wind-comfort screening to Design Metrics.
  - Enter building dimensions and site wind speed manually, or derive dimensions from the model’s bounding box.
  - View Lawson comfort grades, zone speeds, entrance suitability, and suggested standard mitigations.
  - Supports partial assessments and clearly identifies unchecked mechanisms.

- **Documentation**
  - Clarified that results are rapid, offline screening estimates—not CFD or a formal wind study.
  - Results disclose default wind assumptions, bounding-box-derived dimensions, and assessment limitations.
  - Documented that no external service or simulation licence is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->