### PR TITLE
An npm override can no longer disagree with the dependency it overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,18 @@ has lived only in a changelog entry since — and a changelog does not run.
 The population is derived rather than listed: every overridden package that is also a declared
 dependency. Three of the four current overrides pin transitive packages nothing here declares, so
 there is no pair to disagree and they are outside the population rather than exempted. The
-comparator returns `null`, not `false`, for a range shape it cannot read, and `null` reds the
-build — a checker that quietly approves what it cannot parse goes green exactly when it stops
-understanding its subject.
+comparator returns `null`, not `false`, for a shape it cannot read, and `null` reds the build — a
+checker that quietly approves what it cannot parse goes green exactly when it stops understanding
+its subject.
+
+**npm applies two different rules, and the gate now applies each in its own position.** In the
+root manifest — the same file as the `overrides` block — the two specs must match as RAW STRINGS;
+`">=10.9.0"` beside an override of `"10.10.0"` is semver-compatible and npm still refuses it. In a
+workspace manifest the raw rule does not reach, and npm resolves the declared range and rewrites
+it to the override; `package-lock.json` records `apps/web` resolving `^10.10.0` to `10.10.0`,
+which is npm's own proof. A single rule applied to both positions is wrong in one direction or the
+other: too loose at the root, and red on a configuration that demonstrably installs in the
+workspace. `$name`, npm's own escape hatch, is accepted in both.
 
 ### Extension-of-time claims, with the method that produced them
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### An npm override can no longer disagree with the dependency it overrides
+
+`eslint` moves to **10.10.0**, and the engineering standards say so — `toolchainDocs.test.ts`
+refused the bump until the prose caught up, which is exactly what it is for.
+
+The new part is `apps/web/src/tooling/npmOverrides.test.ts`. The root manifest pins some packages
+through `overrides`, and when such a pin drifts from the range a workspace declares, npm refuses
+the whole install with `EOVERRIDE`. That already happened here once, on this same pair. The rule
+has lived only in a changelog entry since — and a changelog does not run.
+
+The population is derived rather than listed: every overridden package that is also a declared
+dependency. Three of the four current overrides pin transitive packages nothing here declares, so
+there is no pair to disagree and they are outside the population rather than exempted. The
+comparator returns `null`, not `false`, for a range shape it cannot read, and `null` reds the
+build — a checker that quietly approves what it cannot parse goes green exactly when it stops
+understanding its subject.
+
 ### Extension-of-time claims, with the method that produced them
 
 **Schedule** now assembles an **extension of time**. Pick an analysis method, and it grades each

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,7 +58,7 @@
     "@eslint/js": "^10.0.1",
     "@types/qrcode": "^1.5.6",
     "@types/three": "0.185.4",
-    "eslint": "^10.9.1",
+    "eslint": "^10.10.0",
     "globals": "^17.12.0",
     "happy-dom": "^20.11.6",
     "openapi-typescript": "^7.13.0",

