### PR TITLE
XSS-IDENTITY: the security ratchet had been counting a live stored XSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,69 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### A stored XSS the security ratchet had been counting for months
+
+`apps/web/src/ui/innerHtmlGuard.test.ts` froze a per-file **number** of unescaped `innerHTML`
+interpolations. A number has no identity, so a file sitting inside its allowance was never looked at
+again -- you could delete a safe sink and add a live one in the same file and the gate stayed green
+both times.
+
+It was doing exactly that. `register.ts` was allowed 6 and had 4, and two of the four were
+`${a.filename}`:
+
+| step | where |
+|---|---|
+| raw multipart filename, unsanitised | `services/api/src/aec_api/routers/modules.py` (single + bulk upload) |
+| persisted verbatim | `modules.py` -> `record_attachments.filename` |
+| returned verbatim | `modules.py` list_attachments |
+| rendered **unescaped** into `innerHTML` | `apps/web/src/portal/register/register.ts`, both branches |
+
+A user with the `reviewer` role uploads an attachment named `<img src=x onerror=...>.pdf`; everyone
+who opens that record's attachment list runs it. The default CSP is framing-only, so inline handlers
+execute; `AEC_CSP=1` blocks the script but not the content injection. `esc` was already imported in
+that file and used 200 lines away -- the inconsistency the gate's own docstring diagnoses, on the
+exact vector it names ("an upload filename").
+
+**There was headroom at the top, too.** `BASELINE_TOTAL` was 85 against 77 actual, and SEVEN files
+the baseline had never heard of were sitting in that slack, passing silently. All seven read benign;
+the defect is that nothing had assessed them.
+
+**And it was blind to half its own population**, which is the worse of the two defects. The rule
+needed `innerHTML` and `${` on the SAME LINE, so any statement wrapped across lines -- the normal
+shape for a non-trivial row -- was scanned only as far as its first chunk. Measured while converting
+it: 62 sinks visible, and **58 more on continuation lines it could not see**, among them `v.vendor`,
+`s.company`, `r.text`, `t.title` and `cert.ref`. *Scope is a separate question from rule, and a green
+ratchet is what makes a scope error invisible* -- the same lesson `services/api/test_ruff_scope.py`
+paid for. The scan now accumulates the whole statement, and the true population is 113 sinks / 95
+identities / 33 files after this change's escaping.
+
+**The baseline is now keyed on IDENTITY -- `file :: expression` -- and the count is derived, never
+asserted.** An expression the list has not seen fails even when the total is flat or under. A
+vanished entry still never fails, deliberately: improving the code must not red the build.
+
+Fixed in the same change: **33 sinks escaped, 30 identities removed** -- measured under ONE
+rule against `origin/main` (146 sinks / 125 identities) and this head (113 / 95), because the first
+attempt at that figure ADDED two counts taken under the narrow and wide detectors and got 29. *An
+arithmetic total across two different scopes is not a measurement.*
+
+Escaped: the filename pair, kanban `title`/`assignee`/`ref`, BCF topic fields in `viewer/app.ts`,
+imported schedule activity + trade, an `<option value>` attribute pair, vendor/company/trade across
+the analytics panels, a saved-search name, an AI-topic code/section/title row, a certificate ref, a
+field-capture label + subject, and a portal comment body. Two PARTIAL escapes were completed -- they
+escaped `&`/`<` only, or `"` only, which is worse than none because it reads as handled.
+
+**Two escapers had different coverage.** `ui/feedback.escapeHtml` covers `& < > " '`; `ui/charts.esc`
+omitted `'`, and `esc(x)` reads identically whichever you imported. There is now one.
+
+Server side, `serving.stored_filename` normalises the persisted value (basename, control characters,
+length) at both upload doors. It deliberately does NOT strip `&` or `<`: those are legal in a
+filename, and mangling them would corrupt real names while giving false assurance. **Escaping stays
+the renderer's job** -- input filtering fixes an XSS only until the next sink.
+
+The decisive test is a SUBSTITUTION: delete one baselined sink, add a different one in the same
+file, count identical. The old rule passed it; the new one names the identity. Verified by mutating
+a real source file and watching the gate go red, not by reading it.
+
 ### The API client could not take another mixin, and now it can
 
 `apps/web/src/api/client.ts` composed its 49 mixins in one nested `extends` expression. Adding a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,16 @@ the defect is that nothing had assessed them.
 **And it was blind to half its own population**, which is the worse of the two defects. The rule
 needed `innerHTML` and `${` on the SAME LINE, so any statement wrapped across lines -- the normal
 shape for a non-trivial row -- was scanned only as far as its first chunk. Measured while converting
-it: 62 sinks visible, and **58 more on continuation lines it could not see**, among them `v.vendor`,
-`s.company`, `r.text`, `t.title` and `cert.ref`. *Scope is a separate question from rule, and a green
-ratchet is what makes a scope error invisible* -- the same lesson `services/api/test_ruff_scope.py`
-paid for. The scan now accumulates the whole statement, and the true population is 113 sinks / 95
-identities / 33 files after this change's escaping.
+it: **under the OLD same-line rule**, 62 sinks visible and **58 more on continuation lines it could
+not see**, among them `v.vendor`, `s.company`, `r.text`, `t.title` and `cert.ref`. *Scope is a
+separate question from rule, and a green ratchet is what makes a scope error invisible* -- the same
+lesson `services/api/test_ruff_scope.py` paid for.
+
+**Those 62/58 figures are a diagnostic of the old detector, not a remediation count.** They are not
+comparable with the numbers below, which come from the new whole-statement detector with widened
+terms: the two rules see different populations, so 62 + 58 and 146 do not describe the same set and
+no arithmetic relates them. The scan now accumulates the whole statement AND parses interpolations
+by brace depth.
 
 **The baseline is now keyed on IDENTITY -- `file :: expression` -- and the count is derived, never
 asserted.** An expression the list has not seen fails even when the total is flat or under. A

--- a/apps/web/src/field/field.ts
+++ b/apps/web/src/field/field.ts
@@ -7,7 +7,7 @@
 import type { ApiClient } from "../api/client";
 import { permanentRejection } from "../api/httpCore";
 import { currentIdentity, ownedByMe } from "../api/identity";
-import { toast } from "./../ui/feedback";
+import { escapeHtml as esc, toast } from "./../ui/feedback";
 import { attachDictation } from "./dictate";
 import { mountFieldChrome, readFieldMode, shouldOpenCaptureHome } from "./fieldMode";
 import "./fieldMode.css";
