### PR TITLE
The blind spot was 70 routes wide, and two of them were written down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ with a name. Triage is deliberately *not* done here — no syntactic probe can c
 the leaf being vouched is the whole problem (a leaf-based search returns 685 hits for `projects` and
 44 for `status`). Each needs a read, and that is its own work.
 
+**Two review findings, both real, both applied.** The derivation matched its probe against all
+code; `leaf_is_called` directly above it matches inside STRING LITERALS, for the documented reason
+that a bare substring test cannot tell a route from a token containing it — so a probe appearing in
+an identifier could drop a route from the set, and since the ratchet fails only on *additions*, that
+removal would never be reported. *This file's own recurring defect, one level down, inside the
+derivation written to measure it.* The differential was **measured, not assumed: 0 routes today**,
+both controls unmoved — so it is preventive rather than corrective, and applied because it closes the
+silent-shrink path for nothing. Second: a route *leaving* the frozen set only printed. It now fails,
+on `KNOWN_UNCALLED`'s stated reasoning — an entry leaves either because it gained a caller, or
+because it was renamed, and then the frozen name is a stale string pre-authorising whatever reuses
+that path. *"Both need a human; neither should print and pass."* The weaker precedent in the same
+file was the wrong one to copy.
+
 **This took four measurements to get right** — 377 and 35 in a previous gate, then 26 and 70 here —
 and the pattern is identical each time: *the checker did not fail, it answered.* So the derivation
 carries two live controls it must separate: `/bsdd/search`, wired an hour earlier, must fall out;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### The reachability gate's blind spot was 70 routes wide, and only two were written down
+
+`LEAF_COLLISION_DARK` is a **triaged** list — routes somebody read, confirmed dark, and recorded. It
+was never the population, and the note above it described it as though it were. The population is
+every route the reachability rule cannot see *at all*: leaf long enough to check, leaf vouched by an
+ordinary English or HTML word (so the rule stays silent), and no caller that builds the path.
+Deriving that instead of listing it gives **70 of 947 routes**.
+
+`services/api/test_route_reachability.py` now derives and freezes that set as `LEAF_COLLISION_BLIND`,
+the way `KNOWN_UNCALLED` already freezes the routes the rule *can* see. It is a **record, not an
+allowlist**: 70 is not a target, and most of the set is probably correct. `/scim/v2/Users` is for an
+identity provider and `/bcf/2.1/projects` for external BIM tools — neither should ever have a web
+caller. Some are false positives of the probe itself: `openDrawing("plan.dxf?…")` builds
+`/projects/{pid}/drawings/plan.dxf` through a helper, so the literal never appears.
+
+**The point is not the number, it is that the number exists.** Before this, the blind spot had no
+measured size and nothing could report a new member; now it can only shrink, and route 71 arrives
+with a name. Triage is deliberately *not* done here — no syntactic probe can classify these, because
+the leaf being vouched is the whole problem (a leaf-based search returns 685 hits for `projects` and
+44 for `status`). Each needs a read, and that is its own work.
+
+**This took four measurements to get right** — 377 and 35 in a previous gate, then 26 and 70 here —
+and the pattern is identical each time: *the checker did not fail, it answered.* So the derivation
+carries two live controls it must separate: `/bsdd/search`, wired an hour earlier, must fall out;
+`/scim/v2/Users`, callerless by design, must stay in. Mutating the derivation to return nothing reds
+the controls rather than silently reporting a clean tree.
+
 ### You can now look up a buildingSMART class, not just be told how few you have
 
 The standards panel has always scored *what fraction* of the model carries a bSDD classification
@@ -64,7 +91,13 @@ as the output of screening "every route whose leaf this rule reads as called but
 path-shaped anywhere in the web source"; re-running exactly that query returns **twenty-six** routes
 against three entries. Most of the remainder are legitimately web-callerless (`/scim/v2/Users` is for
 an identity provider, `/bcf/2.1/projects` for external BIM tools), so twenty-six is an upper bound on
