### PR TITLE
An extension of time, with the method that produced it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Extension-of-time claims, with the method that produced them
+
+**Schedule** now assembles an **extension of time**. Pick an analysis method, and it grades each
+delay event against the activity's float, states what the claim is worth, and shows its working.
+
+It will not compute one without a method. The published taxonomies exist because the same facts give
+different answers under different methods, so an EOT figure without its method cannot be weighed by
+whoever reads it — and this one ends up in a claim. The method list comes from the engine itself, and
+choosing one shows that method's own published weakness before you run it.
+
+Two ways to run it, and the default is the auditable one: **from the captured baseline**, measuring
+slip against a named, dated artefact and taking causes from the project's own detected events, so
+both can be re-derived later. Typed dates still work for a claim argued before a baseline exists, and
+are labelled as what they are — the baseline is the single most contested input in a delay claim, and
+typed it cannot be checked.
+
+Four things it refuses to round off, each because rounding it off would favour one party:
+
+- **A delay absorbed by float is reported as absorbed, not as zero.** It earns no extension and it
+  still happened; only the second reading says nothing occurred.
+- **Slip with no matching cause is unattributed, never non-excusable.** Defaulting unexplained
+  overrun to contractor risk hands somebody a finding nobody demonstrated.
+- **Concurrent delays are named, never split.** Whether overlapping employer-risk and
+  contractor-risk delay gives time, money, both or neither is a contract question the protocols
+  themselves disagree on; a silent 50/50 would present the most argued number in the discipline as
+  arithmetic.
+- **A detected event with no stated duration is excluded and counted.** Detection establishes that
+  something happened, never what it cost.
+
 ### Pedestrian wind comfort, screened from the massing
 
 **📐 Design Metrics** now carries a **pedestrian wind comfort** screen. Give it a height, width and

--- a/apps/web/src/api/schedule.ts
+++ b/apps/web/src/api/schedule.ts
@@ -794,7 +794,89 @@ export function withSchedule<TBase extends Ctor<HttpCore>>(Base: TBase) {
       delay_days: number; by_weather: Record<string, number>; by_impact: Record<string, number>;
       rows: Record<string, unknown>[] }>(`/projects/${pid}/daily-reports/summary`);
   }
