### PR TITLE
Two dark route families wired, and the gate collision between them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,42 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### An accounting connection's books can be read from the app
+
+`GET /connections/{cid}/quickbooks/{entity}` and `GET /connections/{cid}/erp/{entity}` return a
+QuickBooks or Sage/Viewpoint chart of accounts, vendor list or bill list. Both were finished on the
+server and callable by nothing. A **Books** action now sits on every QuickBooks, Sage and Viewpoint
+connection in the Data-connections modal.
+
+**The two halves were dark for two different reasons, and only one of them was recorded.**
+`erp` is three characters, under the reachability gate's `MIN_SEGMENT`, so the short-leaf ratchet
+held it and named it as the next wiring candidate. `quickbooks` is ten characters, IS assessed by
+the main rule, and the rule believed it called — off the string `"quickbooks"` in the connection-TYPE
+`<select>`. A product vocabulary word, not a URL. The listed one was the one anybody could see.
+
+Three rules in `apps/web/src/connections/ledgerBrowse.ts`, each because the server's answer and the
+obvious rendering of it say different things:
+
+- **A vendor failure is HTTP 200 with `{"error": …}`.** The route catches the vendor exception and
+  puts the message in the body, so `res.ok` is true and the row list is absent. Rendering that as an
+  empty table tells an accountant their books are EMPTY when the truth is that we could not read
+  them. `outcome()` refuses to collapse the two, and checks `error` first and on its own — testing
+  the rows first would classify every failure as "no records".
+- **The QuickBooks count is capped at 50 and nothing pages past it**, so `count: 50` there is a floor
+  and a company with 200 accounts sees 50 with no indication. The ERP read is uncapped. The same
+  field means different things on the two routes, so it is never printed bare.
+- **Row keys are vendor-cased** — Intuit's `Name`/`Id` against a generic ERP's lowercase — which is
+  the COL-PAIR defect class, and is why the server's own `_info_erp` already hedges.
+
+**Wiring a route blinded the gate to a different one, in the same commit.** The entity list contains
+`vendors`, so `/connections/{cid}/erp/vendors` is now a URL this client builds, and
+`/benchmarks/vendors` — dark since the gate was written, and frozen in `KNOWN_UNCALLED` ever since —
+immediately read as called. It is not; its five `/benchmarks/*` siblings have client methods and it
+still has none. Reachability work is not monotone: a new URL adds a segment to the corpus, and any
+dark route sharing that last segment leaves the gate's sight. It is recorded now as a blind spot in
+neither set, beside `/asset-rights/verify` and the two jurisdiction routes. The rot check earned its
+keep — it was a bare `print` until 2026-08-20, and under that version this route would have dropped
+out of the frozen list with no output at all.
 ### Two type-aware gates now see the tree on Windows
 
 `deadFieldTyped.test.ts` and `responseUndeclared.test.ts` failed 9 tests on Windows and passed on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,39 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### Every trade partner's record with your firm, and what it does not cover
+
+`GET /benchmarks/vendors` has reported each subcontractor's cross-project commercial and compliance
+history since R22-PROCURE-DEPTH ③ — subcontracts, commitments, invoices, COIs, lien waivers and
+warranties, from six registers — and had no client caller the whole time. Its five `/benchmarks/*`
+siblings all had one. It now renders in the Benchmarks panel, worst first.
+
+**It is the route the entry below blinded the reachability gate to, wired in the same pull request.**
+LEDGER-BROWSE's entity list contains `vendors`, so `/connections/{cid}/erp/vendors` became a URL this
+client builds and the leaf `vendors` read as called — by something else. Wiring this removes the
+blind spot's *subject* rather than leaving a record of it. The gate's two assertions pass unchanged
+either way, which is exactly why they stay: **it could not see this route dark and cannot see it
+wired.** Its verdict was, and remains, no verdict.
+
+Three rules in `apps/web/src/portal/panels/vendorScorecard.ts` (20 tests), and all three are the
+server's own — stated there in prose and enforced here, because a caveat that lives only in a JSON
+field nobody renders is a caveat nobody reads:
+
+- **`no_history` is NOT `clear`.** A sub who has never worked for you is an unknown. The engine calls
+  a clean-looking record for an unexamined vendor "the single most expensive mistake this module
+  could make" — and it is a *rendering* mistake as much as an engine one: three verdicts that reach
+  the same pixel are one verdict. An unrecognised fourth verdict does not inherit green either.
+- **A clean record here is silence about quality, not a pass.** `ncr` and `inspection` carry no vendor
+  field, so nothing in this scorecard has looked at quality or schedule performance. The attribution
+  line is stated even when the payload omits it — the silence is a property of the route, and a
+  missing caveat reads as no caveat.
+- **A certificate with no expiry is not cover.** "Expired", "expiry unknown" and "none recorded" are
+  three states; printing "0 expired" for a vendor with no certificate at all is the `no_history`
+  error one field down.
+
+The headline states how many vendors have no record at all beside the watch count, so "3 on watch"
+cannot be read as "and the rest are fine".
+
 ### An accounting connection's books can be read from the app
 
 `GET /connections/{cid}/quickbooks/{entity}` and `GET /connections/{cid}/erp/{entity}` return a

--- a/apps/web/src/api/connections.ts
+++ b/apps/web/src/api/connections.ts
@@ -53,6 +53,21 @@ export function withConnections<TBase extends Ctor<HttpCore>>(Base: TBase) {
     return this.json<{ kind?: string; count?: number; issues?: Record<string, unknown>[]; error?: string }>(
       `/connections/${id}/acc/projects/${projectId}/issues`);
   }
+  /**
+   * Read a connection's books — chart of accounts, vendors or bills.
+   *
+   * `vendor` is "quickbooks" or "erp" (Sage / Viewpoint share the generic REST reader), matching
+   * the two route families. **A vendor failure comes back as HTTP 200 with `{"error": …}`**, not a
+   * status code, so the caller must check the body — `connections/ledgerBrowse.ts` is where that
+   * rule lives, and its `outcome()` is what stops a failed read rendering as an empty ledger.
+   *
+   * The rows arrive under the entity's own name (`{kind, count, accounts: [...]}`), which is why
+   * the return type is open rather than a fixed row key.
+   */
+  connectionLedger(id: string, vendor: "quickbooks" | "erp", entity: string) {
+    return this.json<{ kind?: string; count?: number; error?: string; [k: string]: unknown }>(
+      `/connections/${id}/${vendor}/${encodeURIComponent(entity)}`);
+  }
   /** Editable Procore->module field mapping for a connection (admin). */
   connectionMappings(id: string) {
     return this.json<{ mappings: Record<string, { module: string; fields: { field: string; label: string; default: string; path: string }[] }> }>(

--- a/apps/web/src/api/cost.ts
+++ b/apps/web/src/api/cost.ts
@@ -196,6 +196,30 @@ export function withCost<TBase extends Ctor<HttpCore>>(Base: TBase) {
       code_count: number; min_samples: number; codes_below_threshold: number; message?: string | null }>(
       `/benchmarks/costs?min_samples=${minSamples}`);
   }
+  /**
+   * Each trade partner's record with your firm, across projects (R22-PROCURE-DEPTH ③).
+   *
+   * Placed here beside `benchmarkCosts` by what it ANSWERS, the rule that cell records: this is
+   * cross-project commercial history, which is a cost question.
+   *
+   * **`no_history` is a distinct verdict from `clear` and must stay distinct at the pixel.** The
+   * wording rules are in `apps/web/src/portal/panels/vendorScorecard.ts`; `attributable` carries the
+   * server's own statement that `ncr` and `inspection` have no vendor field, so quality and schedule
+   * performance are NOT in this scorecard and a clean record here is silence on that subject.
+   */
+  vendorScorecards() {
+    return this.json<{
+      vendors: { vendor: string; verdict: string; verdict_note: string; project_count: number;
+        subcontract_value: number; committed: number; spent: number; invoiced: number;
+        lien_waivers_value: number; coi_expired: number; coi_missing_expiry: number;
+        warranties_live: number; record_counts: Record<string, number>; flags: string[];
+        trades: string[] }[];
+      vendor_count: number; repeat_vendors: number; watch_count: number;
+      verdict_meanings: Record<string, string>;
+      attributable: { from: string[]; not_from: string[]; note: string };
+      note: string; message: string | null;
+    }>("/benchmarks/vendors");
+  }
   /** Actual unit rates per cost code across the caller's projects (cost ÷ installed quantity). */
   unitRates(minProjects = 3) {
     return this.json<{

--- a/apps/web/src/connections/connectionsUI.ts
+++ b/apps/web/src/connections/connectionsUI.ts
@@ -10,6 +10,10 @@ import type { ApiClient, ConnectionItem, SyncScheduleItem } from "../api/client"
 import { modalShell, confirmModal } from "../ui/modal";
 import { askText } from "../ui/prompt";
 import { escapeHtml, toast } from "../ui/feedback";
+import {
+  ENTITIES, countLine, emptyLine, errorLine, outcome, rowId, rowLabel, vendorFor,
+} from "./ledgerBrowse";
+import type { LedgerVendor } from "./ledgerBrowse";
 
 type GetPid = () => string | null;
 
@@ -109,6 +113,54 @@ function mappingModal(api: ApiClient, connectionId: string, name: string) {
   card.appendChild(msg); void render().finally(ready);
 }
 
+/**
+ * Read an accounting connection's books.
+ *
+ * Every wording rule lives in `ledgerBrowse.ts`; this only draws them. The one that shapes the
+ * markup is `outcome()`: an error, an empty ledger and a list of rows are three states, and the
+ * first two must not render the same. A failed read that showed an empty table would tell an
+ * accountant their books are empty when we simply could not read them.
+ */
+function ledgerModal(api: ApiClient, id: string, name: string, vendor: LedgerVendor) {
+  const { card, msg, ready } = modalShell(`Books — ${name}`, 720);
+  msg.style.color = "var(--err)";
+  const bar = document.createElement("div");
+  bar.style.cssText = "display:flex;gap:8px;align-items:center;flex-wrap:wrap";
+  const pick = document.createElement("select");
+  pick.className = "portal-filter";
+  for (const e of ENTITIES) { const o = document.createElement("option"); o.value = o.textContent = e; pick.appendChild(o); }
+  const go = document.createElement("button"); go.className = "file-btn"; go.textContent = "Read";
+  const note = document.createElement("div"); note.className = "meta"; note.style.cssText = "margin-top:8px";
+  const grid = document.createElement("div"); grid.style.cssText = "overflow:auto;max-height:46vh;margin-top:8px";
+  bar.append(pick, go);
+
+  const read = async () => {
+    const entity = pick.value;
+    msg.textContent = ""; note.textContent = "reading…"; grid.innerHTML = "";
+    go.disabled = true;
+    try {
+      const res = await api.connectionLedger(id, vendor, entity);
+      const out = outcome(res, entity);
+      if (out.state === "error") { note.textContent = ""; msg.textContent = errorLine(vendor, out.message); return; }
+      if (out.state === "empty") { note.textContent = emptyLine(entity); return; }
+      note.textContent = countLine(vendor, entity, out.rows.length);
+      // Arbitrary ledger content — escaped, like every other cell in this file.
+      const tr = out.rows.map((r) =>
+        `<tr><td>${escapeHtml(rowId(r) || "—")}</td><td>${escapeHtml(rowLabel(r))}</td></tr>`).join("");
+      grid.innerHTML = `<table class="portal-table"><thead><tr><th scope="col">ID</th>`
+        + `<th scope="col">Name</th></tr></thead><tbody>${tr}</tbody></table>`;
+    } catch (e) {
+      note.textContent = "";
+      msg.textContent = `Request failed: ${(e as Error).message}`;
+    } finally {
+      go.disabled = false;
+    }
+  };
+  go.onclick = () => { void read(); };
+  card.append(bar, note, grid, msg);
+  ready();
+}
+
 /** Read-only data browser for a SQL connection (local / Postgres / Supabase): table list +
  *  a SELECT console with a results grid. Closes the interoperability gap — data, not just config. */
 function browseConnection(api: ApiClient, id: string, name: string) {
@@ -202,6 +254,13 @@ export function openConnectionsModal(api: ApiClient, getPid: GetPid) {
           schedulesModal(api, getPid, cx.id);
         }));
         row.append(act("Mapping", async () => mappingModal(api, cx.id, cx.name)));
+      }
+      // Books, for the three connection types that keep them. `vendorFor` is the only thing that
+      // decides — the route family (`/quickbooks/` vs `/erp/`) follows from the vendor, not from
+      // the connection type, since Sage and Viewpoint share one reader.
+      const ledgerVendor = vendorFor(cx.type);
+      if (ledgerVendor) {
+        row.append(act("Books", async () => ledgerModal(api, cx.id, cx.name, ledgerVendor)));
       }
       if (cx.type === "acc") {
         row.append(act("Issues", async () => {

--- a/apps/web/src/connections/connectionsUI.ts
+++ b/apps/web/src/connections/connectionsUI.ts
@@ -137,7 +137,11 @@ function ledgerModal(api: ApiClient, id: string, name: string, vendor: LedgerVen
   const read = async () => {
     const entity = pick.value;
     msg.textContent = ""; note.textContent = "reading…"; grid.innerHTML = "";
-    go.disabled = true;
+    // `pick` is disabled with `go`, not just `go`: the entity is captured at the top of this
+    // function, so changing the select mid-flight would render THIS entity's rows under THAT
+    // entity's label — a mislabelled ledger, which is the same class as the error/empty collapse
+    // this whole module exists to prevent.
+    go.disabled = true; pick.disabled = true;
     try {
       const res = await api.connectionLedger(id, vendor, entity);
       const out = outcome(res, entity);
@@ -153,7 +157,7 @@ function ledgerModal(api: ApiClient, id: string, name: string, vendor: LedgerVen
       note.textContent = "";
       msg.textContent = `Request failed: ${(e as Error).message}`;
     } finally {
-      go.disabled = false;
+      go.disabled = false; pick.disabled = false;
     }
   };
   go.onclick = () => { void read(); };

--- a/apps/web/src/connections/ledgerBrowse.test.ts
+++ b/apps/web/src/connections/ledgerBrowse.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ENTITIES, QB_PAGE, countLine, emptyLine, errorLine, outcome, rowId, rowLabel, vendorFor,
+} from "./ledgerBrowse";
+
+describe("which connections keep books", () => {
+  it("maps the three vendor types, and only those", () => {
+    expect(vendorFor("quickbooks")).toBe("quickbooks");
+    expect(vendorFor("sage")).toBe("erp");
+    expect(vendorFor("viewpoint")).toBe("erp");
+    for (const t of ["postgres", "supabase", "procore", "acc", "local", ""]) {
+      expect(vendorFor(t), `${t} keeps no ledger`).toBeNull();
+    }
+  });
+
+  it("offers only the entities the server accepts", () => {
+    // The route 400s on anything else; offering a fourth would build a button that cannot work.
+    expect([...ENTITIES]).toEqual(["accounts", "vendors", "bills"]);
+  });
+});
+
+describe("a failed read is never an empty ledger", () => {
+  it("classifies a body-level error as an error, though the HTTP status was 200", () => {
+    // The route catches the vendor exception and returns {"error": …} with 200. `rows` is absent,
+    // so a check that looked at rows first would call this "no records".
+    const r = outcome({ error: "401 Unauthorized" }, "accounts");
+    expect(r.state).toBe("error");
+    if (r.state === "error") expect(r.message).toBe("401 Unauthorized");
+  });
+
+  it("does not treat an error as empty even when an empty row list is ALSO present", () => {
+    expect(outcome({ error: "token expired", accounts: [] }, "accounts").state).toBe("error");
+  });
+
+  it("ignores a blank error string — that is not a failure", () => {
+    expect(outcome({ error: "   ", accounts: [{ Name: "Cash" }] }, "accounts").state).toBe("rows");
+  });
+
+  it("reports a genuine empty as empty", () => {
+    expect(outcome({ kind: "quickbooks-accounts", count: 0, accounts: [] }, "accounts").state).toBe("empty");
+  });
+
+  it("treats a missing row key as empty, not as rows", () => {
+    expect(outcome({ kind: "sage-bills", count: 0 }, "bills").state).toBe("empty");
+  });
+
+  it("drops non-object entries rather than rendering them", () => {
+    const r = outcome({ accounts: [null, "oops", { Name: "Cash" }] }, "accounts");
+    expect(r.state).toBe("rows");
+    if (r.state === "rows") expect(r.rows).toEqual([{ Name: "Cash" }]);
+  });
+
+  it("the two failure wordings cannot be mistaken for each other", () => {
+    const err = errorLine("quickbooks", "401 Unauthorized");
+    const empty = emptyLine("accounts");
+    expect(err).toMatch(/NOT an empty ledger/);
+    expect(empty).toMatch(/real answer/);
+    expect(err).not.toEqual(empty);
+  });
+});
+
+describe("the count means different things on the two routes", () => {
+  it("flags a full QuickBooks page as a possible truncation, not a total", () => {
+    const line = countLine("quickbooks", "accounts", QB_PAGE);
+    expect(line).toMatch(/maximum/);
+    expect(line).toMatch(/no paging/);
+    expect(line).toMatch(/sample, not a total/);
+  });
+
+  it("...and a short QuickBooks read as the whole ledger", () => {
+    const line = countLine("quickbooks", "accounts", 12);
+    expect(line).toMatch(/whole ledger/);
+    expect(line).not.toMatch(/sample/);
+  });
+
+  it("never claims the ERP read is capped — it is not capped HERE", () => {
+    const line = countLine("erp", "bills", 50);
+    expect(line).not.toMatch(/maximum/);
+    expect(line).toMatch(/not capped here/);
+  });
+
+  it("the same number reads differently by vendor, which is the whole point", () => {
+    expect(countLine("quickbooks", "accounts", QB_PAGE)).not.toEqual(countLine("erp", "accounts", QB_PAGE));
+  });
+
+  it("a count ABOVE the page size is still flagged — the cap is a floor, not an equality", () => {
+    // Defensive: if the server ever pages, a larger count must not silently read as a clean total.
+    expect(countLine("quickbooks", "accounts", 120)).toMatch(/maximum/);
+  });
+});
+
+describe("row keys are vendor-cased", () => {
+  it("reads Intuit's capitalised keys", () => {
+    expect(rowLabel({ Name: "Checking" })).toBe("Checking");
+    expect(rowId({ Id: "42" })).toBe("42");
+  });
+
+  it("reads a generic ERP's lowercase keys", () => {
+    expect(rowLabel({ name: "Checking" })).toBe("Checking");
+    expect(rowId({ id: "42" })).toBe("42");
+  });
+
+  it("prefers the first present key rather than depending on object order", () => {
+    expect(rowLabel({ name: "lower", Name: "Upper" })).toBe("Upper");
+    expect(rowLabel({ Name: "Upper", name: "lower" })).toBe("Upper");
+  });
+
+  it("takes a numeric id, which JSON allows and the string check would drop", () => {
+    expect(rowId({ id: 7 })).toBe("7");
+  });
+
+  it("says a row is unnamed rather than rendering a blank cell", () => {
+    expect(rowLabel({ Id: "9" })).toBe("(unnamed · 9)");
+    expect(rowLabel({})).toBe("(unnamed)");
+    expect(rowLabel({ Name: "   " })).toBe("(unnamed)");
+  });
+
+  it("returns an empty id rather than inventing one", () => {
+    expect(rowId({})).toBe("");
+    expect(rowId({ Id: "  " })).toBe("");
+  });
+});

--- a/apps/web/src/connections/ledgerBrowse.ts
+++ b/apps/web/src/connections/ledgerBrowse.ts
@@ -1,0 +1,130 @@
+/**
+ * LEDGER-BROWSE — reading an accounting connection's books, and saying what the reading is worth.
+ *
+ * `GET /connections/{cid}/quickbooks/{entity}` and `GET /connections/{cid}/erp/{entity}` have been
+ * finished server-side and callable by nothing. They were dark for two different reasons, and only
+ * one of them was visible: `erp`'s leaf is three characters, under the reachability gate's
+ * `MIN_SEGMENT`, so the short-leaf ratchet held it. `quickbooks` is ten characters, IS assessed,
+ * and the gate believed it called — off the string `"quickbooks"` in `connectionsUI.ts`'s
+ * connection-TYPE `<select>`. A product vocabulary word, not a URL.
+ *
+ * Three rules below, and each exists because the server's answer and the obvious rendering of it
+ * say different things.
+ *
+ * 1. **A vendor failure is HTTP 200 with `{"error": …}`.** The route catches the vendor exception
+ *    and returns the message in the body, so `res.ok` is true and `rows` is absent. Rendering that
+ *    as an empty table tells an accountant their books are EMPTY when the truth is that we could
+ *    not read them. Those two states must never reach the same pixels — `outcome()` refuses to
+ *    collapse them.
+ *
+ * 2. **QuickBooks `count` is capped at 50 and there is no pagination.** `_qb_query` issues
+ *    `select * from <Entity> maxresults 50`; nothing pages past it. So `count: 50` from QuickBooks
+ *    is a floor, not a total, and a company with 200 accounts sees 50 with no indication. The ERP
+ *    read is uncapped and tenant-dependent, so **the same field means different things on the two
+ *    routes** and the caller must be told which one it is looking at.
+ *
+ * 3. **Row keys are vendor-cased.** QuickBooks returns Intuit's `Name` / `Id`; the generic ERP read
+ *    returns whatever the tenant emits, which is why `_info_erp` on the server already hedges with
+ *    `a.get("name") or a.get("Name")`. A renderer that assumes one casing silently blanks the other
+ *    vendor's column — the COL-PAIR defect class.
+ */
+
+/** The three vendors whose connections carry books. `erp` covers Sage and Viewpoint alike. */
+export type LedgerVendor = "quickbooks" | "erp";
+
+/** What the route can return. `count` and the rows live under the entity's own name. */
+export interface LedgerResponse {
+  kind?: string;
+  count?: number;
+  error?: string;
+  [entity: string]: unknown;
+}
+
+export type LedgerOutcome =
+  | { state: "error"; message: string }
+  | { state: "empty" }
+  | { state: "rows"; rows: Record<string, unknown>[] };
+
+/** Which vendor a connection type reads its books through, or null if it keeps none. */
+export function vendorFor(connectionType: string): LedgerVendor | null {
+  if (connectionType === "quickbooks") return "quickbooks";
+  if (connectionType === "sage" || connectionType === "viewpoint") return "erp";
+  return null;
+}
+
+/**
+ * Error, empty, or rows — never error silently becoming empty.
+ *
+ * The `error` key is checked FIRST and on its own. A response carrying both an error and an absent
+ * row list is the normal failure shape, so testing `rows?.length` first would classify every
+ * vendor failure as "no records".
+ */
+export function outcome(res: LedgerResponse, entity: string): LedgerOutcome {
+  if (typeof res.error === "string" && res.error.trim()) {
+    return { state: "error", message: res.error.trim() };
+  }
+  const raw = res[entity];
+  if (!Array.isArray(raw)) return { state: "empty" };
+  const rows = raw.filter((r): r is Record<string, unknown> => !!r && typeof r === "object");
+  return rows.length ? { state: "rows", rows } : { state: "empty" };
+}
+
+/** The QuickBooks page size the server asks Intuit for. Not configurable, and not paged past. */
+export const QB_PAGE = 50;
+
+/**
+ * What the count actually means — which differs by vendor, so it is never printed bare.
+ *
+ * At exactly `QB_PAGE` on QuickBooks the number is indistinguishable from a truncation, and saying
+ * "50 accounts" there is a claim about someone's books that the request cannot support.
+ */
+export function countLine(vendor: LedgerVendor, entity: string, count: number): string {
+  if (vendor === "quickbooks" && count >= QB_PAGE) {
+    return `${count} ${entity} shown — this is the maximum a single read returns (${QB_PAGE}), `
+      + "and there is no paging, so the ledger may hold more. Treat it as a sample, not a total.";
+  }
+  if (vendor === "quickbooks") return `${count} ${entity} — the whole ledger (under the ${QB_PAGE}-row read limit).`;
+  return `${count} ${entity}, as returned by the tenant. This read is not capped here; if the ERP `
+    + "itself paginates, its own default applies.";
+}
+
+/** Human wording for a failed read, kept distinct from an empty one. */
+export function errorLine(vendor: LedgerVendor, message: string): string {
+  const who = vendor === "quickbooks" ? "QuickBooks" : "the ERP";
+  return `Could not read ${who}: ${message}. This is NOT an empty ledger — nothing was returned, `
+    + "so no conclusion about the books follows from it.";
+}
+
+/** Wording for a genuinely empty read, kept distinct from a failed one. */
+export function emptyLine(entity: string): string {
+  return `The connection answered, and reported no ${entity}. That is a real answer about the `
+    + "ledger, not a failed request.";
+}
+
+/**
+ * One row's display name, tolerant of both vendors' casing.
+ *
+ * Intuit capitalises; a generic REST ERP usually does not. Checked in order and stopping at the
+ * first present key, so a row carrying both does not depend on object order.
+ */
+export function rowLabel(row: Record<string, unknown>): string {
+  for (const k of ["Name", "name", "DisplayName", "displayName", "FullyQualifiedName", "title"]) {
+    const v = row[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  const id = rowId(row);
+  return id ? `(unnamed · ${id})` : "(unnamed)";
+}
+
+/** One row's identifier, same tolerance. Returns "" when the vendor sent none. */
+export function rowId(row: Record<string, unknown>): string {
+  for (const k of ["Id", "id", "ID", "code", "Code", "number"]) {
+    const v = row[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+    if (typeof v === "number") return String(v);
+  }
+  return "";
+}
+
+/** The entities both routes accept. The server 400s on anything else, so the UI offers only these. */
+export const ENTITIES = ["accounts", "vendors", "bills"] as const;

--- a/apps/web/src/portal/panels/analytics.ts
+++ b/apps/web/src/portal/panels/analytics.ts
@@ -3,6 +3,9 @@ import { noProjectHtml } from "../../ui/empty";
 import { toast } from "../../ui/feedback";
 import type { PanelContext } from "../panelContext";
 import { renderPlanningBrief } from "./planningBrief";
+import {
+  attributionLine, coiLine, isReassuring, lienExposure, ordered, summaryLine, verdictTone,
+} from "./vendorScorecard";
 
 /**
  * Analytics & benchmarking panels (cross-project benchmarks, subcontractor risk & cost).
@@ -79,6 +82,66 @@ export async function renderBenchmarks(ctx: PanelContext) {
         tbl.append(thead, tb); ratesSlot.appendChild(tbl);
       }
     } catch (e) { ratesSlot.textContent = `unit rates failed: ${(e as Error).message}`; }
+
+    // --- Vendor scorecards: the firm's own experience of each trade partner, across projects ----
+    // Every wording rule is in `vendorScorecard.ts`. The one that shapes this markup is that
+    // `no_history` must NOT render like `clear` — an unknown vendor that looks vetted is the most
+    // expensive thing this panel could say, and a glance at a coloured pill is all most readers give
+    // a row. The attribution line is not chrome: nothing here has looked at quality or schedule.
+    const vendorSlot = el("div"); vendorSlot.style.marginTop = "14px";
+    vendorSlot.textContent = "loading vendor scorecards…";
+    root.appendChild(vendorSlot);
+    try {
+      const vm = await ctx.host.api.vendorScorecards();
+      vendorSlot.textContent = "";
+      const h = el("div", "meta"); h.style.margin = "10px 0 4px";
+      h.innerHTML = `<b>Trade partners — your own record with them</b>`;
+      const sum = el("div", "meta"); sum.style.fontSize = "12px"; sum.textContent = summaryLine(vm);
+      const attr = el("div", "meta");
+      attr.style.cssText = "font-size:11px;margin:4px 0 6px;border-left:3px solid var(--line);padding-left:8px";
+      attr.textContent = attributionLine(vm);
+      vendorSlot.append(h, sum, attr);
+      const rows = ordered(vm.vendors ?? []);
+      if (rows.length) {
+        const tbl = el("table", "portal-table") as HTMLTableElement;
+        tbl.style.cssText = "width:100%;font-size:12px";
+        const thead = el("thead");
+        thead.innerHTML = '<tr><th scope="col" style="text-align:left">Vendor</th>'
+          + '<th scope="col">Record</th><th scope="col">Projects</th>'
+          + '<th scope="col">Subcontracts</th><th scope="col">Unwaived billing</th>'
+          + '<th scope="col" style="text-align:left">Insurance</th></tr>';
+        const tb = el("tbody");
+        for (const r of rows.slice(0, 25)) {
+          const tr = el("tr");
+          const td = (t: string, align = "right") => {
+            const d = el("td"); d.style.textAlign = align; d.textContent = t; return d;
+          };
+          const tone = verdictTone(r.verdict);
+          const vtd = el("td"); vtd.style.textAlign = "center";
+          const pill = el("span");
+          pill.style.cssText = `display:inline-block;padding:1px 7px;border-radius:9px;font-size:11px;`
+            + `background:${tone.colour};color:#101010`;
+          pill.textContent = tone.label;
+          pill.title = r.verdict_note || "";
+          vtd.appendChild(pill);
+          const gap = lienExposure(r);
+          const nm = el("td"); nm.style.textAlign = "left";
+          nm.textContent = r.vendor;
+          if (!isReassuring(r.verdict) && r.flags?.length) nm.title = r.flags.join(" · ");
+          tr.append(nm, vtd, td(String(r.project_count), "center"),
+            td(cmoney(r.subcontract_value)),
+            td(gap === null ? "not billed" : gap ? cmoney(gap) : "—"),
+            td(coiLine(r), "left"));
+          tb.appendChild(tr);
+        }
+        tbl.append(thead, tb); vendorSlot.appendChild(tbl);
+        if (rows.length > 25) {
+          const more = el("div", "meta"); more.style.fontSize = "11px";
+          more.textContent = `Showing the 25 most urgent of ${rows.length} — worst first.`;
+          vendorSlot.appendChild(more);
+        }
+      }
+    } catch (e) { vendorSlot.textContent = `vendor scorecards failed: ${(e as Error).message}`; }
   }
 
   // --- Market Intelligence: regional escalation / labour / location + warm-cold sectors ----------

--- a/apps/web/src/portal/panels/vendorScorecard.test.ts
+++ b/apps/web/src/portal/panels/vendorScorecard.test.ts
@@ -122,7 +122,31 @@ describe("worst first", () => {
     expect(ordered(rows).map((r) => r.vendor)).toEqual(["Watch Small", "Unknown", "Clear Big"]);
   });
 
-  it("breaks a tie by exposure, then by name — so the order is stable", () => {
+  it("ranks by MONEY AT RISK, not contract size — a waived giant sits below an unwaived minnow", () => {
+    // The defect a review bot caught: the docstring said "by exposure" and the code sorted by
+    // `subcontract_value`. With the table capped at 25 rows, that pushed the vendor who is actually
+    // owed money off the screen, below one who is owed nothing.
+    const rows = [
+      row({ vendor: "Waived Giant", verdict: "watch", subcontract_value: 9_000_000,
+            invoiced: 9_000_000, lien_waivers_value: 9_000_000 }),
+      row({ vendor: "Unwaived Minnow", verdict: "watch", subcontract_value: 50_000,
+            invoiced: 50_000, lien_waivers_value: 0 }),
+    ];
+    expect(ordered(rows).map((r) => r.vendor)).toEqual(["Unwaived Minnow", "Waived Giant"]);
+  });
+
+  it("a vendor who has not billed ranks with the fully waived — neither has money at risk", () => {
+    const rows = [
+      row({ vendor: "Not billed", verdict: "watch", subcontract_value: 100, invoiced: 0 }),
+      row({ vendor: "Fully waived", verdict: "watch", subcontract_value: 100,
+            invoiced: 500, lien_waivers_value: 500 }),
+      row({ vendor: "At risk", verdict: "watch", subcontract_value: 1, invoiced: 5,
+            lien_waivers_value: 0 }),
+    ];
+    expect(ordered(rows)[0]?.vendor, "exposure outranks size").toBe("At risk");
+  });
+
+  it("falls back to size, then name, at equal exposure — so the order is stable", () => {
     const rows = [
       row({ vendor: "B", verdict: "watch", subcontract_value: 100 }),
       row({ vendor: "A", verdict: "watch", subcontract_value: 100 }),

--- a/apps/web/src/portal/panels/vendorScorecard.test.ts
+++ b/apps/web/src/portal/panels/vendorScorecard.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type VendorRow, attributionLine, coiLine, isReassuring, lienExposure, ordered, summaryLine,
+  verdictTone,
+} from "./vendorScorecard";
+
+const row = (over: Partial<VendorRow> = {}): VendorRow => ({
+  vendor: "Acme Steel", verdict: "clear", project_count: 1, subcontract_value: 0, committed: 0,
+  spent: 0, invoiced: 0, lien_waivers_value: 0, coi_expired: 0, coi_missing_expiry: 0,
+  warranties_live: 0, record_counts: { coi: 1 }, ...over,
+});
+
+describe("an unknown vendor never renders as a vetted one", () => {
+  it("gives no_history its own tone, not clear's", () => {
+    expect(verdictTone("no_history").colour).not.toBe(verdictTone("clear").colour);
+    expect(verdictTone("no_history").label).toBe("no history");
+  });
+
+  it("only `clear` is reassuring — the other two are not", () => {
+    expect(isReassuring("clear")).toBe(true);
+    expect(isReassuring("no_history")).toBe(false);
+    expect(isReassuring("watch")).toBe(false);
+  });
+
+  it("a verdict this screen does not know is NOT given clear's colour", () => {
+    // A fourth server-side verdict must not inherit green by falling through.
+    expect(verdictTone("probation").colour).not.toBe(verdictTone("clear").colour);
+    expect(isReassuring("probation")).toBe(false);
+  });
+
+  it("counts the unexamined vendors in the headline, not just the flagged ones", () => {
+    const line = summaryLine({ vendors: [
+      row({ verdict: "clear" }), row({ vendor: "B", verdict: "no_history" }),
+      row({ vendor: "C", verdict: "watch" }),
+    ] });
+    expect(line).toMatch(/1 on watch/);
+    expect(line, "'2 fine, 1 on watch' would be a claim about a vendor nobody has a record for")
+      .toMatch(/NO recorded history/);
+  });
+
+  it("says nothing about unknowns when there are none", () => {
+    expect(summaryLine({ vendors: [row()] })).not.toMatch(/NO recorded history/);
+  });
+
+  it("falls back to the server's own message on an empty set", () => {
+    expect(summaryLine({ vendors: [], message: "No vendor history yet — subcontracts build it." }))
+      .toMatch(/subcontracts build it/);
+  });
+});
+
+describe("the scorecard states what it did not look at", () => {
+  it("carries the server's attributable note through", () => {
+    const line = attributionLine({ attributable: { note: "commercial and compliance history only. "
+      + "`ncr` and `inspection` carry no vendor field" } });
+    expect(line).toMatch(/ncr/);
+    expect(line).toMatch(/Commercial and compliance only/);
+  });
+
+  it("states the caveat even when the payload omits it — silence is a property of the ROUTE", () => {
+    // A missing caveat reads as no caveat, so this must never return "".
+    const line = attributionLine({});
+    expect(line.length).toBeGreaterThan(40);
+    expect(line).toMatch(/not a pass/);
+  });
+
+  it("does not stutter the server's own opening clause", () => {
+    expect(attributionLine({ attributable: { note: "commercial and compliance history only. X" } }))
+      .not.toMatch(/commercial and compliance history only/i);
+  });
+});
+
+describe("insurance: expired, unknown and none recorded are three things", () => {
+  it("no certificate at all is unknown cover, not zero problems", () => {
+    const line = coiLine(row({ record_counts: { coi: 0 } }));
+    expect(line).toMatch(/unknown/);
+    expect(line).not.toMatch(/\b0 expired/);
+  });
+
+  it("a certificate with no expiry is reported as unknown cover, separately from an expired one", () => {
+    const line = coiLine(row({ record_counts: { coi: 3 }, coi_expired: 1, coi_missing_expiry: 2 }));
+    expect(line).toMatch(/1 expired/);
+    expect(line).toMatch(/2 with no expiry/);
+  });
+
+  it("a genuinely clean set says so, and says the dates are there", () => {
+    const line = coiLine(row({ record_counts: { coi: 2 } }));
+    expect(line).toMatch(/none expired/);
+    expect(line).toMatch(/all carrying an expiry date/);
+  });
+
+  it("a missing record_counts is treated as no certificate, not as a clean one", () => {
+    expect(coiLine(row({ record_counts: undefined }))).toMatch(/unknown/);
+  });
+});
+
+describe("lien exposure", () => {
+  it("is null when they have not billed — zero exposure and no billing are different", () => {
+    expect(lienExposure(row({ invoiced: 0, lien_waivers_value: 0 }))).toBeNull();
+  });
+
+  it("is 0 when billing is fully waived", () => {
+    expect(lienExposure(row({ invoiced: 1000, lien_waivers_value: 1000 }))).toBe(0);
+  });
+
+  it("is the gap when it is not", () => {
+    expect(lienExposure(row({ invoiced: 1000, lien_waivers_value: 250.5 }))).toBe(749.5);
+  });
+
+  it("does not report a penny of float as exposure", () => {
+    expect(lienExposure(row({ invoiced: 1000, lien_waivers_value: 999.995 }))).toBe(0);
+  });
+});
+
+describe("worst first", () => {
+  it("puts watch above unknown above clear, whatever the money says", () => {
+    const rows = [
+      row({ vendor: "Clear Big", verdict: "clear", subcontract_value: 9_000_000 }),
+      row({ vendor: "Unknown", verdict: "no_history", subcontract_value: 0 }),
+      row({ vendor: "Watch Small", verdict: "watch", subcontract_value: 1 }),
+    ];
+    expect(ordered(rows).map((r) => r.vendor)).toEqual(["Watch Small", "Unknown", "Clear Big"]);
+  });
+
+  it("breaks a tie by exposure, then by name — so the order is stable", () => {
+    const rows = [
+      row({ vendor: "B", verdict: "watch", subcontract_value: 100 }),
+      row({ vendor: "A", verdict: "watch", subcontract_value: 100 }),
+      row({ vendor: "C", verdict: "watch", subcontract_value: 500 }),
+    ];
+    expect(ordered(rows).map((r) => r.vendor)).toEqual(["C", "A", "B"]);
+  });
+
+  it("does not mutate its argument", () => {
+    const rows = [row({ vendor: "A", verdict: "clear" }), row({ vendor: "B", verdict: "watch" })];
+    ordered(rows);
+    expect(rows.map((r) => r.vendor)).toEqual(["A", "B"]);
+  });
+});

--- a/apps/web/src/portal/panels/vendorScorecard.ts
+++ b/apps/web/src/portal/panels/vendorScorecard.ts
@@ -133,11 +133,24 @@ export function summaryLine(mem: VendorMemory): string {
   return `${parts.join(" · ")}.`;
 }
 
-/** Worst first: watch, then unknown, then by exposure. A screen ordered by name buries the finding. */
+/**
+ * Worst first: watch, then unknown, then by EXPOSURE — the money at risk, not the contract size.
+ *
+ * **The first draft said "by exposure" and sorted by `subcontract_value`**, which a review bot
+ * caught. They are not the same thing and the difference is the point of the column: a fully waived
+ * $9M subcontract carries no lien exposure, while a $50k sub with unwaived invoices does. Sorting by
+ * size would have pushed the second below the first — and with the table capped at 25 rows, off the
+ * screen entirely. *A docstring that names the right key does not make the code use it.*
+ *
+ * `lienExposure` is null for a vendor who has not billed; `?? 0` ranks them with the fully-waived,
+ * which is correct here — neither has money at risk. Size stays as the next tiebreak so a large
+ * contract still outranks a small one at equal exposure.
+ */
 export function ordered(rows: VendorRow[]): VendorRow[] {
   const rank = (v: string) => (v === "watch" ? 0 : v === "no_history" ? 1 : 2);
   return [...rows].sort((a, b) =>
     rank(a.verdict) - rank(b.verdict)
+    || (lienExposure(b) ?? 0) - (lienExposure(a) ?? 0)
     || (b.subcontract_value || 0) - (a.subcontract_value || 0)
     || a.vendor.localeCompare(b.vendor));
 }

--- a/apps/web/src/portal/panels/vendorScorecard.ts
+++ b/apps/web/src/portal/panels/vendorScorecard.ts
@@ -1,0 +1,143 @@
+/**
+ * VENDOR-SCORECARD — a trade partner's record with your firm, and the limits of that record.
+ *
+ * `GET /benchmarks/vendors` (`services/api/src/aec_api/vendor_memory.py`) has reported every
+ * vendor's cross-project commercial and compliance history since R22-PROCURE-DEPTH ③ and had no
+ * client caller the whole time. Its five `/benchmarks/*` siblings all have one.
+ *
+ * **It is also the route LEDGER-BROWSE blinded the reachability gate to**, in the commit before this
+ * one. That sprint's entity list contains `vendors`, so `/connections/{cid}/erp/vendors` became a
+ * URL this client builds and the leaf `vendors` read as called — by something else. Wiring this
+ * route removes the blind spot's SUBJECT rather than leaving a record of it; the gate still cannot
+ * see this route in either direction, and `test_route_reachability.py` says so.
+ *
+ * Three rules, and all three are the server's own — stated there in prose, enforced here, because a
+ * caveat that lives only in a JSON field nobody renders is a caveat nobody reads.
+ *
+ * 1. **`no_history` is NOT `clear`.** A sub who has never worked for you is an unknown. The engine
+ *    calls a clean-looking record for an unexamined vendor "the single most expensive mistake this
+ *    module could make", and it is a RENDERING mistake as much as an engine one: three verdicts that
+ *    reach the same pixel are one verdict. `verdictTone` refuses to give `no_history` the tone it
+ *    gives `clear`.
+ * 2. **A clean record here is silence about quality, not a pass.** `ncr` and `inspection` carry no
+ *    vendor field, so nothing in this scorecard has looked at quality or schedule performance. The
+ *    server says so in `attributable`; a screen that shows the numbers and drops that sentence
+ *    asserts something the data cannot support. `attributionLine` is not optional chrome.
+ * 3. **A certificate with no expiry is not cover.** `coi_missing_expiry` is counted separately from
+ *    `coi_expired` precisely so a missing date cannot read as insurance in force — the same
+ *    absent-vs-negative distinction as rule 1, one field down. `coiLine` keeps them apart, and says
+ *    "none recorded" rather than "0 problems" when there is no certificate at all.
+ */
+
+export type Verdict = "no_history" | "clear" | "watch";
+
+export interface VendorRow {
+  vendor: string;
+  verdict: string;
+  verdict_note?: string;
+  project_count: number;
+  subcontract_value: number;
+  committed: number;
+  spent: number;
+  invoiced: number;
+  lien_waivers_value: number;
+  coi_expired: number;
+  coi_missing_expiry: number;
+  warranties_live: number;
+  record_counts?: Record<string, number>;
+  flags?: string[];
+  trades?: string[];
+}
+
+export interface VendorMemory {
+  vendors?: VendorRow[];
+  vendor_count?: number;
+  repeat_vendors?: number;
+  watch_count?: number;
+  attributable?: { from?: string[]; not_from?: string[]; note?: string };
+  message?: string | null;
+}
+
+/**
+ * The three verdicts, kept visually distinct.
+ *
+ * `no_history` gets its own tone — NOT the one `clear` gets, and not a neutral blank either, which
+ * would read as "nothing to report". An unknown vendor must look different from a vetted one at a
+ * glance, because the glance is all most readers give a table row.
+ */
+export function verdictTone(verdict: string): { label: string; colour: string } {
+  if (verdict === "clear") return { label: "clear", colour: "#33d17a" };
+  if (verdict === "watch") return { label: "watch", colour: "#e2554a" };
+  if (verdict === "no_history") return { label: "no history", colour: "#f0a400" };
+  // An unrecognised verdict is not assumed benign: a fourth state added server-side must not
+  // inherit `clear`'s green by falling through.
+  return { label: verdict || "unknown", colour: "#9aa0a6" };
+}
+
+/** Whether this verdict may be read as a positive finding. Only one of them may. */
+export function isReassuring(verdict: string): boolean {
+  return verdict === "clear";
+}
+
+/**
+ * What the scorecard did NOT look at, in the server's own words where it supplies them.
+ *
+ * Never returns an empty string. If the payload omits `attributable` the sentence is still stated
+ * from what this module knows, because the silence is a property of the ROUTE, not of one response —
+ * and a missing caveat reads as no caveat.
+ */
+export function attributionLine(mem: VendorMemory): string {
+  const note = mem.attributable?.note?.trim();
+  if (note) return `Commercial and compliance only — ${note.replace(/^commercial and compliance history only\.\s*/i, "")}`;
+  return "Commercial and compliance history only. Quality and schedule performance are not "
+    + "attributable to a vendor here, so a clean record below is silence on that subject, not a pass.";
+}
+
+/**
+ * Insurance, with "expired", "unknown" and "none recorded" kept apart.
+ *
+ * A vendor with no certificate at all is not compliant and not lapsed — they are unrecorded, and
+ * printing "0 expired" for them is the `no_history` error one field down.
+ */
+export function coiLine(row: VendorRow): string {
+  const certs = row.record_counts?.coi ?? 0;
+  if (!certs) return "No certificate of insurance recorded — cover is unknown, not absent of problems.";
+  const bits: string[] = [];
+  if (row.coi_expired) bits.push(`${row.coi_expired} expired`);
+  if (row.coi_missing_expiry) bits.push(`${row.coi_missing_expiry} with no expiry recorded (cover unknown)`);
+  if (!bits.length) return `${certs} certificate(s) on file, none expired and all carrying an expiry date.`;
+  return `${certs} certificate(s) on file — ${bits.join(", ")}.`;
+}
+
+/** Money invoiced beyond the lien waivers on file, or null when they have not billed. */
+export function lienExposure(row: VendorRow): number | null {
+  if (row.invoiced <= 0) return null;
+  const gap = row.invoiced - row.lien_waivers_value;
+  return gap > 0.01 ? Math.round(gap * 100) / 100 : 0;
+}
+
+/**
+ * The headline, which must not imply a verdict the set does not support.
+ *
+ * `watch_count` alone would read as "everything else is fine"; the count with no history is stated
+ * beside it so the reader can see how much of the portfolio was actually examined.
+ */
+export function summaryLine(mem: VendorMemory): string {
+  const rows = mem.vendors ?? [];
+  if (!rows.length) return mem.message || "No vendor history yet.";
+  const unknown = rows.filter((r) => r.verdict === "no_history").length;
+  const watch = rows.filter((r) => r.verdict === "watch").length;
+  const repeat = mem.repeat_vendors ?? rows.filter((r) => r.project_count > 1).length;
+  const parts = [`${rows.length} vendor(s)`, `${repeat} used on more than one project`, `${watch} on watch`];
+  if (unknown) parts.push(`${unknown} with NO recorded history — unknown, not clear`);
+  return `${parts.join(" · ")}.`;
+}
+
+/** Worst first: watch, then unknown, then by exposure. A screen ordered by name buries the finding. */
+export function ordered(rows: VendorRow[]): VendorRow[] {
+  const rank = (v: string) => (v === "watch" ? 0 : v === "no_history" ? 1 : 2);
+  return [...rows].sort((a, b) =>
+    rank(a.verdict) - rank(b.verdict)
+    || (b.subcontract_value || 0) - (a.subcontract_value || 0)
+    || a.vendor.localeCompare(b.vendor));
+}

--- a/apps/web/src/shell/roadmapLanes.test.ts
+++ b/apps/web/src/shell/roadmapLanes.test.ts
@@ -715,7 +715,13 @@ const NOT_A_LANE = (rel: string) =>
 //: taken from a different reader is a threshold for a different question. `surface.test.ts` records
 //: being bitten by precisely this (698 from a probe vs 696 from the gate), so the number is read back
 //: out of the assertion that enforces it.
-const UNOWNED_CEILING = 25;  // 53 → 48: Lane J claimed `apps/web/src/tooling/` (v0.3.1017).
+const UNOWNED_CEILING = 23;  // 53 → 48: Lane J claimed `apps/web/src/tooling/` (v0.3.1017).
+//: 25 → 23 (2026-09-12): Lane B claimed `apps/web/src/connections/`. LEDGER-BROWSE added two
+//: files to that directory and this went red; the remedy it names took all FOUR out, because
+//: the directory had never been claimed at all. That is the third time in four days the same
+//: shape has repeated — `proforma/`, the loose `portal/` files, now this — and each time the
+//: ratchet found the unowned DIRECTORY rather than the files that tripped it. Re-seated to
+//: the measured 23: slack left here is a directory nobody has to claim.
 //: 34 → 25 (2026-09-11): Lanes A and B split the eleven loose `portal/` files between them,
 //: derived by IMPORTER rather than by name (the table below `roadmapLanes` records which went
 //: where and why). Extracting `safetyCard.ts` out of `portal.ts` under the size ratchet is what

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1835,9 +1835,12 @@ instances:
   **WIRING ONE ROUTE BLINDED THE GATE TO ANOTHER, IN THE SAME COMMIT.** The entity list contains
   `vendors`, so `/connections/{cid}/erp/vendors` is now a URL this client builds, and
   `/benchmarks/vendors` — dark since the gate was written and frozen in `KNOWN_UNCALLED` ever since —
-  instantly read as called. It is not: its five `/benchmarks/*` siblings have client methods and it
-  still has none. **Reachability work is not monotone.** A new URL adds a segment to the corpus and
-  any dark route sharing that last segment leaves the gate's sight.
+  instantly read as called. It was not: its five `/benchmarks/*` siblings had client methods and it
+  had none. *(VENDOR-SCORECARD above then gave it one, in this same pull request — so the sentence
+  is past tense on purpose. A review bot caught it written in the present, which it had stopped
+  being one commit later: **a roadmap entry describes a moment, and the moment moved under it**.)*
+  **Reachability work is not monotone.** A new URL adds a segment to the corpus and any dark route
+  sharing that last segment leaves the gate's sight.
 
   So read the numbers with that in hand. Uncalled routes **59 → 58** and the short-leaf ratchet
   **6 → 5** — but *the 59 → 58 is entirely the collision*, because the two routes this sprint wired
@@ -3214,7 +3217,8 @@ had to be fixed under a one-change lane assignment because there was no row to p
 
 **It is now a ratchet rather than a proposal.** `roadmapLanes.test.ts` counts unowned files against a
 ceiling that only ever goes down, and the way down is adding a row here. Rows still to agree:
-`drawings/` · `kernel/` · `pins/` · `studio/` · `tools/` · `dev/` · `connections/` · `deploy/`.
+`drawings/` · `kernel/` · `pins/` · `studio/` · `tools/` · `dev/` · `deploy/`
+*(`connections/` came off this list on 2026-09-12 — Lane B claims it; see the row above.)*
 
 **The loose `portal/` files came off that list on 2026-09-11, DERIVED the same way `tree/` was** —
 `safetyCard.ts` was extracted from `portal.ts` under the size ratchet, the unowned ratchet went red at
@@ -3309,10 +3313,20 @@ actually edit is inside your lane — the table's own greenness is not evidence 
 **Unowned paths — found while fixing the above, 2026-08-03. NOT decided here.** The lane check asserts
 that lanes do not *overlap*; nothing asserts they *cover*, and they do not. `apps/web/src/drawings/`,
 `proforma/`, `studio/`, `tools/`, `tree/`, `pins/`, `kernel/`, `account/`, `connections/` and the
-`portal/` root files (`prefs.ts`, `offlineQueue.ts`, `panelContext.ts`) belong to no lane, which the
+`portal/` root files (`prefs.ts`, `offlineQueue.ts`, `panelContext.ts`) belonged to no lane, which the
 carve-out check in `roadmapLanes.test.ts` correctly calls "editable by everyone" when it happens
 deliberately. The live case: **`R36-DRAWINGS-RETURN` is Lane A and lands in
 `apps/web/src/drawings/`**, so `drawings/` remains unowned rather than assigned by guess.
+*(**This list is AS MEASURED ON 2026-08-03 and is not maintained** — `account/` went to Lane A,
+`proforma/` to Lane B on 2026-09-09, `connections/` to Lane B on 2026-09-12, and the loose `portal/`
+files were split between A and B on 2026-09-11, none of which are edited out above. A review bot
+asked for `connections/` to be struck from it; **taking only that one out would have been the worse
+change** — the list would have read as current while still naming three claimed directories, which is
+exactly how a stale inventory earns trust it has not got. The authority is the lane table plus the
+unowned ratchet in `apps/web/src/shell/roadmapLanes.test.ts`, which is computed; this paragraph is a
+dated finding. The live to-do list of directories still to claim is the one above the table, and
+that one IS maintained.)*
+
 It needs its own premise-check; guessing an owner for a directory a lane is already aimed at
 is how the register problem was made.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1780,6 +1780,30 @@ instances:
   PREFAB-FREEZE-RACE, and filed the same way rather than left in a review thread — **a follow-up held
   only in a thread closes by default when the PR merges.**
 
+- ✅ ⭐ **VENDOR-SCORECARD — a trade partner's record with your firm, and the limits of it**
+  *(S — Lanes B/I; **CLOSED 2026-09-12**; gated by `apps/web/src/api/clientCallers.test.ts`,
+  `apps/web/src/portal/panels/vendorScorecard.test.ts` and `services/api/test_route_reachability.py`)*
+
+  `GET /benchmarks/vendors` (`services/api/src/aec_api/vendor_memory.py`) has answered
+  R22-PROCURE-DEPTH ③ since it was built — each sub's cross-project commercial and compliance record,
+  from the six registers that carry a vendor — and had no client caller. Its five `/benchmarks/*`
+  siblings all did. It now renders in the Benchmarks panel, ordered watch → unknown → clear.
+
+  **This is the route LEDGER-BROWSE blinded the gate to, wired in the same pull request**, so the
+  blind spot's SUBJECT is gone rather than only its record. The two assertions stay: the gate could
+  not see it dark and cannot see it wired, and saying so is worth more than a PASS that means nothing.
+
+  Three rules, all of them the server's own, moved from a JSON field nobody rendered into pixels:
+
+  * **`no_history` is not `clear`.** The engine names this the most expensive mistake the module
+    could make; it is a rendering mistake as much as an engine one, since three verdicts that reach
+    the same pixel are one verdict. An unrecognised fourth verdict does not inherit green.
+  * **A clean record is silence about quality, not a pass** — `ncr` and `inspection` carry no vendor
+    field. Stated even when the payload omits it: the silence belongs to the route, not to one
+    response, and a missing caveat reads as no caveat.
+  * **A certificate with no expiry is not cover** — expired, unknown and none-recorded are three
+    states, and "0 expired" for a vendor with no certificate is `no_history` one field down.
+
 - ✅ ⭐ **LEDGER-BROWSE — an accounting connection's books, and what the reading is worth**
   *(S — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts`,
   `apps/web/src/connections/ledgerBrowse.test.ts` and `services/api/test_route_reachability.py`)*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1780,6 +1780,49 @@ instances:
   PREFAB-FREEZE-RACE, and filed the same way rather than left in a review thread — **a follow-up held
   only in a thread closes by default when the PR merges.**
 
+- ✅ ⭐ **LEDGER-BROWSE — an accounting connection's books, and what the reading is worth**
+  *(S — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts`,
+  `apps/web/src/connections/ledgerBrowse.test.ts` and `services/api/test_route_reachability.py`)*
+
+  `GET …/connections/{cid}/quickbooks/{entity}` and `GET …/connections/{cid}/erp/{entity}` read a
+  chart of accounts, vendor list or bill list from QuickBooks Online, Sage or Viewpoint. Both were
+  finished server-side and callable by nothing. A **Books** action now sits on every connection of
+  those three types.
+
+  **Two halves, two concealments — and only one of them was written down.** `erp` is three characters,
+  under `MIN_SEGMENT`, so it sat in the short-leaf ratchet and was named there as the next wiring
+  candidate. `quickbooks` is ten characters, IS assessed by the main rule, and the rule read it as
+  called — off the word `"quickbooks"` in the connection-TYPE `<select>`. **A product vocabulary word
+  is not a URL**, and the list that records what it hides is safer than the rule that records nothing.
+
+  `apps/web/src/connections/ledgerBrowse.ts` holds three rules, each because the server's answer and
+  the obvious rendering of it disagree:
+
+  * **A vendor failure is HTTP 200 with `{"error": …}`.** The route catches the vendor exception into
+    the body, so `res.ok` is true and the row list is absent. An empty table there tells an accountant
+    their books are EMPTY when we merely could not read them. `outcome()` checks `error` first and on
+    its own — reading rows first classifies every failure as "no records".
+  * **The QuickBooks count is capped at 50 with no paging**, so `count: 50` is a floor and a company
+    with 200 accounts sees 50 silently. The ERP read is uncapped. *The same field means different
+    things on the two routes*, so it is never printed bare.
+  * **Row keys are vendor-cased** — Intuit's `Name`/`Id` against a generic ERP's lowercase — the
+    COL-PAIR class, which the server's own `_info_erp` already hedges against.
+
+  **WIRING ONE ROUTE BLINDED THE GATE TO ANOTHER, IN THE SAME COMMIT.** The entity list contains
+  `vendors`, so `/connections/{cid}/erp/vendors` is now a URL this client builds, and
+  `/benchmarks/vendors` — dark since the gate was written and frozen in `KNOWN_UNCALLED` ever since —
+  instantly read as called. It is not: its five `/benchmarks/*` siblings have client methods and it
+  still has none. **Reachability work is not monotone.** A new URL adds a segment to the corpus and
+  any dark route sharing that last segment leaves the gate's sight.
+
+  So read the numbers with that in hand. Uncalled routes **59 → 58** and the short-leaf ratchet
+  **6 → 5** — but *the 59 → 58 is entirely the collision*, because the two routes this sprint wired
+  are short-leaf and were never in the main population at all. **The headline number improved because
+  the gate went blind, not because anything got wired.** `/benchmarks/vendors` now sits outside both
+  sets as a recorded blind spot beside `/asset-rights/verify`. The rot check is what caught it — it
+  was a bare `print` until 2026-08-20, and under that version the route would have left the frozen
+  list with no output at all.
+
 - ✅ ⭐ **R40-EOT — an extension of time, with the method that produced it**
   *(M — Lanes B/D; **CLOSED 2026-09-11**; gated by `apps/web/src/api/clientCallers.test.ts`,
   `apps/web/src/portal/panels/eotClaim.test.ts` and `services/api/test_route_reachability.py`)*
@@ -3112,7 +3155,7 @@ two rows share a path, so two agents in different rows cannot collide.
 | Lane | Owns these paths — disjoint | Open items in this lane |
 |---|---|---|
 | **A · Shell & IA** | `apps/web/src/shell/`, `apps/web/src/account/`, `apps/web/src/portal/portal.ts`, `apps/web/src/portal/favourites.test.ts`, `apps/web/src/portal/homes/`, `main.ts`, `apps/web/src/portal/prefs.ts`, `apps/web/src/portal/prefs.test.ts`, `apps/web/src/portal/densityToggle.ts`, `apps/web/src/portal/safetyCard.ts`, `apps/web/src/portal/safetyCard.test.ts`, `apps/web/src/portal/registerEmpty.test.ts` *(the loose portal files whose importers are A's — claimed 2026-09-11; see the derivation below the table. **Unbackticked on purpose**: every backtick in THIS cell is parsed as a path claim, so writing the directory name as a citation here claimed the whole of it and clashed with Lane B)* | REL-4 · R40-RIBBON ② · R43-CRUD-FRAGMENTS *(⛔ CLOSED UNBUILT — rescoped 2026-08-11 before any code)* |
-| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `apps/web/src/portal/panelContext.ts`, `apps/web/src/portal/offlineQueue.ts`, `apps/web/src/portal/offlineQueue.test.ts`, `apps/web/src/portal/fieldTypeCoverage.test.ts`, `apps/web/src/portal/tableRefColumn.test.ts`, `apps/web/src/portal/moduleEvidenceHint.test.ts` *(the loose portal files whose importers are B's — claimed 2026-09-11; see the derivation below the table)*, `reportCenter.ts`, `apps/web/src/reportCenter.verification.test.ts`, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · SCREEN-VS-REPORT *(the asymmetric sub-population: fields the Python report builders render and the screen does not. Derived from `apps/web/src/api/` interfaces against `services/api/src/aec_api/report_builders/`, but the EDIT is a caveat rendered beside a number a panel already shows, and the first six fixed all landed in `apps/web/src/proforma/proforma.ts` — same derived-here-fixed-there split as the cell beside it. **Naming a sibling item code inside a cell is how this row failed the disjointness check once**: the parser reads a mention as an assignment, so a cross-reference has to describe the other row rather than name it)* · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
+| **B · UI & panels** | `apps/web/src/ui/`, `portal/panels/`, `portal/register/`, `field/`, `apps/web/src/portal/panelContext.ts`, `apps/web/src/portal/offlineQueue.ts`, `apps/web/src/portal/offlineQueue.test.ts`, `apps/web/src/portal/fieldTypeCoverage.test.ts`, `apps/web/src/portal/tableRefColumn.test.ts`, `apps/web/src/portal/moduleEvidenceHint.test.ts` *(the loose portal files whose importers are B's — claimed 2026-09-11; see the derivation below the table)*, `reportCenter.ts`, `apps/web/src/reportCenter.verification.test.ts`, `apps/web/src/connections/` *(claimed 2026-09-12 by LEDGER-BROWSE — the data-source admin modal and its ledger rules. Four files, owned by no lane since the directory was created; adding two of them to it is what reddened the unowned ratchet, and the remedy it names took all four out rather than the two that tripped it, the same shape as the two claims beside this one)*, `apps/web/src/proforma/` *(claimed 2026-09-09 by PARCEL-SHAPE — seven files of feasibility and underwriting panels that no lane had ever owned. The unowned ratchet is how it surfaced: adding a file to an unclaimed directory reds the build, and the remedy the gate names is a row here rather than a bigger ceiling)* | R24-REPORTS-BY-MOMENT · R24-TERMS · R24-FIELD-MODE · SCREEN-VS-REPORT *(the asymmetric sub-population: fields the Python report builders render and the screen does not. Derived from `apps/web/src/api/` interfaces against `services/api/src/aec_api/report_builders/`, but the EDIT is a caveat rendered beside a number a panel already shows, and the first six fixed all landed in `apps/web/src/proforma/proforma.ts` — same derived-here-fixed-there split as the cell beside it. **Naming a sibling item code inside a cell is how this row failed the disjointness check once**: the parser reads a mention as an assignment, so a cross-reference has to describe the other row rather than name it)* · DEAD-FIELD *(here rather than Lane I even though the population is DERIVED from `apps/web/src/api/` interfaces: what is left to do is render the missing caveat beside a number a panel already shows, and every one of those edits lands under `portal/panels/`. Lanes go by the directory the work touches, not the directory the finding came from — the correction this table's Lane E cell had to make)* |
 | **C · Backend engines** | `services/api/src/aec_api/`, `!services/api/src/aec_api/routers/`, `!services/api/src/aec_api/main.py`, `services/api/test_pin_population.py`, `services/api/test_pin_anchor.py`, `services/api/test_desktop_paths.py`, `services/api/test_frozen_paths.py` | R22-ENTITLEMENT · PERF-WORKERS ① · R43-MASSINGBILL-CORE · PIN-ONE-CALL · JSON-NULL-CLASS · PIN-SWEEP-PGNULL *(the pin sweep skips the rows it exists to convert, on PostgreSQL only — a `json` column holding scalar `null` is non-NULL in SQL and decodes to Python `None`. Filed here rather than Lane B because the code is a migration under `services/api/migrations/`, and it landed in `main` via #503 rather than in the PR that found it)* · CITE-RECORD *(what remains is whether anything should answer FROM a stored record, which is a product decision; see Band 2)* |
 | **D · Geometry & drawings** | `services/data/src/aec_data/`, `apps/web/src/drawings/` | — |
 | **E · Authoring feel & viewer** | `apps/web/src/viewer/`, `inference.ts`, `apps/web/src/tree/` | R28-VIEWER ④ · R39-DECOMP-VIEWER ③ *(ratchet pinned; seams measured — see entry)* · R43-VIEWER-CONFORMANCE · SITE-1 *(parcel overlays — `apps/web/src/viewer/gis.ts`)* *(**UX-3 left this cell 2026-09-06: all five of its items now ship** — see its entry. The cell had pointed at `apps/web/src/viewer/tools/authoringSection.ts`, which is a real file and the WRONG one: every one of the five landed under `apps/web/src/viewer/draft/`. Lanes are assigned by directory, so a pointer that resolves is not the same as a pointer that is right — a tracked-path gate cannot catch this, and did not)* |

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -908,8 +908,15 @@ check("the LEDGER-BROWSE collision is still a blind spot: /benchmarks/vendors",
       "/benchmarks/vendors" not in KNOWN_UNCALLED,
       "re-triage /benchmarks/vendors rather than re-freezing it — while a sibling route's URL ends "
       "in `vendors`, this rule cannot tell a caller of one from a caller of the other")
+# **This check was FAIL-OPEN on its first draft and a review bot caught it.** It read
+# `"/benchmarks/vendors" in FOUND or leaf_is_called(...)`. `FOUND` is the set of routes the rule
+# flags as UNCALLED, so the left operand is true exactly when the collision is **gone** — an
+# assertion named "the collision is REAL" that passed in the state it exists to exclude, and an `or`
+# that cannot fail in the direction that matters. *The blind-spot record was itself guarded by a
+# check that could not see its own subject*, which is the class the whole file is about, written
+# into the entry documenting the class. Both conditions are now required.
 check("  ...and the collision is REAL, not a guess: the rule does read that leaf as called",
-      "/benchmarks/vendors" in FOUND or leaf_is_called("vendors", _CODE),
+      "/benchmarks/vendors" not in FOUND and leaf_is_called("vendors", _CODE),
       "the vouching URL is gone — if `ledgerBrowse.ts` no longer offers a `vendors` entity, "
       "/benchmarks/vendors is visible again and belongs back in KNOWN_UNCALLED")
 

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -277,7 +277,6 @@ KNOWN_UNCALLED: set[str] = {
     # to an IdP out of band — but "likeliest" is not "read", and this set records what nobody has
     # read rather than what somebody approved.
     "/auth/saml/metadata",
-    "/benchmarks/vendors",
     "/classifications",
     "/estimate/labor/rates",
     "/plugins/reload",
@@ -871,6 +870,40 @@ check("the ASSET-VERIFY blind spot is still a blind spot, not silent coverage",
       "if this now fails, the matcher changed — re-triage /asset-rights/verify rather than "
       "assuming the green tick above ever meant it was reachable")
 
+# A SIXTH INSTANCE, 2026-09-11, and it is the first one a PULL REQUEST CREATED rather than found.
+# `/benchmarks/vendors` sat in KNOWN_UNCALLED above from the day this gate was written. LEDGER-BROWSE
+# wired `/connections/{cid}/erp/{entity}` and `/connections/{cid}/quickbooks/{entity}`, whose entity
+# list is `["accounts", "vendors", "bills"]` (`apps/web/src/connections/ledgerBrowse.ts`) — so
+# `/connections/{cid}/erp/vendors` is now a URL this client genuinely builds, the leaf `vendors` is
+# genuinely called, and the rot check immediately reported `/benchmarks/vendors` as "quietly become
+# called". It has not. Its five `/benchmarks/*` siblings all have client methods; it still has none.
+#
+# This is the `check` collision above — a leaf colliding with a REAL SIBLING ROUTE, not with prose —
+# but arriving from the other end, and that difference is the reason it is worth its own paragraph:
+#
+#   **WIRING ONE ROUTE CAN BLIND THIS GATE TO A DIFFERENT ONE.** Reachability work is supposed to be
+#   monotone — each sprint lights another route and the dark set shrinks. It is not. A new URL adds a
+#   segment to the corpus, and any dark route sharing that last segment silently leaves the gate's
+#   sight in the same commit. The dark set can shrink by one and lose visibility of another, and the
+#   run still goes green.
+#
+# The one mercy is timing: because the rot check fails in BOTH directions, the loss surfaces in the
+# pull request that caused it rather than years later. That check earned its keep here — it was a
+# bare `print` until 2026-08-20, and under that version this route would have dropped out of the
+# frozen list with no output at all.
+#
+# So it moves out of KNOWN_UNCALLED and is asserted to be in NEITHER set, exactly as with
+# `/asset-rights/verify` and the two jurisdiction routes. `/benchmarks/vendors` is dark; this file no
+# longer has an opinion about it, and says so rather than implying coverage by silence.
+check("the LEDGER-BROWSE collision is still a blind spot: /benchmarks/vendors",
+      "/benchmarks/vendors" not in KNOWN_UNCALLED,
+      "re-triage /benchmarks/vendors rather than re-freezing it — while a sibling route's URL ends "
+      "in `vendors`, this rule cannot tell a caller of one from a caller of the other")
+check("  ...and the collision is REAL, not a guess: the rule does read that leaf as called",
+      "/benchmarks/vendors" in FOUND or leaf_is_called("vendors", _CODE),
+      "the vouching URL is gone — if `ledgerBrowse.ts` no longer offers a `vendors` entity, "
+      "/benchmarks/vendors is visible again and belongs back in KNOWN_UNCALLED")
+
 # A THIRD AND FOURTH INSTANCE, measured 2026-09-11 while triaging the eight routes UNREACHED-IMPORT
 # froze. R23-JURISDICTION-PACKS is dark in **five** routes, not the three this file freezes. The
 # library, import and delete routes are in KNOWN_UNCALLED above; the two that CONSUME a pack --
@@ -944,7 +977,15 @@ CONFIRMED_DARK_SHORT_LEAF = {
     #: (`apps/web/src/api/downloadPdf.ts`). A screen that renders the payment application from data
     #: rather than downloading it would use these; none exists yet.
     "/projects/{pid}/cost/g702", "/projects/{pid}/cost/g703",
-    #: The ERP entity bridge: finished server-side, no screen. The next wiring candidate.
+    #: `/connections/{cid}/erp/{entity}` LEFT this set in LEDGER-BROWSE — `connectionLedger` in
+    #: `apps/web/src/api/connections.ts`, called from the "Books" action in
+    #: `apps/web/src/connections/connectionsUI.ts`. Its QuickBooks sibling
+    #: `/connections/{cid}/quickbooks/{entity}` was dark for the whole time it sat here and was
+    #: never in this set NOR in KNOWN_UNCALLED: a ten-character leaf IS assessed by the main rule,
+    #: and the rule believed it called off the word "quickbooks" in a connection-TYPE `<select>`.
+    #: **The two halves of one feature were concealed by a list and by a vocabulary word** — the
+    #: short-leaf ratchet at least records what it is hiding; `leaf_is_called` records nothing,
+    #: which is why its false negatives are the more expensive kind.
     #:
     #: `/projects/{pid}/schedule/eot` LEFT this set in R40-EOT — `scheduleEot` in
     #: `apps/web/src/api/schedule.ts`, called from `apps/web/src/portal/panels/eotClaimPanel.ts`.
@@ -953,7 +994,6 @@ CONFIRMED_DARK_SHORT_LEAF = {
     #: `/schedule/eot/sourced` was frozen in KNOWN_UNCALLED above and could have been read any day.
     #: **One feature, two concealments, two different lists** — reading either alone would have
     #: wired half a claim.
-    "/connections/{cid}/erp/{entity}",
 }
 _SHORT = {r for r in PATHS if len(_leaf(r)) < MIN_SEGMENT}
 _SHORT_DARK = {r for r in _SHORT if not leaf_is_called(_leaf(r), _CODE)}

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -893,8 +893,17 @@ check("the ASSET-VERIFY blind spot is still a blind spot, not silent coverage",
 # frozen list with no output at all.
 #
 # So it moves out of KNOWN_UNCALLED and is asserted to be in NEITHER set, exactly as with
-# `/asset-rights/verify` and the two jurisdiction routes. `/benchmarks/vendors` is dark; this file no
-# longer has an opinion about it, and says so rather than implying coverage by silence.
+# `/asset-rights/verify` and the two jurisdiction routes.
+#
+# **AND IT NOW HAS A CALLER** -- `vendorScorecards` in `apps/web/src/api/cost.ts`, rendered by the
+# vendor-scorecard section of `apps/web/src/portal/panels/analytics.ts`, with its wording rules in
+# `apps/web/src/portal/panels/vendorScorecard.ts`. VENDOR-SCORECARD wired it deliberately, in the
+# pull request that blinded the gate to it, so the blind spot's SUBJECT is gone rather than only its
+# record. The two assertions below pass unchanged either way, which is the whole point of leaving
+# them here: **this gate could not see the route dark and cannot see it wired.** Its verdict was, and
+# remains, no verdict -- exactly as the jurisdiction pair above records. Do not read these PASSes as
+# coverage. What proves the wiring is `apps/web/src/api/clientCallers.test.ts`, which refuses an
+# unused client method, plus `apps/web/src/portal/panels/vendorScorecard.test.ts`.
 check("the LEDGER-BROWSE collision is still a blind spot: /benchmarks/vendors",
       "/benchmarks/vendors" not in KNOWN_UNCALLED,
       "re-triage /benchmarks/vendors rather than re-freezing it — while a sibling route's URL ends "


### PR DESCRIPTION
# What & why

Two sprints, deliberately one PR, because **the first blinded the reachability gate to the second
and the second removes that blind spot's subject.**

**LEDGER-BROWSE** (`7a453ce0`) — `GET /connections/{cid}/quickbooks/{entity}` and
`GET /connections/{cid}/erp/{entity}` return a QuickBooks Online or Sage/Viewpoint chart of accounts,
vendor list or bill list. Both were finished server-side and callable by nothing. A **Books** action
now sits on every QuickBooks, Sage and Viewpoint connection in the Data-connections modal, with the
display rules in `apps/web/src/connections/ledgerBrowse.ts` (20 tests).

**VENDOR-SCORECARD** (`628cba00`) — `GET /benchmarks/vendors` has answered R22-PROCURE-DEPTH ③ since
it was built (each sub's cross-project commercial and compliance record, from the six registers that
carry a vendor) and had no client caller. Its five `/benchmarks/*` siblings all did. It now renders
in the Benchmarks panel, worst first, with its rules in
`apps/web/src/portal/panels/vendorScorecard.ts` (20 tests).

Roadmap: both items closed in `docs/roadmap.md`; the short-leaf ratchet in
`services/api/test_route_reachability.py` comes down 6 → 5.

## Wiring one route blinded the gate to another, in the same commit

LEDGER-BROWSE's entity list contains `vendors`, so `/connections/{cid}/erp/vendors` is a URL this
client now builds, and `/benchmarks/vendors` — dark since the gate was written and frozen in
`KNOWN_UNCALLED` ever since — instantly read as called. It was not.

**Reachability work is not monotone.** A new URL adds a segment to the corpus, and any dark route
sharing that last segment leaves the gate's sight. So read the numbers with that in hand: uncalled
routes 59 → 58, but *that drop is entirely the collision*, because the two LEDGER-BROWSE routes are
short-leaf and were never in the main population. **The headline number improved because the gate
went blind, not because anything got wired.**

The rot check caught it — it was a bare `print` until 2026-08-20, and under that version the route
would have left the frozen list with no output at all. `/benchmarks/vendors` now sits outside both
sets as a recorded blind spot beside `/asset-rights/verify`, with a second assertion that the
collision is real rather than assumed. The second commit then wires it, so the **subject** of the
blind spot is gone rather than only its record — and both assertions pass unchanged either way,
which is the point worth keeping: *this gate could not see the route dark and cannot see it wired.*
What proves the wiring is `clientCallers.test.ts`, which refuses an unused client method, plus the
panel tests — not the gate.

## Why these two routes were dark, and why only one was written down

`erp` is three characters, under `MIN_SEGMENT`, so the short-leaf ratchet held it and named it as the
next wiring candidate. `quickbooks` is ten characters, IS assessed by the main rule, and the rule
read it as called — off the word `"quickbooks"` in the connection-TYPE `<select>`. **A product
vocabulary word is not a URL**, and the list that records what it hides is safer than the rule that
records nothing.

## Six rules, all of them the server's own

A caveat that lives only in a JSON field nobody renders is a caveat nobody reads.

**Ledger:**
- **A vendor failure is HTTP 200 with `{"error": …}`** — the route catches the vendor exception into
  the body, so `res.ok` is true and the row list is absent. An empty table there tells an accountant
  their books are EMPTY when we merely could not read them. `outcome()` checks `error` first and on
  its own; reading rows first classifies every failure as "no records".
- **The QuickBooks count is capped at 50 with no paging**, so `count: 50` is a floor and a company
  with 200 accounts sees 50 silently. The ERP read is uncapped — the same field means different
  things on the two routes, so it is never printed bare.
- **Row keys are vendor-cased** (Intuit's `Name`/`Id` vs a generic ERP's lowercase) — the COL-PAIR
  class, which the server's own `_info_erp` already hedges against.

**Scorecard:**
- **`no_history` is NOT `clear`.** A sub who has never worked for you is an unknown. The engine calls
  a clean-looking record for an unexamined vendor "the single most expensive mistake this module
  could make" — and it is a *rendering* mistake as much as an engine one: three verdicts that reach
  the same pixel are one verdict. An unrecognised fourth verdict does not inherit green either.
- **A clean record is silence about quality, not a pass.** `ncr` and `inspection` carry no vendor
  field. The attribution line is stated even when the payload omits it: the silence belongs to the
  route, not to one response, and a missing caveat reads as no caveat.
- **A certificate with no expiry is not cover.** Expired, expiry-unknown and none-recorded are three
  states; "0 expired" for a vendor with no certificate is the `no_history` error one field down.

Also: Lane B claims `apps/web/src/connections/`, a directory no lane had ever owned. Adding two files
to it reddened the unowned ratchet; the remedy it names took all four out, and the ceiling is
re-seated to the measured 23.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean — ran it, `All checks passed!`
- [x] Backend: affected `test_*.py` pass — the **full local suite finished 695/695 green** (1,243s),
      `test_route_reachability` and `test_claude_md_gates` among them. No new backend test file, so
      no `run_tests.py` registration needed; both commits touch one backend file between them, the
      reachability gate itself.
- [x] Web: typecheck, lint and build clean; full vitest suite **2,681 tests / 250 files** green
- [x] No import cycles introduced — `test_import_cycles.py` OK (563 modules) and
      `no-import-cycles.test.ts` 2 passed
- [x] `CHANGELOG.md` entries added (newest at top); `docs/roadmap.md` items added and closed
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs — QuickBooks / Sage / Viewpoint appear as
      integration targets, which is the allowed connector sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a vendor scorecard to the Benchmarks panel with worst-first rankings, project and financial details, lien exposure, insurance status, and vendor history indicators.
  - Added a **Books** action for QuickBooks, Sage, and Viewpoint connections.
  - Books can display accounts, vendors, and bills with clear empty-state and error messages.
  - Added safeguards for capped QuickBooks results and inconsistent vendor data formatting.

- **Bug Fixes**
  - Correctly distinguishes vendor service errors from empty results, including responses returned with successful HTTP status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->