-candidates and not a defect count -- but *a hand-curated list that describes itself as derived reads
+candidates and not a defect count
+*(Superseded within the hour: **the real figure is 70 of 947 routes.** Twenty-six was measured with a
+looser probe that asked whether the route's PARENT fragment appeared, which any sibling route
+satisfies — so a called `/lod/assessment` vouched for an uncalled `/lod/matrix`, the same collision
+one segment up. DARK-LIST-DERIVE below carries the corrected derivation and freezes it. Recorded
+rather than edited away: a number that drifts toward the conclusion it supports is the hardest kind
+to catch, and this one drifted in the flattering direction.)* -- but *a hand-curated list that describes itself as derived reads
 exactly like a complete one.* The remaining candidates are filed as their own axis rather than
 smuggled into a wiring change.
 

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -1208,6 +1208,148 @@ for _r in LEAF_COLLISION_DARK:
           "LEAF_COLLISION_DARK and record what wired it, the way /bsdd/class and "
           "/projects/{pid}/cost/calibration were recorded when they left this set")
 
+# ---------------------------------------------------------------------------------------------
+# THE BLIND SPOT, MEASURED — and it is 70 routes wide, not the two named above.
+#
+# DARK-LIST-DERIVE. `LEAF_COLLISION_DARK` is a TRIAGED list: routes somebody read, confirmed dark,
+# and wrote down. It was never the population. The population is every route this rule cannot see
+# AT ALL -- leaf long enough to be checked, leaf vouched by `leaf_is_called` (so the rule stays
+# silent), and no caller found by `_wired_probe`. Deriving that set instead of listing it gives
+# **70** of 947 routes.
+#
+# *The previous note put this at 26.* That was measured with a looser probe -- it asked whether the
+# route's PARENT fragment appeared (`/lod/`), which any sibling route satisfies, so a called
+# `/lod/assessment` vouched for an uncalled `/lod/matrix` exactly the way the English word "matrix"
+# vouches for the leaf. **The same collision, one segment up.** 70 is the count when the question is
+# "does a caller build THIS path", which is the question that was meant. The 26 is corrected rather
+# than quietly replaced, because a number that moves toward the conclusion it supports is the
+# hardest kind to notice.
+#
+# **This is a RECORD, not an allowlist**, on exactly the terms `KNOWN_UNCALLED` above states: 70 is
+# not a target and most entries are probably fine. `/scim/v2/Users` is for an identity provider and
+# `/bcf/2.1/projects` for external BIM tools -- neither should ever have a web caller. Others are
+# reached through a helper that takes a relative suffix (`openDrawing("plan.dxf?…")` in
+# `apps/web/src/viewer/tools/drawingsSection.ts` builds `/projects/{pid}/drawings/plan.dxf` without
+# the literal ever appearing), which this probe cannot see and which is a FALSE POSITIVE here.
+#
+# **So why freeze it at all?** Because the alternative is what was here before: a blind spot of
+# unknown size, with two of its members written down and nothing able to report the rest. Frozen,
+# the set can only shrink, and route 71 arrives with a name instead of silently. Triaging the 70 is
+# its own work and is NOT done here -- no purely syntactic probe can classify them (the leaf is
+# vouched, which is the whole problem, and a leaf-based helper search returns 685 hits for
+# `projects` and 44 for `status`). Each one needs a read.
+LEAF_COLLISION_BLIND: frozenset[str] = frozenset({
+    "/admin/baseline",
+    "/admin/licenses",
+    "/admin/licenses/{lid}",
+    "/asset-rights/verify",
+    "/bcf/2.1/projects",
+    "/bcf/3.0/projects",
+    "/bcf/versions",
+    "/codes/families",
+    "/connections/{cid}/quickbooks/{entity}",
+    "/contractor-statements/portfolio",
+    "/estimate/resources/catalog",
+    "/families/coverage",
+    "/firm/rules",
+    "/lifecycle/reference",
+    "/metrics/budget",
+    "/openbim/capabilities",
+    "/payments/status",
+    "/pricing/status",
+    "/proforma/compare",
+    "/proforma/provenance",
+    "/projects/{pid}/ai/audit",
+    "/projects/{pid}/assistant/snapshot",
+    "/projects/{pid}/authoring/capabilities",
+    "/projects/{pid}/carbon/elements",
+    "/projects/{pid}/clash/analyze",
+    "/projects/{pid}/classify/coverage",
+    "/projects/{pid}/cost/estimate",
+    "/projects/{pid}/cv-progress/ingest",
+    "/projects/{pid}/cv-progress/status",
+    "/projects/{pid}/design/options/board.pdf",
+    "/projects/{pid}/design/options/carbon",
+    "/projects/{pid}/design/options/compare",
+    "/projects/{pid}/design/standards",
+    "/projects/{pid}/design/standards/check",
+    "/projects/{pid}/doctext/search",
+    "/projects/{pid}/draft/scope",
+    "/projects/{pid}/draft/submittal-summary",
+    "/projects/{pid}/drawings/elevation.dxf",
+    "/projects/{pid}/drawings/plan.dxf",
+    "/projects/{pid}/drawings/section.dxf",
+    "/projects/{pid}/drawings/stream",
+    "/projects/{pid}/egress/plan.svg",
+    "/projects/{pid}/elements/properties",
+    "/projects/{pid}/envelope/check",
+    "/projects/{pid}/lod/matrix",
+    "/projects/{pid}/logistics/clash",
+    "/projects/{pid}/mep/graph",
+    "/projects/{pid}/mep/schedule",
+    "/projects/{pid}/model/connections",
+    "/projects/{pid}/model/export.csv",
+    "/projects/{pid}/model/options",
+    "/projects/{pid}/model/options/{slug}",
+    "/projects/{pid}/naming/validate",
+    "/projects/{pid}/notices/draft",
+    "/projects/{pid}/notifications/digest/preview",
+    "/projects/{pid}/productivity/summary",
+    "/projects/{pid}/progress/reconciliation",
+    "/projects/{pid}/project-package/contents",
+    "/projects/{pid}/properties/index",
+    "/projects/{pid}/recipes/export",
+    "/projects/{pid}/reports/catalog",
+    "/projects/{pid}/review/contract",
+    "/projects/{pid}/review/scope",
+    "/projects/{pid}/scene/package",
+    "/projects/{pid}/schedule/status",
+    "/projects/{pid}/stakeholders/analysis",
+    "/projects/{pid}/warranties/expiring",
+    "/projects/{pid}/workflow/{key}",
+    "/scim/v2/Users",
+    "/scim/v2/Users/{user_id}",
+})
+
+
+def _blind_spot() -> set[str]:
+    """Routes this rule is structurally unable to flag: long leaf, leaf vouched, no caller found."""
+    stripped = strip_comments(BLOB)
+    out: set[str] = set()
+    for r in PATHS:
+        if r in FOUND or r in KNOWN_UNCALLED:
+            continue
+        leaf = _leaf(r)
+        if len(leaf) < MIN_SEGMENT or not leaf_is_called(leaf, stripped):
+            continue
+        probe = _wired_probe(r)
+        if probe and probe in stripped:
+            continue
+        out.add(r)
+    return out
+
+
+_BLIND = _blind_spot()
+
+# The derivation must be able to separate the two answers, or every verdict below is vacuous. Both
+# controls are live routes, so neither can pass by naming something that stopped existing.
+check("  the blind-spot derivation SEPARATES wired from unwired (controls)",
+      "/bsdd/search" not in _BLIND and "/scim/v2/Users" in _BLIND,
+      "/bsdd/search was wired by BSDD-LOOKUP and must fall out; /scim/v2/Users has no web caller "
+      "by design and must stay in. If either flipped, the derivation is measuring something else")
+
+check(f"no NEW route joined the blind spot ({len(_BLIND)} frozen)",
+      not (_BLIND - LEAF_COLLISION_BLIND),
+      f"newly blind: {sorted(_BLIND - LEAF_COLLISION_BLIND)[:6]} — this rule cannot see these at "
+      "all, so wire one, or add it to LEAF_COLLISION_BLIND. Adding is not an admission of a "
+      "defect: most of this set is correctly web-callerless")
+
+_LEFT_BLIND = sorted(LEAF_COLLISION_BLIND - _BLIND)
+if _LEFT_BLIND:
+    print(f"  (ratchet down: {len(_LEFT_BLIND)} left the blind spot — delete them from "
+          f"LEAF_COLLISION_BLIND: {_LEFT_BLIND[:6]})")
+
+# ---------------------------------------------------------------------------------------------
 # The probe must be able to SEE a caller, or "no client builds it" is a sentence that can only ever
 # come out true -- the can't-fail shape this file exists to prevent. `/bsdd/search`, wired by
 # BSDD-LOOKUP in the same change that removed `/bsdd/class` above, is the positive control.