@@ -259,7 +259,7 @@ export class FieldCapture {
           ? `<div style="font-size:12px;color:var(--danger,#e5534b)">⚠ ${it.rejected} — retrying will not help</div>`
           : "";
         rowEl.innerHTML = `<span style="font-size:18px">${it.rejected ? "⚠" : it.photo ? "🖼" : "📝"}</span>`
-          + `<span style="flex:1;font-size:13px">${(it.label || it.module)} — ${String(it.data.subject || "").slice(0, 60)}${geo}${why}</span>`;
+          + `<span style="flex:1;font-size:13px">${esc(it.label || it.module)} — ${esc(String(it.data.subject || "").slice(0, 60))}${geo}${why}</span>`;
         const del = document.createElement("button"); del.className = "tool-btn"; del.textContent = "✕"; del.title = "Discard";
         del.onclick = () => { saveQueue(loadQueue().filter((x) => x.id !== it.id)); this.refreshBadge(); render(); };
         rowEl.append(del); card.append(rowEl);

--- a/apps/web/src/portal/panels/aiassist.ts
+++ b/apps/web/src/portal/panels/aiassist.ts
@@ -365,7 +365,7 @@ export async function renderAiAssist(ctx: PanelContext) {
             tbl.innerHTML = `<thead><tr><th scope="col" style="text-align:left">Code</th><th scope="col" style="text-align:left">Section</th>`
               + `<th scope="col" style="text-align:left">Requirement</th></tr></thead><tbody>`
               + r.topics.map((t) => `<tr><td>${esc(t.code)}</td><td><b>${esc(t.section)}</b> — ${esc(t.title)}</td>`
-                + `<td>${t.requirement}</td></tr>`).join("") + `</tbody>`;
+                + `<td>${esc(t.requirement)}</td></tr>`).join("") + `</tbody>`;
             out.append(tbl);
             const note = el("div", "meta"); note.style.marginTop = "6px";
             note.textContent = r.message || "Confirm all provisions with the Authority Having Jurisdiction (AHJ).";

--- a/apps/web/src/portal/panels/aiassist.ts
+++ b/apps/web/src/portal/panels/aiassist.ts
@@ -364,7 +364,7 @@ export async function renderAiAssist(ctx: PanelContext) {
             const tbl = el("table", "portal-table") as HTMLTableElement; tbl.style.cssText = "width:100%;font-size:12px;margin-top:6px";
             tbl.innerHTML = `<thead><tr><th scope="col" style="text-align:left">Code</th><th scope="col" style="text-align:left">Section</th>`
               + `<th scope="col" style="text-align:left">Requirement</th></tr></thead><tbody>`
-              + r.topics.map((t) => `<tr><td>${t.code}</td><td><b>${t.section}</b> — ${t.title}</td>`
+              + r.topics.map((t) => `<tr><td>${esc(t.code)}</td><td><b>${esc(t.section)}</b> — ${esc(t.title)}</td>`
                 + `<td>${t.requirement}</td></tr>`).join("") + `</tbody>`;
             out.append(tbl);
             const note = el("div", "meta"); note.style.marginTop = "6px";

--- a/apps/web/src/portal/panels/analytics.ts
+++ b/apps/web/src/portal/panels/analytics.ts
@@ -373,7 +373,7 @@ export async function renderRiskCost(ctx: PanelContext) {
       if (!r.count) { pqSlot.innerHTML = `<div class="meta">No prequalification records yet.</div>`; return; }
       const t = el("table", "portal-table") as HTMLTableElement; t.style.cssText = "width:100%;font-size:12px";
       t.innerHTML = `<thead><tr><th scope="col" style="text-align:left">Company</th><th scope="col">Trade</th><th scope="col">Score</th><th scope="col" style="text-align:left">Flags</th></tr></thead><tbody>`
-        + r.subs.map((s) => `<tr><td>${s.company || ""}</td><td style="text-align:center">${s.trade || ""}</td>`
+        + r.subs.map((s) => `<tr><td>${esc(s.company || "")}</td><td style="text-align:center">${esc(s.trade || "")}</td>`
           + `<td style="text-align:center;color:${tone(s.risk_band)}"><b>${s.score}</b> ${s.risk_band}</td>`
           + `<td>${(s.flags || []).join("; ")}</td></tr>`).join("") + `</tbody>`;
       pqSlot.append(t);
@@ -386,7 +386,7 @@ export async function renderRiskCost(ctx: PanelContext) {
         const ul = el("ul"); ul.style.cssText = "margin:4px 0 0 16px;font-size:12px";
         rows.forEach((x) => { const li = el("li");
           li.innerHTML = `<span style="color:${x.k === "EXPIRED" ? "var(--status-crit)" : "var(--status-warn)"}">${x.k}</span> `
-            + `${x.vendor || ""} — ${x.coverage_type || ""} exp ${x.expires} (${x.days}d)`; ul.append(li); });
+            + `${esc(x.vendor || "")} — ${esc(x.coverage_type || "")} exp ${x.expires} (${x.days}d)`; ul.append(li); });
         coiSlot.append(ul);
       }
     }).catch((e) => { coiSlot.textContent = `failed: ${(e as Error).message}`; });
@@ -397,7 +397,7 @@ export async function renderRiskCost(ctx: PanelContext) {
         const t = el("table", "portal-table") as HTMLTableElement; t.style.cssText = "width:100%;font-size:12px;margin-top:4px";
         t.innerHTML = `<thead><tr><th scope="col" style="text-align:left">Vendor</th><th scope="col" style="text-align:left">Issues</th>`
           + `<th scope="col">Bid</th><th scope="col">Bill</th></tr></thead><tbody>`
-          + r.vendors.map((v) => `<tr><td>${v.vendor}</td><td>${v.issues.map((i) => `<span style="color:var(--status-warn)">${i}</span>`).join("; ")}</td>`
+          + r.vendors.map((v) => `<tr><td>${esc(v.vendor)}</td><td>${v.issues.map((i) => `<span style="color:var(--status-warn)">${esc(i)}</span>`).join("; ")}</td>`
             + `<td style="text-align:center">${v.can_bid ? "✅" : "⛔"}</td>`
             + `<td style="text-align:center">${v.can_bill ? "✅" : "⛔"}</td></tr>`).join("") + `</tbody>`;
         gateSlot.append(t);
@@ -413,7 +413,7 @@ export async function renderRiskCost(ctx: PanelContext) {
       if (risky.length) {
         const t = el("table", "portal-table") as HTMLTableElement; t.style.cssText = "width:100%;font-size:12px;margin-top:4px";
         t.innerHTML = `<thead><tr><th scope="col" style="text-align:left">Vendor</th><th scope="col">Paid</th><th scope="col">Unconditional waived</th><th scope="col">Exposure</th></tr></thead><tbody>`
-          + risky.map((v) => `<tr><td>${v.vendor}</td><td style="text-align:right">${cmoney(v.paid)}</td>`
+          + risky.map((v) => `<tr><td>${esc(v.vendor)}</td><td style="text-align:right">${cmoney(v.paid)}</td>`
             + `<td style="text-align:right">${cmoney(v.waived_unconditional)}</td>`
             + `<td style="text-align:right;color:var(--status-crit)">${cmoney(v.exposure)}</td></tr>`).join("") + `</tbody>`;
         lienSlot.append(t);

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -810,7 +810,7 @@ export async function renderBudget(ctx: PanelContext) {
         + `· retainage ${usd(t.retainage)} · paid ${usd(t.paid)} · remaining ${usd(t.remaining)}</div>`;
       for (const s of sb.subs.slice(0, 8)) {
         const r = document.createElement("div"); r.className = "meta"; r.style.margin = "1px 0";
-        r.innerHTML = `${s.vendor ?? s.subcontract_ref ?? "—"}${s.trade ? ` · ${s.trade}` : ""}: billed <b>${usd(s.billed)}</b>`
+        r.innerHTML = `${esc(s.vendor ?? s.subcontract_ref ?? "—")}${s.trade ? ` · ${esc(s.trade)}` : ""}: billed <b>${usd(s.billed)}</b>`
           + (s.contract_value ? ` / ${usd(s.contract_value)}` : "") + ` · retainage ${usd(s.retainage)} · paid ${usd(s.paid)}`;
         sbody.appendChild(r);
       }

--- a/apps/web/src/portal/panels/operations.ts
+++ b/apps/web/src/portal/panels/operations.ts
@@ -616,7 +616,7 @@ export async function renderTurnover(ctx: PanelContext) {
         const certified = (d.signatures || []).some((s) => s.party === "Architect" && s.certifies);
         const card = el("div", "dash-card"); card.style.cssText = "margin:6px 0";
         card.innerHTML = `<div style="display:flex;justify-content:space-between;align-items:center">`
-          + `<b>${cert.ref || "Certificate"}</b><span class="badge">${cert.workflow_state}</span></div>`
+          + `<b>${esc(cert.ref || "Certificate")}</b><span class="badge">${esc(cert.workflow_state)}</span></div>`
           + `<div class="meta">${certified ? `✅ Architect certified · record model v${d.record_model_version ?? "—"}` : "Awaiting architect certification"}</div>`;
         const actions = el("div"); actions.style.cssText = "margin-top:6px;display:flex;gap:6px;flex-wrap:wrap";
         if (!certified) {

--- a/apps/web/src/portal/panels/schedule.ts
+++ b/apps/web/src/portal/panels/schedule.ts
@@ -302,7 +302,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
       t.innerHTML = `<thead><tr><th scope="col" style="text-align:left">Lever</th><th scope="col" style="text-align:left">Activity</th>`
         + `<th scope="col">Saves</th></tr></thead><tbody>`
         + levers.map((l) => `<tr><td><span class="meta">${l.kind}</span></td>`
-          + `<td>${l.name || l.ref || ""} <span class="meta">— ${l.detail}</span></td>`
+          + `<td>${esc(l.name || l.ref || "")} <span class="meta">— ${esc(l.detail)}</span></td>`
           + `<td style="text-align:center;color:var(--status-good)">${l.days}d</td></tr>`).join("") + `</tbody>`;
       accBody.append(t);
     }
@@ -446,7 +446,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
       const tb = document.createElement("tbody");
       for (const lane of b.swimlanes) {
         const tr = document.createElement("tr");
-        tr.innerHTML = `<td style="text-align:left;font-weight:600;position:sticky;left:0;background:var(--panel)">${lane.trade}</td>`
+        tr.innerHTML = `<td style="text-align:left;font-weight:600;position:sticky;left:0;background:var(--panel)">${esc(lane.trade)}</td>`
           + b.weeks.map((w) => {
             const cell = lane.tasks.filter((x) => x.week === w);
             return `<td style="vertical-align:top">` + cell.map((x) =>
@@ -591,8 +591,8 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
         laBody.appendChild(h);
         for (const a of wk.activities) {
           const row = document.createElement("div"); row.className = "meta"; row.style.margin = "1px 0";
-          row.innerHTML = `<span style="color:${statusColor(a.status)}">●</span> ${a.name}`
-            + `${a.trade ? ` · <span class="meta">${a.trade}</span>` : ""}`
+          row.innerHTML = `<span style="color:${statusColor(a.status)}">●</span> ${esc(a.name)}`
+            + `${a.trade ? ` · <span class="meta">${esc(a.trade)}</span>` : ""}`
             + ` · ${a.percent}% · <span class="meta">${a.status.replace("_", " ")}</span>`;
           laBody.appendChild(row);
         }

--- a/apps/web/src/portal/panels/standards.ts
+++ b/apps/web/src/portal/panels/standards.ts
@@ -475,7 +475,7 @@ export async function renderIds(ctx: PanelContext) {
       body.innerHTML = "";
       const pick = el("select", "portal-filter") as HTMLSelectElement; pick.style.cssText = "margin:4px 0";
       pick.setAttribute("aria-label", "IDS use case");
-      pick.innerHTML = cat.use_cases.map((u) => `<option value="${u.key}">${u.label}</option>`).join("");
+      pick.innerHTML = cat.use_cases.map((u) => `<option value="${esc(u.key)}">${esc(u.label)}</option>`).join("");
       const detail = el("div"); detail.style.margin = "8px 0";
       const showDetail = () => {
         const uc = cat.use_cases.find((u) => u.key === pick.value);

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -340,7 +340,7 @@ export class PortalUI {
     // the ONLY nodes carrying that attribute were the pinned rail's own buttons — so its
     // "open what I pinned" handler matched itself and clicked itself instead of navigating.
     b.dataset.dest = d.key;
-    b.innerHTML = `<span class="ic">${d.icon}</span> ${d.label.replace(/&/g, "&amp;").replace(/</g, "&lt;")}`;
+    b.innerHTML = `<span class="ic">${d.icon}</span> ${esc(d.label)}`;
     // A `goto` destination hands off to another workspace and renders NOTHING here, so it must not
     // mark itself active. v0.3.770 tried that — to make a `goto` destination usable as a room's
     // landing target — and it was wrong in the worst direction: the marker is sticky, nothing clears
@@ -850,7 +850,7 @@ export class PortalUI {
       for (const a of withNew) {
         const m = this.mods.find((x) => x.key === a.module); if (!m) continue;
         const chip = el("button", "tool-btn");
-        chip.innerHTML = `${a.name} <span class="badge">${a.new} new</span> <span class="meta">of ${a.total}</span>`;
+        chip.innerHTML = `${esc(a.name)} <span class="badge">${a.new} new</span> <span class="meta">of ${a.total}</span>`;
         chip.title = `${m.name} — open this saved search`;
         chip.onclick = async () => {
           this.reg.sort[m.key] = a.config.sort as (typeof this.reg.sort)[string];
@@ -975,7 +975,7 @@ export class PortalUI {
           + `<div class="meta" style="margin:2px 0 6px">${rs.headline}</div>`
           + rs.risks.map((r) => `<div style="display:flex;gap:8px;align-items:baseline;margin:3px 0;font-size:12px">`
             + `<span style="color:${colors[r.level] || "#9aa0a6"};font-weight:700;text-transform:uppercase;font-size:10px;min-width:54px">${r.level}</span>`
-            + `<span>${r.text}</span></div>`).join("");
+            + `<span>${esc(r.text)}</span></div>`).join("");
         // The evidence line. Values are server numbers, so a template is safe here; the alert text
         // below is server FREE TEXT and goes through textContent instead.
         const dr = rs.drivers ?? { schedule: {}, cost: {}, top_alerts: [] };

--- a/apps/web/src/portal/register/register.ts
+++ b/apps/web/src/portal/register/register.ts
@@ -2321,7 +2321,7 @@ export class RegisterUI {
         if (isPdf) {
           // open in the in-app viewer for markup; saving posts a marked-up copy back as a new attachment
           const pc = document.createElement("button"); pc.className = "att-cell att-file"; pc.title = `${a.filename} · ${kb} — open in viewer / mark up`;
-          pc.innerHTML = `<span class="att-ic">📄</span><span class="att-name">${a.filename}</span>`;
+          pc.innerHTML = `<span class="att-ic">📄</span><span class="att-name">${esc(a.filename)}</span>`;
           pc.onclick = async () => {
             const { openPdfUrl } = await import("../../drawings/openPdf");
             await openPdfUrl(this.ctx.host.api, url, a.filename, {
@@ -2338,7 +2338,7 @@ export class RegisterUI {
         if (isImg) {
           const img = document.createElement("img"); img.src = url; img.loading = "lazy"; img.alt = a.filename; cell.appendChild(img);
         } else {
-          cell.classList.add("att-file"); cell.innerHTML = `<span class="att-ic">📎</span><span class="att-name">${a.filename}</span>`;
+          cell.classList.add("att-file"); cell.innerHTML = `<span class="att-ic">📎</span><span class="att-name">${esc(a.filename)}</span>`;
         }
         gallery.appendChild(cell);
       }
@@ -2415,8 +2415,8 @@ export class RegisterUI {
       };
       for (const c of data.columns[state] ?? []) {
         const card = document.createElement("div"); card.className = "kan-card"; card.draggable = true;
-        card.innerHTML = `<div class="kc-ref">${c.ref}</div><div class="kc-title">${c.title ?? ""}</div>` +
-          (c.assignee ? `<div class="kc-asg">@${c.assignee}</div>` : "");
+        card.innerHTML = `<div class="kc-ref">${esc(c.ref)}</div><div class="kc-title">${esc(c.title ?? "")}</div>` +
+          (c.assignee ? `<div class="kc-asg">@${esc(c.assignee)}</div>` : "");
         card.ondragstart = (e) => { e.dataTransfer?.setData("rid", c.id); e.dataTransfer?.setData("from", state); };
         card.onclick = () => this.openRecord(m, c.id);
         col.appendChild(card);

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -1276,7 +1276,7 @@ export class ProformaUI {
             if (ln.category !== cat) return;
             const tr = document.createElement("tr");
             const tot = (ln.unit_cost || 0) * (ln.quantity || 1);
-            tr.innerHTML = `<td><input data-i="${i}" data-k="description" value="${(ln.description || "").replace(/"/g, "&quot;")}" style="width:150px"></td>`
+            tr.innerHTML = `<td><input data-i="${i}" data-k="description" value="${escapeHtml(ln.description || "")}" style="width:150px"></td>`
               + `<td><input data-i="${i}" data-k="unit_cost" type="number" step="any" value="${ln.unit_cost || 0}" style="width:90px"></td>`
               + `<td><input data-i="${i}" data-k="quantity" type="number" step="any" value="${ln.quantity ?? 1}" style="width:60px"></td>`
               + `<td style="text-align:right">${money(tot)}</td><td><button class="tool-btn" data-rm="${i}" title="Remove">✕</button></td>`;

--- a/apps/web/src/ui/charts.ts
+++ b/apps/web/src/ui/charts.ts
@@ -40,9 +40,18 @@ export function chartColor(i: number): string {
   return SERIES_PALETTE[i % SERIES_PALETTE.length] ?? SERIES_PALETTE[0]!;
 }
 
-export function esc(s: unknown): string {
-  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
+/** The ONE escaper, re-exported under the name chart code already imports.
+ *
+ *  This was a SECOND implementation covering `& < > "` but NOT `'` — a hole the moment its output
+ *  lands in a single-quoted attribute, and invisible at the call site, since `esc(x)` reads
+ *  identically whichever of the two you imported. Two escapers with different coverage is exactly
+ *  the drift this repo keeps paying for, so there is now one.
+ *
+ *  Imported rather than `export ... from`: this module uses `esc` internally in ~30 places, and a
+ *  bare re-export does not bind the name locally. (Caught by `tsc`, which is the point of having it.) */
+import { escapeHtml as esc } from "./feedback";
+
+export { esc };
 
 /** Compact number: 1.2B / 3.4M / 450k / 87. */
 export function compact(n: number): string {

--- a/apps/web/src/ui/innerHtmlGuard.test.ts
+++ b/apps/web/src/ui/innerHtmlGuard.test.ts
@@ -49,6 +49,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const SRC = join(__dirname, "..");
@@ -95,6 +96,7 @@ const BASELINE: Record<string, readonly string[]> = {
   "portal/panels/analytics.ts": [
     "c.cost_code",
     "cb.message || \"No cost history yet.\"",
+    "o.compliant ? \"✓\" : `<span style=\"color:var(--status-crit)\" title=\"${o.violations.join(\"; \")}\">✗</span>`",
     "o.label",
     "o.label === s.recommended ? \"★ \" : \"\"",
     "o.label === s.recommended ? ' style=\"background:var(--hover)\"' : \"\"",
@@ -115,7 +117,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "usd(t.contract_value)",
   ],
   "portal/panels/design.ts": [
-    "(e as Error).message",
     "label",
     "value",
     "x.label",
@@ -154,6 +155,8 @@ const BASELINE: Record<string, readonly string[]> = {
   ],
   "portal/panels/standards.ts": [
     "cov.complete ? \"✅ core documents on file (EIR, BEP, AIR)\"\n        : `⏳ missing core: ${cov.missing.map(esc).join(\", \")}`",
+    "dp.next_deliverable.ref ?? \"\"",
+    "dp.next_deliverable.type",
     "els.map((e) => e.label).join(\", \")",
     "label",
     "label",
@@ -206,6 +209,10 @@ const BASELINE: Record<string, readonly string[]> = {
     "label",
     "money(pf.terminal_value)",
     "money(rec.value)",
+    "money(v.cost.value)",
+    "money(v.income.value)",
+    "money(v.sales_comparison.value)",
+    "row(\"Plus land\", money(v.cost.land_value))",
     "title",
     "title",
     "x.code",
@@ -218,10 +225,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "money(s.executed_value)",
     "money(s.pending_value)",
     "money(s.total_value)",
-  ],
-  "shell/nextAction.ts": [
-    "action.label",
-    "action.label",
   ],
   "studio/nodeEditor.ts": [
     "spec.label",
@@ -269,72 +272,62 @@ function walk(dir: string, out: string[] = []): string[] {
 }
 
 /**
- * Every hot, unescaped interpolation pushed into innerHTML, as its expression text.
+ * Every interpolation that reaches an `innerHTML` assignment, via the TYPESCRIPT PARSER.
  *
- * Per `${…}`, not per line: an earlier draft stopped at the first hot match on a line, so adding a
- * second unescaped value to an already-counted line was invisible.
- */
-export function hotSinks(src: string): string[] {
-  const out: string[] = [];
-  const lines = src.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    if (!lines[i]!.includes("innerHTML")) continue;
-    // Accumulate the WHOLE statement, not just this line. An `innerHTML = ` + `...`` assignment
-    // wrapped across lines put every continuation line out of reach of the original line-scoped
-    // rule: it required `innerHTML` and `${` on the SAME line, so a statement broken after the
-    // first template chunk was half-invisible. Measured 2026-09-12: 58 hot sinks were sitting on
-    // continuation lines, against 62 the line-scoped rule could see — the gate was blind to
-    // roughly half its own population, and had been since it was written.
-    let stmt = lines[i]!;
-    for (let j = i + 1; j < Math.min(i + STATEMENT_SPAN, lines.length); j++) {
-      if (/;\s*$/.test(stmt) || lines[j]!.includes("innerHTML")) break;
-      stmt += "\n" + lines[j];
-    }
-    if (!stmt.includes("${")) continue;
-    for (const expr of interpolations(stmt)) {
-      if (SAFE.test(expr) || COLD.test(expr)) continue;
-      if (HOT.test(expr)) out.push(expr);
-    }
-  }
-  return out;
-}
-
-/**
- * Every `${...}` in `src`, matched by BRACE DEPTH rather than by a regex.
+ * Three hand-rolled scanners preceded this, and each one drew a review finding that was correct:
  *
- * `/\$\{([^}]*)\}/g` stops at the FIRST `}`, so any interpolation containing one — an object
- * literal, a nested template, a `.map()` with a block body — was captured truncated. The proof was
- * sitting in this file's own baseline: `statusChip(LABEL[r.review_status], { tone: TONE[...]` had
- * been frozen with its tail cut off at the inner brace. A truncated identity is worse than a
- * missing one, because it is a string that can match a DIFFERENT real expression later.
+ *  1. `/\$\{([^}]*)\}/g` on a single LINE — blind to any statement wrapped across lines, which was
+ *     58 of ~120 sinks.
+ *  2. The same regex over an accumulated statement — truncated at the first `}`, so an object
+ *     literal or nested template was frozen as a FRAGMENT. This file's own baseline carried one.
+ *  3. A brace-depth scanner with an 8-line span — still blind to `}` inside a regex literal
+ *     (`/}/`) or a comment (`/* } *\/`, `// }`), still capped by an arbitrary line budget, and
+ *     still returning only the OUTER expression of a nested template, so an outer `esc(...)` made
+ *     `SAFE` accept an unescaped inner value.
  *
- * Tracks backticks and quotes so a `}` inside a string literal does not close the interpolation.
+ * *Each fix made the scanner more elaborate and left a narrower version of the same gap.* The
+ * convergent answer is not a fourth scanner: `typescript` is already a dependency and
+ * `api/responseUndeclared.test.ts` already parses with it. The real parser handles nesting,
+ * comments, regex literals and statement spans by construction, and cannot be wrong about them in
+ * the way a character scanner is wrong.
+ *
+ * Nested spans are returned INDEPENDENTLY, which is the security-relevant part: an unescaped inner
+ * value is judged on its own rather than hidden behind an outer `esc(`.
  */
 export function interpolations(src: string): string[] {
+  const sf = ts.createSourceFile("x.ts", src, ts.ScriptTarget.Latest, true);
   const out: string[] = [];
-  for (let i = 0; i + 1 < src.length; i++) {
-    if (src[i] !== "$" || src[i + 1] !== "{") continue;
-    let depth = 1, j = i + 2, quote = "";
-    for (; j < src.length && depth > 0; j++) {
-      const c = src[j]!;
-      if (quote) {
-        if (c === "\\") j++;
-        else if (c === quote) quote = "";
-        continue;
+  const collect = (node: ts.Node): void => {
+    if (ts.isTemplateExpression(node)) {
+      for (const span of node.templateSpans) {
+        out.push(span.expression.getText(sf).trim());
+        collect(span.expression);            // nested templates yield their own spans
       }
-      if (c === '"' || c === "'" || c === "`") quote = c;
-      else if (c === "{") depth++;
-      else if (c === "}") depth--;
+      return;
     }
-    if (depth !== 0) continue;              // unterminated within the captured statement
-    out.push(src.slice(i + 2, j - 1).trim());
-    i = j - 1;
-  }
+    ts.forEachChild(node, collect);
+  };
+  const walk = (node: ts.Node): void => {
+    const isInnerHtmlWrite =
+      ts.isBinaryExpression(node)
+      && (node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          || node.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken)
+      && ((ts.isPropertyAccessExpression(node.left) && node.left.name.text === "innerHTML")
+          || (ts.isElementAccessExpression(node.left)
+              && ts.isStringLiteral(node.left.argumentExpression)
+              && node.left.argumentExpression.text === "innerHTML"));
+    if (isInnerHtmlWrite) collect(node.right);
+    ts.forEachChild(node, walk);
+  };
+  walk(sf);
   return out;
 }
 
-/** How many lines a single `innerHTML = ...` statement may span before the scan gives up. */
-const STATEMENT_SPAN = 8;
+/** Every hot, unescaped interpolation reaching innerHTML, as its expression text. */
+export function hotSinks(src: string): string[] {
+  return interpolations(src).filter((e) => !SAFE.test(e) && !COLD.test(e) && HOT.test(e));
+}
+
 
 /**
  * THE VERDICT, separate from the reporting, and mutated directly by the self-tests below.
@@ -443,11 +436,25 @@ describe("innerHTML escaping ratchet (identity-keyed)", () => {
     // test was wrong, not the parser.
     expect(hotSinks('e.innerHTML = `<b>${chip(x, { tone: T[s.name] })}</b>`;'))
       .toEqual(["chip(x, { tone: T[s.name] })"]);
-    // a `}` inside a string literal must not close the interpolation
-    expect(interpolations('${f("a}b")}')).toEqual(['f("a}b")']);
-    // a nested template literal
-    expect(interpolations("${xs.map((i) => `<i>${i.name}</i>`).join(\"\")}"))
-      .toEqual(['xs.map((i) => `<i>${i.name}</i>`).join("")']);
+    // a `}` inside a string literal must not close the interpolation. NB the fixture has to be a
+    // complete `innerHTML` assignment now: the AST walker collects from innerHTML WRITES, so a bare
+    // `${...}` fragment correctly yields nothing — the first draft of this line passed a fragment
+    // and read as a parser failure.
+    expect(interpolations('x.innerHTML = `${f("a}b")}`;')).toEqual(['f("a}b")']);
+    // A nested template returns the outer expression AND the inner span, independently. The
+    // earlier draft asserted the outer ONLY, which is the hole a reviewer then found: `SAFE`
+    // matches `esc(` anywhere in the outer text, so an outer escape made an unescaped INNER value
+    // invisible. Judging each span on its own is the security-relevant behaviour.
+    expect(interpolations("x.innerHTML = `${xs.map((i) => `<i>${i.name}</i>`).join(\"\")}`;"))
+      .toEqual(['xs.map((i) => `<i>${i.name}</i>`).join("")', "i.name"]);
+    // ...so an outer esc() no longer launders an inner unescaped value
+    expect(hotSinks("x.innerHTML = `${esc(a) + xs.map((i) => `${i.name}`).join(\"\")}`;"))
+      .toEqual(["i.name"]);
+    // `}` inside a regex literal or a comment does not terminate the interpolation
+    expect(interpolations("x.innerHTML = `${v && /}/ ? a.name : b.name}`;"))
+      .toEqual(["v && /}/ ? a.name : b.name"]);
+    expect(interpolations("x.innerHTML = `${v /* } */ .label}`;")).toEqual(["v /* } */ .label"]);
+    expect(interpolations("x.innerHTML = `${v // }\n .label}`;")).toEqual(["v // }\n .label"]);
     // and no baselined entry may be a truncated fragment ending mid-expression
     for (const [file, exprs] of Object.entries(BASELINE)) {
       for (const e of exprs) {

--- a/apps/web/src/ui/innerHtmlGuard.test.ts
+++ b/apps/web/src/ui/innerHtmlGuard.test.ts
@@ -1,23 +1,50 @@
 /**
- * SEC — a ratchet on unescaped `innerHTML` interpolation.
+ * SEC — an IDENTITY ratchet on unescaped `innerHTML` interpolation.
  *
  * The 2026-07 audit found user-controlled text reaching `innerHTML` unescaped: a submittal title
- * lifted from an UPLOADED document, a `trade` parameter echoed straight back, an upload filename, and
- * server error strings (a 422 detail can quote the caller's own input). Each was one missed `esc()`
- * away from stored XSS, and the surrounding code in those very functions already used `textContent` —
- * so the defect was inconsistency, not ignorance.
+ * lifted from an UPLOADED document, a `trade` parameter echoed straight back, an upload filename,
+ * and server error strings. Each was one missed `esc()` away from stored XSS, and the surrounding
+ * code in those very functions already used `textContent` — the defect was inconsistency, not
+ * ignorance.
  *
- * Escaping every remaining site at once is not safe to do blind: many interpolations are literals
- * passed to a helper (`stat("Budget", n)`) and a few deliberately carry markup (rail icons). So this
- * does not demand zero — it demands that the number never grows.
+ * **THIS GATE USED TO COUNT, AND A COUNT HAS NO IDENTITY.** The baseline was a per-file NUMBER, so
+ * a file sitting inside its allowance was never looked at again: you could remove a safe sink and
+ * add a live XSS sink in the same file and the gate stayed green both times. On 2026-09-12 it was
+ * doing exactly that. `register.ts` was allowed 6 and had 4, and two of the four were
+ * `${a.filename}` — the raw multipart filename, unsanitised from `routers/modules.py`, persisted
+ * verbatim, and rendered into `innerHTML`. A reviewer role could upload `<img src=x onerror=…>.pdf`
+ * and every viewer of that record ran it. The gate had counted it for months, on the exact vector
+ * its own docstring names.
  *
- * **Improving the code must never fail the build.** An earlier draft also failed when a file dropped
- * BELOW its baseline, to keep the numbers honest. That punished the exact behaviour it wanted: a
- * contributor who escaped one interpolation got a red build, and on this repo an autonomous agent
- * commits straight to main and would trip it without knowing this file exists. The rule is now
- * one-directional — down is always fine, up is never fine.
+ * There was headroom at the top level too: BASELINE_TOTAL was 85 against 77 actual, and SEVEN files
+ * the baseline had never heard of were sitting in that slack, passing silently.
  *
- * CLAUDE.md: "If a rule matters, write it as a test — anything held only as prose will drift."
+ * **AND IT WAS BLIND TO HALF ITS OWN POPULATION, which is the worse of the two defects.** The rule
+ * required `innerHTML` and `${` on the SAME LINE, so a statement wrapped across lines — the normal
+ * shape for any non-trivial row — was scanned only as far as its first chunk. Measured 2026-09-12
+ * while converting this file: 62 sinks visible to the line-scoped rule, and **58 more sitting on
+ * continuation lines it could not see**, among them `v.vendor`, `s.company`, `r.text`, `t.title`
+ * and `cert.ref`. *A ratchet's SCOPE is a separate question from its RULE, and a green ratchet is
+ * exactly what makes a scope error invisible* — the lesson `services/api/test_ruff_scope.py` paid
+ * for, repeated here in a different file. `hotSinks` now accumulates the whole statement.
+ *
+ * **So the baseline is now keyed on IDENTITY — `file :: expression` — and the count is derived,
+ * never asserted.** An expression this list has not seen fails even when the total is flat or under.
+ * A substitution can no longer hide inside an allowance, because there is no allowance.
+ *
+ * **Down is still always fine, and that is deliberate.** An entry that VANISHES never fails. An
+ * earlier draft of the counting version failed when a file dropped below its baseline, which
+ * punished the exact behaviour it wanted — a contributor who escaped one interpolation got a red
+ * build. Improving the code must never fail a build. Prune vanished entries when convenient;
+ * nothing forces it.
+ *
+ * WHAT THE ENTRIES ARE. Most are helper PARAMETERS — `card(label, value)` in `operations.ts:53` and
+ * its ~14 siblings — whose callers today all pass string literals and `String(n)`. That is safe by
+ * accident of caller, not by construction: the parameter is typed `string`, so the day a caller
+ * passes server text this gate sees NO CHANGE, because the identity is already frozen. Identity
+ * keying closes substitution within a file; it cannot see an argument's source change. The durable
+ * fix for those is `esc()` INSIDE each helper, which deletes ~30 entries at once and cannot rot.
+ * That is follow-up work, and it can only ever remove entries from this list.
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
@@ -28,51 +55,189 @@ const SRC = join(__dirname, "..");
 
 /** Escapers that make an interpolation safe. Tested per `${…}`, never per line. */
 const SAFE = /\b(esc|escapeHtml|sanitizeSvg|safeUrl)\s*\(/;
-/** Identifiers that carry free text a user or a third-party document controls. */
+/**
+ * Identifiers that carry free text a user or a third-party document controls.
+ *
+ * `assignee`, `ref`, `owner`, `party` and `recipient` were added on 2026-09-12. They cost NOTHING —
+ * zero new entries — because the sites carrying them were escaped in the same change; what they buy
+ * is that re-introducing `${c.assignee}` unescaped now fails. `status` was CONSIDERED AND REJECTED:
+ * it added 14 hits of which ~12 were CSS-variable ternaries (`good ? "var(--status-good)" : …`) and
+ * `statusColor(a.status)`, all of which produce colour literals. *A detector that mostly reports
+ * false positives makes the frozen list worse, because it buries the real entries in it.*
+ */
 const HOT =
-  /(name|title|desc|description|message|label|file|filename|user|author|comment|note|text|trade|source|summary|subject|company|vendor|email|address|code|mark|tag|reason|detail|question|answer|value|key|spec_section|type)\b/i;
+  /(name|title|desc|description|message|label|file|filename|user|author|comment|note|text|trade|source|summary|subject|company|vendor|email|address|code|mark|tag|reason|detail|question|answer|value|key|spec_section|type|assignee|ref|owner|party|recipient)\b/i;
 /** Structurally safe to interpolate: loop counters, lengths, numbers. */
 const COLD = /^(i|idx|j|n|k|len|count|total|pct|num|\d+)$/i;
 
 /**
- * Known unescaped interpolations, per file. Every entry is a place a future reader should check
- * rather than trust. Lower a number freely; raising one needs a reason.
+ * Known unescaped interpolations, as `file -> expressions`. Every entry is a place a future reader
+ * should CHECK rather than trust — which is what the counting version claimed and could not deliver,
+ * because a number does not say which sink it is describing.
  */
-const BASELINE: Record<string, number> = {
-  // 2 -> 1 on 2026-09-12 (SCENARIO-SOURCES review). One of the two WAS a live stored XSS:
-  // `Latest scenario: <b>${latest.name}</b>`, where `ScenarioIn.name` is an unconstrained `str`
-  // persisted verbatim by `create_scenario`. **This ratchet stayed green over it for months,
-  // because counting a sink is how this file records one** — the entry says "a future reader
-  // should check this", and the check never happened. A review bot found it by reading the
-  // code the baseline had frozen. *A number that licenses a defect is indistinguishable from a
-  // number that merely describes one; only reading the site tells them apart.*
-  "main.ts": 1,
-  "portal/panels/aiassist.ts": 3,
-  "portal/panels/analytics.ts": 6,
-  "portal/panels/budget.ts": 4,
-  "portal/panels/design.ts": 2,
-  "portal/panels/evm.ts": 1,
-  "portal/panels/operations.ts": 5,
-  "portal/panels/resourceLoading.ts": 1,
-  "portal/panels/schedule.ts": 6,
-  "portal/panels/standards.ts": 8,
-  "portal/panels/traceability.ts": 1,
-  "portal/panels/wip.ts": 1,
-  // v0.3.850 split the register renderer out of `portal.ts`; the 14 that lived in one file are now
-  // 8 + 6 across two. Re-split rather than left at 14, because a per-file allowance parked above the
-  // file's real count is headroom for a new sink — the repo-wide total below never noticed the move.
-  "portal/portal.ts": 8,
-  "portal/register/register.ts": 6,
-  "proforma/proforma.ts": 16,
-  "reportCenter.ts": 4,
-  "studio/nodeEditor.ts": 1,
-  "ui/onboarding.ts": 1,
-  "ui/result.ts": 3,
-  "viewer/app.ts": 6,
-  "viewer/draft/draftPanel.ts": 1,
+const BASELINE: Record<string, readonly string[]> = {
+  "main.ts": [
+    "it.label",
+  ],
+  "portal/homes/developerHome.ts": [
+    "label",
+  ],
+  "portal/panels/aiassist.ts": [
+    "(p.title || p.ref || p.id) as string",
+    "r.message || \"No bids to level.\"",
+    "r.recommendation.note",
+    "r.source === \"claude\" ? \"AI\" : \"extract\"",
+    "r.source === \"claude\" ? \"AI\" : \"rules\"",
+    "title",
+  ],
+  "portal/panels/analytics.ts": [
+    "c.cost_code",
+    "cb.message || \"No cost history yet.\"",
+    "o.label",
+    "o.label === s.recommended ? \"★ \" : \"\"",
+    "o.label === s.recommended ? ' style=\"background:var(--hover)\"' : \"\"",
+    "r.label",
+    "r.message || \"No material quantities.\"",
+    "r.message || \"No reclassification suggestions (load a model in the Model workspace).\"",
+    "r.pricing_source",
+    "s.note",
+    "title",
+  ],
+  "portal/panels/budget.ts": [
+    "g.contract_value ? \" · \" : \"\"",
+    "label",
+    "usd(g.contract_value)",
+    "usd(s.contract_value)",
+    "usd(t.contract_value)",
+  ],
+  "portal/panels/design.ts": [
+    "(e as Error).message",
+    "label",
+    "value",
+    "x.label",
+  ],
+  "portal/panels/evm.ts": [
+    "label",
+    "value",
+  ],
+  "portal/panels/masterBuilder.ts": [
+    "st.label",
+  ],
+  "portal/panels/operations.ts": [
+    "d.code ?? \"\"",
+    "label",
+    "title",
+    "value",
+  ],
+  "portal/panels/portfolio.ts": [
+    "label",
+    "usd(w.weighted_value)",
+  ],
+  "portal/panels/resourceLoading.ts": [
+    "label",
+    "value",
+  ],
+  "portal/panels/schedule.ts": [
+    "mi.name",
+    "title",
+    "title.toLowerCase()",
+  ],
+  "portal/panels/selections.ts": [
+    "dirLabel",
+  ],
+  "portal/panels/standards.ts": [
+    "cov.complete ? \"✅ core documents on file (EIR, BEP, AIR)\"\n        : `⏳ missing core: ${cov.missing.map(esc).join(\", \")",
+    "dp.next_deliverable.ref ?? \"\"",
+    "els.map((e) => e.label).join(\", \")",
+    "label",
+    "m.parent_type",
+    "m.type",
+    "n.ref ?? n.title ?? \"?\"",
+    "o.ref ?? \"\"",
+    "o.type",
+    "value",
+  ],
+  "portal/panels/topicBoard.ts": [
+    "e.detail?.reply_to ? \"↳ \" : \"\"",
+    "e.kind === \"comment\" ? \"💬 \" : \"\"",
+  ],
+  "portal/panels/traceability.ts": [
+    "label",
+    "value",
+  ],
+  "portal/panels/wip.ts": [
+    "flagText",
+    "label",
+    "value",
+  ],
+  "portal/portal.ts": [
+    "label",
+    "n.reason === \"assigned\" ? \"rfi\" : \"open\"",
+    "rs.source === \"claude\" ? \"AI\" : \"rules\"",
+    "top.reason",
+  ],
+  "portal/register/register.ts": [
+    "c.geo ? \"\" : \" (text search only)\"",
+  ],
+  "proforma/massingTab.ts": [
+    "label",
+  ],
+  "proforma/proforma.ts": [
+    "cd.by_cost_code.length - top.length",
+    "cipNote",
+    "e.source === \"cip\" ? \" <span class=\\\"meta\\\">(CIP)</span>\" : \"\"",
+    "label",
+    "money(pf.terminal_value)",
+    "money(rec.value)",
+    "title",
+    "x.code",
+  ],
+  "proforma/testfitTab.ts": [
+    "label",
+  ],
+  "reportCenter.ts": [
+    "money(s.approved_value)",
+    "money(s.executed_value)",
+    "money(s.pending_value)",
+    "money(s.total_value)",
+  ],
+  "shell/nextAction.ts": [
+    "action.label",
+  ],
+  "studio/nodeEditor.ts": [
+    "spec.label",
+  ],
+  "ui/checklist.ts": [
+    "isDone ? \"text-decoration:line-through\" : \"\"",
+    "it.label",
+  ],
+  "ui/onboarding.ts": [
+    "desc",
+    "s.title",
+    "title",
+  ],
+  "ui/result.ts": [
+    "m.label",
+    "m.value",
+  ],
+  "viewer/app.ts": [
+    "reason",
+    "title",
+  ],
+  "viewer/tools/authoringSection.ts": [
+    "r.imported.slice(0, 3).map((i) => i.name).join(\", \")",
+  ],
+  "viewer/tools/contentLibrarySection.ts": [
+    "it.label",
+  ],
+  "viewer/tools/modelReviewPanel.ts": [
+    "statusChip(LABEL[r.review_status], { tone: TONE[r.review_status]",
+  ],
+  "viewer/tools/qaSection.ts": [
+    "a.r_value",
+    "label",
+  ],
 };
-
-const BASELINE_TOTAL = Object.values(BASELINE).reduce((a, b) => a + b, 0);
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
@@ -84,63 +249,134 @@ function walk(dir: string, out: string[] = []): string[] {
 }
 
 /**
- * Count EVERY hot, unescaped interpolation pushed into innerHTML — not one per line.
+ * Every hot, unescaped interpolation pushed into innerHTML, as its expression text.
  *
- * An earlier draft stopped at the first hot match on a line, which meant adding a second unescaped
- * value to an already-counted line was invisible: `` `<b>${d.label}</b>` `` growing into
- * `` `<b>${d.label}</b><i>${d.author}</i>` `` kept the count at 1. That is exactly the shape of edit
- * that grows an existing render function.
+ * Per `${…}`, not per line: an earlier draft stopped at the first hot match on a line, so adding a
+ * second unescaped value to an already-counted line was invisible.
  */
-function hotSinks(src: string): number {
-  let n = 0;
-  for (const line of src.split("\n")) {
-    if (!line.includes("innerHTML") || !line.includes("${")) continue;
-    for (const m of line.matchAll(/\$\{([^}]*)\}/g)) {
+export function hotSinks(src: string): string[] {
+  const out: string[] = [];
+  const lines = src.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!lines[i]!.includes("innerHTML")) continue;
+    // Accumulate the WHOLE statement, not just this line. An `innerHTML = ` + `...`` assignment
+    // wrapped across lines put every continuation line out of reach of the original line-scoped
+    // rule: it required `innerHTML` and `${` on the SAME line, so a statement broken after the
+    // first template chunk was half-invisible. Measured 2026-09-12: 58 hot sinks were sitting on
+    // continuation lines, against 62 the line-scoped rule could see — the gate was blind to
+    // roughly half its own population, and had been since it was written.
+    let stmt = lines[i]!;
+    for (let j = i + 1; j < Math.min(i + STATEMENT_SPAN, lines.length); j++) {
+      if (/;\s*$/.test(stmt) || lines[j]!.includes("innerHTML")) break;
+      stmt += "\n" + lines[j];
+    }
+    if (!stmt.includes("${")) continue;
+    for (const m of stmt.matchAll(/\$\{([^}]*)\}/g)) {
       const expr = (m[1] ?? "").trim();
       if (SAFE.test(expr) || COLD.test(expr)) continue;
-      if (HOT.test(expr)) n++;
+      if (HOT.test(expr)) out.push(expr);
     }
   }
-  return n;
+  return out;
+}
+
+/** How many lines a single `innerHTML = ...` statement may span before the scan gives up. */
+const STATEMENT_SPAN = 8;
+
+/**
+ * THE VERDICT, separate from the reporting, and mutated directly by the self-tests below.
+ *
+ * `mixinStaging.test.ts` records why: a check that asserts a site was REPORTED is not asserting how
+ * it was CLASSIFIED, and an analyser mutated to call everything safe can still pass a
+ * "was it reported?" test. So this returns the failing set and the tests mutate this function's
+ * input, not the file walker's.
+ */
+export function unknownIdentities(
+  actual: Record<string, readonly string[]>,
+  baseline: Record<string, readonly string[]>,
+): string[] {
+  const out: string[] = [];
+  for (const [file, exprs] of Object.entries(actual)) {
+    const known = new Set(baseline[file] ?? []);
+    for (const e of exprs) if (!known.has(e)) out.push(`${file} :: ${e}`);
+  }
+  return out.sort();
 }
 
 const ADVICE =
   "Wrap the interpolated value in esc()/escapeHtml() — an uploaded document's title, a filename, " +
-  "or a 422 detail quoting the caller's own input is attacker-controlled text.";
+  "or a 422 detail quoting the caller's own input is attacker-controlled text. If it is genuinely " +
+  "a local literal, add the exact expression to BASELINE with a note saying why.";
 
-describe("innerHTML escaping ratchet", () => {
-  const actual: Record<string, number> = {};
-  for (const file of walk(SRC)) {
-    const n = hotSinks(readFileSync(file, "utf8"));
-    if (n) actual[relative(SRC, file).replace(/\\/g, "/")] = n;
-  }
-  const total = Object.values(actual).reduce((a, b) => a + b, 0);
+const actual: Record<string, string[]> = {};
+for (const file of walk(SRC)) {
+  const hits = hotSinks(readFileSync(file, "utf8"));
+  if (hits.length) actual[relative(SRC, file).replace(/\\/g, "/")] = hits;
+}
+const sinkCount = Object.values(actual).reduce((a, b) => a + b.length, 0);
 
-  it("adds no unescaped innerHTML interpolation to an already-known file", () => {
-    // Only files the baseline names. A file that was renamed away simply reports 0 here, which can
-    // never fail — the total below is what keeps a rename from laundering a new sink.
-    const regressions: string[] = [];
-    for (const [file, allowed] of Object.entries(BASELINE)) {
-      const n = actual[file] ?? 0;
-      if (n > allowed) regressions.push(`${file}: ${n} unescaped, baseline ${allowed}. ${ADVICE}`);
-    }
-    expect(regressions).toEqual([]);
+describe("innerHTML escaping ratchet (identity-keyed)", () => {
+  it("is reading a real source tree", () => {
+    // Without this, a walker returning nothing reports a clean tree — "found nothing" and "did not
+    // look" must not be the same output.
+    expect(Object.keys(actual).length, "no files with hot sinks at all — the walker is broken")
+      .toBeGreaterThan(15);
+    expect(sinkCount, "no sinks at all — the matcher is broken").toBeGreaterThan(40);
   });
 
-  it("does not grow the repo-wide count", () => {
-    // Rename-proof and improvement-friendly: moving a file keeps the total flat, escaping anything
-    // lowers it, and only genuinely NEW unescaped text can push it up. This is also the gate that
-    // covers files the baseline has never heard of.
-    const newcomers = Object.keys(actual)
-      .filter((f) => !(f in BASELINE))
-      .map((f) => `${f} (${actual[f]})`);
-    expect(
-      `${total} unescaped interpolation(s)` +
-        (total > BASELINE_TOTAL && newcomers.length ? ` — not baselined: ${newcomers.join(", ")}` : ""),
-    ).toBe(
-      total > BASELINE_TOTAL
-        ? `at most ${BASELINE_TOTAL}. ${ADVICE}`
-        : `${total} unescaped interpolation(s)`,
-    );
+  it("introduces no interpolation this list has not seen", () => {
+    expect(unknownIdentities(actual, BASELINE).join("\n") || "none", ADVICE).toBe("none");
+  });
+
+  it("never fails because an entry VANISHED — improving the code must not red the build", () => {
+    // SYNTHETIC `actual`, deliberately not the live tree. The first draft of this asserted
+    // `unknownIdentities(actual, {...BASELINE, ghost}) === []` against the real scan, which mixes
+    // two questions: it fails whenever ANY new sink exists, with a message blaming the ghost
+    // ("improving the code must not red the build") while the real cause is that somebody ADDED an
+    // interpolation. *A failure message that can misdiagnose is worse than one that stays silent,
+    // because somebody acts on it* — the lesson `test_scratch_ignored.py` paid for. Caught here by
+    // mutating a real file and reading BOTH failures instead of only the expected one.
+    const fixture = { "a.ts": ["kept.name"] };
+    const withGhosts = { "a.ts": ["kept.name", "gone.title"], "no/such/file.ts": ["ghost.name"] };
+    expect(unknownIdentities(fixture, withGhosts), "a vanished entry must be silent").toEqual([]);
+    // ...while the opposite direction still fires: no baseline at all means every sink is unknown.
+    expect(unknownIdentities(fixture, {})).toEqual(["a.ts :: kept.name"]);
+  });
+
+  it("CATCHES A SUBSTITUTION, which the counting version could not", () => {
+    // This is the whole argument for the rewrite. Take a real baselined file, DELETE one known sink
+    // and ADD a different unescaped one. The count is unchanged, so the old rule stayed green.
+    const file = "portal/panels/evm.ts";
+    const known = BASELINE[file]!;
+    expect(known, "fixture file must still be baselined").toContain("value");
+
+    const before = { [file]: [...known] };
+    const after = { [file]: known.filter((e) => e !== "value").concat("attacker.name") };
+
+    // The mutation must actually have applied — a mutation that does not apply is a test that was
+    // never exercised, and it reports green exactly like a passing one (mixinStaging.test.ts, #542).
+    expect(after[file]).not.toEqual(before[file]);
+    expect(after[file]!.length, "substitution must keep the COUNT identical").toBe(before[file]!.length);
+
+    // Old rule: count <= allowance. Same length, so it passed.
+    expect(after[file]!.length <= before[file]!.length).toBe(true);
+    // New rule: the identity is unknown, so it fails.
+    expect(unknownIdentities(after, BASELINE)).toEqual([`${file} :: attacker.name`]);
+  });
+
+  it("detects the filename sink this gate used to count", () => {
+    // register.ts's `${a.filename}` was a LIVE stored XSS sitting inside a count allowance. It is
+    // escaped now, so it must NOT appear — and the matcher must still be able to see its shape.
+    expect(hotSinks('x.innerHTML = `<span>${a.filename}</span>`;')).toEqual(["a.filename"]);
+    expect(hotSinks('x.innerHTML = `<span>${esc(a.filename)}</span>`;')).toEqual([]);
+    expect(BASELINE["portal/register/register.ts"] ?? []).not.toContain("a.filename");
+  });
+
+  it("sees the free-text identifiers added with this change", () => {
+    // The widened HOT terms, asserted directly: re-introducing any of these unescaped must fail.
+    for (const expr of ["c.assignee", "c.ref", "s.vendor", "lane.trade", "x.owner", "p.recipient"]) {
+      expect(hotSinks("e.innerHTML = `<b>${" + expr + "}</b>`;"), `${expr} must be detected`)
+        .toEqual([expr]);
+    }
   });
 });

--- a/apps/web/src/ui/innerHtmlGuard.test.ts
+++ b/apps/web/src/ui/innerHtmlGuard.test.ts
@@ -66,7 +66,7 @@ const SAFE = /\b(esc|escapeHtml|sanitizeSvg|safeUrl)\s*\(/;
  * false positives makes the frozen list worse, because it buries the real entries in it.*
  */
 const HOT =
-  /(name|title|desc|description|message|label|file|filename|user|author|comment|note|text|trade|source|summary|subject|company|vendor|email|address|code|mark|tag|reason|detail|question|answer|value|key|spec_section|type|assignee|ref|owner|party|recipient)\b/i;
+  /(name|title|desc|description|message|label|file|filename|user|author|comment|note|text|trade|source|summary|subject|company|vendor|email|address|code|mark|tag|reason|detail|question|answer|value|key|spec_section|type|assignee|ref|owner|party|recipient|requirement|section|body|content|remark|scope|clause)\b/i;
 /** Structurally safe to interpolate: loop counters, lengths, numbers. */
 const COLD = /^(i|idx|j|n|k|len|count|total|pct|num|\d+)$/i;
 
@@ -85,8 +85,10 @@ const BASELINE: Record<string, readonly string[]> = {
   "portal/panels/aiassist.ts": [
     "(p.title || p.ref || p.id) as string",
     "r.message || \"No bids to level.\"",
+    "r.recommendation.missing_scope.length ? \"var(--status-warn)\" : \"var(--status-good)\"",
     "r.recommendation.note",
     "r.source === \"claude\" ? \"AI\" : \"extract\"",
+    "r.source === \"claude\" ? \"AI\" : \"rules\"",
     "r.source === \"claude\" ? \"AI\" : \"rules\"",
     "title",
   ],
@@ -97,8 +99,10 @@ const BASELINE: Record<string, readonly string[]> = {
     "o.label === s.recommended ? \"★ \" : \"\"",
     "o.label === s.recommended ? ' style=\"background:var(--hover)\"' : \"\"",
     "r.label",
+    "r.label",
     "r.message || \"No material quantities.\"",
     "r.message || \"No reclassification suggestions (load a model in the Model workspace).\"",
+    "r.pricing_source",
     "r.pricing_source",
     "s.note",
     "title",
@@ -126,11 +130,14 @@ const BASELINE: Record<string, readonly string[]> = {
   "portal/panels/operations.ts": [
     "d.code ?? \"\"",
     "label",
+    "label",
     "title",
+    "value",
     "value",
   ],
   "portal/panels/portfolio.ts": [
     "label",
+    "t.cross_project ? ` <span style=\"color:${col}\" title=\"on ${t.project_count} projects — can be double-booked\">⇄</span>` : \"\"",
     "usd(w.weighted_value)",
   ],
   "portal/panels/resourceLoading.ts": [
@@ -146,15 +153,17 @@ const BASELINE: Record<string, readonly string[]> = {
     "dirLabel",
   ],
   "portal/panels/standards.ts": [
-    "cov.complete ? \"✅ core documents on file (EIR, BEP, AIR)\"\n        : `⏳ missing core: ${cov.missing.map(esc).join(\", \")",
-    "dp.next_deliverable.ref ?? \"\"",
+    "cov.complete ? \"✅ core documents on file (EIR, BEP, AIR)\"\n        : `⏳ missing core: ${cov.missing.map(esc).join(\", \")}`",
     "els.map((e) => e.label).join(\", \")",
+    "label",
+    "label",
     "label",
     "m.parent_type",
     "m.type",
     "n.ref ?? n.title ?? \"?\"",
     "o.ref ?? \"\"",
     "o.type",
+    "value",
     "value",
   ],
   "portal/panels/topicBoard.ts": [
@@ -172,6 +181,8 @@ const BASELINE: Record<string, readonly string[]> = {
   ],
   "portal/portal.ts": [
     "label",
+    "label",
+    "label",
     "n.reason === \"assigned\" ? \"rfi\" : \"open\"",
     "rs.source === \"claude\" ? \"AI\" : \"rules\"",
     "top.reason",
@@ -187,8 +198,15 @@ const BASELINE: Record<string, readonly string[]> = {
     "cipNote",
     "e.source === \"cip\" ? \" <span class=\\\"meta\\\">(CIP)</span>\" : \"\"",
     "label",
+    "label",
+    "label",
+    "label",
+    "label",
+    "label",
+    "label",
     "money(pf.terminal_value)",
     "money(rec.value)",
+    "title",
     "title",
     "x.code",
   ],
@@ -203,6 +221,7 @@ const BASELINE: Record<string, readonly string[]> = {
   ],
   "shell/nextAction.ts": [
     "action.label",
+    "action.label",
   ],
   "studio/nodeEditor.ts": [
     "spec.label",
@@ -213,6 +232,7 @@ const BASELINE: Record<string, readonly string[]> = {
   ],
   "ui/onboarding.ts": [
     "desc",
+    "s.body",
     "s.title",
     "title",
   ],
@@ -231,7 +251,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "it.label",
   ],
   "viewer/tools/modelReviewPanel.ts": [
-    "statusChip(LABEL[r.review_status], { tone: TONE[r.review_status]",
+    "statusChip(LABEL[r.review_status], { tone: TONE[r.review_status] })",
   ],
   "viewer/tools/qaSection.ts": [
     "a.r_value",
@@ -271,11 +291,44 @@ export function hotSinks(src: string): string[] {
       stmt += "\n" + lines[j];
     }
     if (!stmt.includes("${")) continue;
-    for (const m of stmt.matchAll(/\$\{([^}]*)\}/g)) {
-      const expr = (m[1] ?? "").trim();
+    for (const expr of interpolations(stmt)) {
       if (SAFE.test(expr) || COLD.test(expr)) continue;
       if (HOT.test(expr)) out.push(expr);
     }
+  }
+  return out;
+}
+
+/**
+ * Every `${...}` in `src`, matched by BRACE DEPTH rather than by a regex.
+ *
+ * `/\$\{([^}]*)\}/g` stops at the FIRST `}`, so any interpolation containing one — an object
+ * literal, a nested template, a `.map()` with a block body — was captured truncated. The proof was
+ * sitting in this file's own baseline: `statusChip(LABEL[r.review_status], { tone: TONE[...]` had
+ * been frozen with its tail cut off at the inner brace. A truncated identity is worse than a
+ * missing one, because it is a string that can match a DIFFERENT real expression later.
+ *
+ * Tracks backticks and quotes so a `}` inside a string literal does not close the interpolation.
+ */
+export function interpolations(src: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i + 1 < src.length; i++) {
+    if (src[i] !== "$" || src[i + 1] !== "{") continue;
+    let depth = 1, j = i + 2, quote = "";
+    for (; j < src.length && depth > 0; j++) {
+      const c = src[j]!;
+      if (quote) {
+        if (c === "\\") j++;
+        else if (c === quote) quote = "";
+        continue;
+      }
+      if (c === '"' || c === "'" || c === "`") quote = c;
+      else if (c === "{") depth++;
+      else if (c === "}") depth--;
+    }
+    if (depth !== 0) continue;              // unterminated within the captured statement
+    out.push(src.slice(i + 2, j - 1).trim());
+    i = j - 1;
   }
   return out;
 }
@@ -297,8 +350,16 @@ export function unknownIdentities(
 ): string[] {
   const out: string[] = [];
   for (const [file, exprs] of Object.entries(actual)) {
-    const known = new Set(baseline[file] ?? []);
-    for (const e of exprs) if (!known.has(e)) out.push(`${file} :: ${e}`);
+    // OCCURRENCE BUDGET, not set membership. With a Set, a file baselined for ONE `${user.name}`
+    // silently accepted a second one — the identity was "known", so duplicating a sink was free.
+    // That is the counting version's hole in miniature, reintroduced one level down.
+    const budget = new Map<string, number>();
+    for (const e of baseline[file] ?? []) budget.set(e, (budget.get(e) ?? 0) + 1);
+    for (const e of exprs) {
+      const left = budget.get(e) ?? 0;
+      if (left > 0) budget.set(e, left - 1);
+      else out.push(`${file} :: ${e}`);
+    }
   }
   return out.sort();
 }
@@ -370,6 +431,39 @@ describe("innerHTML escaping ratchet (identity-keyed)", () => {
     expect(hotSinks('x.innerHTML = `<span>${a.filename}</span>`;')).toEqual(["a.filename"]);
     expect(hotSinks('x.innerHTML = `<span>${esc(a.filename)}</span>`;')).toEqual([]);
     expect(BASELINE["portal/register/register.ts"] ?? []).not.toContain("a.filename");
+  });
+
+  it("parses NESTED braces in an interpolation, not up to the first `}`", () => {
+    // Review finding on #543, and this file's own baseline was the evidence: the entry for
+    // modelReviewPanel.ts had been frozen as `statusChip(LABEL[...], { tone: TONE[...]` — cut at
+    // the inner brace by `/\$\{([^}]*)\}/g`. A TRUNCATED identity is worse than a missing one: it
+    // is a string that can later match a different real expression.
+    // NB the fixture must carry a HOT term: the first draft used `T[s.status]`, and `status` was
+    // deliberately excluded from HOT for being mostly CSS ternaries — so it returned [] and the
+    // test was wrong, not the parser.
+    expect(hotSinks('e.innerHTML = `<b>${chip(x, { tone: T[s.name] })}</b>`;'))
+      .toEqual(["chip(x, { tone: T[s.name] })"]);
+    // a `}` inside a string literal must not close the interpolation
+    expect(interpolations('${f("a}b")}')).toEqual(['f("a}b")']);
+    // a nested template literal
+    expect(interpolations("${xs.map((i) => `<i>${i.name}</i>`).join(\"\")}"))
+      .toEqual(['xs.map((i) => `<i>${i.name}</i>`).join("")']);
+    // and no baselined entry may be a truncated fragment ending mid-expression
+    for (const [file, exprs] of Object.entries(BASELINE)) {
+      for (const e of exprs) {
+        const open = (e.match(/\{/g) ?? []).length, close = (e.match(/\}/g) ?? []).length;
+        expect(open, `${file} :: ${e} — unbalanced braces, likely a truncated capture`).toBe(close);
+      }
+    }
+  });
+
+  it("counts DUPLICATE identities, so a second copy of a known sink is not free", () => {
+    // Review finding on #543. With Set membership a file baselined for one `${user.name}` accepted
+    // a second silently — the counting version's hole, reintroduced one level down.
+    const baseline = { "a.ts": ["user.name"] };
+    expect(unknownIdentities({ "a.ts": ["user.name"] }, baseline)).toEqual([]);
+    expect(unknownIdentities({ "a.ts": ["user.name", "user.name"] }, baseline))
+      .toEqual(["a.ts :: user.name"]);
   });
 
   it("sees the free-text identifiers added with this change", () => {

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -2300,7 +2300,9 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   }
   function issueCard(t: Topic): HTMLElement {
     const el = document.createElement("div"); el.className = "issue";
-    el.innerHTML = `<div class="t">${t.title}</div><div class="meta"><span class="badge ${t.type}">${t.type}</span> <span class="badge ${t.status}">${t.status}</span> ${t.assignee ?? ""}</div>`;
+    el.innerHTML = `<div class="t">${escapeHtml(t.title)}</div><div class="meta">`
+      + `<span class="badge ${escapeHtml(t.type)}">${escapeHtml(t.type)}</span> `
+      + `<span class="badge ${escapeHtml(t.status)}">${escapeHtml(t.status)}</span> ${escapeHtml(t.assignee ?? "")}</div>`;
     el.onclick = async () => {
       const vps = projectId ? await api.viewpoints(projectId, t.id) : [];
       restoreCamera(viewer.world, vps[0] ?? null);

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -2300,9 +2300,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
   }
   function issueCard(t: Topic): HTMLElement {
     const el = document.createElement("div"); el.className = "issue";
-    el.innerHTML = `<div class="t">${escapeHtml(t.title)}</div><div class="meta">`
-      + `<span class="badge ${escapeHtml(t.type)}">${escapeHtml(t.type)}</span> `
-      + `<span class="badge ${escapeHtml(t.status)}">${escapeHtml(t.status)}</span> ${escapeHtml(t.assignee ?? "")}</div>`;
+    el.innerHTML = `<div class="t">${escapeHtml(t.title)}</div><div class="meta"><span class="badge ${escapeHtml(t.type)}">${escapeHtml(t.type)}</span> <span class="badge ${escapeHtml(t.status)}">${escapeHtml(t.status)}</span> ${escapeHtml(t.assignee ?? "")}</div>`;
     el.onclick = async () => {
       const vps = projectId ? await api.viewpoints(projectId, t.id) : [];
       restoreCamera(viewer.world, vps[0] ?? null);

--- a/services/api/src/aec_api/docmanager.py
+++ b/services/api/src/aec_api/docmanager.py
@@ -18,7 +18,7 @@ import re
 from datetime import datetime
 from typing import Any
 
-from . import classification, folder_template, naming, pid_lock, storage
+from . import classification, folder_template, naming, pid_lock, serving, storage
 from .timeutil import utc_now
 
 _INDEX = "{pid}/docs/_index.json"
@@ -154,6 +154,9 @@ def upload(pid: str, folder: str, filename: str, data: bytes | None, actor: str,
         # Refused rather than defaulted. Accepting both would make it ambiguous which one was
         # stored; accepting neither would write a zero-byte document and index it as real.
         raise ValueError("pass exactly one of `data` or `chunks`")
+    # Same attacker-controlled multipart value as `modules.add_attachment`, and it reaches further
+    # here: `title` and `ext` are both derived from it below, so it lands in the document index.
+    filename = serving.stored_filename(filename)
     if not folder_template.is_valid(folder):
         raise ValueError(f"'{folder}' is not a standard folder — file into the standard taxonomy")
     node = folder_template.node(folder)

--- a/services/api/src/aec_api/modules.py
+++ b/services/api/src/aec_api/modules.py
@@ -708,12 +708,17 @@ def add_attachment(db: Session, key: str, project_id: str, rid: str, filename: s
     the row cannot record a size the stored object does not have. It is used twice below (the row and
     the response) and both now read the same variable rather than re-deriving it.
     """
-    from . import storage
+    from . import serving, storage
     from .models import RecordAttachment
 
     if (data is None) == (chunks is None):
         raise ValueError("pass exactly one of `data` or `chunks`")
     get_record(db, key, project_id, rid)  # 404 if missing
+    # The multipart filename is attacker-controlled and is BOTH persisted for display and spliced
+    # into the storage key. `storage.validate_key` already refuses `..`/absolute/NUL keys; this
+    # normalises the value that gets stored and rendered back to other users. Escaping stays the
+    # renderer's job -- an XSS fixed by input filtering stays fixed only until the next sink.
+    filename = serving.stored_filename(filename)
     aid = str(uuid.uuid4())
     skey = f"records/{project_id}/{key}/{rid}/{aid}_{filename}"
     if chunks is not None:

--- a/services/api/src/aec_api/serving.py
+++ b/services/api/src/aec_api/serving.py
@@ -27,6 +27,30 @@ def content_disposition(filename: str | None, disposition: str = "attachment",
     return f"{disposition}; filename=\"{ascii_name}\"; filename*=UTF-8''{encoded}"
 
 
+def stored_filename(filename: str | None, fallback: str = "file") -> str:
+    """Normalise a client-supplied filename for PERSISTENCE — the value that goes in a row and is
+    later rendered back to other users.
+
+    Strips any path component and every control character, and caps the length. It deliberately
+    does NOT touch `&`, `<`, `>` or quotes: those are legal in a filename (`Q&A notes.pdf`), and
+    mangling them here would corrupt real names while giving a false sense of safety. **Escaping is
+    the renderer's job** — an XSS fixed by input filtering stays fixed only until the next sink.
+
+    This is hygiene, not the XSS control. The control is `escapeHtml` at the point of interpolation.
+
+    One surprise worth naming, because the first check written against this "failed" on it: a name
+    containing `/` is truncated at the last one, so `Q&A <b>notes</b>.pdf` stores as `b>.pdf`. That
+    is `os.path.basename` doing its job, not this function mangling markup — `/` is a path separator
+    and is not legal in a filename on any mainstream filesystem, so a multipart value carrying one
+    is already either a path or an attack. `Q&A notes.pdf`, `a<b>c.pdf` and quoted names all pass
+    through untouched. *The check was wrong, not the code* — which is only obvious once you print
+    `os.path.basename` on its own.
+    """
+    raw = os.path.basename(filename or "").replace("\\", "/").rsplit("/", 1)[-1]
+    raw = "".join(c for c in raw if ord(c) >= 32 and c != "\x7f").strip()
+    return raw[:255] or fallback
+
+
 def range_response(request: Request, key: str, media_type: str,
                    filename: str | None = None, disposition: str = "inline",
                    immutable: bool = True) -> Response:

--- a/services/api/src/aec_api/serving.py
+++ b/services/api/src/aec_api/serving.py
@@ -27,6 +27,11 @@ def content_disposition(filename: str | None, disposition: str = "attachment",
     return f"{disposition}; filename=\"{ascii_name}\"; filename*=UTF-8''{encoded}"
 
 
+# 255 bytes is the ext4/APFS/NTFS path-component limit; `modules.add_attachment` prefixes the
+# stored name with a 36-char uuid and an underscore, so reserve that much of the budget.
+_STORED_NAME_BYTES = 255 - 37
+
+
 def stored_filename(filename: str | None, fallback: str = "file") -> str:
     """Normalise a client-supplied filename for PERSISTENCE — the value that goes in a row and is
     later rendered back to other users.
@@ -48,7 +53,13 @@ def stored_filename(filename: str | None, fallback: str = "file") -> str:
     """
     raw = os.path.basename(filename or "").replace("\\", "/").rsplit("/", 1)[-1]
     raw = "".join(c for c in raw if ord(c) >= 32 and c != "\x7f").strip()
-    return raw[:255] or fallback
+    # Truncate by UTF-8 BYTES, not characters, and leave room for the caller's prefix. `modules.
+    # add_attachment` builds its storage key as `.../{aid}_{filename}`, and on the local backend
+    # that key becomes a filesystem path whose component limit is 255 BYTES on ext4/APFS. 255
+    # characters of non-ASCII is up to 1020 bytes, so a character cap let a legitimate upload fail
+    # at write time with nothing in `validate_key` to explain it. `encode`/`decode(errors=ignore)`
+    # drops a split multibyte character rather than storing a mojibake tail.
+    return raw.encode("utf-8")[:_STORED_NAME_BYTES].decode("utf-8", "ignore").strip() or fallback
 
 
 def range_response(request: Request, key: str, media_type: str,


### PR DESCRIPTION
# What & why

`apps/web/src/ui/innerHtmlGuard.test.ts` froze a per-file **number** of unescaped `innerHTML` interpolations. A number has no identity, so a file inside its allowance was never looked at again — delete a safe sink, add a live one, the count is unchanged and the gate stays green both times.

It was doing exactly that. `register.ts` was allowed 6 and had 4, and two of the four were `${a.filename}`:

| step | where |
|---|---|
| raw multipart filename, unsanitised | `services/api/src/aec_api/routers/modules.py` — both upload doors |
| persisted verbatim | `services/api/src/aec_api/modules.py` → `record_attachments.filename` |
| returned verbatim | same file, `list_attachments` |
| rendered **unescaped** into `innerHTML` | `apps/web/src/portal/register/register.ts`, both branches |

A user with the `reviewer` role uploads an attachment named ``'&lt;img src=x onerror=…&gt;``.pdf`; everyone who opens that record's attachment list runs it. The default CSP is framing-only, so inline handlers execute — `AEC_CSP=1` blocks the script but not the content injection. `esc` was already imported in that file and used 200 lines away: the inconsistency the gate's own docstring diagnoses, on the exact vector it names ("an upload filename").

**Two defects, and the second is worse.**

- **Headroom.** `BASELINE_TOTAL` was 85 against 77 actual, and seven files the baseline had never heard of sat in that slack, passing silently.
- **Scope.** The rule needed `innerHTML` and `${` on the *same line*, so any statement wrapped across lines was scanned only as far as its first chunk. **62 sinks visible, 58 more on continuation lines it could not see** — among them `v.vendor`, `s.company`, `r.text`, `t.title`, `cert.ref`. A ratchet's scope is a separate question from its rule, and green is what makes a scope error invisible. The same lesson `services/api/test_ruff_scope.py` paid for, in a different file.

The baseline is now keyed on **identity** (`file :: expression`) and the count is derived, never asserted. An unseen expression fails even when the total is flat or under. A **vanished** entry still never fails — improving the code must not red the build, which is why the counting version's downward check was removed and stays removed.

**33 sinks escaped, 30 identities removed**, measured under one rule against `origin/main` (146 sinks / 125 identities) and this head (113 / 95). The first attempt at that figure *added* two counts taken under the narrow and wide detectors and got 29; an arithmetic total across two scopes is not a measurement.

Also in scope: `ui/charts.esc` was a second escaper covering `& < > "` but not `'`, indistinguishable at the call site — there is now one. Two *partial* escapes were completed (`&`/`<` only; `"` only), which are worse than none because they read as handled. Server-side, `serving.stored_filename` normalises the persisted value at both upload doors; it deliberately does **not** strip `&` or `<`, because those are legal in a filename and escaping is the renderer's job.

The decisive test is a **substitution** — delete one baselined sink, add a different one, count identical. The old rule passed it; the new one names the identity. Proved by mutating a real source file and watching the gate go red, which also exposed a bug in my own ghost-tolerance test: it reused the live scan, so any new sink tripped it with a message blaming the ghost. A failure message that can misdiagnose is worse than silence; it uses a fixture now.

Follow-up, deliberately not in this PR: most remaining entries are helper *parameters* (`card(label, value)` and ~14 siblings) whose callers pass literals today. Identity keying cannot see an argument's source change — the durable fix is `esc()` inside each helper, which can only ever remove entries from the list.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree)
- [x] Backend: affected `test_*.py` pass — `test_file_sizes`, `test_claude_md_gates`, `test_doc_substance`, `test_declared_imports`, `test_import_cycles` all green; full local suite was still running at push time and is clean through 265 suites with zero failures. **CI is the authority here.**
- [x] Web: typecheck + build clean; `vitest` 256 files / 2783 tests
- [x] No import cycles introduced (`test_import_cycles.py` and `no-import-cycles.test.ts` pass)
- [x] `CHANGELOG.md` entry added (newest at top)
- [ ] Version bump — not a release PR
- [x] No secrets; no competitor names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved protection against malicious markup across portal, viewer, scheduling, analytics, budgeting, and upload interfaces.
  - User-provided filenames are sanitized before storage and limited safely by UTF-8 byte length.
  - Escaping is applied consistently to displayed names, labels, descriptions, statuses, and other user-provided values.

- **Reliability**
  - Security checks now detect unsafe rendering cases across multiline content, nested expressions, and exact expression changes.

- **Documentation**
  - Updated changelog details clarify diagnostic results from the legacy and current detection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->