### PR TITLE
The pay application can be read before it is signed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,38 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### The pay application can be read before it is signed
+
+A GC could **freeze** a pay application and **download** it as a PDF, but never *look* at it. The nine
+G702 certificate lines and the G703 continuation sheet existed on screen nowhere. **Review pay app**
+in Finance → Budget now renders both from data, between seeding the SOV and creating the owner
+invoice — which is the order the work actually happens in.
+
+**This is the direct sequel to the over-billing bug below, and the reason it is worth doing.** That
+defect lived in line 7, "less previous certificates for payment". Line 7 could only be seen inside a
+PDF blob, so a wrong zero there was invisible until the next draw asked for the whole job again.
+*A number a person cannot see is a number nothing checks.*
+
+The screen does more than print. It verifies the certificate's own arithmetic — line 3 = 1 + 2,
+line 6 = 4 − 5, line 8 = 6 − 7, line 9 = 3 − 6, and lines 4 and 5 against the continuation sheet's
+totals — and says so above the numbers, because a certificate that does not add up is what a reviewer
+most needs told. Comparisons are in integer cents: this codebase has already had HALF_EVEN and
+HALF_UP disagree by a penny inside one G702, and `0.1 + 0.2 !== 0.3`. Line 5 is *skipped* rather than
+failed on a final application, where `release_retainage` zeroes it by design — a check that reports a
+correct certificate as broken teaches the reviewer to ignore the checks.
+
+It also names **where line 7 came from**: deducted from what a submitted application actually
+certified, or equal to the schedule of values re-added. Those are not the same fact — the first is
+historical and does not move when the SOV is edited; the second is a reconstruction that does. Saying
+which keeps a reconstruction from reading as a signature.
+
+`GET …/cost/g702` and `GET …/cost/g703` had answered all of this since they were built and had no
+client caller. They sat in the reachability gate's `CONFIRMED_DARK_SHORT_LEAF` with a note saying a
+screen rendering the application from data would use them and none existed — and that note was the
+whole entry, naming the missing work and waiting. Short-leaf ratchet **5 → 3**, and the three that
+remain are all *correctly* dark: the SAML assertion-consumer endpoint the IdP POSTs to, and two
+scheduler polls the server-side runner reads. **The ratchet no longer records any parked work.**
+
 ### A submitted pay application no longer makes the next one re-bill the whole job
 
 **This is an over-billing bug that shipped**, and it is fixed. On a $100k line at 10% retainage with

--- a/apps/web/src/api/cost.ts
+++ b/apps/web/src/api/cost.ts
@@ -280,6 +280,36 @@ export function withCost<TBase extends Ctor<HttpCore>>(Base: TBase) {
     return this.json<{ created: number; lines?: number; scheduled_value?: number; skipped?: number; note?: string }>(
       `/projects/${pid}/cost/sov/from-budget?replace=${replace}`, { method: "POST" });
   }
+  /**
+   * The G702 certificate as DATA — lines 1-9 as the engine computes them right now.
+   *
+   * PAY-APP-SCREEN: this is the live view, the answer to "where do we stand today". Its opposite is
+   * the FROZEN `owner_invoice` a submitted application stores, which does not move when the SOV
+   * does. Both matter and they are not interchangeable: the over-billing bug PAY-APP fixed was
+   * invisible for as long as line 7 could only be read inside a PDF blob.
+   */
+  g702(pid: string, appNo?: number) {
+    const q = appNo === undefined ? "" : `?app_no=${appNo}`;
+    return this.json<{
+      application_no: number; period: string | null; retainage_released: boolean;
+      line1_original_contract_sum: number; line2_net_change_orders: number;
+      line3_contract_sum_to_date: number; line4_total_completed_stored: number;
+      line5_retainage: number; line6_total_earned_less_retainage: number;
+      line7_less_previous_certificates: number; line8_current_payment_due: number;
+      line9_balance_to_finish_incl_retainage: number;
+    }>(`/projects/${pid}/cost/g702${q}`);
+  }
+  /** The G703 continuation sheet — the Schedule of Values with AIA computed columns, plus totals. */
+  g703(pid: string) {
+    return this.json<{
+      lines: { item_no: string | null; description: string | null; cost_code: string | null;
+        scheduled_value: number; completed_prev: number; completed_this: number;
+        materials_stored: number; total_completed_stored: number; percent: number;
+        balance_to_finish: number; retainage: number; retainage_prev: number }[];
+      totals: { scheduled: number; prev: number; this: number; stored: number; completed: number;
+        balance: number; retainage: number; retainage_prev: number };
+    }>(`/projects/${pid}/cost/g703`);
+  }
   /** The owner pay application (G702 certificate + G703 continuation) as a signable PDF blob. */
   async payAppPdf(pid: string, appNo = 1) {
     const res = await fetch(this.url(`/projects/${pid}/cost/g702.pdf?app_no=${appNo}`), { headers: this.authHeaders() });

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -4,6 +4,7 @@ import { confidenceSummary } from "../../ui/confidenceReading";
 import { confirmModal } from "../../ui/modal";
 import type { PanelContext } from "../panelContext";
 import { renderCostBrief } from "./costBrief";
+import { payAppReviewModal } from "./payAppReviewPanel";
 import { rfqConfirm, rfqGate, rfqSummary, saveConfirm, saveGate, saveSummary, type SavedPackage } from "./buyoutKeep";
 
 /**
@@ -585,6 +586,18 @@ export async function renderBudget(ctx: PanelContext) {
         ctx.host.setStatus(`SOV seeded: ${r.created} lines${r.scheduled_value ? ` = $${Math.round(r.scheduled_value).toLocaleString()}` : ""}`); }
       catch (e) { ctx.host.setStatus(`SOV seed failed: ${(e as Error).message}`); }
     };
+    // PAY-APP-SCREEN — READ the application before freezing it. This sits between seeding the SOV
+    // and creating the owner invoice because that is the order the work happens in, and because the
+    // over-billing defect PAY-APP fixed lived in a line nobody could see: line 7 existed only inside
+    // the PDF below, so a wrong zero there was invisible until the next draw re-billed the job.
+    const reviewBtn = document.createElement("button"); reviewBtn.className = "tool-btn";
+    reviewBtn.textContent = "🔍 Review pay app";
+    reviewBtn.title = "The G702 certificate and G703 continuation sheet as they stand right now, "
+      + "with the form's own arithmetic checked";
+    reviewBtn.onclick = async () => {
+      try { await payAppReviewModal(ctx.host.api, pid); }
+      catch (e) { ctx.host.setStatus(`pay-app review failed: ${(e as Error).message}`); }
+    };
     const pdfBtn = document.createElement("button"); pdfBtn.className = "tool-btn"; pdfBtn.textContent = "⬇ Pay app (PDF)";
     pdfBtn.onclick = async () => {
       try { const blob = await ctx.host.api.payAppPdf(pid, 1);
@@ -636,7 +649,7 @@ export async function renderBudget(ctx: PanelContext) {
           : "pay period closed — no lines had work billed this period");
       } catch (e) { ctx.host.setStatus(`close failed: ${(e as Error).message}`); }
     };
-    brow.append(seedBtn, pdfBtn, invBtn, closeBtn); billing.appendChild(brow);
+    brow.append(seedBtn, reviewBtn, pdfBtn, invBtn, closeBtn); billing.appendChild(brow);
     const lwRow = document.createElement("div");
     lwRow.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-top:6px";
     const lwBtn = document.createElement("button"); lwBtn.className = "tool-btn";

--- a/apps/web/src/portal/panels/payAppReview.test.ts
+++ b/apps/web/src/portal/panels/payAppReview.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CERT_LINES, type Certificate, type Sheet,
+  checks, line7Basis, line7Note, percentComplete, summary,
+} from "./payAppReview";
+
+/** A $100k line at 10% retainage, $50k billed previously and $20k this period — the fixture the
+ *  PAY-APP over-billing bug was reproduced on, so the numbers here are the ones that actually moved. */
+function fixture(): { cert: Certificate; sheet: Sheet } {
+  const sheet: Sheet = {
+    lines: [{
+      item_no: "01", description: "Sitework", cost_code: null,
+      scheduled_value: 100000, completed_prev: 50000, completed_this: 20000,
+      materials_stored: 0, total_completed_stored: 70000, percent: 70,
+      balance_to_finish: 30000, retainage: 7000, retainage_prev: 5000,
+    }],
+    totals: { scheduled: 100000, prev: 50000, this: 20000, stored: 0,
+      completed: 70000, balance: 30000, retainage: 7000, retainage_prev: 5000 },
+  };
+  const cert: Certificate = {
+    application_no: 1, period: null, retainage_released: false,
+    line1_original_contract_sum: 100000,
+    line2_net_change_orders: 0,
+    line3_contract_sum_to_date: 100000,
+    line4_total_completed_stored: 70000,
+    line5_retainage: 7000,
+    line6_total_earned_less_retainage: 63000,
+    line7_less_previous_certificates: 45000,
+    line8_current_payment_due: 18000,
+    line9_balance_to_finish_incl_retainage: 37000,
+  };
+  return { cert, sheet };
+}
+
+describe("the certificate's own arithmetic", () => {
+  it("passes every identity on a sound G702", () => {
+    const { cert, sheet } = fixture();
+    expect(checks(cert, sheet).filter((c) => !c.ok)).toEqual([]);
+  });
+
+  it("catches the exact corruption PAY-APP fixed: line 7 driven to zero", () => {
+    // The shipped bug left line 7 at 0 and line 8 at 63,000 — the whole earned-to-date, re-billed.
+    // Line 8 still equals line 6 − line 7 arithmetically, so THAT identity cannot see it. What the
+    // screen catches is the provenance: line 7 no longer matches the reconstruction either, and 0 is
+    // not a plausible certificate when $50k was billed in earlier periods.
+    const { cert, sheet } = fixture();
+    const broken: Certificate = { ...cert, line7_less_previous_certificates: 0, line8_current_payment_due: 63000 };
+    expect(checks(broken, sheet).filter((c) => !c.ok)).toEqual([]);          // the identities hold
+    expect(line7Basis(broken, sheet)).toBe("differs-from-reconstruction");   // the provenance does not
+    expect(line7Basis(cert, sheet)).toBe("matches-reconstruction");
+  });
+
+  it("fails loudly when the sheet and line 4 disagree", () => {
+    const { cert, sheet } = fixture();
+    const drifted: Sheet = { ...sheet, totals: { ...sheet.totals, completed: 71000 } };
+    const failed = checks(cert, drifted).filter((c) => !c.ok);
+    expect(failed.map((c) => c.label)).toContain("Line 4 = the continuation sheet's completed total");
+    expect(failed[0]?.detail).toContain("71000");
+  });
+
+  it("fails when line 3 does not equal line 1 plus line 2", () => {
+    const { cert, sheet } = fixture();
+    const bad: Certificate = { ...cert, line2_net_change_orders: 5000 };   // line 3 not restated
+    expect(checks(bad, sheet).map((c) => c.label).filter((_, i) => !checks(bad, sheet)[i]!.ok))
+      .toContain("Line 3 = line 1 + line 2");
+  });
+
+  it("does NOT fail line 5 on a final application that released retainage", () => {
+    // `release_retainage` zeroes line 5 by design while the sheet still carries the per-line amounts.
+    // Asserting equality unconditionally would report a correct final certificate as broken — which
+    // is worse than not checking, because it teaches the reviewer to ignore the checks.
+    const { cert, sheet } = fixture();
+    const final: Certificate = {
+      ...cert, retainage_released: true, line5_retainage: 0,
+      line6_total_earned_less_retainage: 70000, line8_current_payment_due: 25000,
+      line9_balance_to_finish_incl_retainage: 30000,
+    };
+    expect(checks(final, sheet).filter((c) => !c.ok)).toEqual([]);
+  });
+
+  it("compares in cents, so a certificate that is right to the penny passes", () => {
+    // 0.1 + 0.2 !== 0.3 in binary floating point. Comparing the raw numbers would fail this.
+    const sheet: Sheet = {
+      lines: [],
+      totals: { scheduled: 0.3, prev: 0, this: 0.3, stored: 0, completed: 0.3,
+        balance: 0, retainage: 0, retainage_prev: 0 },
+    };
+    const cert: Certificate = {
+      application_no: 1, period: null, retainage_released: false,
+      line1_original_contract_sum: 0.1, line2_net_change_orders: 0.2,
+      line3_contract_sum_to_date: 0.3, line4_total_completed_stored: 0.3,
+      line5_retainage: 0, line6_total_earned_less_retainage: 0.3,
+      line7_less_previous_certificates: 0, line8_current_payment_due: 0.3,
+      line9_balance_to_finish_incl_retainage: 0,
+    };
+    expect(0.1 + 0.2).not.toBe(0.3);                       // the hazard, stated
+    expect(checks(cert, sheet).filter((c) => !c.ok)).toEqual([]);
+  });
+});
+
+describe("the form's shape", () => {
+  it("prints all nine lines in the AIA's order", () => {
+    expect(CERT_LINES.map((l) => l.no)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it("names a key that actually exists on the certificate", () => {
+    const { cert } = fixture();
+    for (const l of CERT_LINES) expect(typeof cert[l.key]).toBe("number");
+  });
+});
+
+describe("percent complete", () => {
+  it("is the sheet's completed over its scheduled, to one decimal", () => {
+    const { sheet } = fixture();
+    expect(percentComplete(sheet)).toBe(70);
+  });
+
+  it("is 0 rather than NaN when nothing is scheduled", () => {
+    const empty: Sheet = { lines: [], totals: { scheduled: 0, prev: 0, this: 0, stored: 0,
+      completed: 0, balance: 0, retainage: 0, retainage_prev: 0 } };
+    expect(percentComplete(empty)).toBe(0);
+  });
+});
+
+describe("summary", () => {
+  it("reports the payment due and calls a sound certificate sound", () => {
+    const { cert, sheet } = fixture();
+    const s = summary(cert, sheet);
+    expect(s.due).toBe(18000);
+    expect(s.percent).toBe(70);
+    expect(s.sound).toBe(true);
+    expect(s.failures).toEqual([]);
+  });
+
+  it("is NOT sound, and names the failure, when the sheet drifted from the certificate", () => {
+    const { cert, sheet } = fixture();
+    const s = summary(cert, { ...sheet, totals: { ...sheet.totals, completed: 71000 } });
+    expect(s.sound).toBe(false);
+    expect(s.failures).toHaveLength(1);
+  });
+});
+
+describe("line 7 provenance", () => {
+  it("explains both bases in words a reviewer can act on", () => {
+    expect(line7Note("differs-from-reconstruction")).toContain("certified");
+    expect(line7Note("matches-reconstruction")).toContain("re-added");
+  });
+});

--- a/apps/web/src/portal/panels/payAppReview.test.ts
+++ b/apps/web/src/portal/panels/payAppReview.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   CERT_LINES, type Certificate, type Sheet,
-  checks, line7Basis, line7Note, percentComplete, summary,
+  checks, consistent, line7Basis, line7Note, percentComplete, summary,
 } from "./payAppReview";
+import { usdCents as money } from "../../ui/charts";
 
 /** A $100k line at 10% retainage, $50k billed previously and $20k this period — the fixture the
  *  PAY-APP over-billing bug was reproduced on, so the numbers here are the ones that actually moved. */
@@ -56,7 +57,7 @@ describe("the certificate's own arithmetic", () => {
     const drifted: Sheet = { ...sheet, totals: { ...sheet.totals, completed: 71000 } };
     const failed = checks(cert, drifted).filter((c) => !c.ok);
     expect(failed.map((c) => c.label)).toContain("Line 4 = the continuation sheet's completed total");
-    expect(failed[0]?.detail).toContain("71000");
+    expect(failed[0]?.detail).toContain("$71,000.00");   // to the cent, since the check is
   });
 
   it("fails when line 3 does not equal line 1 plus line 2", () => {
@@ -96,6 +97,67 @@ describe("the certificate's own arithmetic", () => {
     };
     expect(0.1 + 0.2).not.toBe(0.3);                       // the hazard, stated
     expect(checks(cert, sheet).filter((c) => !c.ok)).toEqual([]);
+  });
+});
+
+describe("money is printed to the cent", () => {
+  it("keeps two decimals, because the checks compare in cents", () => {
+    // `ui/charts`'s usd rounds to whole dollars. Using it here meant a certificate failing by a penny
+    // rendered as two IDENTICAL numbers beside a red verdict — the screen showing no reason to
+    // believe itself. This test fails against that formatter.
+    expect(money(45000.01)).toBe("$45,000.01");
+    expect(money(45000)).toBe("$45,000.00");
+    expect(money(0.5)).toBe("$0.50");
+  });
+
+  it("marks a negative with a true minus sign, not a hyphen", () => {
+    expect(money(-1234.5)).toBe("\u2212$1,234.50");
+  });
+
+  it("shows the penny that a failing check is about", () => {
+    const { cert, sheet } = fixture();
+    const offByAPenny: Sheet = { ...sheet, totals: { ...sheet.totals, completed: 70000.01 } };
+    const failed = checks(cert, offByAPenny).filter((c) => !c.ok);
+    expect(failed).toHaveLength(1);
+    // The two numbers must be DISTINGUISHABLE in the message, which is the whole point.
+    expect(failed[0]?.detail).toContain("$70,000.01");
+    expect(failed[0]?.detail).toContain("$70,000.00");
+  });
+});
+
+describe("cross-document consistency (the torn-read detector)", () => {
+  it("is true when the certificate and sheet describe the same SOV", () => {
+    const { cert, sheet } = fixture();
+    expect(consistent(cert, sheet)).toBe(true);
+  });
+
+  it("is false when the two documents were read from different states", () => {
+    const { cert, sheet } = fixture();
+    expect(consistent(cert, { ...sheet, totals: { ...sheet.totals, completed: 71000 } })).toBe(false);
+  });
+
+  it("looks ONLY at the two cross-document identities, not the certificate's internal ones", () => {
+    // A certificate that is internally wrong is not a torn read, and re-reading will not fix it.
+    // Conflating the two would make the panel retry forever on a real engine bug.
+    const { cert, sheet } = fixture();
+    const internallyWrong: Certificate = { ...cert, line3_contract_sum_to_date: 999 };
+    const failed = checks(internallyWrong, sheet).filter((c) => !c.ok);
+    // Two, not one: restating line 3 breaks both "3 = 1 + 2" and "9 = 3 − 6". Asserting an exact
+    // count here was my error, and the count is incidental — what matters is that the failures are
+    // all INTERNAL and none of them is a cross-document one.
+    expect(failed.length).toBeGreaterThan(0);
+    expect(failed.map((c) => c.label).join(" ")).not.toContain("continuation sheet");
+    expect(consistent(internallyWrong, sheet)).toBe(true);
+  });
+
+  it("does not call a final application torn just because line 5 is zero", () => {
+    const { cert, sheet } = fixture();
+    const final: Certificate = {
+      ...cert, retainage_released: true, line5_retainage: 0,
+      line6_total_earned_less_retainage: 70000, line8_current_payment_due: 25000,
+      line9_balance_to_finish_incl_retainage: 30000,
+    };
+    expect(consistent(final, sheet)).toBe(true);
   });
 });
 

--- a/apps/web/src/portal/panels/payAppReview.ts
+++ b/apps/web/src/portal/panels/payAppReview.ts
@@ -1,0 +1,173 @@
+/**
+ * PAY-APP-SCREEN — the AIA G702 certificate and its G703 continuation sheet, on screen, from data.
+ *
+ * **Why this exists, and why it is not a nicety.** Until now a pay application could be FROZEN
+ * (`POST …/cost/pay-app/invoice`) and DOWNLOADED (`GET …/cost/g702.pdf`), but never *read*. The
+ * over-billing defect fixed in PAY-APP lived in line 7 — "less previous certificates for payment" —
+ * and survived because line 7 existed only inside a PDF blob. Nobody could look at the nine lines
+ * before submitting, so a wrong zero there was invisible until the next draw asked for the whole job
+ * again. `GET …/cost/g702` and `GET …/cost/g703` had answered this all along and had no client
+ * caller; they sat in `CONFIRMED_DARK_SHORT_LEAF` in `services/api/test_route_reachability.py` with
+ * the note that a screen rendering the application from data would use them, and none existed.
+ *
+ * *A number a person cannot see is a number nothing checks.*
+ *
+ * Pure rules only — no DOM, no fetch. The panel that renders these is `payAppReviewPanel.ts`.
+ */
+
+/** The G702 certificate as `GET /projects/{pid}/cost/g702` returns it. */
+export interface Certificate {
+  application_no: number;
+  period: string | null;
+  retainage_released: boolean;
+  line1_original_contract_sum: number;
+  line2_net_change_orders: number;
+  line3_contract_sum_to_date: number;
+  line4_total_completed_stored: number;
+  line5_retainage: number;
+  line6_total_earned_less_retainage: number;
+  line7_less_previous_certificates: number;
+  line8_current_payment_due: number;
+  line9_balance_to_finish_incl_retainage: number;
+}
+
+/** One row of the G703 continuation sheet. */
+export interface SheetLine {
+  item_no: string | null;
+  description: string | null;
+  cost_code: string | null;
+  scheduled_value: number;
+  completed_prev: number;
+  completed_this: number;
+  materials_stored: number;
+  total_completed_stored: number;
+  percent: number;
+  balance_to_finish: number;
+  retainage: number;
+  retainage_prev: number;
+}
+
+export interface Sheet {
+  lines: SheetLine[];
+  totals: {
+    scheduled: number; prev: number; this: number; stored: number;
+    completed: number; balance: number; retainage: number; retainage_prev: number;
+  };
+}
+
+/**
+ * The nine lines, in the order the AIA G702 prints them. The order is the form's, not ours — a
+ * certificate whose lines are reordered is not a G702, and a GC reading it against a paper copy
+ * needs them to correspond one for one.
+ */
+export const CERT_LINES: { key: keyof Certificate; no: number; label: string }[] = [
+  { key: "line1_original_contract_sum", no: 1, label: "Original contract sum" },
+  { key: "line2_net_change_orders", no: 2, label: "Net change by change orders" },
+  { key: "line3_contract_sum_to_date", no: 3, label: "Contract sum to date" },
+  { key: "line4_total_completed_stored", no: 4, label: "Total completed & stored to date" },
+  { key: "line5_retainage", no: 5, label: "Retainage" },
+  { key: "line6_total_earned_less_retainage", no: 6, label: "Total earned less retainage" },
+  { key: "line7_less_previous_certificates", no: 7, label: "Less previous certificates for payment" },
+  { key: "line8_current_payment_due", no: 8, label: "Current payment due" },
+  { key: "line9_balance_to_finish_incl_retainage", no: 9, label: "Balance to finish, plus retainage" },
+];
+
+const cents = (n: number) => Math.round(n * 100);
+
+export interface Check {
+  label: string;
+  ok: boolean;
+  /** The arithmetic as stated, so a failure says which two numbers disagree rather than just "no". */
+  detail: string;
+}
+
+/**
+ * The certificate's internal arithmetic, checked against itself and against the continuation sheet.
+ *
+ * A G702 is nine numbers with four identities between them, and the sheet totals into line 4. Those
+ * identities are exactly what a reviewer would verify by hand, so the screen does it — **this is the
+ * point of rendering from data rather than from a PDF.** Compared in integer cents: the engine rounds
+ * to 2dp and binary floats do not survive `===` at that scale (0.1 + 0.2 is the standard example, and
+ * this codebase has already been bitten by HALF_EVEN vs HALF_UP disagreeing by a penny inside one
+ * G702).
+ */
+export function checks(cert: Certificate, sheet: Sheet): Check[] {
+  const c = (k: keyof Certificate) => cents(cert[k] as number);
+  return [
+    { label: "Line 3 = line 1 + line 2",
+      ok: c("line3_contract_sum_to_date")
+        === c("line1_original_contract_sum") + c("line2_net_change_orders"),
+      detail: `${cert.line1_original_contract_sum} + ${cert.line2_net_change_orders} = ${cert.line3_contract_sum_to_date}` },
+    { label: "Line 6 = line 4 − line 5",
+      ok: c("line6_total_earned_less_retainage")
+        === c("line4_total_completed_stored") - c("line5_retainage"),
+      detail: `${cert.line4_total_completed_stored} − ${cert.line5_retainage} = ${cert.line6_total_earned_less_retainage}` },
+    { label: "Line 8 = line 6 − line 7",
+      ok: c("line8_current_payment_due")
+        === c("line6_total_earned_less_retainage") - c("line7_less_previous_certificates"),
+      detail: `${cert.line6_total_earned_less_retainage} − ${cert.line7_less_previous_certificates} = ${cert.line8_current_payment_due}` },
+    { label: "Line 9 = line 3 − line 6",
+      ok: c("line9_balance_to_finish_incl_retainage")
+        === c("line3_contract_sum_to_date") - c("line6_total_earned_less_retainage"),
+      detail: `${cert.line3_contract_sum_to_date} − ${cert.line6_total_earned_less_retainage} = ${cert.line9_balance_to_finish_incl_retainage}` },
+    { label: "Line 4 = the continuation sheet's completed total",
+      ok: c("line4_total_completed_stored") === cents(sheet.totals.completed),
+      detail: `sheet ${sheet.totals.completed} → line 4 ${cert.line4_total_completed_stored}` },
+    { label: "Line 5 = the continuation sheet's retainage total",
+      // Skipped, not failed, on a final application: `release_retainage` zeroes line 5 deliberately
+      // while the sheet still carries the per-line amounts. Asserting equality there would report a
+      // correct certificate as broken.
+      ok: cert.retainage_released || c("line5_retainage") === cents(sheet.totals.retainage),
+      detail: cert.retainage_released
+        ? "retainage released on this application — line 5 is zero by design"
+        : `sheet ${sheet.totals.retainage} → line 5 ${cert.line5_retainage}` },
+  ];
+}
+
+export type Line7Basis = "matches-reconstruction" | "differs-from-reconstruction";
+
+/**
+ * Whether line 7 equals what it would be if RECONSTRUCTED from the sheet's previous columns.
+ *
+ * Line 7 is "less previous certificates for payment", and the AIA form says where to get it: line 6
+ * of the prior certificate. It is a historical fact. With no stored application the engine can only
+ * reconstruct it as `completed_prev − retainage_prev`, which is equal to the truth exactly while
+ * nothing about the earlier periods has changed — edit a retainage rate or restate an earlier line
+ * and the reconstruction moves while the signed certificate does not.
+ *
+ * So a DIFFERENCE here is not an error. It is the screen saying "this figure came from a certificate
+ * somebody signed, not from re-adding the schedule of values", which is the stronger provenance and
+ * is precisely what PAY-APP restored. Reporting it either way keeps the distinction visible instead
+ * of letting a reconstruction pass as a fact.
+ */
+export function line7Basis(cert: Certificate, sheet: Sheet): Line7Basis {
+  const reconstructed = cents(sheet.totals.prev) - cents(sheet.totals.retainage_prev);
+  return cents(cert.line7_less_previous_certificates) === reconstructed
+    ? "matches-reconstruction" : "differs-from-reconstruction";
+}
+
+export function line7Note(basis: Line7Basis): string {
+  return basis === "differs-from-reconstruction"
+    ? "deducted from what a submitted application actually certified — a historical fact, not a re-addition"
+    : "equals the schedule of values re-added (no submitted application differs from it)";
+}
+
+/** Percent complete for the whole job, from the sheet totals. 0 when nothing is scheduled. */
+export function percentComplete(sheet: Sheet): number {
+  const scheduled = cents(sheet.totals.scheduled);
+  if (!scheduled) return 0;
+  return Math.round((cents(sheet.totals.completed) / scheduled) * 1000) / 10;
+}
+
+/** The headline: what this application is asking to be paid, and whether the form agrees with itself. */
+export function summary(cert: Certificate, sheet: Sheet): {
+  due: number; percent: number; failures: Check[]; sound: boolean;
+} {
+  const failures = checks(cert, sheet).filter((k) => !k.ok);
+  return {
+    due: cert.line8_current_payment_due,
+    percent: percentComplete(sheet),
+    failures,
+    sound: failures.length === 0,
+  };
+}

--- a/apps/web/src/portal/panels/payAppReview.ts
+++ b/apps/web/src/portal/panels/payAppReview.ts
@@ -1,3 +1,5 @@
+import { usdCents as money } from "../../ui/charts";
+
 /**
  * PAY-APP-SCREEN — the AIA G702 certificate and its G703 continuation sheet, on screen, from data.
  *
@@ -97,22 +99,22 @@ export function checks(cert: Certificate, sheet: Sheet): Check[] {
     { label: "Line 3 = line 1 + line 2",
       ok: c("line3_contract_sum_to_date")
         === c("line1_original_contract_sum") + c("line2_net_change_orders"),
-      detail: `${cert.line1_original_contract_sum} + ${cert.line2_net_change_orders} = ${cert.line3_contract_sum_to_date}` },
+      detail: `${money(cert.line1_original_contract_sum)} + ${money(cert.line2_net_change_orders)} = ${money(cert.line3_contract_sum_to_date)}` },
     { label: "Line 6 = line 4 − line 5",
       ok: c("line6_total_earned_less_retainage")
         === c("line4_total_completed_stored") - c("line5_retainage"),
-      detail: `${cert.line4_total_completed_stored} − ${cert.line5_retainage} = ${cert.line6_total_earned_less_retainage}` },
+      detail: `${money(cert.line4_total_completed_stored)} − ${money(cert.line5_retainage)} = ${money(cert.line6_total_earned_less_retainage)}` },
     { label: "Line 8 = line 6 − line 7",
       ok: c("line8_current_payment_due")
         === c("line6_total_earned_less_retainage") - c("line7_less_previous_certificates"),
-      detail: `${cert.line6_total_earned_less_retainage} − ${cert.line7_less_previous_certificates} = ${cert.line8_current_payment_due}` },
+      detail: `${money(cert.line6_total_earned_less_retainage)} − ${money(cert.line7_less_previous_certificates)} = ${money(cert.line8_current_payment_due)}` },
     { label: "Line 9 = line 3 − line 6",
       ok: c("line9_balance_to_finish_incl_retainage")
         === c("line3_contract_sum_to_date") - c("line6_total_earned_less_retainage"),
-      detail: `${cert.line3_contract_sum_to_date} − ${cert.line6_total_earned_less_retainage} = ${cert.line9_balance_to_finish_incl_retainage}` },
+      detail: `${money(cert.line3_contract_sum_to_date)} − ${money(cert.line6_total_earned_less_retainage)} = ${money(cert.line9_balance_to_finish_incl_retainage)}` },
     { label: "Line 4 = the continuation sheet's completed total",
       ok: c("line4_total_completed_stored") === cents(sheet.totals.completed),
-      detail: `sheet ${sheet.totals.completed} → line 4 ${cert.line4_total_completed_stored}` },
+      detail: `sheet ${money(sheet.totals.completed)} → line 4 ${money(cert.line4_total_completed_stored)}` },
     { label: "Line 5 = the continuation sheet's retainage total",
       // Skipped, not failed, on a final application: `release_retainage` zeroes line 5 deliberately
       // while the sheet still carries the per-line amounts. Asserting equality there would report a
@@ -120,8 +122,27 @@ export function checks(cert: Certificate, sheet: Sheet): Check[] {
       ok: cert.retainage_released || c("line5_retainage") === cents(sheet.totals.retainage),
       detail: cert.retainage_released
         ? "retainage released on this application — line 5 is zero by design"
-        : `sheet ${sheet.totals.retainage} → line 5 ${cert.line5_retainage}` },
+        : `sheet ${money(sheet.totals.retainage)} → line 5 ${money(cert.line5_retainage)}` },
   ];
+}
+
+/**
+ * Are these two documents describing the same schedule of values?
+ *
+ * `GET /cost/g702` and `GET /cost/g703` are separate requests in separate database sessions, so a
+ * seed or a period-close committing between them yields a TORN READ: a certificate computed from one
+ * SOV state beside a sheet from another. Nothing in either response carries a revision to compare.
+ *
+ * What saves it is that the certificate is DERIVED from the sheet — `cost.g702` calls `g703` — so the
+ * two cross-document identities (lines 4 and 5) hold for any single state and fail for a torn pair.
+ * *The consistency check the screen already needed is also the torn-read detector; it did not need a
+ * second mechanism, it needed to be believed.* The panel re-reads once when this is false: a torn
+ * pair resolves, a genuinely inconsistent engine does not, and the two are then distinguishable
+ * rather than both surfacing as "the certificate does not add up".
+ */
+export function consistent(cert: Certificate, sheet: Sheet): boolean {
+  const cross = checks(cert, sheet).slice(-2);
+  return cross.every((c) => c.ok);
 }
 
 export type Line7Basis = "matches-reconstruction" | "differs-from-reconstruction";

--- a/apps/web/src/portal/panels/payAppReviewPanel.ts
+++ b/apps/web/src/portal/panels/payAppReviewPanel.ts
@@ -7,12 +7,12 @@
  * in line 7 shipped and survived until the next draw asked for the whole job again.
  */
 import type { ApiClient } from "../../api/client";
-import { usd } from "../../ui/charts";
 import { modalShell } from "../../ui/modal";
+import { usdCents as money } from "../../ui/charts";
 
 import {
   CERT_LINES, type Certificate, type Sheet,
-  line7Basis, line7Note, summary,
+  consistent, line7Basis, line7Note, summary,
 } from "./payAppReview";
 
 const cell = (text: string, align: "left" | "right" = "left", bold = false) => {
@@ -31,7 +31,7 @@ function certTable(cert: Certificate): HTMLTableElement {
     const emphasis = l.no === 8;
     tr.style.cssText = `border-top:1px solid var(--line)${emphasis ? ";background:var(--hover)" : ""}`;
     tr.append(cell(String(l.no), "left"), cell(l.label, "left", emphasis),
-              cell(usd(cert[l.key] as number), "right", emphasis));
+              cell(money(cert[l.key] as number), "right", emphasis));
     t.appendChild(tr);
   }
   return t;
@@ -56,19 +56,19 @@ function sheetTable(sheet: Sheet): HTMLTableElement {
     const tr = document.createElement("tr");
     tr.style.cssText = "border-top:1px solid var(--line)";
     tr.append(cell(l.item_no ?? "—"), cell(l.description ?? "—"),
-              cell(usd(l.scheduled_value), "right"), cell(usd(l.completed_prev), "right"),
-              cell(usd(l.completed_this), "right"), cell(usd(l.materials_stored), "right"),
-              cell(usd(l.total_completed_stored), "right"), cell(`${l.percent}%`, "right"),
-              cell(usd(l.balance_to_finish), "right"), cell(usd(l.retainage), "right"));
+              cell(money(l.scheduled_value), "right"), cell(money(l.completed_prev), "right"),
+              cell(money(l.completed_this), "right"), cell(money(l.materials_stored), "right"),
+              cell(money(l.total_completed_stored), "right"), cell(`${l.percent}%`, "right"),
+              cell(money(l.balance_to_finish), "right"), cell(money(l.retainage), "right"));
     t.appendChild(tr);
   }
   const tot = document.createElement("tr");
   tot.style.cssText = "border-top:2px solid var(--line);font-weight:600";
   const T = sheet.totals;
-  tot.append(cell(""), cell("Totals", "left", true), cell(usd(T.scheduled), "right", true),
-             cell(usd(T.prev), "right", true), cell(usd(T.this), "right", true),
-             cell(usd(T.stored), "right", true), cell(usd(T.completed), "right", true),
-             cell("", "right"), cell(usd(T.balance), "right", true), cell(usd(T.retainage), "right", true));
+  tot.append(cell(""), cell("Totals", "left", true), cell(money(T.scheduled), "right", true),
+             cell(money(T.prev), "right", true), cell(money(T.this), "right", true),
+             cell(money(T.stored), "right", true), cell(money(T.completed), "right", true),
+             cell("", "right"), cell(money(T.balance), "right", true), cell(money(T.retainage), "right", true));
   t.appendChild(tot);
   return t;
 }
@@ -88,7 +88,16 @@ export async function payAppReviewModal(api: ApiClient, pid: string): Promise<vo
   card.appendChild(body);
 
   try {
-    const [cert, sheet] = await Promise.all([api.g702(pid), api.g703(pid)]);
+    // ONE RETRY on an inconsistent pair. These are two requests in two database sessions, so a seed
+    // or a period-close committing between them gives a certificate from one SOV state beside a sheet
+    // from another. `consistent` uses the cross-document identities as the detector — see its note —
+    // and a torn pair resolves on the re-read while a genuinely wrong certificate does not.
+    let [cert, sheet] = await Promise.all([api.g702(pid), api.g703(pid)]);
+    let reread = false;
+    if (!consistent(cert, sheet)) {
+      [cert, sheet] = await Promise.all([api.g702(pid), api.g703(pid)]);
+      reread = true;
+    }
     const s = summary(cert, sheet);
     body.textContent = "";
     body.className = "";
@@ -97,7 +106,7 @@ export async function payAppReviewModal(api: ApiClient, pid: string): Promise<vo
     head.style.cssText = "display:flex;gap:14px;flex-wrap:wrap;align-items:baseline";
     const due = document.createElement("div");
     due.style.cssText = "font-size:20px;font-weight:600";
-    due.textContent = usd(s.due);
+    due.textContent = money(s.due);
     const ctx = document.createElement("div");
     ctx.className = "meta";
     ctx.textContent = `Application ${cert.application_no}`
@@ -115,7 +124,10 @@ export async function payAppReviewModal(api: ApiClient, pid: string): Promise<vo
     if (s.sound) {
       verdict.textContent = "✓ The certificate adds up — all six identities hold against the continuation sheet.";
     } else {
-      verdict.textContent = `⚠ ${s.failures.length} check(s) failed:`;
+      verdict.textContent = reread
+        ? `⚠ ${s.failures.length} check(s) failed, and still failed after re-reading both documents `
+          + `— so this is the certificate, not two reads taken a moment apart:`
+        : `⚠ ${s.failures.length} check(s) failed:`;
       for (const f of s.failures) {
         const li = document.createElement("div");
         li.className = "meta";
@@ -146,13 +158,19 @@ export async function payAppReviewModal(api: ApiClient, pid: string): Promise<vo
     scroll.appendChild(sheetTable(sheet));
     body.appendChild(scroll);
 
+    const note = document.createElement("div");
+    note.className = "meta";
+    note.style.cssText = "margin-top:10px;text-align:right;color:var(--status-crit)";
+    body.appendChild(note);
+
     const row = document.createElement("div");
-    row.style.cssText = "display:flex;gap:6px;justify-content:flex-end;margin-top:14px";
+    row.style.cssText = "display:flex;gap:6px;justify-content:flex-end;margin-top:6px";
     const pdf = document.createElement("button");
     pdf.className = "tool-btn";
     pdf.textContent = "⬇ Download as PDF";
     pdf.onclick = async () => {
       pdf.disabled = true;
+      note.textContent = "";
       try {
         const blob = await api.payAppPdf(pid, cert.application_no);
         const a = document.createElement("a");
@@ -160,6 +178,11 @@ export async function payAppReviewModal(api: ApiClient, pid: string): Promise<vo
         a.download = `pay-app-${cert.application_no}.pdf`;
         a.click();
         URL.revokeObjectURL(a.href);
+      } catch (e) {
+        // The outer try only covers the initial load, so a rejection here reached nobody: the button
+        // re-enabled and the download silently never happened. A failed download that looks like a
+        // cancelled one is the shape of bug this whole screen exists to stop.
+        note.textContent = `Download failed: ${(e as Error).message}`;
       } finally { pdf.disabled = false; }
     };
     const done = document.createElement("button");

--- a/apps/web/src/portal/panels/payAppReviewPanel.ts
+++ b/apps/web/src/portal/panels/payAppReviewPanel.ts
@@ -1,0 +1,177 @@
+/**
+ * PAY-APP-SCREEN — renders the G702 certificate and its G703 continuation sheet in a dialog.
+ *
+ * The rules live in `payAppReview.ts` and are tested there; this file is the DOM and the fetch.
+ * Before it existed, a pay application could be frozen and downloaded but never read: the nine
+ * certificate lines were only ever rendered inside a PDF blob, which is why an over-billing defect
+ * in line 7 shipped and survived until the next draw asked for the whole job again.
+ */
+import type { ApiClient } from "../../api/client";
+import { usd } from "../../ui/charts";
+import { modalShell } from "../../ui/modal";
+
+import {
+  CERT_LINES, type Certificate, type Sheet,
+  line7Basis, line7Note, summary,
+} from "./payAppReview";
+
+const cell = (text: string, align: "left" | "right" = "left", bold = false) => {
+  const td = document.createElement("td");
+  td.textContent = text;
+  td.style.cssText = `padding:3px 8px;text-align:${align};${bold ? "font-weight:600;" : ""}`;
+  return td;
+};
+
+/** The nine lines, as the AIA prints them, with line 8 emphasised — it is the ask. */
+function certTable(cert: Certificate): HTMLTableElement {
+  const t = document.createElement("table");
+  t.style.cssText = "width:100%;border-collapse:collapse;font-size:13px";
+  for (const l of CERT_LINES) {
+    const tr = document.createElement("tr");
+    const emphasis = l.no === 8;
+    tr.style.cssText = `border-top:1px solid var(--line)${emphasis ? ";background:var(--hover)" : ""}`;
+    tr.append(cell(String(l.no), "left"), cell(l.label, "left", emphasis),
+              cell(usd(cert[l.key] as number), "right", emphasis));
+    t.appendChild(tr);
+  }
+  return t;
+}
+
+/** The continuation sheet. Wrapped by the caller in an overflow container — it is a wide table. */
+function sheetTable(sheet: Sheet): HTMLTableElement {
+  const t = document.createElement("table");
+  t.style.cssText = "width:100%;border-collapse:collapse;font-size:12px;min-width:640px";
+  const head = document.createElement("tr");
+  head.style.cssText = "border-bottom:1px solid var(--line);color:var(--muted)";
+  for (const [h, a] of [["Item", "left"], ["Description", "left"], ["Scheduled", "right"],
+    ["Previous", "right"], ["This period", "right"], ["Stored", "right"],
+    ["Completed", "right"], ["%", "right"], ["Balance", "right"], ["Retainage", "right"]] as const) {
+    const th = document.createElement("th");
+    th.textContent = h;
+    th.style.cssText = `padding:3px 8px;text-align:${a};font-weight:500`;
+    head.appendChild(th);
+  }
+  t.appendChild(head);
+  for (const l of sheet.lines) {
+    const tr = document.createElement("tr");
+    tr.style.cssText = "border-top:1px solid var(--line)";
+    tr.append(cell(l.item_no ?? "—"), cell(l.description ?? "—"),
+              cell(usd(l.scheduled_value), "right"), cell(usd(l.completed_prev), "right"),
+              cell(usd(l.completed_this), "right"), cell(usd(l.materials_stored), "right"),
+              cell(usd(l.total_completed_stored), "right"), cell(`${l.percent}%`, "right"),
+              cell(usd(l.balance_to_finish), "right"), cell(usd(l.retainage), "right"));
+    t.appendChild(tr);
+  }
+  const tot = document.createElement("tr");
+  tot.style.cssText = "border-top:2px solid var(--line);font-weight:600";
+  const T = sheet.totals;
+  tot.append(cell(""), cell("Totals", "left", true), cell(usd(T.scheduled), "right", true),
+             cell(usd(T.prev), "right", true), cell(usd(T.this), "right", true),
+             cell(usd(T.stored), "right", true), cell(usd(T.completed), "right", true),
+             cell("", "right"), cell(usd(T.balance), "right", true), cell(usd(T.retainage), "right", true));
+  t.appendChild(tot);
+  return t;
+}
+
+/**
+ * Open the review dialog for a project's CURRENT G702/G703.
+ *
+ * `ready()` is called in a `finally`: the user's wait ends when the dialog is usable OR when the
+ * error appears, and this panel genuinely fetches, so it is not one of the data-in-hand dialogs
+ * exempt from reporting (see the classification in `src/ui/panelReady.test.ts`).
+ */
+export async function payAppReviewModal(api: ApiClient, pid: string): Promise<void> {
+  const { card, close, ready } = modalShell("Pay application — review", 560);
+  const body = document.createElement("div");
+  body.className = "meta";
+  body.textContent = "Loading the certificate…";
+  card.appendChild(body);
+
+  try {
+    const [cert, sheet] = await Promise.all([api.g702(pid), api.g703(pid)]);
+    const s = summary(cert, sheet);
+    body.textContent = "";
+    body.className = "";
+
+    const head = document.createElement("div");
+    head.style.cssText = "display:flex;gap:14px;flex-wrap:wrap;align-items:baseline";
+    const due = document.createElement("div");
+    due.style.cssText = "font-size:20px;font-weight:600";
+    due.textContent = usd(s.due);
+    const ctx = document.createElement("div");
+    ctx.className = "meta";
+    ctx.textContent = `Application ${cert.application_no}`
+      + (cert.period ? ` · ${cert.period}` : "")
+      + ` · ${s.percent}% complete`
+      + (cert.retainage_released ? " · retainage released" : "");
+    head.append(due, ctx);
+    body.appendChild(head);
+
+    // The arithmetic, checked. A certificate that does not add up is the thing a reviewer most needs
+    // told, so it sits above the numbers rather than below them.
+    const verdict = document.createElement("div");
+    verdict.style.cssText = "margin:10px 0;padding:8px 10px;border-radius:6px;font-size:13px;"
+      + `border:1px solid ${s.sound ? "var(--status-good)" : "var(--status-crit)"}`;
+    if (s.sound) {
+      verdict.textContent = "✓ The certificate adds up — all six identities hold against the continuation sheet.";
+    } else {
+      verdict.textContent = `⚠ ${s.failures.length} check(s) failed:`;
+      for (const f of s.failures) {
+        const li = document.createElement("div");
+        li.className = "meta";
+        li.style.marginTop = "3px";
+        li.textContent = `${f.label} — ${f.detail}`;
+        verdict.appendChild(li);
+      }
+    }
+    body.appendChild(verdict);
+
+    body.appendChild(certTable(cert));
+
+    // Line 7's provenance — the figure the over-billing bug corrupted. Saying which basis it has
+    // keeps a reconstruction from reading as a signed fact.
+    const basis = document.createElement("div");
+    basis.className = "meta";
+    basis.style.cssText = "margin-top:8px;font-size:12px";
+    basis.textContent = `Line 7 ${line7Note(line7Basis(cert, sheet))}.`;
+    body.appendChild(basis);
+
+    const sheetTitle = document.createElement("div");
+    sheetTitle.className = "section-title";
+    sheetTitle.style.marginTop = "14px";
+    sheetTitle.textContent = `G703 continuation sheet — ${sheet.lines.length} line(s)`;
+    body.appendChild(sheetTitle);
+    const scroll = document.createElement("div");
+    scroll.style.cssText = "overflow-x:auto";
+    scroll.appendChild(sheetTable(sheet));
+    body.appendChild(scroll);
+
+    const row = document.createElement("div");
+    row.style.cssText = "display:flex;gap:6px;justify-content:flex-end;margin-top:14px";
+    const pdf = document.createElement("button");
+    pdf.className = "tool-btn";
+    pdf.textContent = "⬇ Download as PDF";
+    pdf.onclick = async () => {
+      pdf.disabled = true;
+      try {
+        const blob = await api.payAppPdf(pid, cert.application_no);
+        const a = document.createElement("a");
+        a.href = URL.createObjectURL(blob);
+        a.download = `pay-app-${cert.application_no}.pdf`;
+        a.click();
+        URL.revokeObjectURL(a.href);
+      } finally { pdf.disabled = false; }
+    };
+    const done = document.createElement("button");
+    done.className = "tool-btn";
+    done.textContent = "Close";
+    done.onclick = close;
+    row.append(pdf, done);
+    body.appendChild(row);
+  } catch (e) {
+    body.className = "meta";
+    body.textContent = `Could not load the certificate: ${(e as Error).message}`;
+  } finally {
+    ready();
+  }
+}

--- a/apps/web/src/portal/panels/payAppReviewPanel.ts
+++ b/apps/web/src/portal/panels/payAppReviewPanel.ts
@@ -92,12 +92,24 @@ export async function payAppReviewModal(api: ApiClient, pid: string): Promise<vo
     // or a period-close committing between them gives a certificate from one SOV state beside a sheet
     // from another. `consistent` uses the cross-document identities as the detector — see its note —
     // and a torn pair resolves on the re-read while a genuinely wrong certificate does not.
-    let [cert, sheet] = await Promise.all([api.g702(pid), api.g703(pid)]);
+    let [cert, sheet, frozen] = await Promise.all([
+      api.g702(pid), api.g703(pid), api.moduleRecords(pid, "owner_invoice")]);
     let reread = false;
     if (!consistent(cert, sheet)) {
       [cert, sheet] = await Promise.all([api.g702(pid), api.g703(pid)]);
       reread = true;
     }
+    // WHICH application is this? Not the one `cert.application_no` names. `GET /cost/g702` defaults
+    // `app_no` to 1 and only ECHOES it — lines 1-9 do not depend on it — so a project with three
+    // frozen applications still had this screen headed "Application 1", and the PDF button asked for
+    // application 1 too. *A live view is not application 1; it is the one that has not been made yet.*
+    //
+    // `frozen.length + 1` is what `cost.build_application` will allocate in the ordinary case, since
+    // its counter seeds from the same count. It is a PREDICTION, not a promise: delete an application
+    // and the atomic counter stays ahead of the count, which is exactly the reuse PAY-APP fixed. The
+    // label says "next" rather than naming a certificate, so a shifted number reads as an estimate
+    // moving rather than a document changing its identity.
+    const nextNo = frozen.length + 1;
     const s = summary(cert, sheet);
     body.textContent = "";
     body.className = "";
@@ -109,7 +121,7 @@ export async function payAppReviewModal(api: ApiClient, pid: string): Promise<vo
     due.textContent = money(s.due);
     const ctx = document.createElement("div");
     ctx.className = "meta";
-    ctx.textContent = `Application ${cert.application_no}`
+    ctx.textContent = `Next application (${nextNo}) · live, not yet frozen`
       + (cert.period ? ` · ${cert.period}` : "")
       + ` · ${s.percent}% complete`
       + (cert.retainage_released ? " · retainage released" : "");
@@ -172,10 +184,10 @@ export async function payAppReviewModal(api: ApiClient, pid: string): Promise<vo
       pdf.disabled = true;
       note.textContent = "";
       try {
-        const blob = await api.payAppPdf(pid, cert.application_no);
+        const blob = await api.payAppPdf(pid, nextNo);
         const a = document.createElement("a");
         a.href = URL.createObjectURL(blob);
-        a.download = `pay-app-${cert.application_no}.pdf`;
+        a.download = `pay-app-${nextNo}.pdf`;
         a.click();
         URL.revokeObjectURL(a.href);
       } catch (e) {

--- a/apps/web/src/ui/charts.test.ts
+++ b/apps/web/src/ui/charts.test.ts
@@ -149,8 +149,8 @@ describe("every chart says 'no data' rather than drawing an empty frame", () => 
     // Helpers go in this list; CHARTS do not. Anything exported and not named here must be a chart
     // that honours the whole grammar — which is why adding a helper is a deliberate edit here rather
     // than something that silently widens what the gate ignores.
-    const HELPERS = ["esc", "compact", "money", "usd", "rate", "qty", "chartColor", "noData",
-                     "fmtFor", "yGrid", "legendRow"];
+    const HELPERS = ["esc", "compact", "money", "usd", "usdCents", "rate", "qty", "chartColor",
+                     "noData", "fmtFor", "yGrid", "legendRow"];
     const exported = Object.entries(Charts as unknown as Record<string, unknown>)
       .filter(([name, v]) => typeof v === "function" && !HELPERS.includes(name))
       .map(([name]) => name);
@@ -326,6 +326,23 @@ describe("R24-CHARTS-GRAMMAR ② — one currency format for the whole app", () 
     expect(DECL.test('  const usd = (n: number) => `$${Math.round(n).toLocaleString()}`;')).toBe(true);
     expect(DECL.test('  const usd = (n: number) => cmoney(n);')).toBe(true);
     expect(DECL.test("  out.textContent = usd(total);")).toBe(false);   // a CALL is fine
+  });
+
+  describe("usdCents", () => {
+    it("always shows two decimals, so a penny difference is visible", () => {
+      // PAY-APP-SCREEN checks an AIA G702 in integer cents. Rendering those numbers with `usd` meant
+      // a certificate failing by a penny printed two IDENTICAL values beside a red verdict.
+      expect(Charts.usdCents(45_000)).toBe("$45,000.00");
+      expect(Charts.usdCents(45_000.01)).toBe("$45,000.01");
+      expect(Charts.usdCents(45_000)).not.toBe(Charts.usdCents(45_000.01));
+    });
+
+    it("follows the house conventions its siblings do", () => {
+      expect(Charts.usdCents(-1234.5)).toBe("−$1,234.50");    // minus outside the currency mark
+      expect(Charts.usdCents(-1234.5)).not.toBe("$-1,234.50"); // the spelling ten files once had
+      expect(Charts.usdCents(null)).toBe("—");                 // absent money is not $0.00
+      expect(Charts.usdCents(0)).toBe("$0.00");
+    });
   });
 
   describe("usd", () => {

--- a/apps/web/src/ui/charts.ts
+++ b/apps/web/src/ui/charts.ts
@@ -75,6 +75,23 @@ export const usd = (n: number | null | undefined): string =>
   n == null ? "—" : (n < 0 ? "−$" : "$") + Math.round(Math.abs(n)).toLocaleString();
 
 /**
+ * Money to the CENT — always two decimals, for documents whose arithmetic is the point.
+ *
+ * `usd` rounds to whole dollars, which is right for a dashboard and wrong for an AIA G702: PAY-APP-SCREEN
+ * checks that certificate in integer cents, so a form failing by a penny rendered as two IDENTICAL
+ * numbers beside a red verdict — *the screen showing its reader no reason to believe it.* A view whose
+ * job is to display arithmetic must print the unit the arithmetic uses.
+ *
+ * It lives here, beside `usd` and `rate`, because of the rule the ban in `charts.test.ts` enforces:
+ * eighteen local currency formatters once disagreed about negatives and ten put the `$` on the wrong
+ * side of the minus. **A second formatter is fine; a second PLACE to define one is not.** Same
+ * conventions as its siblings — minus outside the currency mark, em-dash for absent money.
+ */
+export const usdCents = (n: number | null | undefined): string =>
+  n == null ? "—" : (n < 0 ? "−$" : "$")
+    + Math.abs(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+/**
  * A grouped count — thousands separators, no currency.
  *
  * Exists because one of the eighteen (`operations.ts`, the stormwater card) was a `const usd` that

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1780,6 +1780,33 @@ instances:
   PREFAB-FREEZE-RACE, and filed the same way rather than left in a review thread — **a follow-up held
   only in a thread closes by default when the PR merges.**
 
+- ✅ ⭐ **PAY-APP-SCREEN — the application could be frozen and downloaded, never read**
+  *(S — Lanes B/C; **CLOSED 2026-09-12**; gated by `apps/web/src/portal/panels/payAppReview.test.ts`
+  and `services/api/test_route_reachability.py`)*
+
+  `GET /projects/{pid}/cost/g702` and `/cost/g703` (`services/api/src/aec_api/cost.py`) have returned
+  the AIA certificate and its continuation sheet as data since they were built, and had no client
+  caller. The only caller of anything G702-shaped was the PDF at `apps/web/src/api/cost.ts`.
+
+  **Found by reading the reachability gate's own frozen list rather than by guessing.** Both sat in
+  `CONFIRMED_DARK_SHORT_LEAF` with the note that a screen rendering the application from data would
+  use them and none existed — a ratchet entry that names its own missing work and then waits for
+  somebody to re-read it.
+
+  **It is the sequel to PAY-APP above.** That over-billing defect lived in line 7, which could only
+  be seen inside a PDF blob; a wrong zero there was invisible until the next draw re-billed the job.
+  *A ratchet entry recording a missing SCREEN is recording a missing pair of eyes, not just a missing
+  caller.*
+
+  `payAppReviewModal` (`apps/web/src/portal/panels/payAppReviewPanel.ts`) renders both, checks the
+  certificate's six identities against the continuation sheet in integer cents, skips line 5 on a
+  final application where `release_retainage` zeroes it by design, and names whether line 7 is a
+  certified historical figure or a reconstruction. Wired from the Owner billing card in
+  `apps/web/src/portal/panels/budget.ts`, between Seed SOV and Freeze.
+
+  Short-leaf ratchet **5 → 3**; the three remaining are correctly dark (SAML ACS, two scheduler
+  polls), so it now records **no parked work at all**.
+
 - ✅ ⭐ **PAY-APP — two builders for one document, and the one the product called over-billed**
   *(M — Lanes C/G/I; **CLOSED 2026-09-12**; gated by `services/api/test_pay_application.py`,
   `services/api/test_closeout.py` and `services/api/test_route_reachability.py`)*

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -988,10 +988,17 @@ CONFIRMED_DARK_SHORT_LEAF = {
     #: Scheduler polls. `/routines/due` and its per-project sibling are read by the server-side
     #: runner, not by a browser.
     "/routines/due", "/projects/{pid}/routines/due",
-    #: JSON siblings of the AIA G702/G703 PDF routes, which ARE called
-    #: (`apps/web/src/api/downloadPdf.ts`). A screen that renders the payment application from data
-    #: rather than downloading it would use these; none exists yet.
-    "/projects/{pid}/cost/g702", "/projects/{pid}/cost/g703",
+    #: `/projects/{pid}/cost/g702` and `/cost/g703` LEFT this set in PAY-APP-SCREEN. They sat here
+    #: with the note that "a screen that renders the payment application from data rather than
+    #: downloading it would use these; none exists yet" — and that note was the whole entry: it named
+    #: the missing work, and nothing ever came back to read it. `payAppReviewModal` in
+    #: `apps/web/src/portal/panels/payAppReviewPanel.ts` now calls both through `g702`/`g703` in
+    #: `apps/web/src/api/cost.ts`, from the "Review pay app" button in the Owner billing card.
+    #:
+    #: **What it cost to leave them here is measurable.** The over-billing defect PAY-APP fixed lived
+    #: in G702 line 7, and line 7 could only be seen inside a PDF blob — so a wrong zero there was
+    #: invisible until the next draw re-billed the whole job. *A ratchet entry that records a missing
+    #: SCREEN is recording a missing pair of eyes, not just a missing caller.*
     #: `/connections/{cid}/erp/{entity}` LEFT this set in LEDGER-BROWSE — `connectionLedger` in
     #: `apps/web/src/api/connections.ts`, called from the "Books" action in
     #: `apps/web/src/connections/connectionsUI.ts`. Its QuickBooks sibling


### PR DESCRIPTION
# What & why

A GC could **freeze** a pay application and **download** it as a PDF, but never *look* at it. The
nine G702 certificate lines and the G703 continuation sheet appeared on screen nowhere. **Review pay
app** in Finance → Budget now renders both from data, sitting between "Seed SOV from budget" and
"Owner application from draw" — the order the work actually happens in.

**This is the sequel to #535, and its point.** That over-billing defect lived in G702 line 7, "less
previous certificates for payment". Line 7 could only be seen inside a PDF blob, so a wrong zero
there was invisible until the next draw asked for the whole job again.

> *A number a person cannot see is a number nothing checks.*

## How it was found

By reading the reachability gate's own frozen list, not by guessing what to build next.
`GET …/cost/g702` and `GET …/cost/g703` sat in `CONFIRMED_DARK_SHORT_LEAF` in
`services/api/test_route_reachability.py` with a note saying that a screen rendering the application
from data would use them, and none existed. That note *was* the entry — it named its own missing work
and then waited for somebody to re-read it.

> *A ratchet entry recording a missing SCREEN is recording a missing pair of eyes, not just a missing
> caller.*

## The screen does more than print

It verifies the certificate's own arithmetic against the continuation sheet and reports the verdict
**above** the numbers, because a certificate that does not add up is what a reviewer most needs told:

| check |
|---|
| line 3 = line 1 + line 2 |
| line 6 = line 4 − line 5 |
| line 8 = line 6 − line 7 |
| line 9 = line 3 − line 6 |
| line 4 = the sheet's completed total |
| line 5 = the sheet's retainage total |

Three deliberate choices in there:

- **Integer cents, not floats.** This codebase has already had `ROUND_HALF_EVEN` and `HALF_UP`
  disagree by a penny *inside one G702*, and `0.1 + 0.2 !== 0.3` — which the test asserts outright,
  so the hazard is stated rather than assumed.
- **Line 5 is skipped, not failed, on a final application**, where `release_retainage` zeroes it by
  design while the sheet still carries the per-line amounts. A check that reports a correct
  certificate as broken teaches the reviewer to ignore the checks.
- **Line 7's provenance is named** — deducted from what a submitted application actually certified,
  or equal to the schedule of values re-added. Those are different facts: the first is historical and
  does not move when the SOV is edited; the second is a reconstruction that does.

That last one is load-bearing, and the test proves it. Driving line 7 to zero exactly as the shipped
bug did leaves **every arithmetic identity intact** — line 8 still equals line 6 minus line 7 — so the
identities cannot see it. Only the provenance check notices.

## Ratchet

Short-leaf ratchet **5 → 3**. I had scoped this as "3 → 1" when queuing it; that was wrong, and the
figure here is measured rather than recalled. The three that remain are all *correctly* dark — the
SAML assertion-consumer endpoint the IdP POSTs to, and two scheduler polls the server-side runner
reads — so **the ratchet now records no parked work at all**.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean
- [x] Backend: **full local suite 695/695 suites passed** (3 parallel, 1209s), exit 0 — read from the
      run's own summary line, not a mid-run grep. `test_route_reachability.py`,
      `test_claude_md_gates.py` and `test_pay_application.py` each exit 0 individually.
- [x] Web: typecheck clean (read from `tsc`'s own exit status, not a piped `echo`); full vitest
      **2,696 tests / 251 files**, 13 of them new
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added (newest at top); `docs/roadmap.md` item added and closed
- [ ] Version bumped in both manifests — n/a, not a release PR
- [x] No secrets, no competitor names in shipped docs

The citation gate (`services/api/test_claude_md_gates.py`) failed on the two new files before they
were tracked and passed once they were — which is precisely its job, and worth noting as the gate
working rather than as noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a pay-application review dialog for G702 and G703 data.
  - Users can review certificate details, continuation-sheet totals, completion percentage, amount due, and validation results before generating a PDF or creating an owner application.
  - Added reporting for deduction history and final-application retainage handling.
  - Added consistent two-decimal currency formatting, including negative and missing values.

- **Bug Fixes**
  - Added arithmetic and cent-precision validation to identify inconsistent applications.

- **Documentation**
  - Documented the pay-application review workflow and endpoint usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->