--- a/services/api/test_route_reachability.py
+++ b/services/api/test_route_reachability.py
@@ -1313,8 +1313,22 @@ LEAF_COLLISION_BLIND: frozenset[str] = frozenset({
 
 
 def _blind_spot() -> set[str]:
-    """Routes this rule is structurally unable to flag: long leaf, leaf vouched, no caller found."""
+    """Routes this rule is structurally unable to flag: long leaf, leaf vouched, no caller found.
+
+    The probe is matched inside STRING LITERALS, not against all code, for the reason
+    `leaf_is_called` gives directly above: a bare substring test cannot tell a route from a token
+    that happens to contain it. Matching the whole blob would let a probe appearing in an
+    identifier or a non-path string read as a caller and drop that route from the set — and since
+    the ratchet below fails on ADDITIONS, a route removed that way is never reported. *That is this
+    file's own recurring defect, one level down, inside the derivation written to measure it.*
+
+    Found in review, and the differential was **measured rather than assumed: 0 routes today**, both
+    controls unmoved. It is applied anyway because it costs nothing and closes the silent-shrink
+    path before something lands in it — the same argument the string-literal restriction above was
+    made on in 2026-09-11.
+    """
     stripped = strip_comments(BLOB)
+    literals = string_blob(stripped)
     out: set[str] = set()
     for r in PATHS:
         if r in FOUND or r in KNOWN_UNCALLED:
@@ -1323,7 +1337,7 @@ def _blind_spot() -> set[str]:
         if len(leaf) < MIN_SEGMENT or not leaf_is_called(leaf, stripped):
             continue
         probe = _wired_probe(r)
-        if probe and probe in stripped:
+        if probe and probe in literals:
             continue
         out.add(r)
     return out
@@ -1344,10 +1358,18 @@ check(f"no NEW route joined the blind spot ({len(_BLIND)} frozen)",
       "all, so wire one, or add it to LEAF_COLLISION_BLIND. Adding is not an admission of a "
       "defect: most of this set is correctly web-callerless")
 
+# **A departure has to FAIL, not print.** The short-leaf ratchet above prints and passes, and this
+# followed it; `KNOWN_UNCALLED`'s own rot check does not, and its reasoning applies here verbatim:
+# an entry leaves either because the route gained a caller (good news the list must record) or
+# because it was renamed or deleted — and then the frozen name is a stale string pre-authorising
+# whatever later reuses that path. *"Both need a human; neither should print and pass."* Raised in
+# review; the weaker precedent was the wrong one to copy.
 _LEFT_BLIND = sorted(LEAF_COLLISION_BLIND - _BLIND)
-if _LEFT_BLIND:
-    print(f"  (ratchet down: {len(_LEFT_BLIND)} left the blind spot — delete them from "
-          f"LEAF_COLLISION_BLIND: {_LEFT_BLIND[:6]})")
+check("no frozen blind-spot route has quietly become called or vanished",
+      not _LEFT_BLIND,
+      f"{len(_LEFT_BLIND)}: {_LEFT_BLIND[:6]} — if it now has a caller, DELETE the entry (that is "
+      "the ratchet coming down, and is always welcome); if the path changed, update it. Leaving it "
+      "freezes a name that no longer refers to anything")
 
 # ---------------------------------------------------------------------------------------------
 # The probe must be able to SEE a caller, or "no client builds it" is a sentence that can only ever


### PR DESCRIPTION
# What & why

`LEAF_COLLISION_DARK` in `services/api/test_route_reachability.py` is a **triaged** list — routes
somebody read, confirmed dark, and recorded. The note above it described it as the output of
*"screening every route whose leaf this rule reads as called but which never appears path-shaped"*,
which is a different thing entirely. **A hand-curated list that describes itself as derived reads
exactly like a complete one.**

The actual population is every route the rule cannot see *at all*: leaf long enough to be checked,
leaf vouched by an ordinary English or HTML word (so the rule stays silent), and no caller that
builds the path. Derived rather than listed:

| | routes |
|---|---|
| total routes | 947 |
| flagged by the rule, frozen in `KNOWN_UNCALLED` with reasons | 56 |
| short leaf (its own existing ratchet) | 115 |
| leaf vouched, caller found | 696 |
| **leaf vouched, no caller — the blind spot** | **70** |
| …of which `LEAF_COLLISION_DARK` named | **2** |

## It is a record, not an allowlist

Frozen as `LEAF_COLLISION_BLIND`, on exactly the terms `KNOWN_UNCALLED` already states for the half
the rule *can* see. **70 is not a target and most of the set is probably correct:**

- `/scim/v2/Users` is for an identity provider, `/bcf/2.1/projects` for external BIM tools — neither
  should *ever* have a web caller.
- Some are **false positives of the probe itself**: `openDrawing("plan.dxf?…")` in
  `apps/web/src/viewer/tools/drawingsSection.ts` builds `/projects/{pid}/drawings/plan.dxf` through a
  helper that takes a relative suffix, so the literal never appears anywhere.

The value is not the number — it is that a number now exists. Before this the blind spot had no
measured size and nothing could report a new member. Frozen, it can only shrink, and route 71 arrives
with a name instead of silently.

**Triage is deliberately not attempted here.** No syntactic probe can classify these: the leaf being
vouched *is* the problem, and a leaf-based helper search returns 685 hits for `projects` and 44 for
`status` — the same collision one layer down. Each candidate needs a read, and that is its own work.

## Correcting the 26 I shipped an hour ago

PR #540's note put this at 26. That was measured with a looser probe asking whether the route's
**parent** fragment appeared (`/lod/`), which any sibling route satisfies — so a called
`/lod/assessment` vouched for an uncalled `/lod/matrix`, *the same collision one segment up*. 70 is
the count when the question is "does a caller build **this** path", which is the question that was
meant. Corrected in place in `CHANGELOG.md` rather than edited away, because it drifted in the
flattering direction and that is the hardest kind of drift to notice.

**Four measurements across two gates have now gone the same way** — 377 and 35 in `test_scratch_ignored.py`,
then 26 and 70 here — and the pattern is identical every time: *the checker did not fail, it
answered.* So the derivation carries two live controls it must separate.

## Mutation-tested

| mutation | result |
|---|---|
| drop `/scim/v2/Users` from the frozen set (simulates a 71st arriving) | red, naming the route |
| blind the derivation so it returns nothing | red on the **controls**, not a silently clean tree |

The controls are both live routes, so neither can pass by naming something that stopped existing:
`/bsdd/search`, wired an hour ago, must fall *out* of the set; `/scim/v2/Users`, callerless by design,
must stay *in*.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree) — "All checks passed!"
- [x] Backend: `test_route_reachability.py` passes standalone and was mutated in both directions;
      `test_claude_md_gates.py` (the citation gate, which reads `CHANGELOG.md` paths) passes. Full
      local suite running at push time — result posted in the thread below rather than ticked here.
      No new test file, so `run_tests.py` `TESTS` is unchanged.
- [x] Web: no TypeScript changed, so tsc/vitest/build were not re-run
- [x] No import cycles introduced
- [x] `CHANGELOG.md` entry added under `## Unreleased`, plus the correction to #540's figure
- [ ] Version bump — not a release PR
- [x] No secrets; no competitor names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated reachability documentation to record 70 routes affected by a measured blind spot among 947 routes.
  - Clarified that the recorded set is not an allowlist and that route triage remains separate work.
  - Superseded the previous estimate of 26 candidates with the corrected measurement.

- **Tests**
  - Added coverage for blind-spot identification and positive and negative control cases.
  - Added checks to detect newly affected routes and ensure unexpected changes fail validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->