### PR TITLE
Two type-aware gates now see the tree on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Two type-aware gates now see the tree on Windows
+
+`deadFieldTyped.test.ts` and `responseUndeclared.test.ts` failed 9 tests on Windows and passed on
+CI. Both compared a root built with `path.resolve` — backslashed on Windows — against TypeScript's
+`sf.fileName`, which is forward-slashed on every OS, so `startsWith` rejected every source file and
+both derivations walked an empty tree. Linux has no backslashes, which is why CI never saw it.
+(`ts.sys.resolvePath` is not the fix: it hands the backslashed path back unchanged.)
+
+They failed closed, which is the point of their vacuity guards — with one exception worth naming:
+*"the tree's undeclared keys are exactly the known ones"* **passed** on the empty tree, because
+`KNOWN_GAPS` is empty and so is a walk that looked at nothing. Only the guard beside it went red.
+
+The fix had a trap in it. `deadFieldTyped`'s two filesystem scans compared their walked paths
+against the same `API` prefix, and matched on Windows only because both sides were backslashed.
+Normalising the prefix alone lets `api/` into both scans and every assertion still passes —
+measured: the sound candidate set fell from 386 to 348, all green. So the two identical walks are
+now one normalised walk, and a new assertion requires every declaring file the checker found to be
+one the scans' `api/` exclusion removes; the un-normalised walk now fails it. `extract()` normalises
+its own root, and a new self-test hands it a backslashed one, so the regression is caught on Linux
+CI too.
+
 ### An npm override can no longer disagree with the dependency it overrides
 
 `eslint` moves to **10.10.0**, and the engineering standards say so — `toolchainDocs.test.ts`

--- a/apps/web/src/api/deadFieldTyped.test.ts
+++ b/apps/web/src/api/deadFieldTyped.test.ts
@@ -44,8 +44,14 @@ import { describe, expect, it } from "vitest";
  * rather than vanish, which is the failure mode that looks like a finding.
  */
 
-const WEB = resolve(process.cwd(), "src");
-const API = resolve(WEB, "api");
+/** TypeScript reports every `sf.fileName` with forward slashes on every OS, while `resolve` and
+ *  `join` return backslashes on Windows — so every path compared below goes through this first.
+ *  Before it, `startsWith(WEB)` was false for EVERY source file on Windows and the derivation found
+ *  nothing; the positive control caught it, which is the case for having one. (`ts.sys.resolvePath`
+ *  does not help: it hands the backslashed path back unchanged.) */
+const posix = (p: string) => p.replace(/\\/g, "/");
+const WEB = posix(resolve(process.cwd(), "src"));
+const API = `${WEB}/api`;
 const isApiDecl = (f: string) =>
   f.startsWith(API) && !f.endsWith("schema.d.ts") && !f.endsWith(".test.ts");
 const isTest = (f: string) => f.endsWith(".test.ts") || f.endsWith(".test.tsx");
@@ -123,18 +129,24 @@ function derive() {
   return { keyToFile, readers };
 }
 
+/** Every .ts/.tsx under src/, in TypeScript's slash form so `startsWith(API)` below compares like
+ *  with like. The two scans that read it once walked separately and un-normalised, which matched
+ *  only because `API` was backslashed too; normalising one side alone lets api/ into both scans and
+ *  every assertion still passes — which is why the exclusion's reach is asserted below. */
+const walk = (dir: string, out: string[] = []): string[] => {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(posix(p));
+  }
+  return out;
+};
+const webFiles = walk(WEB);
+
 /** Every string literal appearing outside `api/` — the typed pass's blind spot, made measurable. */
 function stringLiterals(): Set<string> {
-  const walk = (dir: string, out: string[] = []): string[] => {
-    for (const e of readdirSync(dir)) {
-      const p = join(dir, e);
-      if (statSync(p).isDirectory()) walk(p, out);
-      else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
-    }
-    return out;
-  };
   const out = new Set<string>();
-  for (const f of walk(WEB)) {
+  for (const f of webFiles) {
     if (f.startsWith(API) || isTest(f)) continue;
     for (const m of readFileSync(f, "utf-8").matchAll(/["'`]([A-Za-z_]\w*)["'`]/g)) out.add(m[1]!);
   }
@@ -146,16 +158,8 @@ function stringLiterals(): Set<string> {
  *  This is the derivation's SECOND blind spot, and unlike the first it cannot be narrowed by a better
  *  checker — it is a limit of static reading, not of this implementation. */
 function dynamicallyReadInterfaces(): Set<string> {
-  const walk = (dir: string, out: string[] = []): string[] => {
-    for (const e of readdirSync(dir)) {
-      const p = join(dir, e);
-      if (statSync(p).isDirectory()) walk(p, out);
-      else if (p.endsWith(".ts") || p.endsWith(".tsx")) out.push(p);
-    }
-    return out;
-  };
   const out = new Set<string>();
-  for (const f of walk(WEB)) {
+  for (const f of webFiles) {
     if (f.startsWith(API) || isTest(f)) continue;
     const src = readFileSync(f, "utf-8");
     if (!/Object\.(keys|entries|values)|\.\.\./.test(src)) continue;
@@ -180,6 +184,18 @@ describe("DEAD-FIELD: the type-aware derivation", () => {
     expect(readersOutsideDecl("Appraisal.reconciliation.value").length,
       "the checker resolved NO reader for a field the valuation panel renders — the derivation is "
       + "broken, and an unread count taken from it would be fiction").toBeGreaterThan(0);
+  });
+
+  it("the scans' api/ exclusion reaches every file the declarations came from", () => {
+    // The two scans walk the FILESYSTEM; the declarations come from the CHECKER. Unless both spell a
+    // path the same way, `startsWith(API)` excludes nothing from the scans and api/'s own literals
+    // clear candidates they should not — measured on Windows with the walk left un-normalised: the
+    // sound set fell 386 → 348 and every other assertion in this file still passed.
+    const declFiles = new Set(keyToFile.values());
+    const excluded = new Set(webFiles.filter((f) => f.startsWith(API)));
+    expect(declFiles.size).toBeGreaterThan(0);
+    expect([...declFiles].filter((f) => !excluded.has(f)),
+      "declaring files the scans' api/ exclusion does not match").toEqual([]);
   });
 
   it("sees NESTED members, which the identifier derivation's two-space anchor could not", () => {

--- a/apps/web/src/api/responseUndeclared.test.ts
+++ b/apps/web/src/api/responseUndeclared.test.ts
@@ -175,14 +175,18 @@ export function extract(program: ts.Program, root: string, relBase = root):
     { rows: Site[]; unresolved: Unresolved[] } {
   const checker = program.getTypeChecker();
   const rows: Site[] = [], unresolved: Unresolved[] = [];
+  // `sf.fileName` is forward-slashed on every OS; a caller's `path.resolve` is backslashed on
+  // Windows. Compared raw, `startsWith` failed for every file there and the walk found an empty tree.
+  const posix = (p: string) => p.replace(/\\/g, "/");
+  const rootTs = posix(root), baseTs = posix(relBase);
   for (const sf of program.getSourceFiles()) {
-    if (sf.isDeclarationFile || !sf.fileName.startsWith(root)) continue;
+    if (sf.isDeclarationFile || !sf.fileName.startsWith(rootTs)) continue;
     if (sf.fileName.includes("/vendor/") || sf.fileName.endsWith(".test.ts")) continue;
     const visit = (node: ts.Node): void => {
       const pathArg = ts.isCallExpression(node) ? node.arguments[0] : undefined;
       if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)
           && node.expression.name.text === "json" && pathArg !== undefined) {
-        const rel = sf.fileName.slice(relBase.length).replace(/^\//, "");
+        const rel = sf.fileName.slice(baseTs.length).replace(/^\//, "");
         const line = sf.getLineAndCharacterOfPosition(node.getStart()).line + 1;
         const raw = pathOf(pathArg);
         const method = methodOf(node.arguments[1]);
@@ -317,6 +321,18 @@ describe("RESPONSE-UNDECLARED", () => {
     // above, and a test that leans on that ordering is a test that breaks for the wrong reason.
     expect(r.map((x) => ({ key: x.key, keys: x.keys })))
       .toEqual([{ key: "GET /x", keys: ["a"] }]);       // `b` returned by a server would be a gap
+  });
+
+  it("accepts a BACKSLASHED root, which is what `path.resolve` returns on Windows", () => {
+    // The whole-tree run above builds its root with `path.resolve`, which on Linux never contains a
+    // backslash — so CI could not see this. On Windows every file failed the prefix test: four tree
+    // assertions went red, and the fifth, `exactly the known ones`, PASSED — `KNOWN_GAPS` is empty,
+    // and so is a walk that looked at nothing. Only the vacuity guard stood between that and a green
+    // gate. Pinned here, where it runs on every OS.
+    const { program: p } = syntheticProgram(
+      `declare const c: any;\nfunction f() { return c.json<{ a: number }>("/x"); }\n`);
+    const { rows: r } = extract(p, "\\synthetic");
+    expect(r.map((x) => ({ rel: x.rel, key: x.key }))).toEqual([{ rel: "probe.ts", key: "GET /x" }]);
   });
 
   it("analyses a concatenated path, which the first draft reported as unresolvable", () => {


### PR DESCRIPTION
# What & why

`apps/web/src/api/deadFieldTyped.test.ts` and `apps/web/src/api/responseUndeclared.test.ts` failed **9 tests on Windows** (reproducible on unmodified 48d6cf4f) while CI stayed green.

**Cause, confirmed by printing both sides:** each test builds its root with `path.resolve` — `C:\Server\...\apps\web\src` on Windows — and compares it with `startsWith` against TypeScript's `sf.fileName`, which is forward-slashed on every OS (`C:/Server/.../src/errorReporting.ts`). Every source file was filtered out and both derivations walked an empty tree. Linux has no backslashes, so CI could not see it. (`ts.sys.resolvePath` does **not** fix this — it returns the backslashed path unchanged. `ts.normalizePath` would, but it is not in the public `.d.ts`, so a local `replace(/\/g, "/")` is used.)

**The gates failed closed — with one exception:** *"the tree's undeclared keys are exactly the known ones"* **passed** on the empty tree, because `KNOWN_GAPS` is `{}` and so is a walk that looked at nothing. Only the vacuity guard beside it went red.

## Changes

- **`deadFieldTyped.test.ts`:** `WEB`/`API` normalised. The two filesystem scans had to change *with* them: they compared walked paths against `API` and matched on Windows only because both sides were backslashed. Normalising the prefix alone lets `api/` into both scans with **every assertion still green** — measured: sound candidate set 386 → 348. The two verbatim-duplicate walks are now one normalised `webFiles`, and a new test asserts every declaring file the checker found is one the scans' `api/` exclusion removes.
- **`responseUndeclared.test.ts`:** `extract()` normalises its own `root`/`relBase`, so any caller is covered. New self-test passes it a backslashed root — this runs on **Linux CI too**, so the regression is now visible there.
- `CHANGELOG.md` entry under Unreleased.

## Verification (Windows, Node 24.18.0, vitest 4.1.11, TypeScript 5.9.3)

- Baseline full `vitest run`: 2 files / **9 failed**, 2626 passed — exactly these 9, nothing else Windows-specific among the 41 test files using `process.cwd()`.
- After: **248 files / 2637 tests pass** (2635 + 2 new), exit 0.
- Mutation checks: removing `extract()`'s normalisation reds the new self-test (plus the 4 tree assertions); leaving the walk un-normalised — which previously passed all 5 tests — reds the new reach test alone.
- `tsc --noEmit` clean, eslint clean on both files; `docsCurrent`, `npmOverrides`, `test_changelog_current`, `test_no_secrets`, `test_no_comparative_names` pass.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: no backend change (CHANGELOG gates run and pass)
- [x] Web: `typecheck` + `lint` clean (build not affected — test files only)
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added (newest at top)
- [ ] Version bump — not a release PR
- [x] No secrets, no competitor names

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API file discovery and path handling on Windows.
  * Fixed analyses that could miss API declarations when paths used Windows-style separators.
  * Added safeguards to ensure excluded files are handled correctly.
  * Added regression coverage for cross-platform path behavior.

* **Documentation**
  * Documented the Windows-related test failures and their resolution in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->