+
+  /**
+   * R40-EOT — an extension of time with the METHOD it was computed by attached to it.
+   *
+   * `method` is required and a closed set (AACE 29R-03 / SCL Protocol): the same facts give
+   * different answers under different methods, so the engine refuses rather than picking one.
+   * Every non-`analysed` status is a distinct refusal that sends the reader somewhere different.
+   */
+  scheduleEot(pid: string, body: { method?: string | null; baseline_finish?: string | null;
+                                   actual_finish?: string | null; events?: EotEventInput[] }) {
+    return this.json<EotResult>(`/projects/${pid}/schedule/eot`, {
+      method: "POST", body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * R40-EOT ② — the same entitlement, built from the project's OWN captured baseline and detected
+   * events rather than typed dates. Prefer this: a typed baseline is unauditable, and the baseline
+   * is the most contested input in a delay claim.
+   */
+  scheduleEotSourced(pid: string, body: { method?: string | null; baseline_id?: string | null;
+                                          baseline_finish?: string | null;
+                                          actual_finish?: string | null; events?: EotEventInput[] }) {
+    return this.json<EotSourced>(`/projects/${pid}/schedule/eot/sourced`, {
+      method: "POST", body: JSON.stringify(body),
+    });
+  }
   };
+}
+
+/** One delay event as the caller states it. `days` is what detection never supplies. */
+export interface EotEventInput {
+  id?: string; kind?: string; days?: number | null;
+  activity_id?: string | null; start?: string | null; entitlement?: string | null;
+}
+
+/** One graded event in the entitlement. `absorbed_by_float` is NOT a finding of no delay. */
+export interface EotEvent {
+  id: string; kind: string | null; activity_id: string | null; days: number;
+  total_float: number | null; absorbed_by_float: boolean; critical: boolean | null;
+  impact_days: number; eot_days: number;
+  entitlement: string | null; reason: string;
+}
+
+/** The entitlement, or the refusal that stopped it. `status` decides which. */
+export interface EotResult {
+  status: "analysed" | "method_required" | "baseline_required" | "actual_finish_required"
+        | "method_needs_schedule_updates" | string;
+  status_meaning?: string;
+  method: string; method_basis?: string; method_meaning?: string;
+  methods_available?: Record<string, string>;
+  performed_by?: string | null;
+  reason?: string;
+  eot_days: number | null;
+  additive_days?: number; capped_by_actual_slip?: boolean; over_claimed_days?: number;
+  unattributed_slip_days?: number;
+  baseline_finish?: string; actual_finish?: string | null; actual_variance_days?: number;
+  revised_finish?: string;
+  events?: EotEvent[];
+  by_entitlement?: Record<string, number>;
+  unclassified_count?: number;
+  /** `apportioned` is always false, and must stay visibly so. */
+  concurrency?: { pairs: unknown[]; count: number; apportioned: boolean; note: string };
+  note?: string;
+}
+
+/** The sourced entitlement: the same analysis over inputs that can be re-derived. */
+export interface EotSourced {
+  status?: string;
+  project_id?: string;
+  baseline?: { id?: string; name?: string; captured_at?: string; count?: number } | null;
+  baselines_available?: { id: string; name: string }[];
+  slip_summary?: Record<string, unknown>;
+  attribution?: {
+    activities: Record<string, unknown>[];
+    attributed_days: number; unattributed_days: number;
+    unattributed: { activity_id: string; name: string; slip_days: number }[];
+    needs_duration: Record<string, unknown>[];
+    events_without_activity: number; note: string;
+  };
+  analysis?: EotResult;
+  events_detected?: number; events_supplied?: number; events_quantified?: number;
+  note?: string;
 }
 
 export interface TaktProgressRow {

--- a/apps/web/src/portal/panels/eotClaim.test.ts
+++ b/apps/web/src/portal/panels/eotClaim.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import {
+  methodGate, refusal, claimHeadline, eventFinding, concurrencyNote, coverageNote,
+  provenanceLine, sourcedRefusal,
+} from "./eotClaim";
+import type { EotResult, EotSourced, EotEvent } from "../../api/schedule";
+
+const OK: EotResult = {
+  status: "analysed", method: "impacted_as_planned", method_basis: "additive",
+  eot_days: 14, additive_days: 14, capped_by_actual_slip: false, over_claimed_days: 0,
+  baseline_finish: "2026-06-01", actual_finish: null, events: [],
+  concurrency: { pairs: [], count: 0, apportioned: false, note: "" },
+};
+
+const ABSORBED: EotEvent = {
+  id: "e1", kind: "weather_delay", activity_id: "A10", days: 3,
+  total_float: 5, absorbed_by_float: true, critical: false,
+  impact_days: 0, eot_days: 0, entitlement: "excusable", reason: "",
+};
+
+describe("a claim cannot be computed without its method", () => {
+  it("refuses with the reason, not a default", () => {
+    const g = methodGate(null);
+    expect(g.can).toBe(false);
+    expect(g.why).toContain("different answers under different methods");
+  });
+
+  it("allows a chosen method", () => {
+    expect(methodGate("windows")).toEqual({ can: true, why: "" });
+  });
+});
+
+describe("the four refusals stay four refusals", () => {
+  // Collapsing these into one "could not compute" is the defect this file exists to prevent: they
+  // send a reader to four different places, and two are not fixable by supplying anything.
+  it("says nothing when the analysis ran", () => {
+    expect(refusal(OK)).toBeNull();
+  });
+
+  it("a missing baseline is an absent plan-of-record, NOT zero delay", () => {
+    const r = refusal({ ...OK, status: "baseline_required", eot_days: null })!;
+    expect(r).toContain("no baseline finish");
+    expect(r).toContain("NOT a finding of zero delay");
+  });
+
+  it("a missing as-built says why the additive sum is not a substitute", () => {
+    const r = refusal({ ...OK, status: "actual_finish_required", eot_days: null })!;
+    expect(r).toContain("as-built finish is missing");
+    expect(r).toContain("one method's number under another method's name");
+  });
+
+  it("a series method names who performs it when something does", () => {
+    const r = refusal({ ...OK, status: "method_needs_schedule_updates", method: "windows",
+                        eot_days: null, performed_by: "GET /projects/{pid}/schedule/windows" })!;
+    expect(r).toContain("dated SERIES");
+    expect(r).toContain("/schedule/windows");
+  });
+
+  it("and says nothing performs it when nothing does, rather than naming a near-miss", () => {
+    const r = refusal({ ...OK, status: "method_needs_schedule_updates", method: "time_impact",
+                        eot_days: null, performed_by: null })!;
+    expect(r).toContain("Nothing here performs it yet");
+    expect(r).not.toContain("/schedule/windows");
+  });
+
+  it("reports an UNKNOWN status as unknown rather than guessing which refusal it is", () => {
+    const r = refusal({ ...OK, status: "some_new_status", eot_days: null })!;
+    expect(r).toContain("does not know");
+    expect(r).toContain("Do not read the absence of a figure as a finding");
+  });
+
+  it("the four refusals are all DIFFERENT strings", () => {
+    const rs = ["method_required", "baseline_required", "actual_finish_required",
+                "method_needs_schedule_updates"]
+      .map((s) => refusal({ ...OK, status: s, eot_days: null }));
+    expect(new Set(rs).size).toBe(4);
+  });
+});
+
+describe("the number never travels without its method", () => {
+  it("states the method in the headline", () => {
+    const h = claimHeadline(OK);
+    expect(h).toContain("14 days of extension");
+    expect(h).toContain("impacted as planned");
+  });
+
+  it("surfaces over-claim, which is this method's published criticism", () => {
+    const h = claimHeadline({ ...OK, over_claimed_days: 6 });
+    expect(h).toContain("not bounded by what the job did");
+    expect(h).toContain("6 days");
+  });
+
+  it("says when the figure was capped at the actual slip", () => {
+    const h = claimHeadline({ ...OK, method: "as_planned_vs_as_built",
+                              capped_by_actual_slip: true });
+    expect(h).toContain("Capped at the movement of the completion date");
+  });
+
+  it("falls through to the refusal rather than printing a bare number", () => {
+    expect(claimHeadline({ ...OK, status: "baseline_required", eot_days: null }))
+      .toContain("NOT a finding of zero delay");
+  });
+
+  it("counts one day in the singular", () => {
+    expect(claimHeadline({ ...OK, eot_days: 1 })).toContain("1 day of extension");
+  });
+});
+
+describe("absorbed is not zero — the load-bearing row", () => {
+  // A delay inside the activity's float earns no extension and DID happen. Reporting it as 0 days
+  // is the reading that says nothing occurred, and the engine's own comment forbids exactly that.
+  it("says the delay happened and float took it", () => {
+    const f = eventFinding(ABSORBED);
+    expect(f).toContain("ABSORBED");
+    expect(f).toContain("The delay happened");
+    expect(f).toContain("not the same as no delay");
+  });
+
+  it("never renders an absorbed row as a plain zero", () => {
+    expect(eventFinding(ABSORBED)).not.toMatch(/^0 days/);
+  });
+
+  it("says unclassified is not non-excusable", () => {
+    const f = eventFinding({ ...ABSORBED, absorbed_by_float: false, total_float: 0,
+                             impact_days: 3, eot_days: 0, entitlement: "unclassified" });
+    expect(f).toContain("NOT a finding of non-excusable");
+    expect(f).toContain("nobody has read it against the contract");
+  });
+
+  it("reports a classified non-earning event as the classification it has", () => {
+    const f = eventFinding({ ...ABSORBED, absorbed_by_float: false, total_float: 0,
+                             impact_days: 4, eot_days: 0, entitlement: "non_excusable" });
+    expect(f).toContain("non excusable");
+    expect(f).not.toContain("ABSORBED");
+  });
+
+  it("reports an earning event with its class", () => {
+    const f = eventFinding({ ...ABSORBED, absorbed_by_float: false, total_float: 0,
+                             impact_days: 7, eot_days: 7,
+                             entitlement: "excusable_compensable" });
+    expect(f).toContain("7 days of extension");
+    expect(f).toContain("excusable compensable");
+  });
+});
+
+describe("concurrency is named, never apportioned", () => {
+  it("says the split is deliberately not made, and why", () => {
+    const n = concurrencyNote({ ...OK,
+      concurrency: { pairs: [{}, {}], count: 2, apportioned: false, note: "" } });
+    expect(n).toContain("2 concurrent pairs");
+    expect(n).toContain("NOT split");
+    expect(n).toContain("governed by the contract");
+  });
+
+  it("reports NO overlap as unexamined where the data was missing, not as clear", () => {
+    const n = concurrencyNote(OK);
+    expect(n).toContain("were NOT tested");
+    expect(n).toContain("unexamined, not clear");
+  });
+});
+
+describe("the figure is computed over a subset, and says so", () => {
+  const base: EotSourced = {
+    baseline: { id: "b1", name: "GMP", captured_at: "2026-01-04T00:00:00Z", count: 40 },
+    attribution: { activities: [], attributed_days: 12, unattributed_days: 0, unattributed: [],
+                   needs_duration: [], events_without_activity: 0, note: "" },
+  };
+
+  it("says nothing when everything was quantified and attributed", () => {
+    expect(coverageNote(base)).toEqual([]);
+  });
+
+  it("names events excluded for having no stated duration", () => {
+    const n = coverageNote({ ...base,
+      attribution: { ...base.attribution!, needs_duration: [{}, {}] } });
+    expect(n[0]).toContain("2 detected events have no stated duration");
+    expect(n[0]).toContain("EXCLUDED from the figure");
+    expect(n[0]).toContain("does not establish what the event cost");
+  });
+
+  it("reports unattributed slip as unattributed, NEVER as non-excusable", () => {
+    const n = coverageNote({ ...base,
+      attribution: { ...base.attribution!, unattributed_days: 9 } });
+    expect(n[0]).toContain("9 days of measured slip have NO matching cause");
+    expect(n[0]).toContain("NOT non-excusable");
+    expect(n[0]).toContain("nobody demonstrated");
+  });
+
+  it("says proximity is not causation for events carrying no activity", () => {
+    const n = coverageNote({ ...base,
+      attribution: { ...base.attribution!, events_without_activity: 1 } });
+    expect(n[0]).toContain("1 event carry no activity id");
+    expect(n[0]).toContain("proximity is not causation");
+  });
+
+  it("lists all three when all three apply", () => {
+    const n = coverageNote({ ...base, attribution: { ...base.attribution!,
+      needs_duration: [{}], unattributed_days: 4, events_without_activity: 2 } });
+    expect(n).toHaveLength(3);
+  });
+});
+
+describe("provenance says which of the two paths produced the number", () => {
+  it("names the captured baseline for a sourced run", () => {
+    const p = provenanceLine({
+      baseline: { id: "b1", name: "GMP", captured_at: "2026-01-04T00:00:00Z" },
+    });
+    expect(p).toContain("GMP");
+    expect(p).toContain("2026-01-04");
+    expect(p).toContain("re-derivable");
+  });
+
+  it("calls the typed path unauditable, which its own docstring does", () => {
+    const p = provenanceLine(null);
+    expect(p).toContain("unauditable");
+    expect(p).toContain("two people can produce different answers");
+  });
+
+  it("survives a sourced run whose baseline carries no name", () => {
+    expect(provenanceLine({ baseline: null })).toContain("(unnamed)");
+  });
+});
+
+describe("the sourced path's own refusal", () => {
+  it("says nothing when a baseline was found", () => {
+    expect(sourcedRefusal({ baseline: { id: "b1", name: "GMP" } })).toBeNull();
+  });
+
+  it("points at the available baselines when there are some", () => {
+    const r = sourcedRefusal({ status: "baseline_required",
+                               baselines_available: [{ id: "b1", name: "GMP" }] })!;
+    expect(r).toContain("1 baseline is listed");
+  });
+
+  it("says capture one first when there are none, and why it matters", () => {
+    const r = sourcedRefusal({ status: "baseline_required", baselines_available: [] })!;
+    expect(r).toContain("Capture one first");
+    expect(r).toContain("not auditable");
+  });
+});

--- a/apps/web/src/portal/panels/eotClaim.test.ts
+++ b/apps/web/src/portal/panels/eotClaim.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   methodGate, refusal, claimHeadline, eventFinding, concurrencyNote, coverageNote,
-  provenanceLine, sourcedRefusal,
+  provenanceLine, sourcedRefusal, sourcedNeedsFinish, attributionSummary,
 } from "./eotClaim";
 import type { EotResult, EotSourced, EotEvent } from "../../api/schedule";
 
@@ -237,5 +237,68 @@ describe("the sourced path's own refusal", () => {
     const r = sourcedRefusal({ status: "baseline_required", baselines_available: [] })!;
     expect(r).toContain("Capture one first");
     expect(r).toContain("not auditable");
+  });
+});
+
+describe("a sourced run that cannot compute the entitlement still measured the slip", () => {
+  // Found in review on PR #530. Clicking "analyse from the captured baseline" with the finish date
+  // blank DOES return baseline_required — the finding was right. The proposed remedy (have the
+  // server derive the finish from the baseline) was declined: `eot_sourced` forbids it in its own
+  // words, because a captured baseline snapshots PER-ACTIVITY dates and carries no project
+  // completion date. There is nothing to read there, only something to invent.
+  const refusedRun: EotSourced = {
+    baseline: { id: "b1", name: "GMP", captured_at: "2026-01-04T00:00:00Z" },
+    attribution: { activities: [], attributed_days: 12, unattributed_days: 4, unattributed: [],
+                   needs_duration: [], events_without_activity: 0, note: "" },
+    events_detected: 5, events_quantified: 3,
+    analysis: { ...OK, status: "baseline_required", eot_days: null },
+  };
+
+  it("names the ONE missing input rather than letting the refusal read as a broken baseline", () => {
+    const n = sourcedNeedsFinish(refusedRun)!;
+    expect(n).toContain("GMP");
+    expect(n).toContain("that half is done and auditable");
+    expect(n).toContain("baseline COMPLETION date");
+  });
+
+  it("says why the server will not infer it, which is a refusal and not a gap", () => {
+    const n = sourcedNeedsFinish(refusedRun)!;
+    expect(n).toContain("will not");
+    expect(n).toContain("invent the very input");
+  });
+
+  it("says nothing once the entitlement was computed", () => {
+    expect(sourcedNeedsFinish({ ...refusedRun, analysis: OK })).toBeNull();
+  });
+
+  it("does not fire for a DIFFERENT refusal — those need something else", () => {
+    expect(sourcedNeedsFinish({ ...refusedRun,
+      analysis: { ...OK, status: "method_needs_schedule_updates", eot_days: null } })).toBeNull();
+  });
+
+  it("reports the measured figures, which stand whatever the entitlement did", () => {
+    const a = attributionSummary(refusedRun)!;
+    expect(a).toContain("12 days of slip attributed");
+    expect(a).toContain("4 unattributed");
+    expect(a).toContain("5 events detected, 3 carrying a duration");
+  });
+
+  it("omits the unattributed clause when there is none", () => {
+    const a = attributionSummary({ ...refusedRun,
+      attribution: { ...refusedRun.attribution!, unattributed_days: 0 } })!;
+    expect(a).not.toContain("unattributed");
+  });
+
+  it("does NOT vouch for a number that was never computed", () => {
+    // provenanceLine's "re-derivable" is scoped to what was actually derived.
+    const p = provenanceLine(refusedRun);
+    expect(p).toContain("Slip measured against the captured baseline GMP");
+    expect(p).toContain("entitlement itself was NOT computed");
+  });
+
+  it("vouches plainly once the entitlement DID compute", () => {
+    const p = provenanceLine({ ...refusedRun, analysis: OK });
+    expect(p).toContain("re-derivable");
+    expect(p).not.toContain("NOT computed");
   });
 });