--- a/apps/web/src/tooling/npmOverrides.test.ts
+++ b/apps/web/src/tooling/npmOverrides.test.ts
@@ -1,0 +1,163 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * An npm `overrides` entry may not silently disagree with the dependency it overrides.
+ *
+ * Written from a live failure this repo already paid for. `CHANGELOG.md` records
+ * `EOVERRIDE: Override for eslint@10.8.0 conflicts with direct dependency` — the root manifest
+ * pinned eslint through `overrides` while a workspace declared a range that no longer admitted that
+ * pin. npm refuses the install outright, which is the GOOD case and the reason it was caught: the
+ * bad case is an override that still *satisfies* the declared range while being a different version
+ * from the one the manifest advertises, so `npm run lint` runs a linter nobody declared and every
+ * document describing the toolchain is quietly wrong.
+ *
+ * That rule has lived only in a changelog entry ever since. Nothing read it, which is the same
+ * failure mode `toolchainDocs.test.ts` exists for one layer up: **prose does not run**.
+ *
+ * SCOPE IS DERIVED, NOT LISTED. The population is every key in the root `overrides` block that is
+ * ALSO declared as a dependency somewhere in the workspace — today exactly one (eslint); the other
+ * three overrides (fast-uri, js-yaml, postcss) pin transitive packages nothing here declares, so
+ * there is no pair to disagree and they are correctly outside the population rather than exempted.
+ * Add a fourth overridden package that IS declared and it joins automatically.
+ *
+ * IT FAILS CLOSED. `satisfies` understands exact, `^`, `~` and `>=` and returns `null` for anything
+ * else; a `null` reds the build rather than passing. A comparator that quietly returns "fine" for a
+ * range shape it cannot read is the fail-open shape this repo keeps finding — the gate would go
+ * green precisely when it stopped understanding its own subject.
+ */
+
+// Walk up to a MARKER rather than counting directories, for the reason `toolchainDocs.test.ts`
+// records: `resolve(cwd, "..", "..")` resolves somewhere useless when vitest is invoked from the
+// repo root instead of from `apps/web`, and the suite then fails with ENOENT rather than saying so.
+function repoRoot(): string {
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i += 1) {
+    if (existsSync(resolve(dir, ".github/workflows/ci.yml"))) return dir;
+    const up = resolve(dir, "..");
+    if (up === dir) break;
+    dir = up;
+  }
+  throw new Error("repo root not found — no ancestor holds .github/workflows/ci.yml");
+}
+
+const REPO = repoRoot();
+
+type Manifest = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  overrides?: Record<string, string>;
+};
+
+function manifest(rel: string): Manifest {
+  const text = readFileSync(resolve(REPO, rel), "utf8");
+  expect(text.length, `${rel} did not load — every assertion below would pass vacuously`)
+    .toBeGreaterThan(200);
+  return JSON.parse(text) as Manifest;
+}
+
+/** The manifests that can declare a dependency an override could contradict. */
+const MANIFESTS = ["package.json", "apps/web/package.json"] as const;
+
+const parts = (v: string): [number, number, number] | null => {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+};
+
+const cmp = (a: [number, number, number], b: [number, number, number]): number =>
+  a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+
+/**
+ * Does the exact version `pin` satisfy the declared range `range`?
+ *
+ * Returns `null` — NOT `false` — for a shape this cannot read, so the caller can tell "violates the
+ * range" apart from "I do not know what this range means". Those deserve different messages and
+ * both must red the build; collapsing them is how a gate starts lying.
+ *
+ * Deliberately hand-rolled rather than importing `semver`. `semver` is present in `node_modules`
+ * only as a transitive dependency of other tooling, and CLAUDE.md's `test_declared_imports` lesson
+ * is exactly this: a package our own source imports is a DIRECT dependency however else it happens
+ * to arrive, and leaning on somebody else's metadata means a release nobody here reviews can delete
+ * it. The four shapes below are the ones these manifests actually use.
+ */
+export function satisfies(pin: string, range: string): boolean | null {
+  const p = parts(pin);
+  if (!p) return null;
+  const r = range.trim();
+  const op = /^(\^|~|>=)?\s*(\d+\.\d+\.\d+)$/.exec(r);
+  // `noUncheckedIndexedAccess` is on, so a matched group is `string | undefined` to the compiler
+  // even though this regex cannot match without group 2. Re-parse rather than assert with `!`: a
+  // non-null assertion here would be a claim about the regex that the next edit to it could
+  // silently falsify, and this function's whole contract is that it never guesses.
+  const floor = op ? parts(op[2] ?? "") : null;
+  if (!op || !floor) return null;
+  if (cmp(p, floor) < 0) return false;
+  switch (op[1]) {
+    case undefined: return cmp(p, floor) === 0;
+    case ">=": return true;
+    case "^": return p[0] === floor[0];
+    case "~": return p[0] === floor[0] && p[1] === floor[1];
+    default: return null;
+  }
+}
+
+type Pair = { pkg: string; pin: string; where: string; range: string };
+
+function population(): Pair[] {
+  const root = manifest("package.json");
+  const overrides = root.overrides ?? {};
+  const out: Pair[] = [];
+  for (const rel of MANIFESTS) {
+    const m = rel === "package.json" ? root : manifest(rel);
+    for (const field of ["dependencies", "devDependencies"] as const) {
+      for (const [pkg, range] of Object.entries(m[field] ?? {})) {
+        const pin = overrides[pkg];
+        if (pin !== undefined) out.push({ pkg, pin, where: `${rel} ${field}`, range });
+      }
+    }
+  }
+  return out;
+}
+
+describe("an npm override agrees with the dependency it overrides", () => {
+  const PAIRS = population();
+
+  it("the comparator reads the shapes these manifests use, and refuses the ones it cannot", () => {
+    // The historical failure, as an assertion: the override this repo shipped against the range it
+    // shipped beside. If this ever returns true the gate has stopped being able to see its own
+    // founding defect.
+    expect(satisfies("10.8.0", "^10.9.1"), "the EOVERRIDE case must be REJECTED").toBe(false);
+    expect(satisfies("10.10.0", "^10.10.0")).toBe(true);
+    expect(satisfies("10.10.0", "10.10.0")).toBe(true);
+    expect(satisfies("10.10.1", "10.10.0"), "an exact pin means exact").toBe(false);
+    expect(satisfies("11.0.0", "^10.9.1"), "a caret does not cross a major").toBe(false);
+    expect(satisfies("10.11.0", "~10.10.0"), "a tilde does not cross a minor").toBe(false);
+    expect(satisfies("10.11.0", ">=10.10.0")).toBe(true);
+    // Fail-closed: unreadable shapes are `null`, never a quiet pass.
+    expect(satisfies("10.10.0", "workspace:*"), "unreadable range must be null").toBeNull();
+    expect(satisfies("10.10.0", "10.9.x"), "unreadable range must be null").toBeNull();
+    expect(satisfies("latest", "^10.9.1"), "unreadable pin must be null").toBeNull();
+  });
+
+  it("there is something to check — otherwise every assertion below is vacuous", () => {
+    // If the root overrides block is emptied, or every overridden package stops being declared,
+    // this gate proves nothing and should say so rather than going green.
+    expect(PAIRS.length, "no overridden package is also a declared dependency").toBeGreaterThan(0);
+  });
+
+  it("no override contradicts a range a manifest declares, and none is unreadable", () => {
+    const violations: string[] = [];
+    const unknown: string[] = [];
+    for (const { pkg, pin, where, range } of PAIRS) {
+      const ok = satisfies(pin, range);
+      if (ok === null) unknown.push(`${pkg}: override "${pin}" vs ${where} "${range}"`);
+      else if (!ok) violations.push(`${pkg}: override "${pin}" does not satisfy ${where} "${range}"`);
+    }
+    expect(unknown, "a range shape the comparator cannot read — teach it, do not exempt it")
+      .toEqual([]);
+    expect(violations, "npm will refuse this install with EOVERRIDE, or run a version nobody declared")
+      .toEqual([]);
+  });
+});

--- a/apps/web/src/tooling/npmOverrides.test.ts
+++ b/apps/web/src/tooling/npmOverrides.test.ts
@@ -103,7 +103,14 @@ export function satisfies(pin: string, range: string): boolean | null {
   }
 }
 
-type Pair = { pkg: string; pin: string; where: string; range: string };
+/**
+ * One override paired with one declaration of the same package.
+ *
+ * `sameFile` is the whole reason this is not a flat list: npm applies TWO DIFFERENT RULES depending
+ * on where the declaration sits, and a gate that applied one rule to both would be wrong in one
+ * direction or the other. See `verdict` below.
+ */
+type Pair = { pkg: string; pin: string; where: string; range: string; sameFile: boolean };
 
 function population(): Pair[] {
   const root = manifest("package.json");
@@ -114,11 +121,40 @@ function population(): Pair[] {
     for (const field of ["dependencies", "devDependencies"] as const) {
       for (const [pkg, range] of Object.entries(m[field] ?? {})) {
         const pin = overrides[pkg];
-        if (pin !== undefined) out.push({ pkg, pin, where: `${rel} ${field}`, range });
+        if (pin !== undefined) {
+          out.push({ pkg, pin, where: `${rel} ${field}`, range, sameFile: rel === "package.json" });
+        }
       }
     }
   }
   return out;
+}
+
+/**
+ * Is this override/declaration pair one npm will accept? `null` means "cannot tell" and reds the build.
+ *
+ * **THE RULE IS NOT THE SAME IN BOTH POSITIONS, and getting that wrong in either direction breaks
+ * something.** `overrides` is only read from the ROOT manifest, and npm's constraint is scoped to
+ * "a package already listed as a direct dependency IN THE SAME package.json", where the two specs
+ * must then match *as raw strings* — not merely be semver-compatible.
+ *
+ * - **Root's own dependencies (`sameFile`): raw-string equality.** `">=10.9.0"` beside an override
+ *   of `"10.10.0"` is semver-compatible and npm still refuses it with EOVERRIDE. A `satisfies()`
+ *   check here is LOOSER than npm and would pass an install that cannot happen. This is the pair
+ *   that produced `Override for eslint@10.8.0 conflicts with direct dependency`.
+ * - **A workspace's dependencies: semver compatibility.** The override is not in that file, so the
+ *   raw-string rule does not reach it; npm resolves the declared range and rewrites it to the
+ *   override. Measured in this repository: `apps/web/package.json` declares `^10.10.0`, the root
+ *   override pins `10.10.0`, and `package-lock.json` records `apps/web`'s resolved devDependency as
+ *   `10.10.0`. npm produced that lock. Demanding raw equality here would red a configuration that
+ *   demonstrably installs.
+ *
+ * `$name` is npm's own escape hatch — an override of `"$foo"` means "whatever the direct dependency
+ * declares", so it cannot disagree with it by construction and is accepted wherever it appears.
+ */
+export function verdict(p: Pair): boolean | null {
+  if (p.pin.startsWith("$")) return p.pin === `$${p.pkg}` ? true : null;
+  return p.sameFile ? p.pin.trim() === p.range.trim() : satisfies(p.pin, p.range);
 }
 
 describe("an npm override agrees with the dependency it overrides", () => {
@@ -147,15 +183,43 @@ describe("an npm override agrees with the dependency it overrides", () => {
     expect(PAIRS.length, "no overridden package is also a declared dependency").toBeGreaterThan(0);
   });
 
-  it("no override contradicts a range a manifest declares, and none is unreadable", () => {
+  it("the two rules are actually different, and each is applied in its own position", () => {
+    const p = (over: Partial<Pair>): Pair =>
+      ({ pkg: "eslint", pin: "10.10.0", where: "t", range: "^10.10.0", sameFile: false, ...over });
+
+    // The pair this repository ships. A workspace declares a caret, the root override pins exact,
+    // and `package-lock.json` records apps/web resolving to 10.10.0 — npm produced that lock, so
+    // this MUST be accepted. Demanding raw equality here would red a working configuration.
+    expect(verdict(p({ sameFile: false })), "workspace caret vs exact override is fine").toBe(true);
+
+    // ...and the SAME two strings in the root manifest are refused, because npm compares raw specs
+    // there. This is the asymmetry: one rule per position, not one rule.
+    expect(verdict(p({ sameFile: true })), "root raw-spec mismatch is EOVERRIDE").toBe(false);
+
+    // The hole the loose rule left: semver-compatible but not raw-equal, in the root file.
+    expect(verdict(p({ sameFile: true, pin: "10.10.0", range: ">=10.9.0" })),
+      "root: compatible is NOT enough").toBe(false);
+    expect(verdict(p({ sameFile: true, pin: "10.10.0", range: "10.10.0" })),
+      "root: raw equality passes").toBe(true);
+
+    // npm's own escape hatch, accepted in both positions because it cannot disagree.
+    expect(verdict(p({ sameFile: true, pin: "$eslint" })), "$name self-reference").toBe(true);
+    expect(verdict(p({ sameFile: false, pin: "$eslint" })), "$name self-reference").toBe(true);
+    // A `$` pointing at a DIFFERENT package resolves elsewhere; this gate cannot follow it.
+    expect(verdict(p({ pin: "$other" })), "cross-package $ reference is unreadable").toBeNull();
+  });
+
+  it("no override contradicts a declaration npm will check it against, and none is unreadable", () => {
     const violations: string[] = [];
     const unknown: string[] = [];
-    for (const { pkg, pin, where, range } of PAIRS) {
-      const ok = satisfies(pin, range);
+    for (const pair of PAIRS) {
+      const { pkg, pin, where, range, sameFile } = pair;
+      const ok = verdict(pair);
+      const rule = sameFile ? "must match RAW (same file as the overrides block)" : "must satisfy";
       if (ok === null) unknown.push(`${pkg}: override "${pin}" vs ${where} "${range}"`);
-      else if (!ok) violations.push(`${pkg}: override "${pin}" does not satisfy ${where} "${range}"`);
+      else if (!ok) violations.push(`${pkg}: override "${pin}" ${rule} ${where} "${range}"`);
     }
-    expect(unknown, "a range shape the comparator cannot read — teach it, do not exempt it")
+    expect(unknown, "a spec shape the comparator cannot read — teach it, do not exempt it")
       .toEqual([]);
     expect(violations, "npm will refuse this install with EOVERRIDE, or run a version nobody declared")
       .toEqual([]);

--- a/docs/engineering/web-standards.md
+++ b/docs/engineering/web-standards.md
@@ -31,7 +31,7 @@
 
 - **Node 24 from Program Files locally** (`export PATH="/c/Program Files/nodejs:$PATH"` — the PATH
   Node 18 breaks the build); CI runs Node 24. Both manifests declare `"engines": {"node": ">=24"}`.
-- Gate per release: `npm run typecheck` + `npm run lint` (eslint 10.9.1 — the 9.x pin was lifted once
+- Gate per release: `npm run typecheck` + `npm run lint` (eslint 10.10.0 — the 9.x pin was lifted once
   the local Node reached 24; `@eslint/js` is a *different* package and still on 9.x) + `npx vitest
   run` + `npm run build`. `lint:fast` (oxlint) is an additive pre-lint in CI.
   <!-- The versions in these two bullets are asserted against the manifests by

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "apps/web"
       ],
       "devDependencies": {
-        "eslint": "10.9.1",
+        "eslint": "10.10.0",
         "happy-dom": "^20.11.6",
         "vite": "8.2.2"
       },
@@ -47,7 +47,7 @@
         "@eslint/js": "^10.0.1",
         "@types/qrcode": "^1.5.6",
         "@types/three": "0.185.4",
-        "eslint": "^10.9.1",
+        "eslint": "10.10.0",
         "globals": "^17.12.0",
         "happy-dom": "^20.11.6",
         "openapi-typescript": "^7.13.0",
@@ -1542,6 +1542,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
     "node_modules/@capacitor/android": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.5.1.tgz",
@@ -1762,9 +1786,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+      "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2081,6 +2105,30 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
@@ -4511,6 +4559,20 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -5157,9 +5219,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
-      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+      "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -5171,7 +5233,7 @@
         "@eslint/config-array": "^0.23.5",
         "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint/plugin-kit": "^0.7.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -5186,7 +5248,7 @@
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
+        "file-entry-cache": "11.1.5 || >11.1.6 <12",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "ignore": "^5.2.0",
@@ -5521,15 +5583,13 @@
       "dev": true
     },
     "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/filelist": {
@@ -5582,16 +5642,15 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/flatbuffers": {
@@ -5600,10 +5659,11 @@
       "integrity": "sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw=="
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -5978,6 +6038,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -5989,6 +6062,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -6621,12 +6701,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -6689,12 +6763,13 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/kleur": {
@@ -7720,6 +7795,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/qrcode": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "node": ">=24"
   },
   "overrides": {
-    "eslint": "10.9.1",
+    "eslint": "10.10.0",
     "fast-uri": "^3.1.7",
     "js-yaml": "^4.3.1",
     "postcss": "^8.5.18"
   },
   "devDependencies": {
-    "eslint": "10.9.1",
+    "eslint": "10.10.0",
     "happy-dom": "^20.11.6",
     "vite": "8.2.2"
   }


### PR DESCRIPTION
# What & why

Supersedes #513. eslint moves 10.9.1 → 10.10.0, and the missing gate underneath that bump is added: nothing asserted that the root manifest's `overrides` entry agreed with the dependency range a workspace declares, a rule this repository has already paid for once and has held only in a changelog entry since.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (the WHOLE tree) — `All checks passed!`, exit 0. No `.py` files in this diff.
- [x] Backend: affected `test_*.py` pass — none affected; no backend test added, so no `run_tests.py` TESTS registration is needed.
- [x] Web: `npm run typecheck && npm run lint && npm run build` clean (Node 24) — all three exit 0. Full suite additionally green: **248 files / 2634 tests**.
- [x] No import cycles introduced — `no-import-cycles.test.ts` 2/2 pass; `test_import_cycles.py` OK across 563 first-party modules / 1095 import edges.
- [x] `CHANGELOG.md` entry added (newest at top, under `## Unreleased`); no roadmap item applies — this supersedes a Dependabot PR rather than a roadmap line.
- [ ] Version bumped in both `apps/web/package.json` and `apps/web/src-tauri/tauri.conf.json` — **n/a, not a release PR.**
- [x] No secrets, no competitor names in shipped docs (interop names OK) — the only shipped-doc change is one eslint version number in `docs/engineering/web-standards.md`.

---

## What was actually wrong with #513

Nothing about eslint. Dependabot got all three manifest sites right — `apps/web` `^10.10.0`, root `overrides.eslint` `10.10.0`, root `devDependencies.eslint` `10.10.0`, lock consistent. It failed on `apps/web/src/shell/toolchainDocs.test.ts`, which reads the declared version out of the manifest and refuses any governed document naming a different one. `docs/engineering/web-standards.md:34` still said "eslint 10.9.1".

That is a prose fix Dependabot structurally cannot make, so this PR takes its commit and makes it.

## The gate that was missing one layer down

The root manifest pins some packages through `overrides`. When such a pin drifts from the range a workspace declares, npm refuses the whole install with `EOVERRIDE`.

That already happened in this repository, on this exact pair — `CHANGELOG.md` records `Override for eslint@10.8.0 conflicts with direct dependency`. Since then the rule has lived only in that changelog entry. **A changelog does not run.**

`apps/web/src/tooling/npmOverrides.test.ts`:

- **Population is derived, not listed** — every overridden package that is also a declared dependency. Three of the four current overrides (`fast-uri`, `js-yaml`, `postcss`) pin transitive packages nothing here declares, so there is no pair to disagree; they sit outside the population rather than on an exemption list. A fourth overridden package that *is* declared joins automatically.
- **It fails closed.** The comparator returns `null`, never `false`, for a range shape it cannot read, and `null` reds the build. A checker that quietly approves what it cannot parse goes green precisely when it stops understanding its own subject.
- **`semver` is deliberately not imported.** It is present in `node_modules` only as a transitive dependency, and `services/api/test_declared_imports.py` exists because leaning on someone else's metadata means a release nobody here reviews can delete a package our own source imports.
- The `EOVERRIDE` case is an assertion, not a comment: `satisfies("10.8.0", "^10.9.1")` must be `false`, so the gate can never stop seeing its founding defect.

## Verification

Both halves mutation-checked rather than asserted:

- reverting the prose line → `toolchainDocs` fails with `docs/engineering/web-standards.md: "…eslint 10.9.1" — declared is 10.10.0`
- putting `overrides.eslint` back to `10.9.1` → the new gate reports **both** declaring sites

The local eslint binary is still the installed 10.9.1; the lock carries 10.10.0 and CI installs from the lock.

## Not in this PR, deliberately

`#516` (numpy) and `#517` (manifold3d) fail the same way as each other and need a recompiled `services/api/requirements.lock`, which must come from `pip-tools==7.6.1` inside `python:3.12-slim`. Both raise a floor in `services/data/requirements.txt` while `services/api/requirements.in` carries the comment *"floor raised WITH services/data/requirements.txt"* — an invariant written beside the line, enforced by `test_lock_satisfies_requirements`, and unreadable to Dependabot, which bumps one source per PR. Landing the floors without the lock would knowingly push red, so they are held for a follow-up.

A local Python 3.12 `pip-compile` was tried and **does not reproduce CI's lock**: 117 pinned packages against the committed 109, the extra eight being the `aiohttp` subtree that `uvicorn[standard]` resolves differently outside `python:3.12-slim`. The lock can only come from the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA