### PR TITLE
A coverage score you could read but not act on — and a dark-route list that named 3 of 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,62 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### You can now look up a buildingSMART class, not just be told how few you have
+
+The standards panel has always scored *what fraction* of the model carries a bSDD classification
+URI -- "bSDD / classification coverage, 38%" -- and offered no way whatsoever to look one up. **A
+coverage number with no means of closing the gap it reports.** The engine was already complete:
+`services/api/src/aec_api/bsdd.py` is a read-only buildingSMART Data Dictionary client, and
+`GET /bsdd/search` and `GET /bsdd/class` had been exposed for months with **no client caller at
+all**. There is now a lookup card beside that figure: search the dictionary, open a class, read the
+properties it defines.
+
+**An outage must not render as an empty result.** bSDD is a remote service, so three states look
+identical as a blank list and mean opposite things -- the dictionary is unreachable (try again), the
+dictionary has no such class (it does not exist), your search matched nothing (your query was
+wrong). `routers/standards.py` already separated the first two into 502 and 404 for exactly this
+reason; `apps/web/src/portal/panels/bsddLookup.ts` is the pure rule that spends them, tested without
+a DOM. 500 and 503 deliberately do **not** fold into "unavailable": those are our own bug and our own
+deployment, not evidence about buildingSMART, and saying otherwise sends the reader to wait for a
+recovery that is not coming.
+
+#### Two corrections to the reachability gate, both about the list rather than the routes
+
+`/bsdd/class` was one of three routes frozen in `LEAF_COLLISION_DARK` in
+`services/api/test_route_reachability.py` -- routes the reachability rule cannot see because their
+last segment is also an ordinary English or HTML word (`class` is vouched for by ~1,756
+`class="..."` attributes). Wiring it turned up two problems with the *list*:
+
+**It was never complete.** `/bsdd/search` is the identical case -- same route group, same absent
+`/bsdd/` fragment, leaf vouched by the English word -- and was not in it. The list describes itself
+as the output of screening "every route whose leaf this rule reads as called but which never appears
+path-shaped anywhere in the web source"; re-running exactly that query returns **twenty-six** routes
+against three entries. Most of the remainder are legitimately web-callerless (`/scim/v2/Users` is for
+an identity provider, `/bcf/2.1/projects` for external BIM tools), so twenty-six is an upper bound on
+candidates and not a defect count -- but *a hand-curated list that describes itself as derived reads
+exactly like a complete one.* The remaining candidates are filed as their own axis rather than
+smuggled into a wiring change.
+
+**And nothing could have noticed the fix.** All three per-entry checks assert the blind spot
+*persists* -- not flagged, still a live route, leaf still vouched -- and every one of them stays green
+after the route is wired, because the blindness is a fact about the leaf collision and has nothing to
+do with whether a caller exists. That was measured, not assumed: `/bsdd/class` was wired and the file
+re-run unchanged, all green. So the list could only ever decay in one direction, toward naming routes
+that are actually reachable. A fourth check now probes for a real caller and reds when one appears,
+with a positive control (`/bsdd/search`, wired by this change) so it cannot pass by measuring nothing.
+
+#### `client.ts` has hit a hard compiler ceiling, and it changes where new routes can live
+
+`/bsdd` is its own route group, so by the rule the API client has followed for ~20 SCALE-SEAM PRs --
+*the seam is the ROUTE* -- these two methods should have been their own `withBsdd` mixin. They are
+not. **Adding a 51st mixin to the chain in `apps/web/src/api/client.ts` makes `tsc` fail outright**
+with TS2589, *"Type instantiation is excessively deep and possibly infinite"*, on the `extends`
+clause; removing it makes the error vanish, so the count is the cause and not anything in the new
+code. New route groups can no longer get their own mixin -- they must lodge with a neighbour -- until
+the chain is composed in stages. Recorded in `apps/web/src/api/ids.ts`, which took them, because the
+next person to reach for `withX()` will hit the same wall and the error message names neither the
+cause nor the limit.
+
 ### Test scratch directories no longer make `git status` read as uncommitted work
 
 A stop hook flagged `services/api/_shelf_famgeom/` as work somebody had forgotten to commit. It was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,26 @@ a DOM. 500 and 503 deliberately do **not** fold into "unavailable": those are ou
 deployment, not evidence about buildingSMART, and saying otherwise sends the reader to wait for a
 recovery that is not coming.
 
+#### A slower answer could overwrite a newer one
+
+Review (CodeRabbit, PR #540) found a stale-render race, and it was real: the card's two actions —
+search, and open a class — both write their result into the **same** element after an await, so the
+slower request won regardless of which was asked for last. Search "wall", search "door", and if
+"wall" resolved second you read wall results under the door query; clicking a class and then
+"← results" raced the same way.
+
+`requestGate()` in `apps/web/src/portal/panels/bsddLookup.ts` is one shared generation counter for
+both actions. **One gate, not one per action** — two independent counters would each be internally
+consistent and still let a stale class detail overwrite a newer search, because what is contended is
+the output element, not the endpoint. Its own test then caught an off-by-one in it: generations count
+from 1, so `0` — the value a caller holds before claiming anything — compared equal to the initial
+state and read as the live request.
+
+And asserting the gate's behaviour is not the same as asserting the panel uses it that way: giving
+each action its own gate **typechecks cleanly** and leaves every behavioural test green. So the tests
+also read `standards.ts` and assert one `requestGate()` construction with a guard on both writers.
+*Asserting an outcome without asserting the path to it ran is vacuous.*
+
 #### Two corrections to the reachability gate, both about the list rather than the routes
 
 `/bsdd/class` was one of three routes frozen in `LEAF_COLLISION_DARK` in

--- a/apps/web/src/api/bsdd.test.ts
+++ b/apps/web/src/api/bsdd.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiClient } from "./client";
+import { HttpError } from "./httpCore";
+
+/**
+ * BSDD-LOOKUP's gate: the two `/bsdd` routes shipped with no client caller at all, and the one
+ * thing a reference lookup must never do is make "the dictionary is down" look like "nothing
+ * matched".
+ *
+ * WHY THESE ASSERTIONS AND NOT OTHERS. Two things can be wrong here in a way nothing else notices:
+ *
+ *  1. **The class URI is a URL inside a URL.** A bSDD class is identified by
+ *     `https://identifier.buildingsmart.org/uri/<org>/<dict>/<ver>/class/<code>`, and it goes into
+ *     our own query string as `?uri=…`. Interpolating it raw happens to work for the common case
+ *     and truncates silently the moment a code carries `&` or `#` — the server then looks up a
+ *     prefix of the URI and answers 404 for a class that exists. So the test asserts the ENCODED
+ *     URL, the way `shareTokenGrants.test.ts` asserts the encoded body: what reaches the server is
+ *     the only thing the route can be wrong about.
+ *
+ *  2. **502 must survive as a status, not as prose.** `routers/standards.py` deliberately maps a
+ *     bSDD outage to 502 rather than letting it 500, so the panel can say "reference service
+ *     unavailable" instead of rendering an empty result. That disclosure reads `HttpError.status`;
+ *     if the client flattened it to a bare `Error` the panel would fall through to its generic
+ *     branch and an outage would be indistinguishable from a dictionary with no matches — which is
+ *     precisely the failure the 502 exists to prevent.
+ */
+
+function captureUrls(response: unknown, status = 200) {
+  const seen: string[] = [];
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    seen.push(String(url));
+    return new Response(JSON.stringify(response), {
+      status, headers: { "content-type": "application/json" },
+    });
+  }));
+  return seen;
+}
+
+const api = () => new ApiClient("http://x");
+
+describe("GET /bsdd/search", () => {
+  it("sends the free-text query", async () => {
+    const seen = captureUrls({ classes: [] });
+    await api().bsddSearch("exterior wall");
+    expect(seen).toHaveLength(1);
+    const u = new URL(seen[0]!);
+    expect(u.pathname).toBe("/bsdd/search");
+    expect(u.searchParams.get("q")).toBe("exterior wall");
+    expect(u.searchParams.has("dictionary")).toBe(false);   // absent, not empty-string
+  });
+
+  it("scopes to one dictionary only when asked", async () => {
+    const seen = captureUrls({ classes: [] });
+    const dict = "https://identifier.buildingsmart.org/uri/buildingsmart/ifc";
+    await api().bsddSearch("wall", { dictionary: dict, limit: 5 });
+    const u = new URL(seen[0]!);
+    expect(u.searchParams.get("dictionary")).toBe(dict);
+    expect(u.searchParams.get("limit")).toBe("5");
+  });
+});
+
+describe("GET /bsdd/class", () => {
+  it("encodes the class URI, so a code carrying & or # is not truncated", async () => {
+    const seen = captureUrls({ uri: "u", name: "n", code: null, dictionary: null, properties: [] });
+    // Not hypothetical punctuation for its own sake: `&` ends a query parameter, so a raw
+    // interpolation would send `uri=https://…/class/Pr_20` and lose everything after it.
+    const uri = "https://identifier.buildingsmart.org/uri/x/d/1.0/class/A&B#c";
+    await api().bsddClass(uri);
+    expect(seen[0]).toContain(`uri=${encodeURIComponent(uri)}`);
+    // And it round-trips: the server would read back exactly what we meant.
+    expect(new URL(seen[0]!).searchParams.get("uri")).toBe(uri);
+  });
+
+  it("raises a 502 the panel can tell apart from an empty result", async () => {
+    captureUrls({ detail: "bSDD unavailable" }, 502);
+    // `.rejects.toThrow(HttpError)` alone would pass against an HttpError carrying status 0 —
+    // and 0 is what the panel's generic branch renders. The status is the assertion.
+    const err = await api().bsddClass("https://identifier.buildingsmart.org/uri/x/d/1.0/class/A")
+      .then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(502);
+  });
+
+  it("raises a 404 with its own status, so 'no such class' is not reported as an outage", async () => {
+    captureUrls({ detail: "class not found" }, 404);
+    const err = await api().bsddClass("https://identifier.buildingsmart.org/uri/x/d/1.0/class/Z")
+      .then(() => null, (e: unknown) => e);
+    expect((err as HttpError).status).toBe(404);
+  });
+});

--- a/apps/web/src/api/ids.ts
+++ b/apps/web/src/api/ids.ts
@@ -9,10 +9,41 @@
  *  splitting on transport would put two halves of one feature in two files.
  *
  *  A mixin, so every call site resolves unchanged. `api/surface.test.ts` is what proves it.
+ *
+ *  **BSDD-LOOKUP added `bsddSearch` / `bsddClass` here, and NOT as their own mixin, because
+ *  `client.ts` has hit a hard compiler ceiling.** Route-group `/bsdd` is its own group, so by this
+ *  file's own stated rule — the seam is the ROUTE — they should have been `withBsdd`. Adding a 51st
+ *  mixin to the chain in `client.ts` makes `tsc` fail outright with TS2589, *"Type instantiation is
+ *  excessively deep and possibly infinite"*, on the `extends` clause; removing it makes the error
+ *  vanish, so the count is the cause and not anything in the new code. **That quietly reverses the
+ *  SCALE-SEAM strategy: new route groups can no longer get their own mixin, they must lodge with a
+ *  neighbour, until the chain is composed in stages.** Recorded here rather than worked around
+ *  silently, because the next person to reach for `withX()` will hit the same wall and the error
+ *  message names neither the cause nor the limit.
+ *
+ *  Of the available neighbours this is the honest one: bSDD and IDS are both buildingSMART
+ *  REFERENCE surfaces — one says what a class *is*, the other what a deliverable must *carry* — and
+ *  both are consumed by the same screen (`portal/panels/standards.ts`). They are also the only
+ *  methods in this file that are **not** project-scoped: a bSDD class is the same class for every
+ *  project, which is why the server caches it module-wide.
  */
 import { HttpCore, HttpError } from "./httpCore";
 
 type Ctor<T> = new (...args: any[]) => T;
+
+/** One hit from a bSDD free-text search (`GET /bsdd/search`). */
+export interface BsddHit {
+  uri: string | null;
+  name: string | null;
+  code: string | null;
+  dictionary: string | null;
+}
+
+/** One bSDD class with the properties the dictionary defines for it (`GET /bsdd/class`). */
+export interface BsddClass extends BsddHit {
+  properties: { name: string | null; code: string | null; dataType: string | null }[];
+}
+
 
 export function withIds<TBase extends Ctor<HttpCore>>(Base: TBase) {
   return class Ids extends Base {
@@ -55,6 +86,22 @@ export function withIds<TBase extends Ctor<HttpCore>>(Base: TBase) {
   }
   unpinProjectIds(pid: string) {
     return this.json<{ deleted: boolean }>(`/projects/${pid}/ids`, { method: "DELETE" });
+  }
+
+  /** One hit from a bSDD free-text search. Every field is nullable: the live bSDD response shape
+   *  varies by dictionary and `bsdd.py` parses it defensively rather than asserting a schema. */
+  bsddSearch(q: string, opts: { dictionary?: string; limit?: number } = {}) {
+    const params = new URLSearchParams({ q });
+    if (opts.dictionary) params.set("dictionary", opts.dictionary);
+    if (opts.limit != null) params.set("limit", String(opts.limit));
+    return this.json<{ classes: BsddHit[] }>(`/bsdd/search?${params.toString()}`);
+  }
+  /** One bSDD class and the properties the dictionary defines for it, by full class URI.
+   *  404 when the dictionary has no such class; 502 when bSDD itself is unreachable — the caller
+   *  MUST tell those two apart, because an outage and an empty dictionary look identical on screen
+   *  and mean opposite things. Both arrive as `HttpError`, which carries `.status`. */
+  bsddClass(uri: string) {
+    return this.json<BsddClass>(`/bsdd/class?uri=${encodeURIComponent(uri)}`);
   }
   };
 }

--- a/apps/web/src/portal/panels/bsddLookup.test.ts
+++ b/apps/web/src/portal/panels/bsddLookup.test.ts
@@ -1,6 +1,9 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
-import { bsddFailure, bsddFailureText } from "./bsddLookup";
+import { bsddFailure, bsddFailureText, requestGate } from "./bsddLookup";
 
 /**
  * BSDD-LOOKUP's behavioural half. `api/bsdd.test.ts` proves the client CARRIES the status;
@@ -59,5 +62,89 @@ describe("what the reader is told", () => {
     // ...and never leaks the transport's words into the two states the product can describe itself.
     expect(bsddFailureText("unavailable", "x", "boom")).not.toContain("boom");
     expect(bsddFailureText("not-found", "x", "boom")).not.toContain("boom");
+  });
+});
+
+/**
+ * The stale-response guard (CodeRabbit review, PR #540). The lookup card's two actions — search,
+ * and open a class — both write their result into the SAME element after an await, so before this
+ * the slower request won regardless of which was asked for last.
+ *
+ * Tested here rather than through the DOM because the defect is a SCHEDULING ORDER. A rendering
+ * test would have to provoke a specific interleaving to see it, and would pass by accident whenever
+ * the responses happened to arrive in request order — which is most of the time, and is exactly why
+ * this kind of bug ships.
+ */
+describe("the shared request gate", () => {
+  it("lets the newest request write", () => {
+    const g = requestGate();
+    const gen = g.start();
+    expect(g.isCurrent(gen)).toBe(true);
+  });
+
+  it("locks out an earlier request once a later one starts", () => {
+    const g = requestGate();
+    const first = g.start();
+    const second = g.start();
+    // The real sequence: search "wall", search "door", then "wall" resolves LAST and must not win.
+    expect(g.isCurrent(first)).toBe(false);
+    expect(g.isCurrent(second)).toBe(true);
+  });
+
+  it("is shared across both actions, so a class detail cannot overwrite a newer search", () => {
+    // One gate, not one per endpoint. Two independent counters would each be internally consistent
+    // and still let this through, because what is contended is the output element, not the route.
+    const g = requestGate();
+    const openClass = g.start();     // user clicks a result
+    const newSearch = g.start();     // user hits "← results" / searches again before it lands
+    expect(g.isCurrent(openClass)).toBe(false);
+    expect(g.isCurrent(newSearch)).toBe(true);
+  });
+
+  it("gives each request a distinct generation, so none can be mistaken for another", () => {
+    const g = requestGate();
+    const seen = new Set([g.start(), g.start(), g.start()]);
+    expect(seen.size).toBe(3);
+  });
+
+  it("starts with nothing current, so a generation never claimed cannot write", () => {
+    // Guards the off-by-one: if `current` began at 1 and `start()` returned the pre-increment
+    // value, a request holding 0 would read as current and the gate would be open by default.
+    const g = requestGate();
+    expect(g.isCurrent(0)).toBe(false);
+  });
+});
+
+/**
+ * ...and that the PANEL actually wires ONE gate into both writers.
+ *
+ * The unit tests above assert a property of a single `requestGate()` instance. They say nothing
+ * about how `standards.ts` uses it — giving each action its OWN gate typechecks cleanly, leaves
+ * every test above green, and reinstates exactly the bug they exist to forbid, because what is
+ * contended is the output element rather than the endpoint.
+ *
+ * *Asserting an outcome without asserting the path to it ran is vacuous.* So this reads the panel.
+ */
+describe("the standards panel wires one gate, not one per action", () => {
+  //: `__dirname`, not `import.meta.url` — under vitest's transform the module URL is a virtual
+  //: path that does not exist on disk (the reason `api/httpStatus.test.ts` gives).
+  const src = readFileSync(join(resolve(__dirname), "standards.ts"), "utf8");
+
+  it("is reading the panel it thinks it is", () => {
+    // Without this the two assertions below pass forever against an empty string.
+    expect(src).toContain("bsddSearch");
+    expect(src).toContain("bsddClass");
+  });
+
+  it("constructs exactly one request gate", () => {
+    const gates = src.match(/requestGate\(\)/g) ?? [];
+    expect(gates).toHaveLength(1);
+  });
+
+  it("guards every write that follows an await on it", () => {
+    // Both async writers must consult the gate before touching the shared element: one `start()`
+    // each, and a check in both the success and the failure path (4 checks total).
+    expect((src.match(/bdGate\.start\(\)/g) ?? [])).toHaveLength(2);
+    expect((src.match(/bdGate\.isCurrent\(/g) ?? []).length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/apps/web/src/portal/panels/bsddLookup.test.ts
+++ b/apps/web/src/portal/panels/bsddLookup.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { bsddFailure, bsddFailureText } from "./bsddLookup";
+
+/**
+ * BSDD-LOOKUP's behavioural half. `api/bsdd.test.ts` proves the client CARRIES the status;
+ * this proves the screen SPENDS it — and they are different questions. A client that raised a
+ * perfect `HttpError` into a panel that rendered every failure as "no results" would pass the
+ * first file and ship the defect this one exists to prevent.
+ *
+ * The failure being guarded is specific: bSDD is a remote reference service, so "the dictionary
+ * is unreachable", "the dictionary has no such class" and "your search matched nothing" are three
+ * different answers that a blank list renders identically. One says try again, one says that class
+ * does not exist, one says your query was wrong.
+ */
+describe("classifying a failed bSDD call", () => {
+  it("reads 502 as the reference service being unreachable", () => {
+    expect(bsddFailure(502)).toBe("unavailable");
+  });
+
+  it("reads 404 as the dictionary answering, with no such class", () => {
+    // The distinction that matters: 404 is bSDD SUCCEEDING at being asked. Folding it into
+    // "unavailable" would tell the reader to wait for a recovery that will never change the answer.
+    expect(bsddFailure(404)).toBe("not-found");
+  });
+
+  it("refuses to guess on any other status", () => {
+    for (const s of [0, 400, 401, 403, 500, 503]) {
+      expect(bsddFailure(s), `status ${s}`).toBe("unknown");
+    }
+  });
+
+  it("does not treat 503 or 500 as the service being down", () => {
+    // Deliberate and easy to get wrong the other way: our API converts a bSDD outage to 502
+    // SPECIFICALLY so the panel can say so. A 500 is our own bug and a 503 is our own deployment —
+    // neither is evidence about buildingSMART, and claiming otherwise misdirects the reader.
+    expect(bsddFailure(500)).not.toBe("unavailable");
+    expect(bsddFailure(503)).not.toBe("unavailable");
+  });
+});
+
+describe("what the reader is told", () => {
+  it("says the service is unavailable AND that this is not an empty result", () => {
+    const t = bsddFailureText("unavailable", "the dictionary");
+    expect(t).toContain("unavailable");
+    // The load-bearing clause. Without it the sentence still reads like "nothing found".
+    expect(t).toContain("not an empty result");
+    expect(t).toContain("the dictionary");
+  });
+
+  it("says the class does not exist, without inviting a retry", () => {
+    const t = bsddFailureText("not-found", "that class");
+    expect(t).toContain("no such class");
+    expect(t).not.toMatch(/try again/i);
+  });
+
+  it("carries the underlying message only when it has nothing better to say", () => {
+    expect(bsddFailureText("unknown", "that class", "boom")).toContain("boom");
+    // ...and never leaks the transport's words into the two states the product can describe itself.
+    expect(bsddFailureText("unavailable", "x", "boom")).not.toContain("boom");
+    expect(bsddFailureText("not-found", "x", "boom")).not.toContain("boom");
+  });
+});

--- a/apps/web/src/portal/panels/bsddLookup.ts
+++ b/apps/web/src/portal/panels/bsddLookup.ts
@@ -1,0 +1,45 @@
+/** The bSDD lookup's failure wording — pure, so the rules can be tested without a DOM.
+ *
+ *  bSDD is an ONLINE reference service, and the standards panel already scored *what fraction* of
+ *  the model carries a bSDD classification URI while offering no way to look one up. BSDD-LOOKUP
+ *  wired `GET /bsdd/search` and `GET /bsdd/class`; this module owns the one decision in that screen
+ *  that is easy to get quietly wrong.
+ *
+ *  **The whole point is that an outage must not render as an empty result.** `routers/standards.py`
+ *  deliberately maps an unreachable dictionary to 502 rather than letting it 500, and a missing
+ *  class to 404. On screen those two, plus "the dictionary genuinely matched nothing", are three
+ *  states that look identical if you render them all as a blank list — and they mean opposite
+ *  things: one says *try again*, one says *that class does not exist*, one says *your search was
+ *  wrong*. Collapsing them is the offered-and-refused shape `lodProxy.ts` beside this file exists
+ *  to remove, in its reading form.
+ */
+
+/** What went wrong, as the screen must distinguish it. */
+export type BsddFailure = "unavailable" | "not-found" | "unknown";
+
+/** Classify a rejected bSDD call by the status our own API attached to it.
+ *
+ *  Takes the status rather than the error so the rule can be tested without constructing an
+ *  `HttpError`, and so a caller that has already unwrapped one cannot accidentally pass `undefined`
+ *  and land in a branch that reads as a definite answer. Anything that is not 502 or 404 is
+ *  `"unknown"` — deliberately NOT folded into `"unavailable"`, because claiming the reference
+ *  service is down when a request was merely malformed sends the reader to wait for a recovery
+ *  that is not coming.
+ */
+export function bsddFailure(status: number): BsddFailure {
+  if (status === 502) return "unavailable";
+  if (status === 404) return "not-found";
+  return "unknown";
+}
+
+/** What to tell the reader, given the failure and what was being asked for. `detail` carries the
+ *  underlying message for the `"unknown"` case only — the two known states are described in the
+ *  product's own words rather than the transport's. */
+export function bsddFailureText(kind: BsddFailure, what: string, detail = ""): string {
+  if (kind === "unavailable") {
+    return `buildingSMART reference service unavailable — ${what} could not be checked. `
+      + `This is not an empty result; try again shortly.`;
+  }
+  if (kind === "not-found") return "The dictionary has no such class.";
+  return `failed: ${detail}`;
+}

--- a/apps/web/src/portal/panels/bsddLookup.ts
+++ b/apps/web/src/portal/panels/bsddLookup.ts
@@ -43,3 +43,30 @@ export function bsddFailureText(kind: BsddFailure, what: string, detail = ""): s
   if (kind === "not-found") return "The dictionary has no such class.";
   return `failed: ${detail}`;
 }
+
+/** A last-writer-wins guard for a single output element shared by several async actions.
+ *
+ *  The lookup card has two actions — search, and open a class — that both write their result into
+ *  the SAME element after an await. Without a guard the slower request wins regardless of which was
+ *  asked for last: search "wall", search "door", and if "wall" resolves second the card shows wall
+ *  results under the door query. Clicking a class and then "← results" races the same way.
+ *
+ *  **One gate shared by both actions, not one each.** Two independent counters would each be
+ *  internally consistent and still let a stale class detail overwrite a newer search, because the
+ *  thing being contended is the element, not the endpoint.
+ *
+ *  Separated from the DOM so the rule can be tested directly: the failure it prevents is a
+ *  scheduling order, which a rendering test would only reproduce by accident.
+ */
+export function requestGate(): { start: () => number; isCurrent: (gen: number) => boolean } {
+  let current = 0;
+  return {
+    /** Claim the output for a new request and return its generation. */
+    start: () => ++current,
+    /** True only if `gen` claimed the output and no later request has started since.
+     *  The `> 0` is not decoration: generations count from 1, so 0 is the value a caller holds
+     *  before it has claimed anything — and without this it compared equal to the initial
+     *  `current` and read as the live request. Found by its own test, not by review. */
+    isCurrent: (gen: number) => gen > 0 && gen === current,
+  };
+}

--- a/apps/web/src/portal/panels/standards.ts
+++ b/apps/web/src/portal/panels/standards.ts
@@ -2,7 +2,7 @@ import { HttpError } from "../../api/httpCore";
 import { destLabel, destTitle } from "../../shell/destinations";
 import { noProjectHtml } from "../../ui/empty";
 import { escapeHtml as esc, toast } from "../../ui/feedback";
-import { bsddFailure, bsddFailureText } from "./bsddLookup";
+import { bsddFailure, bsddFailureText, requestGate } from "./bsddLookup";
 import { proxyConfirm, proxyOffer, proxySummary } from "./lodProxy";
 import type { PanelContext } from "../panelContext";
 
@@ -401,11 +401,18 @@ export async function renderStandards(ctx: PanelContext) {
       return `<div class="meta"${warn}>${kind === "unavailable" ? "⚠️ " : ""}${text}</div>`;
     };
 
+    // ONE gate for both actions: they race over `bdOut`, not over their own endpoints. A slower
+    // earlier request must not overwrite a newer result. `bsddLookup.test.ts` asserts both the
+    // gate's behaviour AND that this panel wires a single instance into both writers.
+    const bdGate = requestGate();
+
     const bdShowClass = async (uri: string) => {
+      const gen = bdGate.start();
       bdOut.innerHTML = `<div class="meta">loading class…</div>`;
       let cls;
       try { cls = await ctx.host.api.bsddClass(uri); }
-      catch (e) { bdOut.innerHTML = bdFail(e, "that class"); return; }
+      catch (e) { if (bdGate.isCurrent(gen)) bdOut.innerHTML = bdFail(e, "that class"); return; }
+      if (!bdGate.isCurrent(gen)) return;      // a newer search or class won the output
       const back = el("button", "mini-btn"); back.textContent = "← results";
       bdOut.innerHTML = `<div><b>${esc(cls.name ?? cls.code ?? "(unnamed class)")}</b> `
         + `<span class="meta">${esc(cls.code ?? "")}${cls.dictionary ? ` · ${esc(cls.dictionary)}` : ""}</span></div>`
@@ -424,11 +431,13 @@ export async function renderStandards(ctx: PanelContext) {
 
     const bdSearch = async () => {
       const q = bdQ.value.trim();
+      const gen = bdGate.start();
       if (!q) { bdOut.innerHTML = `<div class="meta">Type something to search for.</div>`; return; }
       bdOut.innerHTML = `<div class="meta">searching…</div>`;
       let hits;
       try { hits = (await ctx.host.api.bsddSearch(q, { dictionary: bdDict.value || undefined })).classes; }
-      catch (e) { bdOut.innerHTML = bdFail(e, "the dictionary"); return; }
+      catch (e) { if (bdGate.isCurrent(gen)) bdOut.innerHTML = bdFail(e, "the dictionary"); return; }
+      if (!bdGate.isCurrent(gen)) return;      // a newer search or class won the output
       if (!hits.length) {
         bdOut.innerHTML = `<div class="meta">No classes match “${esc(q)}”.</div>`;
         return;

--- a/apps/web/src/portal/panels/standards.ts
+++ b/apps/web/src/portal/panels/standards.ts
@@ -1,6 +1,8 @@
+import { HttpError } from "../../api/httpCore";
 import { destLabel, destTitle } from "../../shell/destinations";
 import { noProjectHtml } from "../../ui/empty";
 import { escapeHtml as esc, toast } from "../../ui/feedback";
+import { bsddFailure, bsddFailureText } from "./bsddLookup";
 import { proxyConfirm, proxyOffer, proxySummary } from "./lodProxy";
 import type { PanelContext } from "../panelContext";
 
@@ -359,6 +361,93 @@ export async function renderStandards(ctx: PanelContext) {
       q.innerHTML = `<b>openBIM model quality</b><div class="meta">Load a model (Model workspace) to `
         + `score LOIN, IDS compliance, export health and bSDD alignment.</div>`;
     }
+
+    // --- bSDD lookup: search the buildingSMART Data Dictionary and read one class ---------------
+    // Reference data, not project data — the same class for every project. It sits in this panel
+    // because this is where classification is already being scored ("bSDD / classification
+    // coverage" above): the score tells you how much of the model is aligned, this tells you what
+    // to align it TO.
+    const bd = el("div", "dash-card"); bd.style.marginTop = "8px";
+    const bdHead = el("div");
+    bdHead.innerHTML = `<b>🔤 buildingSMART Data Dictionary</b> `
+      + `<span class="meta">look up a classification class and the properties it defines</span>`;
+    const bdForm = el("form"); bdForm.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-top:6px";
+    const bdQ = el("input", "portal-filter") as HTMLInputElement;
+    bdQ.type = "search"; bdQ.placeholder = "e.g. exterior wall"; bdQ.style.minWidth = "180px";
+    bdQ.setAttribute("aria-label", "bSDD search text");
+    const bdDict = el("select", "portal-filter") as HTMLSelectElement;
+    bdDict.setAttribute("aria-label", "bSDD dictionary");
+    // A short list of the dictionaries an AEC author actually reaches for, plus "all". The URIs are
+    // bSDD identifiers, not our own — they are passed through to the server verbatim.
+    const DICTS: [string, string][] = [
+      ["", "All dictionaries"],
+      ["https://identifier.buildingsmart.org/uri/buildingsmart/ifc", "IFC"],
+      ["https://identifier.buildingsmart.org/uri/nbs/uniclass", "Uniclass"],
+    ];
+    bdDict.innerHTML = DICTS.map(([v, l]) => `<option value="${esc(v)}">${esc(l)}</option>`).join("");
+    const bdBtn = el("button", "mini-btn on") as HTMLButtonElement;
+    bdBtn.type = "submit"; bdBtn.textContent = "Search";
+    bdForm.append(bdQ, bdDict, bdBtn);
+    const bdOut = el("div"); bdOut.style.marginTop = "6px";
+    bd.append(bdHead, bdForm, bdOut);
+    body.append(bd);
+
+    // The 502-vs-404-vs-empty decision lives in `bsddLookup.ts` so it can be tested without a DOM;
+    // this only picks the colour, which is the part that genuinely needs an element.
+    const bdFail = (e: unknown, what: string) => {
+      const kind = bsddFailure(e instanceof HttpError ? e.status : 0);
+      const text = esc(bsddFailureText(kind, what, (e as Error)?.message ?? ""));
+      const warn = kind === "unavailable" ? ` style="color:var(--status-warn)"` : "";
+      return `<div class="meta"${warn}>${kind === "unavailable" ? "⚠️ " : ""}${text}</div>`;
+    };
+
+    const bdShowClass = async (uri: string) => {
+      bdOut.innerHTML = `<div class="meta">loading class…</div>`;
+      let cls;
+      try { cls = await ctx.host.api.bsddClass(uri); }
+      catch (e) { bdOut.innerHTML = bdFail(e, "that class"); return; }
+      const back = el("button", "mini-btn"); back.textContent = "← results";
+      bdOut.innerHTML = `<div><b>${esc(cls.name ?? cls.code ?? "(unnamed class)")}</b> `
+        + `<span class="meta">${esc(cls.code ?? "")}${cls.dictionary ? ` · ${esc(cls.dictionary)}` : ""}</span></div>`
+        + `<div class="meta" style="word-break:break-all;margin-top:2px">${esc(cls.uri ?? uri)}</div>`
+        + (cls.properties.length
+          ? `<table class="fin-table" style="width:100%;font-size:12px;margin-top:6px">`
+            + `<tr><th style="text-align:left">Property</th><th style="text-align:left">Code</th>`
+            + `<th style="text-align:left">Data type</th></tr>`
+            + cls.properties.map((p) => `<tr><td>${esc(p.name ?? "—")}</td><td>${esc(p.code ?? "—")}</td>`
+              + `<td>${esc(p.dataType ?? "—")}</td></tr>`).join("")
+            + `</table>`
+          : `<div class="meta" style="margin-top:6px">This class defines no properties.</div>`);
+      bdOut.append(back);
+      back.onclick = () => void bdSearch();
+    };
+
+    const bdSearch = async () => {
+      const q = bdQ.value.trim();
+      if (!q) { bdOut.innerHTML = `<div class="meta">Type something to search for.</div>`; return; }
+      bdOut.innerHTML = `<div class="meta">searching…</div>`;
+      let hits;
+      try { hits = (await ctx.host.api.bsddSearch(q, { dictionary: bdDict.value || undefined })).classes; }
+      catch (e) { bdOut.innerHTML = bdFail(e, "the dictionary"); return; }
+      if (!hits.length) {
+        bdOut.innerHTML = `<div class="meta">No classes match “${esc(q)}”.</div>`;
+        return;
+      }
+      bdOut.innerHTML = `<div class="meta">${hits.length} class(es)</div>`;
+      const list = el("div"); list.style.cssText = "display:flex;flex-direction:column;gap:2px;margin-top:4px";
+      for (const h of hits) {
+        const row = el("button", "file-btn") as HTMLButtonElement;
+        row.style.cssText = "text-align:left;font-size:12px";
+        row.innerHTML = `<b>${esc(h.name ?? h.code ?? "(unnamed)")}</b>`
+          + `<span class="meta"> ${esc(h.code ?? "")}${h.dictionary ? ` · ${esc(h.dictionary)}` : ""}</span>`;
+        // A hit with no URI cannot be read back — bSDD returned a name without an identifier.
+        if (!h.uri) { row.disabled = true; row.title = "this hit carries no class URI"; }
+        else row.onclick = () => void bdShowClass(h.uri as string);
+        list.append(row);
+      }
+      bdOut.append(list);
+    };
+    bdForm.onsubmit = (ev) => { ev.preventDefault(); void bdSearch(); };
   }
 
   // --- IDS Requirements: author buildingSMART IDS + EIR from templates --------------------------

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -1108,6 +1108,10 @@ check("  the siblings that motivated this gate are STILL reachable — the fix m
 # case again -- a dark route can be a duplicate rather than a hole, and the gate cannot tell the
 # difference.* `/proforma/scenarios/{sid}/provenance` has since been WIRED (SCENARIO-SOURCES), so
 # what is left unread is `/bsdd/class` and `/projects/{pid}/workflow/{key}`.
+# *(Superseded 2026-09-12: `/bsdd/class` was wired by BSDD-LOOKUP, leaving
+# `/projects/{pid}/workflow/{key}` as the only unread entry. Left standing rather than edited for the
+# reason the bracket above it gives -- this run of sentences is a RECORD of successive corrections,
+# and rewriting each one in place would erase the thing it documents.)*
 #: **`/proforma/scenarios/{sid}/provenance` LEFT THIS SET IN SCENARIO-SOURCES**, and it was the one
 #: worth building rather than recording: the engine behind it (`assumption_provenance.py`) names WHICH
 #: of a deal's material assumptions carry a document citation and which carry none, and an investment
@@ -1116,11 +1120,56 @@ check("  the siblings that motivated this gate are STILL reachable — the fix m
 #:
 #: Three remain. One of them is READ AND TRIAGED rather than unread -- see the note above -- and two
 #: are genuinely unexamined.
+#:
+#: **`/bsdd/class` LEFT THIS SET IN BSDD-LOOKUP.** `bsddClass` and `bsddSearch` in
+#: `apps/web/src/api/ids.ts` back a lookup card in `apps/web/src/portal/panels/standards.ts`: search
+#: the dictionary, open a class, read the properties it defines. It was worth building because the
+#: same panel already scored *what fraction* of the model carries a bSDD URI and offered no way to
+#: look one up -- a coverage number with no means of closing the gap it reports.
+#:
+#: **And finding it forced two corrections to this section, both about the list rather than the
+#: routes.**
+#:
+#: FIRST: `/bsdd/search` was never in this list, and it is the IDENTICAL case -- same route group,
+#: same absent `/bsdd/` fragment, leaf vouched by the English word "search". The screen that produced
+#: the five above is described as covering "every route whose leaf this rule reads as called but
+#: which never appears path-shaped anywhere in the web source". Re-running exactly that query returns
+#: **twenty-six** routes; this list named three of them. Most of the rest are legitimately
+#: web-callerless -- `/scim/v2/Users` is for an identity provider, `/bcf/2.1/projects` for external
+#: BIM tools -- so twenty-six is an upper bound on candidates and not a defect count. But the gap
+#: between "derived by screening every route" and "three entries" is the thing: *a list that
+#: DESCRIBES itself as derived, and is in fact hand-curated, reads exactly like a complete one.* The
+#: remaining candidates are not triaged here; that is filed as its own axis rather than smuggled into
+#: a wiring change.
+#:
+#: SECOND, and worse: **nothing here could have noticed.** The three per-entry checks below assert
+#: the blind spot PERSISTS, and all three stay green after a route is wired -- measured, by wiring
+#: `/bsdd/class` and re-running this file unchanged. A fourth check now probes for a real caller and
+#: reds when one appears, with a positive control so it cannot pass by measuring nothing.
 LEAF_COLLISION_DARK = (
-    "/bsdd/class",
     "/proforma/provenance",
     "/projects/{pid}/workflow/{key}",
 )
+
+
+def _wired_probe(route: str) -> str:
+    """The substring a real client caller building `route` must contain.
+
+    The longest run of consecutive STATIC segments ending at the last static one, plus a trailing
+    slash when the route continues into a template. `/bsdd/class` -> `bsdd/class`;
+    `/projects/{pid}/workflow/{key}` -> `workflow/`. Deliberately not the leaf alone: `provenance`
+    alone is carried by `/proforma/scenarios/{sid}/provenance`, a DIFFERENT route that IS wired,
+    and conflating the two is the very collision this section is about.
+    """
+    segs = [x for x in route.split("/") if x]
+    last_static = max((i for i, x in enumerate(segs) if not x.startswith("{")), default=-1)
+    run: list[str] = []
+    for i in range(last_static, -1, -1):
+        if segs[i].startswith("{"):
+            break
+        run.insert(0, segs[i])
+    probe = "/".join(run)
+    return probe + "/" if last_static < len(segs) - 1 else probe
 for _r in LEAF_COLLISION_DARK:
     check(f"the LEAF-COLLISION blind spot is still a blind spot: {_r}",
           _r not in FOUND and _r not in KNOWN_UNCALLED,
@@ -1141,6 +1190,31 @@ for _r in LEAF_COLLISION_DARK:
           leaf_is_called(_leaf(_r), BLOB),
           f"the vouching text for {_leaf(_r)!r} is gone, so this route should now be flaggable -- "
           "move it into KNOWN_UNCALLED with a reason, or wire it")
+
+# **AND THE LIST MUST NOTICE WHEN AN ENTRY STOPS BEING DARK.** The three checks above all assert the
+# blind spot PERSISTS -- not in FOUND, still a route, leaf still vouched. Every one of them stays
+# green after somebody wires the route, because the rule's blindness is a fact about the LEAF
+# COLLISION and has nothing to do with whether a caller exists. So the list could only ever decay in
+# one direction: toward naming routes that are actually reachable, with nothing to say so. *That was
+# measured, not assumed -- BSDD-LOOKUP wired `/bsdd/class` and re-ran this file, and all of its
+# checks passed unchanged.* The probe below is the missing direction: it reds when an entry acquires
+# a real caller, which is the moment the entry must be deleted.
+_STRIPPED = strip_comments(BLOB)
+for _r in LEAF_COLLISION_DARK:
+    _p = _wired_probe(_r)
+    check(f"  ...and it is still UNWIRED -- no client builds {_p!r}",
+          _p not in _STRIPPED,
+          f"{_r} now has a client caller, so it is no longer dark: DELETE it from "
+          "LEAF_COLLISION_DARK and record what wired it, the way /bsdd/class and "
+          "/projects/{pid}/cost/calibration were recorded when they left this set")
+
+# The probe must be able to SEE a caller, or "no client builds it" is a sentence that can only ever
+# come out true -- the can't-fail shape this file exists to prevent. `/bsdd/search`, wired by
+# BSDD-LOOKUP in the same change that removed `/bsdd/class` above, is the positive control.
+check("  the wired-probe can actually detect a caller (positive control: /bsdd/search)",
+      _wired_probe("/bsdd/search") in _STRIPPED,
+      "the probe found no caller for a route this repo demonstrably wired -- it is measuring "
+      "nothing, and every 'still unwired' verdict above is vacuous")
 
 print()
 if FAILED:


### PR DESCRIPTION
# What & why

The standards panel has always scored **what fraction** of the model carries a bSDD classification
URI — *"bSDD / classification coverage, 38%"* — and offered no way whatsoever to look one up. **A
coverage number with no means of closing the gap it reports.** The engine was already complete:
`services/api/src/aec_api/bsdd.py` is a read-only buildingSMART Data Dictionary client, and
`GET /bsdd/search` / `GET /bsdd/class` had been exposed with **no client caller at all**. There is
now a lookup card beside that figure: search the dictionary, open a class, read the properties it
defines.

**An outage must not render as an empty result.** bSDD is a remote service, so three states look
identical as a blank list and mean opposite things — unreachable (*try again*), no such class (*it
does not exist*), no matches (*your query was wrong*). `routers/standards.py` already separated the
first two into 502 and 404 for exactly this reason; `apps/web/src/portal/panels/bsddLookup.ts` is the
pure rule that spends them, tested without a DOM. 500 and 503 deliberately do **not** fold into
"unavailable" — those are our own bug and our own deployment, not evidence about buildingSMART, and
saying otherwise sends the reader to wait for a recovery that is not coming.

## Two corrections to the reachability gate — both about the list, not the routes

`/bsdd/class` was one of three routes frozen in `LEAF_COLLISION_DARK`
(`services/api/test_route_reachability.py`), invisible to the rule because its leaf is also an
ordinary HTML word (~1,756 `class="..."` attributes vouch for it).

**It was never complete.** `/bsdd/search` is the identical case — same route group, same absent
`/bsdd/` fragment, leaf vouched by the English word — and was not in the list. The list describes
itself as the output of screening *"every route whose leaf this rule reads as called but which never
appears path-shaped anywhere in the web source"*. Re-running exactly that query:

| | routes |
|---|---|
| returned by the screen the list describes | **26** |
| named in `LEAF_COLLISION_DARK` | **3** |

Most of the remainder are legitimately web-callerless — `/scim/v2/Users` is for an identity provider,
`/bcf/2.1/projects` for external BIM tools — so **26 is an upper bound on candidates, not a defect
count**, and that triage is filed as its own axis rather than smuggled into a wiring change. The
point is the gap: *a hand-curated list that describes itself as derived reads exactly like a complete
one.* (The probe was validated before being believed — two apparent extra hits turned out to be in
comments, which is precisely why the gate strips them.)

**And nothing could have noticed the fix.** All three per-entry checks assert the blind spot
*persists* — not flagged, still a live route, leaf still vouched — and **every one stays green after
the route is wired**, because the blindness is a fact about the leaf collision and has nothing to do
with whether a caller exists. Measured, not assumed: `/bsdd/class` was wired and the file re-run
unchanged, all green. So the list could only ever decay in one direction, toward naming routes that
are actually reachable. A fourth check now probes for a real caller and reds when one appears.

## `client.ts` has hit a hard compiler ceiling, and it changes where new routes can live

`/bsdd` is its own route group, so by the rule this client has followed for ~20 SCALE-SEAM PRs —
*the seam is the ROUTE* — these methods should have been their own `withBsdd` mixin. They are not.
**A 51st mixin in the `extends` chain fails the build outright** with TS2589, *"Type instantiation is
excessively deep and possibly infinite"*; removing it makes the error vanish, so the count is the
cause and not the contents. New route groups can no longer get their own mixin — they must lodge with
a neighbour — until the chain is composed in stages. Recorded in `apps/web/src/api/ids.ts`, which
took them, because the next person to reach for `withX()` will hit the same wall and the error
message names neither the cause nor the limit.

## Mutation-tested

| mutation | result |
|---|---|
| drop `encodeURIComponent` on the class URI | red — a code carrying `&` would be truncated to a prefix |
| `HttpError` carries 0 instead of the real status | red ×2 — both the 502 and 404 assertions |
| fold 5xx into `"unavailable"` | red ×2 — 500/503 are not evidence about buildingSMART |
| drop the *"not an empty result"* clause | red — the sentence reverts to reading like "nothing found" |
| leave the now-wired `/bsdd/class` in `LEAF_COLLISION_DARK` | red — **and the three original checks all still PASS**, which is the finding |
| blind `_wired_probe` so it can see no caller | red on the positive control, not silently green |

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree) — "All checks passed!"
- [x] Backend: `test_route_reachability.py` is the only backend file changed; it passes standalone and
      was mutation-tested in both directions. The full local suite was still running at push time —
      its result is posted in the thread below, and the CI gate is the authority either way. No new
      backend test file, so `run_tests.py` `TESTS` is unchanged.
- [x] Web: `tsc --noEmit` clean, `vitest run` **255 files / 2766 tests passed**, `vite build` exit 0
- [x] No import cycles introduced (`no-import-cycles.test.ts` passes in the full run)
- [x] `CHANGELOG.md` entry added under `## Unreleased`. No roadmap item — this came from the
      reachability gate's dark list, not `docs/roadmap.md`.
- [ ] Version bump — not a release PR
- [x] No secrets; no competitor names (buildingSMART / bSDD are open standards, not competitors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a bSDD lookup card to the Standards panel.
  - Search for classes by text and optionally filter by IFC or Uniclass dictionaries.
  - View class details, including name, code, dictionary, URI, and properties.
  - Navigate between search results and detailed class views.

- **Bug Fixes**
  - Improved bSDD error messaging by distinguishing unavailable services from missing classes and other errors.
  - Prevented older search or detail responses from replacing newer results.
  - Corrected route reachability checks for bSDD endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->