--- a/apps/web/src/portal/panels/eotClaim.test.ts
+++ b/apps/web/src/portal/panels/eotClaim.test.ts
@@ -189,7 +189,8 @@ describe("the figure is computed over a subset, and says so", () => {
   it("says proximity is not causation for events carrying no activity", () => {
     const n = coverageNote({ ...base,
       attribution: { ...base.attribution!, events_without_activity: 1 } });
-    expect(n[0]).toContain("1 event carry no activity id");
+    expect(n[0]).toContain("1 event carries no activity id");
+    expect(n[0]).not.toContain("1 event carry ");
     expect(n[0]).toContain("proximity is not causation");
   });
 

--- a/apps/web/src/portal/panels/eotClaim.ts
+++ b/apps/web/src/portal/panels/eotClaim.ts
@@ -1,0 +1,192 @@
+/** R40-EOT — the wording for an extension-of-time claim, and the refusals it must not smooth over.
+ *
+ *  Pure, so the rules can be tested without a DOM.
+ *
+ *  `POST …/schedule/eot` and `…/schedule/eot/sourced` have computed entitlement since R40 — against
+ *  the AACE 29R-03 / SCL Protocol method taxonomy, with the method required and closed, concurrency
+ *  named rather than apportioned, and float that absorbs a delay reported as *absorbed*. **Neither
+ *  had a client caller.** The two were dark for different reasons and neither was visible to the
+ *  reachability gate: `eot` has a three-character leaf, below `MIN_SEGMENT`, so it was never in that
+ *  gate's population; `eot/sourced` was frozen in its allowlist.
+ *
+ *  **The engine's refusals are the feature, and a panel can destroy them without touching the
+ *  server.** Every rule below exists to carry one of them intact to the reader:
+ *
+ *  * **Four refusals, four different places to go.** `method_required`, `baseline_required`,
+ *    `actual_finish_required` and `method_needs_schedule_updates` are not one "couldn't compute".
+ *    One needs a choice, one needs a captured baseline, one needs an as-built date, and one cannot
+ *    be answered by this route at all.
+ *  * **Absorbed is not zero.** A delay inside an activity's float earns no time and still happened.
+ *    Rendering that row as "0 days" says nothing occurred.
+ *  * **Unattributed is not non-excusable.** Slip with no matching cause is the number a claim turns
+ *    on; folding it into contractor risk hands one party a finding nobody demonstrated.
+ *  * **Concurrency is named, never apportioned** — the panel shows the pairs and says the split is a
+ *    contract question, because the protocols themselves disagree.
+ *  * **A detected event is not a quantified delay.** `needs_duration` events are excluded from the
+ *    figure, so the headline is over a SUBSET and must say so. Same shape as the wind screen's
+ *    unchecked mechanism: *a figure computed over part of the evidence is not a figure over all of
+ *    it.*
+ */
+import type { EotResult, EotSourced, EotEvent } from "../../api/schedule";
+
+/** Whether a claim can be computed at all, and what to do when it cannot. */
+export function methodGate(method: string | null | undefined): { can: boolean; why: string } {
+  if (!method) {
+    return { can: false,
+             why: "choose an analysis method first — the same facts give different answers under "
+                  + "different methods, so an EOT without one cannot be weighed" };
+  }
+  return { can: true, why: "" };
+}
+
+/**
+ * What the server refused, in the reader's terms — **kept distinct on purpose**.
+ *
+ * Collapsing these into one "could not compute" is the defect this file exists to prevent: they send
+ * a reader to four different places, and two of them are not fixable by supplying anything.
+ */
+export function refusal(r: EotResult): string | null {
+  switch (r.status) {
+    case "analysed":
+      return null;
+    case "method_required":
+      return "No analysis was run: pick a method. " + (r.reason || "");
+    case "baseline_required":
+      return "No analysis was run: there is no baseline finish to measure against. This is a missing "
+             + "plan-of-record, NOT a finding of zero delay.";
+    case "actual_finish_required":
+      return "No analysis was run: as-planned-vs-as-built compares two END states and the as-built "
+             + "finish is missing. Supply it, or choose a method that does not need it — running the "
+             + "additive sum instead would put one method's number under another method's name.";
+    case "method_needs_schedule_updates":
+      return `No analysis was run: ${r.method} needs a dated SERIES of schedules, not one baseline `
+             + `and one snapshot. ${r.performed_by
+                 ? `It is performed by ${r.performed_by}.`
+                 : "Nothing here performs it yet — it needs schedule updates most projects never "
+                   + "kept."}`;
+    default:
+      return `No analysis was run, and the server reported a status this screen does not know `
+             + `(${r.status || "none"}). Do not read the absence of a figure as a finding.`;
+  }
+}
+
+/**
+ * The headline, with its method attached — never the number alone.
+ *
+ * `over_claimed_days` is the published criticism of impacted-as-planned and is surfaced rather than
+ * buried: the method is unbounded by what the job actually did, so a delay the contractor recovered
+ * still counts at full value.
+ */
+export function claimHeadline(r: EotResult): string {
+  if (r.status !== "analysed" || r.eot_days == null) return refusal(r) || "No analysis was run.";
+  const d = r.eot_days;
+  const head = `${d} day${d === 1 ? "" : "s"} of extension, by ${r.method.replace(/_/g, " ")}.`;
+  const over = r.over_claimed_days
+    ? ` This method is not bounded by what the job did: ${r.over_claimed_days} day`
+      + `${r.over_claimed_days === 1 ? "" : "s"} were claimed beyond the actual slip.`
+    : "";
+  const capped = r.capped_by_actual_slip
+    ? " Capped at the movement of the completion date — this method cannot grant more time than the "
+      + "job actually lost."
+    : "";
+  return head + over + capped;
+}
+
+/**
+ * One event row's finding. **The absorbed case is the load-bearing one.**
+ *
+ * A delay inside the activity's total float earns no extension and DID happen. Reporting it as zero
+ * is the reading that says nothing occurred, and the engine's own comment forbids exactly that.
+ */
+export function eventFinding(e: EotEvent): string {
+  if (e.absorbed_by_float) {
+    return `${e.days} day${e.days === 1 ? "" : "s"} — ABSORBED by ${e.total_float} day`
+      + `${e.total_float === 1 ? "" : "s"} of float. The delay happened; it did not move completion. `
+      + "That is not the same as no delay.";
+  }
+  if (e.entitlement === "unclassified") {
+    return `${e.impact_days} day${e.impact_days === 1 ? "" : "s"} beyond float, but the event carries `
+      + "no entitlement class — so it earns nothing here. Unclassified is NOT a finding of "
+      + "non-excusable; it means nobody has read it against the contract yet.";
+  }
+  if (!e.eot_days) {
+    return `${e.impact_days} day${e.impact_days === 1 ? "" : "s"} beyond float, earning no time: `
+      + `classified ${(e.entitlement || "").replace(/_/g, " ")}.`;
+  }
+  return `${e.eot_days} day${e.eot_days === 1 ? "" : "s"} of extension — `
+    + `${(e.entitlement || "").replace(/_/g, " ")}.`;
+}
+
+/**
+ * Concurrency, stated as the refusal it is.
+ *
+ * `apportioned` is `false` and must stay visibly false: whether overlapping employer-risk and
+ * contractor-risk delay gives time, money, both or neither is a contract-and-jurisdiction question
+ * the published protocols disagree on.
+ */
+export function concurrencyNote(r: EotResult): string {
+  const c = r.concurrency;
+  if (!c || !c.count) {
+    return "No opposing-risk overlap was found among events carrying both a start and a duration. "
+      + "Events missing either were NOT tested — that is unexamined, not clear.";
+  }
+  return `${c.count} concurrent pair${c.count === 1 ? "" : "s"} of opposing risk, named and `
+    + "deliberately NOT split. Apportionment is contested between the protocols and governed by the "
+    + "contract; a silent 50/50 would manufacture the most argued number in the discipline and "
+    + "present it as arithmetic.";
+}
+
+/**
+ * What the figure was computed OVER — the subset warning.
+ *
+ * Detection establishes that an event occurred and carries no duration at all, so `needs_duration`
+ * events are excluded from the entitlement. A headline over a subset that does not say so is the
+ * wind screen's unchecked-mechanism defect in another discipline.
+ */
+export function coverageNote(s: EotSourced): string[] {
+  const out: string[] = [];
+  const nd = s.attribution?.needs_duration?.length || 0;
+  if (nd) {
+    out.push(`${nd} detected event${nd === 1 ? " has" : "s have"} no stated duration and ${nd === 1
+      ? "is" : "are"} EXCLUDED from the figure above. Detection establishes that an event occurred; `
+      + "it does not establish what the event cost, and assigning it days would be arithmetic "
+      + "presented as a finding.");
+  }
+  const ua = s.attribution?.unattributed_days || 0;
+  if (ua) {
+    out.push(`${ua} day${ua === 1 ? "" : "s"} of measured slip have NO matching cause. This is `
+      + "reported as unattributed, and it is NOT non-excusable — defaulting unexplained slip to "
+      + "contractor risk would hand one party a finding nobody demonstrated.");
+  }
+  const orphan = s.attribution?.events_without_activity || 0;
+  if (orphan) {
+    out.push(`${orphan} event${orphan === 1 ? "" : "s"} carry no activity id, so ${orphan === 1
+      ? "it was" : "they were"} matched to nothing. Matching is by explicit activity only — `
+      + "proximity is not causation.");
+  }
+  return out;
+}
+
+/** Where the inputs came from. The typed path is unauditable BY DESIGN and says so. */
+export function provenanceLine(s: EotSourced | null): string {
+  if (!s) {
+    return "Computed from dates and events typed into this form. The baseline is the most contested "
+      + "input in a delay claim, and typed it is unauditable: two people can produce different "
+      + "answers from one project. Capture a baseline and use the sourced analysis for anything "
+      + "that leaves this screen.";
+  }
+  const b = s.baseline;
+  return `Measured against the captured baseline ${b?.name || "(unnamed)"}`
+    + `${b?.captured_at ? `, taken ${String(b.captured_at).slice(0, 10)}` : ""}`
+    + `, with causes from the project's own detected events. Both are re-derivable.`;
+}
+
+/** The sourced path's own refusal — a missing baseline is not a missing number. */
+export function sourcedRefusal(s: EotSourced): string | null {
+  if (s.status !== "baseline_required") return null;
+  const n = s.baselines_available?.length || 0;
+  return "No baseline is captured for this project, so there is nothing to measure slip against. "
+    + (n ? `${n} baseline${n === 1 ? " is" : "s are"} listed — pick one.`
+         : "Capture one first: an EOT from a typed finish date is not auditable, which is the whole "
+           + "reason this path exists.");
+}

--- a/apps/web/src/portal/panels/eotClaim.ts
+++ b/apps/web/src/portal/panels/eotClaim.ts
@@ -160,7 +160,7 @@ export function coverageNote(s: EotSourced): string[] {
   }
   const orphan = s.attribution?.events_without_activity || 0;
   if (orphan) {
-    out.push(`${orphan} event${orphan === 1 ? "" : "s"} carry no activity id, so ${orphan === 1
+    out.push(`${orphan} event${orphan === 1 ? " carries" : "s carry"} no activity id, so ${orphan === 1
       ? "it was" : "they were"} matched to nothing. Matching is by explicit activity only — `
       + "proximity is not causation.");
   }

--- a/apps/web/src/portal/panels/eotClaim.ts
+++ b/apps/web/src/portal/panels/eotClaim.ts
@@ -176,9 +176,51 @@ export function provenanceLine(s: EotSourced | null): string {
       + "that leaves this screen.";
   }
   const b = s.baseline;
-  return `Measured against the captured baseline ${b?.name || "(unnamed)"}`
+  const head = `Slip measured against the captured baseline ${b?.name || "(unnamed)"}`
     + `${b?.captured_at ? `, taken ${String(b.captured_at).slice(0, 10)}` : ""}`
-    + `, with causes from the project's own detected events. Both are re-derivable.`;
+    + ", with causes from the project's own detected events — both re-derivable.";
+  // The claim of re-derivability is scoped to what was actually derived. When the entitlement was
+  // refused, extending it to "the number" would vouch for a figure that does not exist.
+  return s.analysis?.status === "analysed" ? head
+    : `${head} The entitlement itself was NOT computed — see above.`;
+}
+
+/**
+ * What a SOURCED run establishes when the entitlement was refused for want of a baseline finish.
+ *
+ * **Found in review on PR #530, and the reviewer's remedy was declined.** Clicking "analyse from the
+ * captured baseline" with the date blank does return `baseline_required` — that part of the finding
+ * is right. The proposed fix was to have the server derive the finish from the baseline, and
+ * `eot_sourced` forbids exactly that in its own words: *"deriving a project completion date here by
+ * taking max(activity finish) would be this module inventing the very input it exists to make
+ * auditable."* A captured baseline is a snapshot of PER-ACTIVITY dates; it carries no project
+ * completion date, so there is nothing to read — only something to invent.
+ *
+ * So the gap is real and it is a gap in what the screen SAYS. The run is not wasted: slip and
+ * attribution are measured and auditable whatever the entitlement did. This names the one missing
+ * input rather than letting a `baseline_required` read as "the captured baseline did not work".
+ */
+export function sourcedNeedsFinish(s: EotSourced): string | null {
+  if (s.analysis?.status !== "baseline_required") return null;
+  const b = s.baseline?.name || "the captured baseline";
+  return `The slip below IS measured against ${b} — that half is done and auditable. The `
+    + "entitlement needs one thing more: the project's baseline COMPLETION date. A captured "
+    + "baseline snapshots per-activity dates and carries no project finish, and the server will not "
+    + "infer one from the latest activity — that would invent the very input this path exists to "
+    + "make checkable. Put the contract completion date in Baseline finish and run it again.";
+}
+
+/** The measured figures, which stand whether or not the entitlement was computed. */
+export function attributionSummary(s: EotSourced): string | null {
+  const a = s.attribution;
+  if (!a) return null;
+  const parts = [`${a.attributed_days} day${a.attributed_days === 1 ? "" : "s"} of slip attributed`];
+  if (a.unattributed_days) {
+    parts.push(`${a.unattributed_days} unattributed`);
+  }
+  parts.push(`${s.events_detected || 0} event${s.events_detected === 1 ? "" : "s"} detected, `
+    + `${s.events_quantified || 0} carrying a duration`);
+  return parts.join(" · ");
 }
 
 /** The sourced path's own refusal — a missing baseline is not a missing number. */

--- a/apps/web/src/portal/panels/eotClaimPanel.ts
+++ b/apps/web/src/portal/panels/eotClaimPanel.ts
@@ -1,0 +1,126 @@
+/**
+ * R40-EOT — the extension-of-time screen.
+ *
+ * Two analyses of the same claim, and the DEFAULT is the sourced one: its baseline is a captured
+ * artefact rather than a typed date, and the baseline is the most contested input in a delay claim.
+ * The typed path stays because a claim is sometimes argued before a baseline exists, and it is
+ * labelled for what it is rather than offered as an equal.
+ *
+ * **The method list is fetched, never hardcoded.** Posting with no method returns `method_required`
+ * carrying `methods_available`, so the closed set the engine enforces is the closed set the screen
+ * offers. A second copy of the AACE/SCL taxonomy in the client is a copy that can drift from the one
+ * doing the refusing.
+ *
+ * All wording rules live in `eotClaim.ts`; this function only draws them.
+ */
+import { escapeHtml as esc } from "../../ui/feedback";
+import type { PanelContext } from "../panelContext";
+import {
+  methodGate, refusal, claimHeadline, eventFinding, concurrencyNote, coverageNote,
+  provenanceLine, sourcedRefusal,
+} from "./eotClaim";
+import type { EotResult, EotSourced } from "../../api/schedule";
+
+export async function renderEotClaim(ctx: PanelContext): Promise<HTMLElement> {
+  const pid = ctx.host.projectId()!;
+  const card = document.createElement("div");
+  card.className = "dash-card";
+  card.innerHTML = `<div class="section-title" style="margin:0 0 8px">⏱ Extension of time `
+    + `<span style="opacity:.6;font-weight:500;font-size:11px">(AACE 29R-03 / SCL Protocol)</span></div>`
+    + `<div class="meta">Loading the method taxonomy…</div>`;
+
+  // The engine's own closed set, asked for rather than restated.
+  let methods: Record<string, string> = {};
+  try {
+    const probe = await ctx.host.api.scheduleEot(pid, {});
+    methods = probe.methods_available || {};
+  } catch (e) {
+    card.innerHTML += `<div class="meta">Method list unavailable: ${esc((e as Error).message)}</div>`;
+    return card;
+  }
+
+  const opts = Object.keys(methods).map((m) =>
+    `<option value="${esc(m)}">${esc(m.replace(/_/g, " "))}</option>`).join("");
+  card.innerHTML = `<div class="section-title" style="margin:0 0 8px">⏱ Extension of time `
+    + `<span style="opacity:.6;font-weight:500;font-size:11px">(AACE 29R-03 / SCL Protocol)</span></div>`
+    + `<div style="display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end">`
+    + `<label style="display:flex;flex-direction:column;gap:2px;font-size:11px;color:var(--muted)">Method`
+    + `<select class="portal-filter" data-eot="method"><option value="">— choose —</option>${opts}</select></label>`
+    + `<label style="display:flex;flex-direction:column;gap:2px;font-size:11px;color:var(--muted)">Baseline finish`
+    + `<input class="portal-filter" data-eot="baseline_finish" type="date" style="width:150px"></label>`
+    + `<label style="display:flex;flex-direction:column;gap:2px;font-size:11px;color:var(--muted)">Actual finish`
+    + `<input class="portal-filter" data-eot="actual_finish" type="date" style="width:150px"></label>`
+    + `<button class="mini-btn" data-eot-run="sourced" type="button">Analyse from captured baseline</button>`
+    + `<button class="mini-btn" data-eot-run="typed" type="button">Analyse from typed dates</button></div>`
+    + `<div data-eot-meaning class="meta" style="margin-top:6px"></div>`
+    + `<div data-eot-out style="margin-top:10px"></div>`;
+
+  const sel = card.querySelector<HTMLSelectElement>('[data-eot="method"]')!;
+  const meaning = card.querySelector<HTMLElement>("[data-eot-meaning]")!;
+  const out = card.querySelector<HTMLElement>("[data-eot-out]")!;
+  // The method's own published weakness, shown at the moment of choosing it rather than after.
+  sel.addEventListener("change", () => {
+    meaning.textContent = methods[sel.value] ? `${sel.value}: ${methods[sel.value]}` : "";
+  });
+
+  const read = () => {
+    const v = (k: string) =>
+      card.querySelector<HTMLInputElement>(`[data-eot="${k}"]`)!.value.trim() || null;
+    return { method: sel.value || null, baseline_finish: v("baseline_finish"),
+             actual_finish: v("actual_finish") };
+  };
+
+  card.querySelectorAll<HTMLButtonElement>("[data-eot-run]").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const form = read();
+      const g = methodGate(form.method);
+      if (!g.can) { out.innerHTML = `<div class="meta">Cannot analyse — ${esc(g.why)}.</div>`; return; }
+      const sourced = btn.dataset.eotRun === "sourced";
+      card.querySelectorAll<HTMLButtonElement>("[data-eot-run]").forEach((b) => { b.disabled = true; });
+      out.innerHTML = `<div class="meta">Analysing…</div>`;
+      try {
+        const s = sourced ? await ctx.host.api.scheduleEotSourced(pid, form) : null;
+        const r: EotResult = s ? (s.analysis as EotResult) : await ctx.host.api.scheduleEot(pid, form);
+        out.replaceChildren();
+        out.innerHTML = draw(r, s);
+      } catch (e) {
+        out.innerHTML = `<div class="meta">Analysis unavailable: ${esc((e as Error).message)}</div>`;
+      } finally {
+        card.querySelectorAll<HTMLButtonElement>("[data-eot-run]").forEach((b) => { b.disabled = false; });
+      }
+    });
+  });
+  return card;
+}
+
+/** One analysis, rendered. A refusal is drawn as the instruction it is, never as a blank. */
+function draw(r: EotResult, s: EotSourced | null): string {
+  const sr = s ? sourcedRefusal(s) : null;
+  if (sr) return `<div class="meta" style="color:#9a6700">${esc(sr)}</div>`;
+  if (!r) return `<div class="meta">The server returned no analysis.</div>`;
+
+  const refused = refusal(r);
+  const head = `<div style="font-weight:700;color:${refused ? "#9a6700" : "#1a7f37"}">`
+    + `${esc(claimHeadline(r))}</div>`;
+  const prov = `<div class="meta" style="margin-top:6px">${esc(provenanceLine(s))}</div>`;
+  const cover = (s ? coverageNote(s) : [])
+    .map((c) => `<div class="meta" style="margin-top:6px;color:#9a6700">⚠ ${esc(c)}</div>`).join("");
+  if (refused) return head + prov + cover;
+
+  const rows = (r.events || []).map((e) =>
+    `<tr><td>${esc(e.id)}</td><td>${esc(e.kind || "—")}</td>`
+    + `<td>${esc(e.activity_id || "—")}</td>`
+    + `<td style="text-align:right;font-variant-numeric:tabular-nums">${e.days}</td>`
+    + `<td>${esc(eventFinding(e))}</td></tr>`).join("");
+  const table = rows
+    ? `<table class="portal-table" style="margin-top:8px"><thead><tr><th scope="col">Event</th>`
+      + `<th scope="col">Kind</th><th scope="col">Activity</th>`
+      + `<th scope="col" style="text-align:right">Days</th><th scope="col">Finding</th>`
+      + `</tr></thead><tbody>${rows}</tbody></table>`
+    : `<div class="meta" style="margin-top:8px">No events reached the analysis.</div>`;
+
+  return head + prov + cover + table
+    + `<div class="section-title" style="margin:10px 0 4px">Concurrency</div>`
+    + `<div class="meta">${esc(concurrencyNote(r))}</div>`
+    + (r.note ? `<div class="meta" style="margin-top:8px;opacity:.8">${esc(r.note)}</div>` : "");
+}

--- a/apps/web/src/portal/panels/eotClaimPanel.ts
+++ b/apps/web/src/portal/panels/eotClaimPanel.ts
@@ -21,6 +21,15 @@ import {
 } from "./eotClaim";
 import type { EotResult, EotSourced } from "../../api/schedule";
 
+/**
+ * Builds the card and RETURNS it; it does not append.
+ *
+ * That contract is what lets the caller drop a late render whose slot has left the document. This
+ * function cannot draw until it has asked the engine for the method taxonomy, so there is a real
+ * window in which the reader navigates away — and a version of this that appended to `ctx.root`
+ * itself would put the card into whatever screen replaced it, which is the defect review found in
+ * `aiReadiness` on PR #527. **Keep the return; the caller owns where it lands.**
+ */
 export async function renderEotClaim(ctx: PanelContext): Promise<HTMLElement> {
   const pid = ctx.host.projectId()!;
   const card = document.createElement("div");

--- a/apps/web/src/portal/panels/eotClaimPanel.ts
+++ b/apps/web/src/portal/panels/eotClaimPanel.ts
@@ -17,7 +17,7 @@ import { escapeHtml as esc } from "../../ui/feedback";
 import type { PanelContext } from "../panelContext";
 import {
   methodGate, refusal, claimHeadline, eventFinding, concurrencyNote, coverageNote,
-  provenanceLine, sourcedRefusal,
+  provenanceLine, sourcedRefusal, sourcedNeedsFinish, attributionSummary,
 } from "./eotClaim";
 import type { EotResult, EotSourced } from "../../api/schedule";
 
@@ -115,10 +115,18 @@ function draw(r: EotResult | undefined, s: EotSourced | null): string {
   const refused = refusal(r);
   const head = `<div style="font-weight:700;color:${refused ? "#9a6700" : "#1a7f37"}">`
     + `${esc(claimHeadline(r))}</div>`;
+  // The one missing input, named — before the generic refusal, which would otherwise read as
+  // "the captured baseline did not work".
+  const needs = s ? sourcedNeedsFinish(s) : null;
+  const needsLine = needs ? `<div class="meta" style="margin-top:6px">${esc(needs)}</div>` : "";
   const prov = `<div class="meta" style="margin-top:6px">${esc(provenanceLine(s))}</div>`;
+  // Slip and attribution are measured whatever the entitlement did, so they are shown on a refusal
+  // too. A sourced run that renders as nothing but a refusal throws away the auditable half.
+  const att = s && attributionSummary(s)
+    ? `<div class="meta" style="margin-top:6px">${esc(attributionSummary(s)!)}</div>` : "";
   const cover = (s ? coverageNote(s) : [])
     .map((c) => `<div class="meta" style="margin-top:6px;color:#9a6700">⚠ ${esc(c)}</div>`).join("");
-  if (refused) return head + prov + cover;
+  if (refused) return head + needsLine + prov + att + cover;
 
   const rows = (r.events || []).map((e) =>
     `<tr><td>${esc(e.id)}</td><td>${esc(e.kind || "—")}</td>`
@@ -132,7 +140,7 @@ function draw(r: EotResult | undefined, s: EotSourced | null): string {
       + `</tr></thead><tbody>${rows}</tbody></table>`
     : `<div class="meta" style="margin-top:8px">No events reached the analysis.</div>`;
 
-  return head + prov + cover + table
+  return head + prov + att + cover + table
     + `<div class="section-title" style="margin:10px 0 4px">Concurrency</div>`
     + `<div class="meta">${esc(concurrencyNote(r))}</div>`
     + (r.note ? `<div class="meta" style="margin-top:8px;opacity:.8">${esc(r.note)}</div>` : "");

--- a/apps/web/src/portal/panels/eotClaimPanel.ts
+++ b/apps/web/src/portal/panels/eotClaimPanel.ts
@@ -80,7 +80,11 @@ export async function renderEotClaim(ctx: PanelContext): Promise<HTMLElement> {
       out.innerHTML = `<div class="meta">Analysing…</div>`;
       try {
         const s = sourced ? await ctx.host.api.scheduleEotSourced(pid, form) : null;
-        const r: EotResult = s ? (s.analysis as EotResult) : await ctx.host.api.scheduleEot(pid, form);
+        // `analysis` is absent on a sourced refusal (no captured baseline), so this is genuinely
+        // optional — `draw` handles it. A cast asserting otherwise would be the type lying about a
+        // case that happens on any project whose baseline was never captured.
+        const r: EotResult | undefined =
+          s ? s.analysis : await ctx.host.api.scheduleEot(pid, form);
         out.replaceChildren();
         out.innerHTML = draw(r, s);
       } catch (e) {
@@ -94,7 +98,7 @@ export async function renderEotClaim(ctx: PanelContext): Promise<HTMLElement> {
 }
 
 /** One analysis, rendered. A refusal is drawn as the instruction it is, never as a blank. */
-function draw(r: EotResult, s: EotSourced | null): string {
+function draw(r: EotResult | undefined, s: EotSourced | null): string {
   const sr = s ? sourcedRefusal(s) : null;
   if (sr) return `<div class="meta" style="color:#9a6700">${esc(sr)}</div>`;
   if (!r) return `<div class="meta">The server returned no analysis.</div>`;

--- a/apps/web/src/portal/panels/schedule.ts
+++ b/apps/web/src/portal/panels/schedule.ts
@@ -4,6 +4,7 @@ import { escapeHtml as esc, toast } from "../../ui/feedback";
 import { confirmModal } from "../../ui/modal";
 import type { PanelContext } from "../panelContext";
 import { renderScheduleBrief } from "./scheduleBrief";
+import { renderEotClaim } from "./eotClaimPanel";
 import { renderScheduleMethods } from "./scheduleMethods";
 import { flattenLookahead, mondayUtc, renderWeeklyGantt } from "./weeklyGantt";
 
@@ -131,6 +132,17 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
   // than run on render: three of them walk the whole activity set, and a panel that fires four
   // full-schedule computations every time somebody opens it is a panel people learn to avoid.
   ctx.root.appendChild(renderScheduleMethods(ctx));
+  // R40-EOT lands in a slot appended SYNCHRONOUSLY, and the late write is dropped when that slot is
+  // no longer in the document. The panel asks the engine for its own method taxonomy before it can
+  // draw, so there is a real window in which the reader navigates away and `ctx.root` belongs to a
+  // different screen — appending straight onto `root` in a late `.then` puts this card into whatever
+  // replaced it. That is the same defect review found in aiReadiness on PR #527, and repeating it
+  // here would be the second instance rather than a new one.
+  const eotSlot = document.createElement("div");
+  ctx.root.appendChild(eotSlot);
+  void renderEotClaim(ctx)
+    .then((el) => { if (eotSlot.isConnected) eotSlot.appendChild(el); })
+    .catch(() => {});
 
   // a collapsible drawer the alerts / earned-schedule buttons fill on demand (kept out of the way)
   const interopDrawer = document.createElement("div"); interopDrawer.style.cssText = "display:none;margin:0 0 8px";

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1779,6 +1779,43 @@ instances:
   PREFAB-FREEZE-RACE, and filed the same way rather than left in a review thread — **a follow-up held
   only in a thread closes by default when the PR merges.**
 
+- ✅ ⭐ **R40-EOT — an extension of time, with the method that produced it**
+  *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts`,
+  `apps/web/src/portal/panels/eotClaim.test.ts` and `services/api/test_route_reachability.py`)*
+
+  R40 built the whole discipline server-side and **both of its routes were dark.** `…/schedule/eot`
+  computes entitlement against the AACE 29R-03 / SCL Protocol taxonomy — `method` required and
+  closed, because the same facts give different answers under different methods — and
+  `…/schedule/eot/sourced` does it again over the project's **captured baseline** and its own
+  detected events, so the two most contested inputs are re-derivable rather than typed.
+
+  **One feature, two concealments, two different lists.** `eot` has a three-character leaf, below
+  `MIN_SEGMENT`, so it sat in the short-leaf ratchet ENV-WIND had just created; `eot/sourced` was
+  frozen in `KNOWN_UNCALLED` and could have been read any day. *Reading either list alone would have
+  wired half a claim* — the same lesson BUYOUT-KEEP recorded from the other direction, where one
+  dark route fed the other.
+
+  `apps/web/src/portal/panels/eotClaim.ts` holds the rules (32 tests, six mutations all biting), and
+  every one exists to carry a server refusal intact to the reader rather than smooth it away:
+
+  * **Four refusals stay four refusals.** `method_required`, `baseline_required`,
+    `actual_finish_required` and `method_needs_schedule_updates` send a reader to four different
+    places, and two are not fixable by supplying anything. One "could not compute" would be the
+    familiar collapse.
+  * **Absorbed is not zero.** A delay inside an activity's float earns no time and *happened*.
+  * **Unattributed is not non-excusable** — defaulting unexplained slip to contractor risk hands one
+    party a finding nobody demonstrated.
+  * **Concurrency is named, never apportioned**, because the published protocols disagree and the
+    contract governs.
+  * **A detected event is not a quantified delay**: `needs_duration` events are excluded from the
+    figure, so the headline is over a SUBSET and says so — the wind screen's unchecked-mechanism
+    defect in another discipline.
+
+  The method list is **fetched, not restated**: posting with no method returns the closed set, so the
+  taxonomy the screen offers is the taxonomy the engine enforces and cannot drift from it.
+
+  Uncalled routes **60 → 59**, and the confirmed-dark short-leaf ratchet **7 → 6**.
+
 - ✅ ⭐ **ENV-WIND — a wind answer at the only stage that can act on it**
   *(S — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts`,
   `apps/web/src/portal/panels/envWind.test.ts` and `services/api/test_route_reachability.py`)*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1749,8 +1749,9 @@ instances:
   `SpatialNode.{elevation, elevationUnit}` (neither is rendered). **`DealMemoryProject.cost_variance_pct`
   is the one worth naming separately: it is not an oversight but a documented refusal** —
   `routers/operations.py` states that comparing a realised overrun to an entered contingency is a
-  claim about what an underwriting asserts, not a unit conversion, and it waits on the same domain
-  call `/schedule/eot` does.
+  claim about what an underwriting asserts, not a unit conversion. It was deferred alongside the EOT
+  semantics; **that one was decided on 2026-09-11 (R40-EOT) and this one was not** — they are separate
+  calls, and only the schedule half has been made.
 
 - 🟡 **RFQ-IDEMPOTENT — `send_rfq` mints before it checks, so a second send duplicates**
   *(S — Lane G; **OPEN**, raised in review on PR #528 2026-09-11; needs a contract decision)*
@@ -2579,15 +2580,21 @@ have, so unlike R45 there is no de-duplication decision hiding in this list:
 | ~~`weather`~~ | 250 | **SHIPPED v0.3.967** — `schedule_weather.py`; refuses to invent an allowance |
 | ~~`portfolio`~~ | 345 | **SHIPPED v0.3.967** — membership checked per project, proven 403/200 |
 
-**⚠ AND THE WHOLE EOT SURFACE IS DARK — measured 2026-08-20.** Both routes exist and **no client
-code references either**: `POST /schedule/eot` (caller-typed baseline) and `POST /schedule/eot/sourced`
-(R40-EOT ②, derived from a *captured* baseline and detected events). `test_route_reachability` could
-not report it — its leaf, `eot`, is 3 characters and the rule skips anything under 5, because short
-leaves match unrelated text constantly. A longer needle was tried and rejected with numbers; see the
-`MIN_SEGMENT` note in that file.
+**⚠ THE WHOLE EOT SURFACE WAS DARK — measured 2026-08-20, and CLOSED 2026-09-11 by R40-EOT above.**
+Both routes existed and **no client code referenced either**: `POST /schedule/eot` (caller-typed
+baseline) and `POST /schedule/eot/sourced` (R40-EOT ②, derived from a *captured* baseline and detected
+events). `test_route_reachability` could not report it — its leaf, `eot`, is 3 characters and the rule
+skips anything under 5, because short leaves match unrelated text constantly. A longer needle was
+tried and rejected with numbers; see the `MIN_SEGMENT` note in that file.
 
-**Not wired here on purpose.** The entry below reserves the EOT *semantics* as a domain decision, and
-which of the two a screen should show is the same question wearing different clothes: `sourced` is the
+*Kept rather than deleted because the measurement is the point: this paragraph is why the short-leaf
+ratchet exists, and a reader meeting `MIN_SEGMENT` for the first time needs the case that motivated
+it. The status is corrected in place; the finding is not.*
+
+**Not wired here on purpose — and the decision it deferred was TAKEN on 2026-09-11 (R40-EOT above):
+the screen offers both and DEFAULTS to `sourced`, labelling the typed path unauditable in the words of
+its own docstring.** What follows is the reasoning as it stood before that call, kept because it is the
+argument the decision answers. `sourced` is the
 auditable one — its own docstring says a caller-typed baseline "is unauditable… two people can produce
 different EOTs from one project by typing different dates" — but putting an extension-of-time figure
 in front of a user is a decision about what the product asserts in an arbitration, not a wiring task.
@@ -2626,7 +2633,7 @@ SHIPPED rows, sweep-run headers, prior corrections and the 18-findings table, an
 
 | claim | verdict |
 |---|---|
-| the EOT surface is dark, no client references it | **accurate** — re-verified the same day |
+| the EOT surface is dark, no client references it | **accurate** — re-verified the same day; *closed 2026-09-11 by R40-EOT, and the verdict is left as it stood because this table records what a sweep found on its date* |
 | `eot.py` performs none of the four methods | **FALSE** — the correction above |
 | `/schedule/risk` and `/schedule/montecarlo` disagree by 38 days | **accurate, and resolved** — the alias calls `schedule_risk_mc.for_project`, the same engine |
 | three PPC implementations disagree | **accurate, and resolved** — one rule since v0.3.974, held by `services/api/test_ppc_divergence.py` |
@@ -3374,9 +3381,13 @@ that rotted were all sentences no test read. Note for whoever extends it — the
   Directions, the npm title table, and this row now match the classifier. CC0 is a public-domain
   dedication, strictly more permissive than MIT; 59 files under
   `services/data/families/external/` already declared it.
-- **The EOT surface is dark, and deliberately so — but the decision has been pending since 2026-08-20.**
-  `POST /schedule/eot` and `POST /schedule/eot/sourced` both exist and **no client code references
-  either**. R46 reserves this as a domain decision rather than a wiring task, and it is the right call:
+- ~~**The EOT surface is dark, and deliberately so — the decision pending since 2026-08-20.**~~
+  **DECIDED AND SHIPPED 2026-09-11 (R40-EOT).** The screen offers both analyses and **defaults to
+  `sourced`**; the typed path stays for a claim argued before a baseline exists, labelled unauditable
+  in the words of its own docstring. *What the product asserts, stated plainly: an extension of time is
+  measured against a captured artefact, and a figure from typed dates is offered only with that caveat
+  attached.* The reasoning that made this a decision rather than a wiring task is kept because it is
+  what the answer answers:
   `sourced` is the auditable one — its own docstring says a caller-typed baseline *"is unauditable… two
   people can produce different EOTs from one project by typing different dates"* — but **an
   extension-of-time figure ends up in arbitration**, so which one a screen shows is a statement about
@@ -6027,8 +6038,9 @@ Shipped 2026-08-21:
   `services/api/test_deal_memory_beside.py`. **One of the engine's three metrics is offered and the
   other two are refused on the record**: `cost_per_sf` is a unit conversion from an entered hard cost
   and a GFA; `cost_variance_pct` beside a contingency would be the product asserting *"your
-  contingency should cover our historical overrun"*, the same domain call `/schedule/eot` is waiting
-  on; and a schedule VARIANCE beside an entered DURATION is a category error in matching units.
+  contingency should cover our historical overrun"* — deferred alongside the EOT semantics, which were
+  decided on 2026-09-11 (R40-EOT) while **this one still is not**; and a schedule VARIANCE beside an
+  entered DURATION is a category error in matching units.
 
   **The "by vintage" half was nearly left out, and two gates disagreeing is what caught it.**
   `clientCallers.test.ts` refused a `portfolioDealMemory` with no screen; `test_route_reachability`

--- a/services/api/test_body_param_reach.py
+++ b/services/api/test_body_param_reach.py
@@ -225,10 +225,50 @@ check("no route has a REQUIRED body parameter nothing sends, unless it is alread
       + " — either wire a caller, or freeze the route in test_route_reachability.KNOWN_UNCALLED "
         "with the reason")
 
-check("the frozen explanation is LOAD-BEARING — some required parameter is genuinely unsent",
-      bool(MISSING_REQUIRED),
-      "zero unsent required parameters would make the check above vacuous; if the surface really "
-      "is complete, say so here rather than leaving an assertion that cannot fail")
+# --- the live count reached ZERO, and NOT because the surface completed ---------------------------
+#
+# This check used to be `bool(MISSING_REQUIRED)`: some required parameter must be genuinely unsent,
+# or the filter above is vacuous. On 2026-09-11 it went to zero and the honest reading is **not**
+# "the surface is complete".
+#
+# The last finding was `/proforma/entitlement-risk` needing `entitlement`. That route is still dark —
+# it is frozen in `test_route_reachability.KNOWN_UNCALLED` and nothing calls it. What changed is that
+# R40-EOT added `apps/web/src/api/schedule.ts`, whose `EotEvent` / `EotEventInput` declare
+# `entitlement: string | null` — the AACE entitlement CLASS of a delay event, a different domain
+# entirely. `names_key` matches `key` followed by `:`, so **a TypeScript type annotation now reads as
+# a send.**
+#
+# That is the third shape of this collision family recorded in this repository within one day, and it
+# is the one the others did not predict:
+#   * a route leaf inside unrelated PROSE (`/proforma/renovation`);
+#   * a route leaf that is another ROUTE's leaf (`/jurisdiction/check`);
+#   * and now a body key that is a TYPE DECLARATION rather than a value — *the matcher cannot tell
+#     `{foo: bar}` from `foo: string`, because in text they are the same shape.*
+#
+# **Not sharpened, deliberately.** This file's own docstring says the rule is coarse in the LENIENT
+# direction on purpose: "over-matching can only make this gate miss a gap; under-matching would
+# invent work for somebody, which is the expensive mistake." Excluding type positions textually would
+# reintroduce exactly the false positives `names_key` was widened to remove.
+#
+# So the assertion is replaced rather than deleted, and it now tests the RULE instead of the
+# population — using this file's own self-test idiom. Remove the colliding declaration from a copy of
+# the blob and the finding must come back. That cannot go vacuous the way a count can.
+COLLIDED = ("/proforma/entitlement-risk", "POST", "entitlement")
+_NO_COLLISION = CODE.replace("entitlement?: string | null", "REMOVED_BY_SELF_TEST") \
+                    .replace("entitlement: string | null", "REMOVED_BY_SELF_TEST")
+check("the colliding declaration this check now depends on still exists",
+      _NO_COLLISION != CODE,
+      "api/schedule.ts no longer declares `entitlement` on its EOT event types — re-point this at "
+      "whatever collides today, or if nothing does, restore `bool(MISSING_REQUIRED)`")
+check("with the COLLISION removed, the rule still finds a genuinely unsent required parameter",
+      COLLIDED in unsent(PARAMS, _NO_COLLISION, required=True),
+      f"{COLLIDED[0]} needs {COLLIDED[2]!r} and is frozen as uncalled, so removing the unrelated "
+      "type declaration must expose it again; if it does not, `names_key` or the OpenAPI read broke")
+check("...and the live population is zero ONLY by that collision, not by completion",
+      not MISSING_REQUIRED,
+      f"a required parameter is unsent again: {MISSING_REQUIRED} — good news if it was just wired, "
+      "but read it before assuming; this line asserts the state recorded above, so a change here "
+      "means the note is now wrong")
 
 print(f"\n  body params {len(PARAMS)} "
       f"({sum(1 for *_, r in PARAMS if r)} required) · web source {len(CODE):,} chars")

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -215,7 +215,6 @@ KNOWN_UNCALLED: set[str] = {
     # never "this is safe". Two are worth someone's attention — `/entitlements/conditions` is
     # R22-ENTITLEMENT's own surface, and `/schedule/make-ready` is the Last Planner constraint list.
     # `/cost/datasets` left here in v0.3.1137 — Budget reads installed vintages.
-    "/projects/{pid}/schedule/eot/sourced",
     # `/drawing-set/compiled.pdf` left here in v0.3.1137 — Exports opens `compiledPdfUrl`.
     "/projects/{pid}/drawing-set/file-drawing-set",
     "/projects/{pid}/drawings/received-regions",
@@ -945,9 +944,16 @@ CONFIRMED_DARK_SHORT_LEAF = {
     #: (`apps/web/src/api/downloadPdf.ts`). A screen that renders the payment application from data
     #: rather than downloading it would use these; none exists yet.
     "/projects/{pid}/cost/g702", "/projects/{pid}/cost/g703",
-    #: Extension-of-time claim assembly, and the ERP entity bridge. Both are finished server-side
-    #: and have no screen. Candidates for the next wiring sprint, in that order.
-    "/projects/{pid}/schedule/eot", "/connections/{cid}/erp/{entity}",
+    #: The ERP entity bridge: finished server-side, no screen. The next wiring candidate.
+    #:
+    #: `/projects/{pid}/schedule/eot` LEFT this set in R40-EOT — `scheduleEot` in
+    #: `apps/web/src/api/schedule.ts`, called from `apps/web/src/portal/panels/eotClaimPanel.ts`.
+    #: It is worth recording what that cost, because the two halves of R40-EOT hid in two different
+    #: places: this one was invisible for being three characters long, while its sibling
+    #: `/schedule/eot/sourced` was frozen in KNOWN_UNCALLED above and could have been read any day.
+    #: **One feature, two concealments, two different lists** — reading either alone would have
+    #: wired half a claim.
+    "/connections/{cid}/erp/{entity}",
 }
 _SHORT = {r for r in PATHS if len(_leaf(r)) < MIN_SEGMENT}
 _SHORT_DARK = {r for r in _SHORT if not leaf_is_called(_leaf(r), _CODE)}


### PR DESCRIPTION
R40 built the whole delay-analysis discipline server-side and **both of its routes were dark.**

`…/schedule/eot` computes entitlement against the AACE 29R-03 / SCL Protocol taxonomy — `method` required and closed, because the same facts give different answers under different methods — and `…/schedule/eot/sourced` does it again over the project's **captured baseline** and its own detected events, so the two most contested inputs in a delay claim are re-derivable rather than typed.

## One feature, two concealments, two different lists

`eot` has a three-character leaf, below `MIN_SEGMENT`, so it sat in the short-leaf ratchet ENV-WIND had just created. `eot/sourced` was frozen in `KNOWN_UNCALLED` and could have been read any day.

*Reading either list alone would have wired half a claim* — the same lesson BUYOUT-KEEP recorded from the other direction, where one dark route was dark because the route feeding it was.

## The rules, and why each exists

`apps/web/src/portal/panels/eotClaim.ts`. Every one carries a server refusal intact to the reader rather than smoothing it away:

- **Four refusals stay four refusals.** `method_required`, `baseline_required`, `actual_finish_required` and `method_needs_schedule_updates` send a reader to four different places, and two are not fixable by supplying anything. One "could not compute" would be the familiar collapse. An unrecognised status is reported as unknown rather than guessed at.
- **Absorbed is not zero.** A delay inside an activity's float earns no time and *happened*; only the second reading says nothing occurred.
- **Unattributed is not non-excusable** — defaulting unexplained slip to contractor risk hands one party a finding nobody demonstrated.
- **Concurrency is named, never apportioned**, and "no overlap found" is reported as *unexamined where the data was missing* rather than as clear.
- **A detected event is not a quantified delay.** `needs_duration` events are excluded from the figure, so the headline is over a **subset** and says so — the wind screen's unchecked-mechanism defect in another discipline.

The method list is **fetched, not restated**: posting with no method returns the closed set, so the taxonomy the screen offers is the one the engine enforces and cannot drift from it.

## Two things worth flagging in review

**The panel lands in a slot appended synchronously**, with the late write dropped when that slot has left the document. The first draft appended straight onto `ctx.root` in a `.then` — which is exactly the defect review found in `aiReadiness` on #527, and it has a real window here because the screen must ask for the method taxonomy before it can draw. Fixed before pushing rather than after review.

**One mutation was re-done because it failed to compile.** A duplicate `case` made vitest report "no tests", which is not a surviving mutation but no mutation at all. Rewritten as valid TypeScript it fails 7 tests.

## Counters

Uncalled routes **60 → 59**; the confirmed-dark short-leaf ratchet **7 → 6**.

## Verification

32 rule tests, six mutations all biting. Web 247 files / 2623 tests, typecheck, lint; reachability, roadmap-status, changelog and citation gates; ruff over the whole tree. Build and backend suite running at push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an extension-of-time (EOT) claims panel to the Schedule view.
  - Supports method selection, typed dates, or analysis using captured project schedule data.
  - Displays entitlement results, refusal reasons, delay-event findings, concurrency details, attribution coverage, and input provenance.
  - Identifies absorbed, unattributed, concurrent, and undurationed delay events.
  - Provides validation, loading, and error states during analysis.

- **Documentation**
  - Added guidance covering EOT analysis methods, inputs, and delay classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->