### PR TITLE
A submitted pay application no longer makes the next one re-bill the whole job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ and the deterministic half is the worse one.*
 The allocation now goes through `modules.next_counter`, extracted from `_next_ref` so the primitive
 is shared rather than private to its first caller. Its seed is a callable, consulted only when the
 counter row does not yet exist, so the ordinary path stays one atomic `UPDATE … RETURNING`.
+**And a second review round found the counter half-wired.** Only the *allocating* path moved the
+mark, so a number chosen explicitly by a caller did not. Measured rather than argued: applications
+1, explicit 7, then omitted produced **[1, 7, 2]** — no duplicate yet, which is exactly why the
+first round missed it. The collision is deferred to whichever allocation later climbs back to 7 and
+names an application that already exists. `modules.raise_counter` now lifts the mark to any explicit
+number, atomically and portably (`CASE WHEN n < :v THEN :v ELSE n END` — Postgres spells the scalar
+maximum `GREATEST`, SQLite has no such function and its `MAX` is the aggregate). *An off-by-one you
+can see is safer than a collision you have to wait for.*
+
 Two more from the same review: a non-positive `app_no` stored `"App -2"` while the route's
 trailing-digit parse reported `2` — refused now at the builder, so a direct caller cannot bypass it —
 and the "Owner application from draw" button is disabled for its own round trip, since creating an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,50 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### A submitted pay application no longer makes the next one re-bill the whole job
+
+**This is an over-billing bug that shipped**, and it is fixed. On a $100k line at 10% retainage with
+$18,000 genuinely due, creating an owner invoice with the button in Finance → Budget and submitting
+it moved G702 **line 7 from $45,000 to $0 and line 8 from $18,000 to $63,000**. The next draw asked
+for everything earned to date, again.
+
+**Why.** There were two builders for the same document. `cost.build_application` freezes the whole
+application — the G703 continuation sheet, all nine certificate lines, `sov_snapshot_at` — and sat
+behind `POST …/cost/pay-application` with **no client caller ever**. The route the button actually
+called, `…/cost/pay-app/invoice`, assembled its own record from `g702()` **line 8 alone** and stored
+`{number, amount, period, status, prime_contract}`.
+
+The thin record was not merely smaller. `cost._certified_to_date` fills line 7 by reading
+`current_payment_due` off submitted applications — a key the thin record does not have. So the sum
+came out `0.0`, and **`0.0` is not `None`**. `None` is the sentinel meaning *fall back to
+reconstructing from `completed_prev`*, which would have been right. A real number suppresses the
+fallback. Creating the invoice therefore replaced a correct answer with a wrong zero — *the failure
+needed the feature to be used*, which is why nothing caught it.
+
+**The fix, and it is a consolidation rather than a patch.** `…/cost/pay-app/invoice` now calls
+`build_application`, so there is exactly one builder and the record it writes carries its own
+arithmetic. `…/cost/pay-application` is retired. The `prime_contract` link, the one field the thin
+route set and the builder did not, is carried into the builder so consolidating trades no fact away.
+
+Two more things fell out of reading it:
+
+- **Every application was called "App 1."** `app_no` defaulted to `1` server-side *and* the client
+  always sent `1`. It is optional now in both places, and the server numbers from the applications
+  that exist. The button is relabelled **"Owner application from draw"**, because that is what it
+  makes.
+- **The period roll had two implementations too**, and they disagreed. `…/cost/pay-app/advance` was
+  dark and counted *every* SOV row; the live `…/cost/advance-period` counts only rows with work
+  billed this period. The dark one also returned a `next_application_no` derived from an
+  `application_no` field on SOV lines that nothing sets. It is retired, and `test_closeout.py` — which
+  had been written against the dark route's response shape — now exercises the live one.
+
+Six regression assertions pin the money, including that the retired builder stays retired: its
+response shape differed, so a caller written against it would silently receive a record where the
+survivor returns an envelope. Routes 949 → 947, uncalled 58 → 56, short-leaf ratchet 5 → 3.
+
+*A record that keeps the answer and discards the arithmetic is not a smaller record — it is one that
+something downstream was already trying to read.*
+
 ### Every trade partner's record with your firm, and what it does not cover
 
 `GET /benchmarks/vendors` has reported each subcontractor's cross-project commercial and compliance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,14 +40,34 @@ route set and the builder did not, is carried into the builder so consolidating 
 Two more things fell out of reading it:
 
 - **Every application was called "App 1."** `app_no` defaulted to `1` server-side *and* the client
-  always sent `1`. It is optional now in both places, and the server numbers from the applications
-  that exist. The button is relabelled **"Owner application from draw"**, because that is what it
-  makes.
+  always sent `1`. It is optional now in both places, and the server allocates the number from the
+  same atomic `ref_counters` row the human refs use. The button is relabelled **"Owner application
+  from draw"**, because that is what it makes.
 - **The period roll had two implementations too**, and they disagreed. `…/cost/pay-app/advance` was
   dark and counted *every* SOV row; the live `…/cost/advance-period` counts only rows with work
   billed this period. The dark one also returned a `next_application_no` derived from an
   `application_no` field on SOV lines that nothing sets. It is retired, and `test_closeout.py` — which
   had been written against the dark route's response shape — now exercises the live one.
+
+**Review found that the first draft of that numbering was itself a defect, and named the wrong half
+of it.** It read `app_no = 1 + len(records)`. `RefCounter`'s own docstring, in `services/api/src/aec_api/models.py`,
+says that counter exists *because* a COUNT(*) scheme let a later create reuse a number after a
+delete — so the fix for a money bug had reintroduced, on a money register, the exact scheme this
+codebase retired for refs. The review described it as a race between concurrent requests, which is
+real: no unique index on `data.number` refuses either writer, so two applications both become
+"App 3". But the reuse half needs no concurrency at all — delete application 3 and the next one is
+"App 3" again, every time — and that is the half that leaves a register unable to say which
+application was paid. *A race-shaped description hides the half that reproduces deterministically,
+and the deterministic half is the worse one.*
+
+The allocation now goes through `modules.next_counter`, extracted from `_next_ref` so the primitive
+is shared rather than private to its first caller. Its seed is a callable, consulted only when the
+counter row does not yet exist, so the ordinary path stays one atomic `UPDATE … RETURNING`.
+Two more from the same review: a non-positive `app_no` stored `"App -2"` while the route's
+trailing-digit parse reported `2` — refused now at the builder, so a direct caller cannot bypass it —
+and the "Owner application from draw" button is disabled for its own round trip, since creating an
+application is not idempotent and server-side numbering labels duplicates rather than preventing
+them.
 
 Six regression assertions pin the money, including that the retired builder stays retired: its
 response shape differed, so a caller written against it would silently receive a record where the

--- a/apps/web/src/api/cost.ts
+++ b/apps/web/src/api/cost.ts
@@ -286,10 +286,22 @@ export function withCost<TBase extends Ctor<HttpCore>>(Base: TBase) {
     if (!res.ok) throw new HttpError(`pay-app PDF -> ${res.status}`, res.status);
     return res.blob();
   }
-  /** Create an owner-invoice record from the current pay application (amount = current payment due). */
-  payAppInvoice(pid: string, appNo = 1) {
+  /**
+   * Create the owner pay application — the FROZEN document, not a receipt for its total.
+   *
+   * **`appNo` is omitted by default on purpose.** It used to default to `1` and was always sent, so
+   * every application in the register was numbered "App 1". The server numbers from the applications
+   * that already exist when it is not told; pass one only to re-state a specific application.
+   *
+   * Since PAY-APP this route stores the whole G703 continuation sheet and G702 lines 1-9, not line 8
+   * alone. That is what makes the next draw correct: `cost._certified_to_date` fills line 7 by
+   * reading `current_payment_due` off submitted applications, and the old thin record had no such
+   * key — so line 7 read zero and the next application re-billed everything earned to date.
+   */
+  payAppInvoice(pid: string, appNo?: number) {
     return this.json<{ owner_invoice: ModuleRecord; application_no: number; amount: number }>(
-      `/projects/${pid}/cost/pay-app/invoice`, { method: "POST", body: JSON.stringify({ app_no: appNo }) });
+      `/projects/${pid}/cost/pay-app/invoice`,
+      { method: "POST", body: JSON.stringify(appNo === undefined ? {} : { app_no: appNo }) });
   }
 
   /**

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -598,10 +598,15 @@ export async function renderBudget(ctx: PanelContext) {
     invBtn.textContent = "＋ Owner application from draw";
     invBtn.title = "Freeze the current G702/G703 into a draft application — its continuation sheet "
       + "and all nine certificate lines, so a later SOV edit cannot restate it";
+    // Disabled for the whole round trip, and re-enabled ONLY on failure. Creating an application
+    // is not idempotent — a second click before the first resolves freezes a second owner_invoice,
+    // and server-side numbering cannot help: it labels the duplicates, it does not prevent them.
+    // On success the handler navigates away, so the button re-enables when the panel next renders.
     invBtn.onclick = async () => {
+      invBtn.disabled = true;
       try { const r = await ctx.host.api.payAppInvoice(pid);
         ctx.host.setStatus(`owner invoice created: $${Math.round(r.amount).toLocaleString()}`); jumpTo("owner_invoice"); }
-      catch (e) { ctx.host.setStatus(`invoice failed: ${(e as Error).message}`); }
+      catch (e) { invBtn.disabled = false; ctx.host.setStatus(`invoice failed: ${(e as Error).message}`); }
     };
     // C1 — CLOSE THE PERIOD. `cost.advance_period` is the only code anywhere that rolls an SOV
     // line's `completed_this` into `completed_prev`, and its route had no caller until v0.3.1050:

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -592,10 +592,14 @@ export async function renderBudget(ctx: PanelContext) {
         ctx.host.setStatus("pay-app PDF generated"); }
       catch (e) { ctx.host.setStatus(`pay app failed: ${(e as Error).message}`); }
     };
+    // PAY-APP — the application, frozen. No `app_no` is passed: the server numbers from the
+    // applications that exist, where this used to send `1` every time and label them all "App 1".
     const invBtn = document.createElement("button"); invBtn.className = "tool-btn"; invBtn.dataset.cap = "edit";
-    invBtn.textContent = "＋ Owner invoice from draw";
+    invBtn.textContent = "＋ Owner application from draw";
+    invBtn.title = "Freeze the current G702/G703 into a draft application — its continuation sheet "
+      + "and all nine certificate lines, so a later SOV edit cannot restate it";
     invBtn.onclick = async () => {
-      try { const r = await ctx.host.api.payAppInvoice(pid, 1);
+      try { const r = await ctx.host.api.payAppInvoice(pid);
         ctx.host.setStatus(`owner invoice created: $${Math.round(r.amount).toLocaleString()}`); jumpTo("owner_invoice"); }
       catch (e) { ctx.host.setStatus(`invoice failed: ${(e as Error).message}`); }
     };

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1805,6 +1805,20 @@ instances:
 
   Routes **949 → 947**, uncalled **58 → 56**, short-leaf ratchet **5 → 3**.
 
+  **Review caught the replacement numbering doing the thing the fix was about.** The first draft
+  allocated with `app_no = 1 + len(records)` — and `RefCounter` in `services/api/src/aec_api/models.py`
+  documents that it exists *because* a COUNT(*) scheme let a delete free a number for reuse. A money
+  bug's fix had therefore reintroduced, on a money register, the scheme this repo already retired for
+  refs. The review framed it as a concurrency race, which it also is; but the reuse half needs no
+  threads (delete application 3, the next one is "App 3") and is the half that leaves a register
+  unable to say which application was paid. *A race-shaped description hides the deterministic half,
+  and the deterministic half is worse.* Now allocated through `modules.next_counter`, extracted from
+  `_next_ref` so the atomic primitive is shared rather than private to its first caller; the seed is
+  a callable so the ordinary path stays one `UPDATE … RETURNING`. Also from that review: a
+  non-positive `app_no` stored `"App -2"` and was reported back as `2`, refused now at the builder
+  so no direct caller bypasses it; and the create button is disabled for its own round trip, because
+  creating an application is not idempotent and numbering labels duplicates rather than stopping them.
+
 - ✅ ⭐ **VENDOR-SCORECARD — a trade partner's record with your firm, and the limits of it**
   *(S — Lanes B/I; **CLOSED 2026-09-12**; gated by `apps/web/src/api/clientCallers.test.ts`,
   `apps/web/src/portal/panels/vendorScorecard.test.ts` and `services/api/test_route_reachability.py`)*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1780,6 +1780,31 @@ instances:
   PREFAB-FREEZE-RACE, and filed the same way rather than left in a review thread — **a follow-up held
   only in a thread closes by default when the PR merges.**
 
+- ✅ ⭐ **PAY-APP — two builders for one document, and the one the product called over-billed**
+  *(M — Lanes C/G/I; **CLOSED 2026-09-12**; gated by `services/api/test_pay_application.py`,
+  `services/api/test_closeout.py` and `services/api/test_route_reachability.py`)*
+
+  **A live over-billing bug, reproduced before it was fixed.** $100k line, 10% retainage, $18,000
+  genuinely due. Create an owner invoice from the Budget panel, submit it, and G702 line 7 went
+  **45,000 → 0** while line 8 went **18,000 → 63,000**: the next draw claimed everything earned to
+  date all over again.
+
+  `cost.build_application` freezes the whole application and had **no caller, ever**. The button
+  called `…/cost/pay-app/invoice`, which built its own record from `g702()` line 8 and stored five
+  keys. `cost._certified_to_date` fills line 7 by reading `current_payment_due` off submitted
+  applications — absent from that record — so the sum was `0.0`. **`0.0` is not `None`**, and `None`
+  was the sentinel that would have fallen back to a correct reconstruction. *Using the feature is
+  what broke it*, which is why the suite had never seen it.
+
+  Consolidated rather than patched, per the maintainer's call: one builder, the dark route retired,
+  the `prime_contract` link carried into the survivor so nothing is traded away. Two further finds
+  in the same read — every application was numbered "App 1" (`app_no` defaulted to 1 on *both* sides
+  of the wire), and the period roll also had two implementations, the dark one counting every SOV row
+  where the live one counts only rows with work. `test_closeout.py` had been written against the dark
+  route's response shape, which is how that pair announced itself.
+
+  Routes **949 → 947**, uncalled **58 → 56**, short-leaf ratchet **5 → 3**.
+
 - ✅ ⭐ **VENDOR-SCORECARD — a trade partner's record with your firm, and the limits of it**
   *(S — Lanes B/I; **CLOSED 2026-09-12**; gated by `apps/web/src/api/clientCallers.test.ts`,
   `apps/web/src/portal/panels/vendorScorecard.test.ts` and `services/api/test_route_reachability.py`)*

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -187,7 +187,11 @@ def build_application(db: Session, pid: str, app_no: int | None = None, period: 
     cert = g702(db, pid, app_no=app_no, period=period, release_retainage=release_retainage,
                 previous_certificates=_certified_to_date(db, pid))
     data = {
-        "number": str(app_no), "period": period or "", "period_from": period_from or "",
+        # "App N", not "N" — the format every owner_invoice already in the field carries, because
+        # the thin router builder this replaced wrote it that way. Two tests disagreed about this
+        # and the shipped records broke the tie: a money register whose rows read "App 1, App 2, 3"
+        # is worse than either format consistently.
+        "number": f"App {app_no}", "period": period or "", "period_from": period_from or "",
         "period_to": period_to or "",
         "line_items": sheet["lines"],
         "original_contract_sum": cert["line1_original_contract_sum"],

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -6,12 +6,18 @@ from __future__ import annotations
 
 from typing import Any
 
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from . import modules as me
 from . import money
 
 DEFAULT_RETAINAGE = 5.0
+
+#: Counter key for pay-application numbers. NOT a module key — `modules.next_counter` requires a
+#: key no module can hold, and module keys are directory names under `services/api/modules/`, which
+#: cannot contain a colon.
+APP_NO_COUNTER = "owner_invoice:app_no"
 
 
 def _n(v: Any) -> float:
@@ -181,9 +187,23 @@ def build_application(db: Session, pid: str, app_no: int | None = None, period: 
     record the arithmetic can no longer be checked against, and here something downstream was
     already trying to check.*
     """
+    # Rejected BEFORE anything is created, and here rather than in the route, so a direct caller
+    # cannot get round it. `number` is a display string, so `app_no=-2` stored "App -2" while the
+    # route's trailing-digit parse read it back as 2: the response and the record disagreed.
+    if app_no is not None and app_no < 1:
+        raise HTTPException(422, "app_no must be 1 or greater")
     sheet = g703(db, pid)
     if app_no is None:
-        app_no = 1 + len(_records(db, "owner_invoice", pid))
+        # ATOMIC, not `1 + len(_records(...))`. That was a COUNT(*) allocation — and `RefCounter`'s
+        # own docstring says it exists because a COUNT(*) scheme let a later create reuse a number
+        # after a delete. So the first draft of this consolidation reintroduced, on a money
+        # register, the exact scheme this codebase had already retired for refs: two concurrent
+        # applications both became "App 3" (no unique index on `data.number` refuses either), and
+        # deleting application 3 made the next one "App 3" again — deterministically, no
+        # concurrency needed. *The second is the worse half and it is the half a race-shaped
+        # description hides.*
+        app_no = me.next_counter(db, pid, APP_NO_COUNTER,
+                                 lambda: len(_records(db, "owner_invoice", pid)))
     cert = g702(db, pid, app_no=app_no, period=period, release_retainage=release_retainage,
                 previous_certificates=_certified_to_date(db, pid))
     data = {

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -204,6 +204,13 @@ def build_application(db: Session, pid: str, app_no: int | None = None, period: 
         # description hides.*
         app_no = me.next_counter(db, pid, APP_NO_COUNTER,
                                  lambda: len(_records(db, "owner_invoice", pid)))
+    else:
+        # An explicit number must move the mark too, or the allocator hands it out again later.
+        # Measured before fixing: applications 1, explicit 7, then omitted gave [1, 7, 2] — no
+        # duplicate yet, which is exactly why it survived the first round of this review. The
+        # collision is deferred to the allocation that reaches 7.
+        me.raise_counter(db, pid, APP_NO_COUNTER, app_no,
+                         lambda: len(_records(db, "owner_invoice", pid)))
     cert = g702(db, pid, app_no=app_no, period=period, release_retainage=release_retainage,
                 previous_certificates=_certified_to_date(db, pid))
     data = {

--- a/services/api/src/aec_api/cost.py
+++ b/services/api/src/aec_api/cost.py
@@ -165,6 +165,21 @@ def build_application(db: Session, pid: str, app_no: int | None = None, period: 
 
     Draft, deliberately. This produces the record; submitting and certifying it are workflow
     transitions a person performs, because a certificate nobody signed is not a certificate.
+
+    **THIS IS THE ONLY BUILDER, since PAY-APP.** A second one lived in the router
+    (`/cost/pay-app/invoice`) and was the one the product actually called. It ran `g702()`, kept
+    LINE 8 ALONE, and stored `{number, amount, period, status, prime_contract}` — no line items, no
+    lines 1-7 or 9, no `sov_snapshot_at`. That was not merely a thinner record; it was an
+    OVER-BILLING BUG, and `_certified_to_date` above is why. It reads `current_payment_due` from
+    submitted applications; the thin record has no such key, so the sum came out 0.0 — **not None**.
+    None would have fallen through to the reconstruction and been right. 0.0 is a number, so line 7
+    became zero and the next application re-billed the whole earned-to-date. Measured on a $100k
+    line at 10% retainage with $18,000 genuinely due: submitting the invoice the button created
+    moved line 7 from 45,000 to 0 and line 8 from 18,000 to 63,000.
+
+    *A record that stores the answer and discards the arithmetic is not a smaller record — it is a
+    record the arithmetic can no longer be checked against, and here something downstream was
+    already trying to check.*
     """
     sheet = g703(db, pid)
     if app_no is None:
@@ -187,6 +202,12 @@ def build_application(db: Session, pid: str, app_no: int | None = None, period: 
         "sov_snapshot_at": _now_date(),
         "status": "draft",
     }
+    # The prime contract this draw bills against. Carried in from the thin `/cost/pay-app/invoice`
+    # builder this function replaced (PAY-APP): it was the one field that route set and this one did
+    # not, and dropping it on consolidation would have traded one missing fact for another.
+    pc = next((r for r in me.list_records(db, "prime_contract", pid, limit=1)), None)
+    if pc:
+        data["prime_contract"] = pc["id"]
     return me.create_record(db, "owner_invoice", pid, {"data": data}, actor, "GC")
 
 

--- a/services/api/src/aec_api/modules.py
+++ b/services/api/src/aec_api/modules.py
@@ -11,6 +11,7 @@ Implements the patent-described system (provisional 514712205), modernised on Fa
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 
 from fastapi import HTTPException
@@ -168,10 +169,24 @@ def _validate_values(mod: dict, data: dict) -> None:
         raise HTTPException(422, "; ".join(problems))
 
 
-def _next_ref(db: Session, key: str, project_id: str, mod: dict) -> str:
-    """Atomically allocate the next ref number from a per-(project, module) counter row, taking a row
-    lock (Postgres) so concurrent creates can't read the same value and mint duplicate refs. On first
-    use the counter seeds from the current row count so existing data keeps its sequence."""
+def next_counter(db: Session, project_id: str, counter_key: str,
+                 seed: Callable[[], int] = lambda: 0) -> int:
+    """Atomically allocate the next integer from the per-(project, `counter_key`) `ref_counters` row.
+
+    Extracted from `_next_ref` in PAY-APP so that anything needing a per-project sequence uses this
+    primitive instead of growing its own. The one that prompted it was a pay application's number,
+    which had been `1 + len(records)` — the COUNT(*) scheme `RefCounter`'s own docstring says it
+    exists to replace, reintroduced on a money register a year later. *A retired scheme is not gone
+    while the primitive that replaced it is private to its first caller.*
+
+    `seed` is a CALLABLE on purpose. It is consulted ONLY when the counter row does not exist yet,
+    so the ordinary path stays a single atomic UPDATE and no caller pays for a COUNT it will not
+    use — which is what a plain `int` parameter would have cost on every allocation.
+
+    `counter_key` is the module key for refs. Any other caller must pass a key no module can hold:
+    module keys are directory names under `services/api/modules/` (139 of them), so a ':' is
+    unavailable to them and is what the non-module keys use.
+    """
     from sqlalchemy import update as sa_update
     from sqlalchemy.exc import IntegrityError
 
@@ -187,12 +202,12 @@ def _next_ref(db: Session, key: str, project_id: str, mod: dict) -> str:
     for _ in range(2):
         n = db.execute(
             sa_update(RefCounter)
-            .where(RefCounter.project_id == project_id, RefCounter.module == key)
+            .where(RefCounter.project_id == project_id, RefCounter.module == counter_key)
             .values(n=RefCounter.n + 1)
             .returning(RefCounter.n)
         ).scalar()
         if n is not None:
-            return f"{mod.get('ref_prefix', key.upper())}-{n:03d}"
+            return n
 
         # No counter row yet — seed it. SEEDING is the one moment no row-level mechanism can
         # protect (there is no row), so two concurrent FIRST creates can both get here; the
@@ -201,14 +216,21 @@ def _next_ref(db: Session, key: str, project_id: str, mod: dict) -> str:
         # SAVEPOINT so the loser's refusal stays local (the same pattern, for the same reason, as
         # `rbac.consume_stepup`), and the loser simply loops back into the atomic increment against
         # the winner's row.
-        seed = db.execute(select(func.count()).select_from(TABLES[key])
-                          .where(TABLES[key].c.project_id == project_id)).scalar() or 0
         try:
             with db.begin_nested():
-                db.add(RefCounter(project_id=project_id, module=key, n=seed))
+                db.add(RefCounter(project_id=project_id, module=counter_key, n=seed()))
         except IntegrityError:
             pass                                    # another writer seeded first — use their row
     raise RuntimeError("ref counter neither existed nor could be seeded")   # unreachable
+
+
+def _next_ref(db: Session, key: str, project_id: str, mod: dict) -> str:
+    """The human ref (RFI-001, …), allocated from the shared atomic counter above. On first use the
+    counter seeds from the current row count so existing data keeps its sequence."""
+    n = next_counter(db, project_id, key,
+                     lambda: db.execute(select(func.count()).select_from(TABLES[key])
+                                        .where(TABLES[key].c.project_id == project_id)).scalar() or 0)
+    return f"{mod.get('ref_prefix', key.upper())}-{n:03d}"
 
 
 def create_record(db: Session, key: str, project_id: str, body: dict, actor: str,

--- a/services/api/src/aec_api/modules.py
+++ b/services/api/src/aec_api/modules.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from fastapi import HTTPException
 from sqlalchemy import (
     Float,
+    case,
     cast,
     func,
     insert,
@@ -221,6 +222,44 @@ def next_counter(db: Session, project_id: str, counter_key: str,
                 db.add(RefCounter(project_id=project_id, module=counter_key, n=seed()))
         except IntegrityError:
             pass                                    # another writer seeded first — use their row
+    raise RuntimeError("ref counter neither existed nor could be seeded")   # unreachable
+
+
+def raise_counter(db: Session, project_id: str, counter_key: str, at_least: int,
+                  seed: Callable[[], int] = lambda: 0) -> None:
+    """Raise the counter to at least `at_least`, so a number chosen EXPLICITLY by a caller cannot be
+    handed out again later by `next_counter`.
+
+    An allocator and an explicit choice draw from the same namespace, and only the allocator was
+    moving the mark: create application 1, then an explicit 7, and the next allocation was 2 — not a
+    duplicate yet, which is what makes it easy to miss. The collision arrives later, when the counter
+    climbs back to 7 and names an application that already exists. *An off-by-one you can see is
+    safer than a collision you have to wait for.*
+
+    `case` rather than `GREATEST`/`MAX`: Postgres spells the scalar maximum `GREATEST` while SQLite
+    has no such function, and SQLite's `MAX` is the aggregate — so the portable atomic form is a
+    single `UPDATE ... SET n = CASE WHEN n < :v THEN :v ELSE n END`.
+    """
+    from sqlalchemy import update as sa_update
+    from sqlalchemy.exc import IntegrityError
+
+    from .models import RefCounter
+
+    for _ in range(2):
+        n = db.execute(
+            sa_update(RefCounter)
+            .where(RefCounter.project_id == project_id, RefCounter.module == counter_key)
+            .values(n=case((RefCounter.n < at_least, at_least), else_=RefCounter.n))
+            .returning(RefCounter.n)
+        ).scalar()
+        if n is not None:
+            return
+        try:                                        # same seed-once-then-retry shape as next_counter
+            with db.begin_nested():
+                db.add(RefCounter(project_id=project_id, module=counter_key,
+                                  n=max(seed(), at_least)))
+        except IntegrityError:
+            pass                                    # another writer seeded first — raise theirs
     raise RuntimeError("ref counter neither existed nor could be seeded")   # unreachable
 
 

--- a/services/api/src/aec_api/routers/closeout.py
+++ b/services/api/src/aec_api/routers/closeout.py
@@ -85,31 +85,6 @@ def compliance_expiring(pid: str, within_days: int = 30, db: Session = Depends(g
             "count": len(out["expired"]) + len(out["expiring"])}
 
 
-@router.post("/projects/{pid}/cost/pay-app/advance")
-def payapp_advance(pid: str, db: Session = Depends(get_db),
-                   actor: str = Depends(require_role("editor"))):
-    """Close the current pay-app period: roll each SOV line's `completed_this` into
-    `completed_prev` and zero `completed_this`, so the next G702/G703 application starts a fresh
-    period with the prior work correctly shown as previous certificates. Returns the next app no."""
-    if "sov" not in me.TABLES:
-        raise HTTPException(409, "SOV module not loaded")
-    rows = me.list_records(db, "sov", pid, limit=1_000_000)
-    if not rows:
-        raise HTTPException(409, "no schedule-of-values lines to advance")
-    advanced = 0
-    for r in rows:
-        d = dict(r.get("data") or {})
-        this = float(d.get("completed_this") or 0)
-        prev = float(d.get("completed_prev") or 0)
-        d["completed_prev"] = round(prev + this, 2)
-        d["completed_this"] = 0
-        me.update_record(db, "sov", pid, r["id"], {"completed_prev": d["completed_prev"],
-                                                    "completed_this": 0}, actor, "GC")
-        advanced += 1
-    next_app = int(max((float((r.get("data") or {}).get("application_no") or 0) for r in rows), default=0)) + 1
-    return {"advanced_lines": advanced, "next_application_no": next_app}
-
-
 @router.post("/projects/{pid}/cost/lien-waiver", status_code=201)
 def lien_waiver_from_payapp(pid: str, app_no: int = Body(1, embed=True),
                             vendor: str = Body("", embed=True),

--- a/services/api/src/aec_api/routers/cost.py
+++ b/services/api/src/aec_api/routers/cost.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import re
 from datetime import date
 from pathlib import Path
 
@@ -431,8 +432,13 @@ def payapp_invoice(pid: str, app_no: int | None = Body(None, embed=True),
     rec = cost.build_application(db, pid, app_no, period, period_from, period_to,
                                  release_retainage, actor)
     data = rec.get("data") or {}
+    # `number` is a DISPLAY string ("App 3"), so the count comes off its trailing digits rather than
+    # from `float()`, which raised on the prefix. The first draft of this consolidation parsed it as
+    # a bare number and would have 500'd the moment the format matched the records already stored —
+    # *a round-trip through a human-facing field is a parse, and a parse needs a format it agrees on.*
+    m = re.search(r"(\d+)\s*$", str(data.get("number") or ""))
     return {"owner_invoice": rec,
-            "application_no": int(float(data.get("number") or 0)),
+            "application_no": int(m.group(1)) if m else 0,
             "amount": data.get("current_payment_due")}
 
 

--- a/services/api/src/aec_api/routers/cost.py
+++ b/services/api/src/aec_api/routers/cost.py
@@ -366,28 +366,6 @@ def g702(pid: str, app_no: int = 1, period: str | None = None, release_retainage
                      previous_certificates=cost._certified_to_date(db, pid))
 
 
-@router.post("/projects/{pid}/cost/pay-application", status_code=201)
-def build_pay_application(pid: str, app_no: int | None = Body(None, embed=True),
-                          period: str | None = Body(None, embed=True),
-                          period_from: str | None = Body(None, embed=True),
-                          period_to: str | None = Body(None, embed=True),
-                          release_retainage: bool = Body(False, embed=True),
-                          db: Session = Depends(get_db),
-                          user: str = Depends(require_role("reviewer"))):
-    """MOD-G702 — snapshot the live SOV and G702 into a draft `owner_invoice`.
-
-    `GET /cost/g702` stays a live view, which is the right thing for "where do we stand today". This
-    is the other thing: the application you actually send, with its numbers frozen. A pay application
-    is a claim made on a date, and everything feeding it keeps moving afterwards — so a certificate
-    reassembled on demand silently restates applications already signed and paid.
-
-    Created as a DRAFT. Submitting and certifying are transitions a person performs; a certificate
-    nobody signed is not a certificate.
-    """
-    return cost.build_application(db, pid, app_no, period, period_from, period_to,
-                                  release_retainage, user)
-
-
 def _proforma_hard(p) -> float | None:
     if not p or not p.dev_budget:
         return None
@@ -423,22 +401,39 @@ def g702_pdf(pid: str, app_no: int = 1, period: str | None = None, release_retai
 
 
 @router.post("/projects/{pid}/cost/pay-app/invoice", status_code=201)
-def payapp_invoice(pid: str, app_no: int = Body(1, embed=True), period: str | None = Body(None, embed=True),
+def payapp_invoice(pid: str, app_no: int | None = Body(None, embed=True),
+                   period: str | None = Body(None, embed=True),
+                   period_from: str | None = Body(None, embed=True),
+                   period_to: str | None = Body(None, embed=True),
                    release_retainage: bool = Body(False, embed=True),
                    db: Session = Depends(get_db), actor: str = Depends(require_role("editor"))):
-    """Create an owner-invoice record from the current pay application — amount = G702 current payment
-    due — so each draw produces its owner invoice, linked to the prime contract. Closes the loop:
-    budget → SOV → G702/G703 → owner invoice."""
+    """Create the owner pay application — the FROZEN document, not a receipt for its total.
+
+    Closes the loop budget → SOV → G702/G703 → owner invoice, and since PAY-APP it does so through
+    the one builder, `cost.build_application`. This route used to assemble its own record from
+    `g702()` line 8 and nothing else. Two things were wrong with that and only one was cosmetic:
+
+    * **It over-billed.** `cost._certified_to_date` reads `current_payment_due` off submitted
+      applications to fill line 7. The thin record had no such key, so the sum was 0.0 rather than
+      `None` — and `None` is the value that means "fall back to the reconstruction". Submitting a
+      draw therefore drove line 7 to zero and made the NEXT application re-bill everything earned to
+      date. Reproduced before the fix: line 7 45,000 → 0, line 8 18,000 → 63,000.
+    * **It always said "App 1".** `app_no` defaulted to 1 rather than to None, and the web client
+      passed 1 explicitly, so every application in the register carried the same number. `app_no` is
+      now optional and `build_application` numbers from what already exists when it is omitted.
+
+    `GET /cost/g702` remains the live view — the right thing for "where do we stand today". This is
+    the other thing: the claim as made on its date, with its numbers and its continuation sheet
+    frozen into it.
+    """
     if "owner_invoice" not in me.TABLES:
         raise HTTPException(409, "owner_invoice module not loaded")
-    g702 = cost.g702(db, pid, app_no=app_no, period=period, release_retainage=release_retainage)
-    amount = round(float(g702["line8_current_payment_due"]), 2)
-    pc = next((r for r in me.list_records(db, "prime_contract", pid, limit=1)), None)
-    data = {"number": f"App {app_no}", "amount": amount, "period": period or "", "status": "draft"}
-    if pc:
-        data["prime_contract"] = pc["id"]
-    rec = me.create_record(db, "owner_invoice", pid, {"data": data}, actor, "GC")
-    return {"owner_invoice": rec, "application_no": app_no, "amount": amount}
+    rec = cost.build_application(db, pid, app_no, period, period_from, period_to,
+                                 release_retainage, actor)
+    data = rec.get("data") or {}
+    return {"owner_invoice": rec,
+            "application_no": int(float(data.get("number") or 0)),
+            "amount": data.get("current_payment_due")}
 
 
 @router.post("/projects/{pid}/cost/advance-period")

--- a/services/api/test_closeout.py
+++ b/services/api/test_closeout.py
@@ -98,9 +98,17 @@ with TestClient(app) as c:
     # period 1 lien waiver = current payment due (completed - retainage)
     lw = c.post(f"/projects/{pid}/cost/lien-waiver", json={"app_no": 1, "vendor": "Concrete Co"}, headers=H)
     assert lw.status_code == 201 and lw.json()["amount"] == 237_500, lw.text
-    # advance the period: this -> prev, ready for application no. 2
-    adv = c.post(f"/projects/{pid}/cost/pay-app/advance", headers=H).json()
-    assert adv["advanced_lines"] == 1 and adv["next_application_no"] >= 1, adv
+    # advance the period: this -> prev, ready for application no. 2.
+    #
+    # PAY-APP retired `/cost/pay-app/advance`, a SECOND implementation of this roll that this test
+    # used to call, and the two did not agree: the retired one advanced every SOV row and counted
+    # them all (`advanced_lines`), while this one touches only rows with work billed this period and
+    # counts those (`lines_advanced`). It also returned a `next_application_no` derived from an
+    # `application_no` field on the SOV lines, which nothing sets — the real next number comes from
+    # `cost.build_application`, which counts the applications that exist. *Two implementations of one
+    # money operation, disagreeing on both the count and the number, one of them dark.*
+    adv = c.post(f"/projects/{pid}/cost/advance-period", headers=H).json()
+    assert adv["lines_advanced"] == 1, adv
     g703 = c.get(f"/projects/{pid}/cost/g703", headers=H).json()
     assert g703["totals"]["prev"] == 250_000 and g703["totals"]["this"] == 0, g703["totals"]
 

--- a/services/api/test_pay_application.py
+++ b/services/api/test_pay_application.py
@@ -212,6 +212,20 @@ with TestClient(app) as c:
           n3["owner_invoice"]["data"]["number"] == f"App {n3['application_no']}",
           n3["owner_invoice"]["data"]["number"])
 
+    # An EXPLICIT app_no must move the high-water mark too. Review round two: the counter only
+    # advanced when a number was allocated, so an explicit number and a later omitted one could name
+    # the same application. Sequenced here rather than described, because the reviewer's trace and
+    # the real one differ by a step and only the run settles it.
+    p3 = c.post("/projects", json={"name": "G702 AppNo"}).json()["id"]
+    c.post(f"/projects/{p3}/modules/sov", json={"data": {
+        "item_no": "01", "description": "Sitework", "scheduled_value": 1000, "completed_this": 100}})
+    seq = [c.post(f"/projects/{p3}/cost/pay-app/invoice", json={}).json()["application_no"]]
+    seq.append(c.post(f"/projects/{p3}/cost/pay-app/invoice",
+                      json={"app_no": 7}).json()["application_no"])
+    seq.append(c.post(f"/projects/{p3}/cost/pay-app/invoice", json={}).json()["application_no"])
+    check("  APP-NO: an explicit number advances the counter, so the next one cannot collide",
+          len(set(seq)) == len(seq) and seq[2] > seq[1], seq)
+
     # `number` is a DISPLAY string and the route reads the count back off its trailing digits, so a
     # negative app_no stored "App -2" and was reported as 2 — the response and the record
     # disagreeing about which application had just been created. Refused at the builder rather than

--- a/services/api/test_pay_application.py
+++ b/services/api/test_pay_application.py
@@ -117,7 +117,12 @@ with TestClient(app) as c:
 
     app2 = c.post(f"/projects/{pid}/cost/pay-app/invoice",
                   json={"period_to": "2026-08-31"}).json()["owner_invoice"]
-    check("  the next application numbers itself", app2["data"]["number"] == "2", app2["data"]["number"])
+    # "App 2", not "2": the display format every owner_invoice already in the field carries. This
+    # assertion said "2" until PAY-APP, because it was written against the DARK builder, which had
+    # never written a record anybody kept. `test_project_budget.py` asserted "App 1" against the
+    # live one — *two tests disagreeing about a money register's display format, and only the one
+    # exercising the shipped route was describing reality.*
+    check("  the next application numbers itself", app2["data"]["number"] == "App 2", app2["data"]["number"])
     check("  and deducts what app 1 certified",
           app2["data"]["previous_certificates"] == 63000.0, app2["data"]["previous_certificates"])
     # completed 140k (50k prev + 90k this); retainage 14k; earned 126k; less 63k = 63k due

--- a/services/api/test_pay_application.py
+++ b/services/api/test_pay_application.py
@@ -189,6 +189,38 @@ with TestClient(app) as c:
     check("  OVERBILL: the second builder is retired — one route builds an application",
           gone.status_code == 404, gone.status_code)
 
+    # --- 3c. APP-NO: the number is allocated, not counted --------------------------------------------
+    # Review of the consolidation above found that `app_no = 1 + len(records)` had been introduced
+    # here. `RefCounter`'s own docstring in `models.py` says that counter exists *because* a
+    # COUNT(*) scheme let a later create reuse a number after a delete — so this reintroduced, on a
+    # money register, the scheme the codebase had already retired for refs.
+    #
+    # The race half needs threads to show. THE REUSE HALF DOES NOT, and it is the worse of the two:
+    # a register with two rows both reading "App 3" has no way to say which application was paid.
+    # *A race-shaped description of this defect hides the half that reproduces deterministically.*
+    n1 = c.post(f"/projects/{p2}/cost/pay-app/invoice", json={}).json()
+    n2 = c.post(f"/projects/{p2}/cost/pay-app/invoice", json={}).json()
+    check("  APP-NO: successive applications get successive numbers",
+          n2["application_no"] == n1["application_no"] + 1,
+          (n1["application_no"], n2["application_no"]))
+    c.delete(f"/projects/{p2}/modules/owner_invoice/{n2['owner_invoice']['id']}")
+    n3 = c.post(f"/projects/{p2}/cost/pay-app/invoice", json={}).json()
+    check("  APP-NO: deleting an application does NOT free its number for reuse",
+          n3["application_no"] > n2["application_no"],
+          f"deleted App {n2['application_no']}, next was App {n3['application_no']}")
+    check("  APP-NO: ...and the stored record agrees with the number the route reported",
+          n3["owner_invoice"]["data"]["number"] == f"App {n3['application_no']}",
+          n3["owner_invoice"]["data"]["number"])
+
+    # `number` is a DISPLAY string and the route reads the count back off its trailing digits, so a
+    # negative app_no stored "App -2" and was reported as 2 — the response and the record
+    # disagreeing about which application had just been created. Refused at the builder rather than
+    # at the route, so a direct caller cannot get round it.
+    for bad in (0, -2):
+        r = c.post(f"/projects/{p2}/cost/pay-app/invoice", json={"app_no": bad})
+        check(f"  APP-NO: app_no={bad} is refused before any record is created",
+              r.status_code == 422, r.status_code)
+
     # --- 4. the form is a form ----------------------------------------------------------------------
     mods = {m["key"]: m for m in c.get("/modules").json()}
     oi = mods["owner_invoice"]

--- a/services/api/test_pay_application.py
+++ b/services/api/test_pay_application.py
@@ -80,10 +80,10 @@ with TestClient(app) as c:
           g["line8_current_payment_due"] == 18000.0, g["line8_current_payment_due"])
 
     # --- 2. THE FREEZE ------------------------------------------------------------------------------
-    made = c.post(f"/projects/{pid}/cost/pay-application",
+    made = c.post(f"/projects/{pid}/cost/pay-app/invoice",
                   json={"period_from": "2026-07-01", "period_to": "2026-07-31"})
-    check("  POST /cost/pay-application creates a record", made.status_code == 201, made.text[:200])
-    app1 = made.json()
+    check("  POST /cost/pay-app/invoice creates a record", made.status_code == 201, made.text[:200])
+    app1 = made.json()["owner_invoice"]
     d1 = app1["data"]
     check("  it is a DRAFT — a certificate nobody signed is not a certificate",
           app1["workflow_state"] == "draft", app1["workflow_state"])
@@ -115,7 +115,8 @@ with TestClient(app) as c:
     check("  line 7 comes from the submitted certificate, not from completed_prev",
           g["line7_less_previous_certificates"] == 63000.0, g["line7_less_previous_certificates"])
 
-    app2 = c.post(f"/projects/{pid}/cost/pay-application", json={"period_to": "2026-08-31"}).json()
+    app2 = c.post(f"/projects/{pid}/cost/pay-app/invoice",
+                  json={"period_to": "2026-08-31"}).json()["owner_invoice"]
     check("  the next application numbers itself", app2["data"]["number"] == "2", app2["data"]["number"])
     check("  and deducts what app 1 certified",
           app2["data"]["previous_certificates"] == 63000.0, app2["data"]["previous_certificates"])
@@ -132,11 +133,56 @@ with TestClient(app) as c:
           g["line7_less_previous_certificates"] == 113000.0, g["line7_less_previous_certificates"])
 
     # a DRAFT certifies nothing — it has been signed by nobody
-    draft = c.post(f"/projects/{pid}/cost/pay-application", json={}).json()
+    draft = c.post(f"/projects/{pid}/cost/pay-app/invoice", json={}).json()["owner_invoice"]
     g2 = c.get(f"/projects/{pid}/cost/g702").json()
     check("  an unsubmitted draft does not move line 7",
           g2["line7_less_previous_certificates"] == 113000.0, g2["line7_less_previous_certificates"])
     assert draft["workflow_state"] == "draft"
+
+    # --- 3b. PAY-APP — THE RECORD THE PRODUCT ACTUALLY CREATED WAS AN OVER-BILLING BUG -------------
+    # Until PAY-APP there were TWO builders. This route assembled its own record from `g702()` line 8
+    # and stored `{number, amount, period, status, prime_contract}` — while `cost.build_application`,
+    # which freezes everything, sat behind `/cost/pay-application` with NO client caller. The button
+    # in `apps/web/src/portal/panels/budget.ts` called the thin one.
+    #
+    # That was not a cosmetic difference. `_certified_to_date` fills line 7 by reading
+    # `current_payment_due` off submitted applications. The thin record has no such key, so the sum
+    # came to 0.0 — and 0.0 is NOT None. None is the sentinel that means "fall back to reconstructing
+    # from completed_prev", which would have been right. A real number suppresses the fallback, so
+    # line 7 went to zero and the next application re-billed everything earned to date.
+    #
+    # Measured on this fixture before the fix: line 7 45,000 -> 0 and line 8 18,000 -> 63,000.
+    # *A record that keeps the answer and discards the arithmetic is not a smaller record — it is one
+    # that something downstream was already trying to read.*
+    p2 = c.post("/projects", json={"name": "G702 Overbill"}).json()["id"]
+    c.post(f"/projects/{p2}/modules/sov", json={"data": {
+        "item_no": "01", "description": "Sitework", "scheduled_value": 100000,
+        "completed_prev": 50000, "completed_this": 20000, "retainage_pct": 10}})
+    before = c.get(f"/projects/{p2}/cost/g702").json()
+    check("  OVERBILL: $18,000 is due before any application exists",
+          before["line8_current_payment_due"] == 18000.0, before["line8_current_payment_due"])
+
+    made2 = c.post(f"/projects/{p2}/cost/pay-app/invoice", json={}).json()["owner_invoice"]
+    stored = made2["data"]
+    check("  OVERBILL: the record the BUTTON creates stores line 8 under the key line 7 reads",
+          stored.get("current_payment_due") == 18000.0, sorted(stored))
+    check("  OVERBILL: ...and its continuation sheet, so the total can be checked against its parts",
+          isinstance(stored.get("line_items"), list) and stored["line_items"], stored.get("line_items"))
+    c.post(f"/projects/{p2}/modules/owner_invoice/{made2['id']}/transition", json={"action": "submit"})
+
+    after = c.get(f"/projects/{p2}/cost/g702").json()
+    check("  OVERBILL: submitting it moves line 7 to what was certified, NOT to zero",
+          after["line7_less_previous_certificates"] == 63000.0,
+          after["line7_less_previous_certificates"])
+    check("  OVERBILL: so the next draw asks for nothing more, not for the whole job again",
+          after["line8_current_payment_due"] == 0.0, after["line8_current_payment_due"])
+
+    # The one-builder guarantee, asserted rather than trusted: the retired route must stay retired,
+    # because its return SHAPE differed and a caller written against it would silently get a record
+    # instead of an envelope.
+    gone = c.post(f"/projects/{p2}/cost/pay-application", json={})
+    check("  OVERBILL: the second builder is retired — one route builds an application",
+          gone.status_code == 404, gone.status_code)
 
     # --- 4. the form is a form ----------------------------------------------------------------------
     mods = {m["key"]: m for m in c.get("/modules").json()}
@@ -159,7 +205,7 @@ if FAILED:
     print(f"PAY-APPLICATION FAILED ({len(FAILED)}): " + "; ".join(FAILED))
     raise SystemExit(1)
 print("PAY-APPLICATION OK - G702 line 7 now retains at each line's own rate, so a 10% contract no "
-      "longer reports a NEGATIVE payment due (closeout.py reads that number); POST /cost/pay-application "
+      "longer reports a NEGATIVE payment due (closeout.py reads that number); POST /cost/pay-app/invoice "
       "freezes the G703 continuation sheet and lines 1-9 into an owner_invoice, so editing the SOV "
       "cannot restate an application already submitted; and line 7 deducts what was actually "
       "certified — including a reduced architect certification — instead of reconstructing it.")

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -159,7 +159,7 @@ KNOWN_UNCALLED: set[str] = {
     # reads the sourced rules. Leaving it frozen would have claimed it was still unreachable.
     # "/projects/{pid}/code/amendments" REMOVED v0.3.1137 — Model Analysis shows the local overlay.
     # "/projects/{pid}/cost-vintage" REMOVED v0.3.1137 — Budget reports the resolved vintage.
-    "/projects/{pid}/cost/pay-application", "/projects/{pid}/dev-budget/sync-from-model",
+    "/projects/{pid}/dev-budget/sync-from-model",
     # "/projects/{pid}/documents/file-model" REMOVED v0.3.1137 — Documents files source.ifc on demand.
     # "/projects/{pid}/documents/model-history" REMOVED v0.3.1137 — Documents lists filed revisions.
     # --- 2026-08-20: MASKED BY THE GENERATED TYPES, not newly broken -----------------------------
@@ -284,7 +284,6 @@ KNOWN_UNCALLED: set[str] = {
     "/projects/{pid}/accounting/journal",
     "/projects/{pid}/classify/proposals",
     "/projects/{pid}/coordination/stale",
-    "/projects/{pid}/cost/pay-app/advance",
     "/projects/{pid}/design/options/economics",
     "/projects/{pid}/drawing-set/references",
     "/projects/{pid}/drawings/schedule.svg",


### PR DESCRIPTION
# What & why

**An over-billing bug that shipped**, reproduced before it was fixed.

$100k SOV line, 10% retainage, **$18,000 genuinely due**. Create an owner invoice with the button in
Finance → Budget, submit it, and:

```
BEFORE  line7 = 45,000   line8 = 18,000     ← correct
AFTER   line7 =      0   line8 = 63,000     ← the next draw re-bills everything earned to date
```

## Why

There were **two builders for the same document**. `cost.build_application` freezes the whole
application — the G703 continuation sheet, all nine certificate lines, `sov_snapshot_at` — and sat
behind `POST …/cost/pay-application` with **no client caller, ever**. The route the button actually
called, `…/cost/pay-app/invoice`, assembled its own record from `g702()` **line 8 alone** and stored
five keys: `{number, amount, period, status, prime_contract}`.

The thin record was not merely smaller. `cost._certified_to_date` fills line 7 by reading
`current_payment_due` off submitted applications — **a key that record does not have**. So the sum
came out `0.0`, and **`0.0` is not `None`**. `None` is the sentinel meaning *fall back to
reconstructing from `completed_prev`*, which would have been right. A real number suppresses the
fallback.

So creating the invoice **replaced a correct answer with a wrong zero**. The failure needed the
feature to be *used* — which is why the suite had never seen it.

## The fix is a consolidation, not a patch

Per the maintainer's call: `…/cost/pay-app/invoice` now calls `build_application`, so there is
exactly one builder and the record carries its own arithmetic. `…/cost/pay-application` is retired.
The `prime_contract` link — the one field the thin route set and the builder did not — is carried
into the builder, so consolidating trades no fact away.

## Two more findings from the same read

- **Every application was called "App 1."** `app_no` defaulted to `1` server-side *and* the client
  always sent `1`. Optional in both places now, and the number is allocated from the same atomic
  `ref_counters` row the human refs use. The button is relabelled **"Owner application from draw"**.
- **The period roll had two implementations too, and they disagreed.** `…/cost/pay-app/advance` was
  dark and counted *every* SOV row; the live `…/cost/advance-period` counts only rows with work
  billed this period. The dark one also returned a `next_application_no` derived from an
  `application_no` field on SOV lines that nothing sets. Retired — and `test_closeout.py` had been
  written against the **dark** route's response shape, which is how that pair announced itself.

Routes **949 → 947**, uncalled **58 → 56**, short-leaf ratchet **5 → 3**.

> *A record that keeps the answer and discards the arithmetic is not a smaller record — it is one
> that something downstream was already trying to read.*

## A second defect, found by the local suite and not by CI

The first commit chose the **wrong `number` format**. Two tests disagreed about a money register's
display string: `test_project_budget` asserted `"App 1"` — the format every `owner_invoice` already
in the field carries, because the route that *ships* wrote it that way — while `test_pay_application`
asserted `"2"`, written against the **dark** builder, which had never produced a record anybody kept.
**Only the test exercising the shipped route was describing reality.**

**And the wrong choice concealed a bug the same commit introduced**: the route returned
`int(float(data["number"]))`, which raises on `"App 1"`. Picking the correct format first would have
500'd it immediately; picking the dark one made it pass. *A round-trip through a human-facing field
is a parse, and a parse needs a format it agrees on.*

CI never judged that commit — the push of the fix cancelled its run. The **local suite** caught it, at
694/695.

## Two review rounds, four findings, and the biggest was introduced by this PR

1. **`app_no = 1 + len(records)` reintroduced a retired scheme, on a money register.** `RefCounter`'s
   own docstring in `services/api/src/aec_api/models.py` says that counter exists *because* a
   COUNT(*) scheme let a later create reuse a number after a delete. The review framed it as a
   concurrency race; that is real but secondary. **The reuse half needs no threads** — delete
   application 3 and the next one is "App 3" again, every time — and it is the half that leaves a
   register unable to say which application was paid. Confirmed by mutation: reverted to the
   COUNT(*) line and the assertion fails `deleted App 3, next was App 3`. *A race-shaped description
   hides the half that reproduces deterministically, and that half is worse.*
2. **The replacement was then half-wired**: only the *allocating* path moved the mark, so an
   explicitly supplied number did not. Sequenced before fixing: applications 1, explicit 7, then
   omitted gives **`[1, 7, 2]`** — no duplicate yet, which is exactly why round one missed it. The
   collision is deferred to whichever allocation later climbs back to 7. *An off-by-one you can see
   is safer than a collision you have to wait for.*
3. **A non-positive `app_no` made the response disagree with the record** — `-2` stored `"App -2"`
   while the trailing-digit parse reported `2`. Refused at the builder, so a direct caller cannot
   bypass it.
4. **Creating an application is not idempotent** — a second click before the first resolved froze a
   second `owner_invoice`. Numbering labels duplicates; it does not prevent them. The button is
   disabled for its own round trip.

`modules.next_counter` and `modules.raise_counter` are extracted from `_next_ref` so the atomic
primitive is **shared** rather than private to its first caller — which is why the second caller grew
its own. The high-water form is `CASE WHEN n < :v THEN :v ELSE n END`, portable because Postgres
spells the scalar maximum `GREATEST` while SQLite has no such function and its `MAX` is the aggregate.

All four findings verified fixed by the reviewer; all four threads resolved.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean
- [x] Backend: **full local suite 695/695 suites passed** (3 parallel, 1202s) on the final state, from
      a clean single-state run — an earlier run was discarded because source changed underneath it,
      making its verdict a statement about neither state. `test_pay_application.py` **42/42**;
      `test_closeout.py`, `test_race_conditions.py` (the test written for the refactored function),
      `test_seeding_sweep.py`, `test_route_reachability.py`, `test_project_budget.py` and
      `test_claude_md_gates.py` all green. No new test file, so no `run_tests.py` registration needed.
- [x] Web: typecheck clean; full vitest suite **2,683 tests / 250 files** green
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added (newest at top); `docs/roadmap.md` item added and closed
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

Not actioned, deliberately: the "Docstring Coverage" pre-merge warning. `CLAUDE.md` forbids padding
docstring coverage, and the counted functions are a lambda and small helpers whose reasoning is in
the block comments beside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA