### PR TITLE
HELPER-ESCAPE: the escaping gate could not see a helper's parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,34 @@ only because the suspects were *read* rather than counted. And the single real f
 i.e. in the class the new rule deliberately excludes: *the documented gap was live, not theoretical,*
 which is the whole argument for measuring an exclusion instead of asserting one.
 
+**A review round then found the detector's real boundary, and it was hiding a live sink.** The
+scanner walked only the interpolations lexically inside an `innerHTML =` expression. But markup is
+usually assembled into a local FIRST and only then interpolated — `const rows = deals.map(d =>
+\`<tr><th>${d.name}</th>\`)`, then `panel.innerHTML = \`…${rows}…\``. Every span inside that builder
+was invisible to **both** rules: not baselined, not flagged, live. The reviewer found one symptom
+(`d.name`, a saved scenario name that any user can set); behind that one hop sat **15 hot
+interpolations across 8 files**. *The scanner was measuring syntax where the question is
+reachability.* It now follows one hop, and stops there deliberately — a local built from another
+local is still uncovered, and the test asserts that limit rather than leaving it to be discovered.
+
+Nine of the fifteen were real and are escaped: a scenario name, vendor names in a bid-levelling
+matrix, carbon hotspot element names, a takt trade name, project-health domain labels, sources-uses
+line labels, forecast line names, and test-fit scheme names. The remaining six are one shape — a
+ternary whose branches are literal markup or a glyph (`s.name === r.best ? " ★" : ""`) — which match
+the term list on their *condition*, never their value. Escaping any of them would render markup as
+visible text, so they are baselined with that reason: **the fix would be the bug.**
+
+Three more findings from the same round, all real. The value-binding rule ignored **constructor and
+setter parameters** — a coverage hole in a security gate. It resolved bindings **file-wide**, so a
+destructured `rows` in one function made an unrelated plain local `rows` in a sibling fail the
+plain-local exclusion; the rationale written beside that code ("a false positive only costs one
+`esc()` that was already correct") was wrong, because for *this* exclusion the suggested fix escapes
+assembled HTML and breaks the page — *a false positive is only cheap when the fix it suggests is
+safe.* Bindings resolve lexically now. And a milestone `<option>` escaped its **text but not its
+value**: `esc` turns `&` into `&amp;` and the old `.replace(/"/g, …)` did not, so a milestone named
+`A &amp; B` parsed back out as `A & B` and the next request queried the wrong one — asserted now
+through a real DOM parse rather than by reading the template.
+
 One test had to be repaired as a consequence, and the repair is the point. The substitution check
 hardcoded `portal/panels/evm.ts` and the identity `"value"` as its fixture; this change escaped
 every sink in that file, so a legitimate improvement red the test with a message about a missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,56 @@ meaning anything as a heading and the file read as 34 pending releases rather th
 titles are unchanged and now sit at `###` beneath this, in the same order; no text was edited,
 added or dropped in the fold.
 
+### The escaping gate could not see a helper's parameters, so 108 sinks sat outside it
+
+The identity ratchet shipped in the previous entry freezes `file :: expression`. That constrains a
+sink whose expression NAMES its source — `${a.filename}` cannot start carrying something else
+without the identity moving. It does nothing for a bare value binding:
+
+```ts
+const card = (label: string, value: string) => {
+  c.innerHTML = `<div>${value}</div><div class="meta">${label}</div>`;   // identity: "value"
+};
+```
+
+`value` is the identity whatever the caller passes. Every call site could switch from a literal to
+a user-controlled field and the baseline would not move — **the sink goes live while the gate stays
+green**. That is the same defect the ratchet was built to fix, one level up: there the frozen key
+was a count with no identity, here it is an identity with no source.
+
+**108 interpolations across 27 files**, all now escaped. The population was derived by AST — bare
+identifiers reaching `innerHTML` that resolve to a function parameter or a destructuring binding —
+and the fix is verifiable in a way most sweeps are not: escaping a sink can only ever REMOVE entries
+from the ratchet's baseline, never add one. It went **119 → 74 with zero additions**.
+
+Three things this found that the existing gate could not:
+
+- **The HOT term list was hiding 53 of them.** `budget.ts` interpolated a bare `val` and `evm.ts` a
+  bare `sub`; neither word matches any term in the list, so both were invisible to the ratchet while
+  being exactly the shape the new rule exists to catch. Under the term filter the population read
+  32; under the shape rule it read 85. *A keyword list derived from what someone happened to be
+  looking at cannot bound a population — a shape can.*
+- **The first draft of the new rule tested only for parameters, and reported the tree clean at 85
+  fixed sites.** 23 more were live in `for (const [label, val] of cards)` — a destructuring binding
+  is a value handed in from elsewhere exactly as a parameter is, and the name says nothing about the
+  source either way. *A predicate that decides what to LOOK at hides everything it excludes from its
+  own count*, which is why the count looked complete both times.
+- **`register.ts` carried a comment reading "textContent/esc throughout: ref+title are user data
+  (stored-XSS guard)"** directly above the one interpolation on that line that was not escaped.
+
+The new rule takes **no baseline and admits no exemption** — the fix is always available and always
+correct, so there is nothing to grandfather, and grandfathering one would freeze a sink open by
+definition. Its boundary is stated rather than implied: a plain `const x = …` local is out of scope,
+because 157 of those reach `innerHTML` in this tree and most hold markup assembled a few lines
+earlier (`rows`, `thead`, `bars`, `cells`) where escaping would destroy it. A local assigned from
+user data and interpolated bare is caught by neither rule in this file, and the test says so.
+
+One test had to be repaired as a consequence, and the repair is the point. The substitution check
+hardcoded `portal/panels/evm.ts` and the identity `"value"` as its fixture; this change escaped
+every sink in that file, so a legitimate improvement red the test with a message about a missing
+baseline entry rather than about the substitution it guards. The fixture is derived now. *A failure
+message that can misdiagnose is worse than one that stays silent, because somebody acts on it.*
+
 ### A stored XSS the security ratchet had been counting for months
 
 `apps/web/src/ui/innerHtmlGuard.test.ts` froze a per-file **number** of unescaped `innerHTML`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,21 @@ because 157 of those reach `innerHTML` in this tree and most hold markup assembl
 earlier (`rows`, `thead`, `bars`, `cells`) where escaping would destroy it. A local assigned from
 user data and interpolated bare is caught by neither rule in this file, and the test says so.
 
+**The excluded class was then triaged, not assumed** — an exclusion nobody measures is a blind spot
+with a justification attached. All 134 bare locals were classified by their declaration's initialiser
+(41 build markup, 39 literal, 15 numeric, 1 already escaped, 36 suspect, 2 unresolvable) and every
+suspect and unresolvable one was read. Exactly **one was a real sink**: the CPM panel's critical-path
+line, where the server builds `critical_path` as `[r["ref"] or r["id"] …]` — stored, user-entered
+activity refs — and the panel joined and interpolated them raw into `innerHTML`. Anyone who can name
+a schedule activity could put markup in it and have it run for everyone who opens that panel. Fixed.
+
+Two things about that triage are worth keeping. Its first draft resolved declarations **file-wide and
+kept the last match**, so one panel's `gap` (a number) was attributed to an unrelated `el("div")`
+hundreds of lines away and reported suspect — the lookup is scope-aware now, and the bug surfaced
+only because the suspects were *read* rather than counted. And the single real finding was a **local**,
+i.e. in the class the new rule deliberately excludes: *the documented gap was live, not theoretical,*
+which is the whole argument for measuring an exclusion instead of asserting one.
+
 One test had to be repaired as a consequence, and the repair is the point. The substitution check
 hardcoded `portal/panels/evm.ts` and the identity `"value"` as its fixture; this change escaped
 every sink in that file, so a legitimate improvement red the test with a message about a missing

--- a/apps/web/src/account/accountUI.ts
+++ b/apps/web/src/account/accountUI.ts
@@ -648,14 +648,14 @@ function errorsModal() {
       data.errors.map((e, i) => {
         const where = [e.method, e.path].filter(Boolean).join(" ") + (e.status ? ` · ${e.status}` : "");
         const rid = e.request_id ? `<div class="meta" style="font-size:10px">${escapeHtml(e.request_id)}</div>` : "";
-        const tb = e.traceback ? `<button class="tool-btn" data-tb="${i}" style="font-size:10px;padding:1px 6px">trace</button>` : "";
+        const tb = e.traceback ? `<button class="tool-btn" data-tb="${escapeHtml(i)}" style="font-size:10px;padding:1px 6px">trace</button>` : "";
         return `<tr>` +
           c(new Date(e.ts).toLocaleString(), "white-space:nowrap") + c(badge(e.source)) +
           c(escapeHtml(e.kind ?? "—"), "white-space:nowrap") +
           c(escapeHtml(where) + rid) +
           c(escapeHtml((e.message ?? "").slice(0, 160)), "color:var(--muted)") + c(tb) +
           `</tr>` +
-          (e.traceback ? `<tr id="tb-${i}" style="display:none"><td colspan="6" style="padding:0 8px 8px"><pre style="white-space:pre-wrap;font-size:11px;max-height:220px;overflow:auto;background:var(--panel-2,rgba(128,128,128,.08));padding:8px;border-radius:6px">${escapeHtml(e.traceback)}</pre></td></tr>` : "");
+          (e.traceback ? `<tr id="tb-${escapeHtml(i)}" style="display:none"><td colspan="6" style="padding:0 8px 8px"><pre style="white-space:pre-wrap;font-size:11px;max-height:220px;overflow:auto;background:var(--panel-2,rgba(128,128,128,.08));padding:8px;border-radius:6px">${escapeHtml(e.traceback)}</pre></td></tr>` : "");
       }).join("") + `</table>`;
     table.querySelectorAll<HTMLButtonElement>("button[data-tb]").forEach((b) => {
       b.onclick = () => { const row = table.querySelector<HTMLElement>(`#tb-${b.dataset.tb}`); if (row) row.style.display = row.style.display === "none" ? "table-row" : "none"; };

--- a/apps/web/src/drawings/layoutEditor.ts
+++ b/apps/web/src/drawings/layoutEditor.ts
@@ -1,6 +1,7 @@
 import type { ApiClient } from "../api/client";
 import { sanitizeSvg } from "../ui/sanitizeSvg";
 import { PAGE_CATALOG, isSheetPage, readSheetPage, writeSheetPage } from "../viewer/sheetSpecs";
+import { escapeHtml as esc } from "../ui/feedback";
 
 /** SHEET-VIEWPORTS — the interactive paper-space editor over the v0.3.449 layout endpoints.
  *
@@ -47,7 +48,7 @@ export function openLayoutEditor(api: ApiClient, pid: string, mount: HTMLElement
   };
   const mkSel = (opts: string[], val?: string) => {
     const s = document.createElement("select"); s.className = "portal-filter";
-    s.innerHTML = opts.map((o) => `<option${o === val ? " selected" : ""}>${o}</option>`).join("");
+    s.innerHTML = opts.map((o) => `<option${o === val ? " selected" : ""}>${esc(o)}</option>`).join("");
     return s;
   };
   const mkNum = (val: number | "" = "", step = 0.05, w = 62) => {

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1306,7 +1306,7 @@ async function openPortfolioTab() {
     ["Portfolio IRR", pc(t.portfolio_irr ?? null)], ["Portfolio EM", `${t.portfolio_equity_multiple ?? "—"}×`],
   ];
   const rows = p.deals.map((d) =>
-    `<tr><th style="text-align:left">${d.name}</th><td>${m(d.total_uses)}</td>` +
+    `<tr><th style="text-align:left">${escapeHtml(d.name)}</th><td>${m(d.total_uses)}</td>` +
     `<td>${m(d.equity)}</td><td>${pc(d.equity_irr)}</td><td>${d.equity_multiple ?? "—"}×</td></tr>`).join("");
   panel.innerHTML =
     `<div class="section-title">Portfolio roll-up — ${p.deal_count} deal(s)</div>` +

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1311,7 +1311,7 @@ async function openPortfolioTab() {
   panel.innerHTML =
     `<div class="section-title">Portfolio roll-up — ${p.deal_count} deal(s)</div>` +
     `<div class="kpi-grid">` +
-    kpis.map(([l, v]) => `<div class="kpi"><div class="kpi-v" style="font-size:15px">${v}</div><div class="kpi-l">${l}</div></div>`).join("") +
+    kpis.map(([l, v]) => `<div class="kpi"><div class="kpi-v" style="font-size:15px">${escapeHtml(v)}</div><div class="kpi-l">${escapeHtml(l)}</div></div>`).join("") +
     `</div>` +
     (p.deal_count ? `<table class="sens-table"><tr><th>Deal</th><th>Cap</th><th>Equity</th><th>IRR</th><th>EM</th></tr>${rows}</table>`
                   : `<div class="meta" style="margin-top:8px">No solved scenarios yet — build one in the Proforma tab and it rolls up here.</div>`);

--- a/apps/web/src/portal/homes/developerHome.ts
+++ b/apps/web/src/portal/homes/developerHome.ts
@@ -15,6 +15,7 @@ import type { ModuleDef } from "../../api/types";
 import { countNarrative } from "../../ui/chips";
 import { usd } from "../../ui/charts";
 import type { PortalHost } from "../portal";
+import { escapeHtml as esc } from "../../ui/feedback";
 
 /** Exactly what this screen needs off the portal class — deliberately not the class itself. */
 export interface DeveloperHomeCtx { host: PortalHost; mods: ModuleDef[] }
@@ -70,7 +71,7 @@ export async function renderDeveloperHome(ctx: DeveloperHomeCtx, root: HTMLEleme
     ];
     for (const [label, val, onClick] of cards) {
       const c = el("div", "kpi" + (onClick ? " kpi-click" : "")) as HTMLElement;
-      c.innerHTML = `<div class="kpi-v">${val}</div><div class="kpi-l">${label}</div>`;
+      c.innerHTML = `<div class="kpi-v">${esc(val)}</div><div class="kpi-l">${esc(label)}</div>`;
       if (onClick) { c.onclick = onClick; c.tabIndex = 0; c.setAttribute("role", "button"); c.onkeydown = (e) => { if ((e as KeyboardEvent).key === "Enter") onClick(); }; }
       kpis.appendChild(c);
     }

--- a/apps/web/src/portal/panels/aiassist.ts
+++ b/apps/web/src/portal/panels/aiassist.ts
@@ -211,7 +211,7 @@ export async function renderAiAssist(ctx: PanelContext) {
     };
     const list = (title: string, items: string[]) => {
       const w = el("div"); w.style.marginTop = "6px";
-      const h = el("div", "meta"); h.innerHTML = `<b>${title}</b> (${items.length})`; w.appendChild(h);
+      const h = el("div", "meta"); h.innerHTML = `<b>${esc(title)}</b> (${items.length})`; w.appendChild(h);
       const ul = el("ul"); ul.style.cssText = "margin:2px 0 0 16px;font-size:12px";
       items.forEach((s) => { const li = el("li"); li.textContent = s; ul.appendChild(li); });
       if (!items.length) { const li = el("div", "meta"); li.textContent = "—"; li.style.marginLeft = "4px"; w.appendChild(li); }

--- a/apps/web/src/portal/panels/aiassist.ts
+++ b/apps/web/src/portal/panels/aiassist.ts
@@ -499,7 +499,7 @@ export async function renderAiAssist(ctx: PanelContext) {
     }
     // scope matrix
     const tbl = el("table", "portal-table") as HTMLTableElement; tbl.style.cssText = "width:100%;font-size:11px;margin-top:6px";
-    const thead = `<tr><th scope="col" style="text-align:left">Scope item</th>${r.vendors.map((v) => `<th scope="col">${v}</th>`).join("")}</tr>`;
+    const thead = `<tr><th scope="col" style="text-align:left">Scope item</th>${r.vendors.map((v) => `<th scope="col">${esc(v)}</th>`).join("")}</tr>`;
     const rows = r.scope_rows.map((row) => {
       const cells = r.vendors.map((v) => {
         const inc = row.included_by.includes(v); const exc = row.excluded_by.includes(v);
@@ -508,7 +508,7 @@ export async function renderAiAssist(ctx: PanelContext) {
         return `<td style="text-align:center;color:${col}">${mark}</td>`;
       }).join("");
       const bg = row.gap ? ' style="background:var(--status-warn-bg,#3a2a0022)"' : "";
-      return `<tr${bg}><td>${row.item}${row.gap ? ' <span title="scope gap">⚠️</span>' : ""}</td>${cells}</tr>`;
+      return `<tr${bg}><td>${esc(row.item)}${row.gap ? ' <span title="scope gap">⚠️</span>' : ""}</td>${cells}</tr>`;
     }).join("");
     tbl.innerHTML = `<thead>${thead}</thead><tbody>${rows}</tbody>`;
     out.append(tbl);

--- a/apps/web/src/portal/panels/analytics.ts
+++ b/apps/web/src/portal/panels/analytics.ts
@@ -448,7 +448,7 @@ export async function renderRiskCost(ctx: PanelContext) {
         carbonCompSlot.append(t);
       }
       if (e.hotspots?.length) {
-        const tops = e.hotspots.slice(0, 3).map((h) => `${h.name || h.guid} (${h.category}, ${(h.kgco2e / 1000).toFixed(1)} t)`).join(" · ");
+        const tops = e.hotspots.slice(0, 3).map((h) => `${esc(h.name || h.guid)} (${esc(h.category)}, ${(h.kgco2e / 1000).toFixed(1)} t)`).join(" · ");
         carbonCompSlot.insertAdjacentHTML("beforeend", `<div class="meta" style="margin-top:2px">Hotspots: ${tops}</div>`);
       }
     }).catch(() => { carbonCompSlot.innerHTML = `<div class="meta">Load a model in the Model workspace to compute per-element carbon.</div>`; });

--- a/apps/web/src/portal/panels/analytics.ts
+++ b/apps/web/src/portal/panels/analytics.ts
@@ -30,7 +30,7 @@ export async function renderBenchmarks(ctx: PanelContext) {
       rr.innerHTML = "";
       const card = (title: string, m: { total: number; open: number; avg_turnaround_days: number | null; overdue: number; overdue_pct: number }) => {
         const c = el("div", "kpi-card"); c.style.cssText = "display:inline-block;margin:4px 8px 4px 0;padding:8px 12px;border:1px solid var(--line);border-radius:8px";
-        c.innerHTML = `<div class="meta"><b>${title}</b></div>`
+        c.innerHTML = `<div class="meta"><b>${esc(title)}</b></div>`
           + `<div style="font-size:12px">${m.total} total · ${m.open} open · ${m.overdue} overdue (${m.overdue_pct}%)`
           + ` · avg turnaround ${m.avg_turnaround_days ?? "—"} d</div>`;
         return c;
@@ -491,10 +491,10 @@ export async function renderRiskCost(ctx: PanelContext) {
       ceWrap.innerHTML = "";
       const type = el("select", "portal-filter") as HTMLSelectElement; type.style.cssText = "margin:2px 4px 2px 0";
       type.setAttribute("aria-label", "Building type");
-      type.innerHTML = cat.building_types.map((t) => `<option value="${t}">${t}</option>`).join("");
+      type.innerHTML = cat.building_types.map((t) => `<option value="${esc(t)}">${esc(t)}</option>`).join("");
       const region = el("select", "portal-filter") as HTMLSelectElement; region.style.cssText = "margin:2px 4px";
       region.setAttribute("aria-label", "Region");
-      region.innerHTML = cat.regions.map((rg) => `<option value="${rg}"${rg === "us_average" ? " selected" : ""}>${rg}</option>`).join("");
+      region.innerHTML = cat.regions.map((rg) => `<option value="${esc(rg)}"${rg === "us_average" ? " selected" : ""}>${esc(rg)}</option>`).join("");
       const gfa = el("input", "portal-filter") as HTMLInputElement; gfa.type = "number"; gfa.placeholder = "GFA (sf)"; gfa.setAttribute("aria-label", "Gross floor area (sf)"); gfa.style.cssText = "width:110px;margin:2px 4px";
       const go = el("button", "file-btn") as HTMLButtonElement; go.textContent = "Estimate";
       const out = el("div"); out.style.marginTop = "6px";

--- a/apps/web/src/portal/panels/budget.ts
+++ b/apps/web/src/portal/panels/budget.ts
@@ -522,7 +522,7 @@ export async function renderBudget(ctx: PanelContext) {
     const kpis = document.createElement("div"); kpis.className = "dash-cols"; kpis.style.marginBottom = "10px";
     const kpi = (label: string, val: string, color?: string) => {
       const c = document.createElement("div"); c.className = "dash-card"; c.style.flex = "1";
-      c.innerHTML = `<div class="meta">${label}</div><div style="font-size:18px;font-weight:700${color ? `;color:${color}` : ""}">${val}</div>`;
+      c.innerHTML = `<div class="meta">${esc(label)}</div><div style="font-size:18px;font-weight:700${color ? `;color:${esc(color)}` : ""}">${esc(val)}</div>`;
       return c;
     };
     // defensive defaults so the page renders against any API version (new fields fill once present)

--- a/apps/web/src/portal/panels/design.ts
+++ b/apps/web/src/portal/panels/design.ts
@@ -104,7 +104,7 @@ export async function renderLifecycle(ctx: PanelContext) {
           + `<div><b>${ph.riba_stage}</b> <span class="meta">→ ${ph.aia_phase}</span></div>`
           + `<span class="badge">${ph.state}</span></div>`
           + `<div class="meta" style="margin-top:2px">Fee ${ph.design_fee_pct || 0}%${fee} · ${ph.iso_status || ""}</div>`
-          + (ph.deliverables.length ? `<ul style="margin:4px 0 0 16px;font-size:12px">${ph.deliverables.map((d) => `<li>${d}</li>`).join("")}</ul>` : "");
+          + (ph.deliverables.length ? `<ul style="margin:4px 0 0 16px;font-size:12px">${ph.deliverables.map((d) => `<li>${esc(d)}</li>`).join("")}</ul>` : "");
         // gate actions
         const actions = el("div"); actions.style.cssText = "margin-top:6px;display:flex;gap:6px;flex-wrap:wrap;align-items:center";
         const act = (label: string, action: string, pre?: () => Promise<boolean>) => {
@@ -481,7 +481,7 @@ export async function renderEsg(ctx: PanelContext) {
     const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
     const card = (label: string, value: string) => {
       const c = el("div", "dash-card"); c.style.minWidth = "125px";
-      c.innerHTML = `<div style="font-size:20px;font-weight:600">${value}</div><div class="meta">${label}</div>`;
+      c.innerHTML = `<div style="font-size:20px;font-weight:600">${esc(value)}</div><div class="meta">${esc(label)}</div>`;
       return c;
     };
     cards.append(

--- a/apps/web/src/portal/panels/documents.ts
+++ b/apps/web/src/portal/panels/documents.ts
@@ -59,11 +59,11 @@ export async function renderDocuments(ctx: PanelContext) {
   const roleSel = el("select", "portal-filter") as HTMLSelectElement;
   roleSel.setAttribute("aria-label", "Filter folders by owner role");
   roleSel.innerHTML = ["All roles", "PM", "Superintendent", "Architect", "Engineer", "QS"]
-    .map((r) => `<option>${r}</option>`).join("");
+    .map((r) => `<option>${esc(r)}</option>`).join("");
   const phaseSel = el("select", "portal-filter") as HTMLSelectElement;
   phaseSel.setAttribute("aria-label", "Check required documents for a design phase");
   phaseSel.innerHTML = `<option value="">Phase gaps…</option>`
-    + ["SD", "DD", "CD", "CA", "CLOSEOUT"].map((p) => `<option>${p}</option>`).join("");
+    + ["SD", "DD", "CD", "CA", "CLOSEOUT"].map((p) => `<option>${esc(p)}</option>`).join("");
   controls.append(roleSel, phaseSel); root.appendChild(controls);
 
   // two-pane, but wraps to stacked on narrow viewports (min-width:0 lets the table scroll, not overflow)

--- a/apps/web/src/portal/panels/evm.ts
+++ b/apps/web/src/portal/panels/evm.ts
@@ -59,8 +59,8 @@ export async function renderEvm(ctx: PanelContext) {
   const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
   const card = (label: string, value: string, color?: string, sub?: string) => {
     const c = el("div", "dash-card"); c.style.cssText = `min-width:104px${color ? `;border-left:3px solid ${color}` : ""}`;
-    c.innerHTML = `<div style="font-size:19px;font-weight:600${color ? `;color:${color}` : ""}">${value}</div>`
-      + `<div class="meta">${label}</div>` + (sub ? `<div class="meta" style="font-size:10px">${sub}</div>` : "");
+    c.innerHTML = `<div style="font-size:19px;font-weight:600${color ? `;color:${esc(color)}` : ""}">${esc(value)}</div>`
+      + `<div class="meta">${esc(label)}</div>` + (sub ? `<div class="meta" style="font-size:10px">${esc(sub)}</div>` : "");
     return c;
   };
   const es = d.earned_schedule;

--- a/apps/web/src/portal/panels/margin.ts
+++ b/apps/web/src/portal/panels/margin.ts
@@ -132,7 +132,7 @@ export async function renderMargin(ctx: PanelContext) {
           + `<td style="text-align:right;font-variant-numeric:tabular-nums">${usd(r.actual)}</td>`
           + `<td style="text-align:right;font-variant-numeric:tabular-nums;color:${marginCol(r.buyout_margin)}">${usd(r.buyout_margin)}</td>`
           + `<td style="text-align:right;font-variant-numeric:tabular-nums;color:${marginCol(r.variance)}">${usd(r.variance)}</td>`
-          + `<td style="text-align:left" data-act="${i}"></td></tr>`;
+          + `<td style="text-align:left" data-act="${esc(i)}"></td></tr>`;
       }).join("") + `</tbody>`;
     // UX-ACT: inject the one-click resolve buttons into each flagged row's Fix cell (onclick needs DOM)
     m.rows.forEach((r, i) => {

--- a/apps/web/src/portal/panels/moduleGraph.ts
+++ b/apps/web/src/portal/panels/moduleGraph.ts
@@ -69,7 +69,7 @@ export async function renderModuleGraph(ctx: PanelContext) {
   const sel = document.createElement("select"); sel.className = "portal-filter";
   sel.setAttribute("aria-label", "Filter the module-relations graph by workspace");
   sel.innerHTML = `<option value="">All workspaces</option>`
-    + ["construction", "developer", "design", "operations"].map((w) => `<option value="${w}">${w}</option>`).join("");
+    + ["construction", "developer", "design", "operations"].map((w) => `<option value="${esc(w)}">${esc(w)}</option>`).join("");
   controls.appendChild(Object.assign(document.createElement("span"), { className: "meta", textContent: "Workspace:" }));
   controls.appendChild(sel);
   const summary = document.createElement("span"); summary.className = "meta";

--- a/apps/web/src/portal/panels/operations.ts
+++ b/apps/web/src/portal/panels/operations.ts
@@ -52,7 +52,7 @@ export async function renderOperations(ctx: PanelContext) {
       const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
       const card = (label: string, value: string, warn = false) => {
         const c = el("div", "dash-card"); c.style.cssText = `min-width:110px${warn ? ";border-left:3px solid var(--status-warn)" : ""}`;
-        c.innerHTML = `<div style="font-size:20px;font-weight:600">${value}</div><div class="meta">${label}</div>`;
+        c.innerHTML = `<div style="font-size:20px;font-weight:600">${esc(value)}</div><div class="meta">${esc(label)}</div>`;
         return c;
       };
       cards.append(card("open work orders", String(k.open)),
@@ -272,7 +272,7 @@ export async function renderSpine(ctx: PanelContext) {
       const gapList = (title: string, items: string[]) => {
         if (!items.length) return;
         const d = el("div", "meta"); d.style.margin = "3px 0";
-        d.innerHTML = `<b>${title} (${items.length}):</b> ${items.slice(0, 12).map(esc).join(", ")}${items.length > 12 ? " …" : ""}`;
+        d.innerHTML = `<b>${esc(title)} (${items.length}):</b> ${items.slice(0, 12).map(esc).join(", ")}${items.length > 12 ? " …" : ""}`;
         gc.appendChild(d);
       };
       gapList("Specs with no bid package", g.specs_without_bid_package.map((x) => x.section || x.ref));
@@ -436,7 +436,7 @@ export async function renderEnergy(ctx: PanelContext) {
     const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
     const card = (label: string, value: string) => {
       const c = el("div", "dash-card"); c.style.minWidth = "120px";
-      c.innerHTML = `<div style="font-size:20px;font-weight:600">${value}</div><div class="meta">${label}</div>`;
+      c.innerHTML = `<div style="font-size:20px;font-weight:600">${esc(value)}</div><div class="meta">${esc(label)}</div>`;
       return c;
     };
     cards.append(card("EUI (kBtu/sf/yr)", e0.eui_kbtu_sf_yr != null ? String(e0.eui_kbtu_sf_yr) : "—"),

--- a/apps/web/src/portal/panels/portfolio.ts
+++ b/apps/web/src/portal/panels/portfolio.ts
@@ -44,7 +44,7 @@ export async function renderPortfolio(ctx: PanelContext) {
     const kpis = document.createElement("div"); kpis.className = "dash-cols"; kpis.style.marginBottom = "10px";
     const kpi = (label: string, val: string, color?: string) => {
       const c = document.createElement("div"); c.className = "dash-card"; c.style.flex = "1";
-      c.innerHTML = `<div class="meta">${label}</div><div style="font-size:18px;font-weight:700${color ? `;color:${color}` : ""}">${val}</div>`;
+      c.innerHTML = `<div class="meta">${esc(label)}</div><div style="font-size:18px;font-weight:700${color ? `;color:${esc(color)}` : ""}">${esc(val)}</div>`;
       return c;
     };
     const irrPct = (v: number | null) => v == null ? "—" : `${(v * 100).toFixed(1)}%`;
@@ -69,7 +69,7 @@ export async function renderPortfolio(ctx: PanelContext) {
       const [lbl, col] = pill[p.status] ?? ["—", "var(--muted)"];
       const irrCol = p.equity_irr == null ? "var(--muted)" : p.equity_irr >= 0.15 ? "var(--status-good)" : p.equity_irr >= 0.12 ? "var(--status-warn)" : "var(--status-crit)";
       tr.innerHTML = `<td>${esc(p.name)}${p.id === here ? " ·" : ""}</td>`
-        + `<td><span class="ball-badge" style="background:${col}22;color:${col};border-color:${col}">${lbl}</span></td>`
+        + `<td><span class="ball-badge" style="background:${esc(col)}22;color:${esc(col)};border-color:${esc(col)}">${esc(lbl)}</span></td>`
         + `<td style="text-align:right;color:${p.cpi == null ? "var(--muted)" : p.cpi >= 0.95 ? "var(--status-good)" : "var(--status-crit)"}">${p.cpi ?? "—"}</td>`
         + `<td style="text-align:right;color:${p.spi == null ? "var(--muted)" : p.spi >= 0.95 ? "var(--status-good)" : "var(--status-crit)"}">${p.spi ?? "—"}</td>`
         + `<td style="text-align:right">${p.pct_complete}%</td><td style="text-align:right">${usd(p.gmp)}</td>`
@@ -201,7 +201,7 @@ export async function renderPortfolio(ctx: PanelContext) {
         // A trade on more than one project is the only kind that CAN be double-booked, so it is
         // the only kind worth colouring — this is a fact from the data, not a severity guess.
         const col = t.cross_project ? "var(--status-warn)" : "var(--muted)";
-        tr.innerHTML = `<td>${esc(t.trade)}${t.cross_project ? ` <span style="color:${col}" title="on ${t.project_count} projects — can be double-booked">⇄</span>` : ""}</td>`
+        tr.innerHTML = `<td>${esc(t.trade)}${t.cross_project ? ` <span style="color:${esc(col)}" title="on ${t.project_count} projects — can be double-booked">⇄</span>` : ""}</td>`
           + `<td style="text-align:right;font-weight:600">${t.peak_units}</td>`
           + `<td class="meta">${esc(t.peak_week ?? "—")}</td>`
           + `<td style="text-align:right">${t.project_count}</td>`

--- a/apps/web/src/portal/panels/resourceLoading.ts
+++ b/apps/web/src/portal/panels/resourceLoading.ts
@@ -52,8 +52,8 @@ export async function renderResourceLoading(ctx: PanelContext) {
     const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
     const card = (label: string, value: string, color?: string, sub?: string) => {
       const cc = el("div", "dash-card"); cc.style.cssText = `min-width:104px${color ? `;border-left:3px solid ${color}` : ""}`;
-      cc.innerHTML = `<div style="font-size:19px;font-weight:600${color ? `;color:${color}` : ""}">${value}</div>`
-        + `<div class="meta">${label}</div>` + (sub ? `<div class="meta" style="font-size:10px">${sub}</div>` : "");
+      cc.innerHTML = `<div style="font-size:19px;font-weight:600${color ? `;color:${esc(color)}` : ""}">${esc(value)}</div>`
+        + `<div class="meta">${esc(label)}</div>` + (sub ? `<div class="meta" style="font-size:10px">${esc(sub)}</div>` : "");
       return cc;
     };
     const overCount = ld.over_allocation.length;
@@ -68,7 +68,7 @@ export async function renderResourceLoading(ctx: PanelContext) {
     const hist = el("div", "dash-card"); hist.style.marginBottom = "8px";
     hist.innerHTML = stackedBar(ld.histogram.map((w) => ({
       label: w.week.slice(5), segments: ld.trades.map((t) => ({ name: t, value: w.by_trade[t] || 0 })),
-    })), { title: `Manpower histogram (units/week, by trade) · cap ${cap}`, fmt: (n) => `${n}`, height: 200 });
+    })), { title: `Manpower histogram (units/week, by trade) · cap ${cap}`, fmt: (n) => `${esc(n)}`, height: 200 });
     body.append(hist);
 
     // cost S-curve

--- a/apps/web/src/portal/panels/schedule.ts
+++ b/apps/web/src/portal/panels/schedule.ts
@@ -698,7 +698,11 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
   ctx.root.appendChild(estBtn);
   void ctx.host.api.scheduleCpm(pid).then((c) => {
     if (!c.activity_count) { cpmBox.textContent = "CPM: no activities with durations yet."; return; }
-    const cp = c.critical_path.slice(0, 12).join(" → ") || "—";
+    // `critical_path` is a list of stored activity REFS (schedule_engine builds it as
+    // `[r["ref"] or r["id"] ...]`), so it is user-entered text reaching innerHTML. Escaped AFTER the
+    // join because the " → " separator holds nothing escapable. Found by triaging the bare-local
+    // class this PR's new rule deliberately leaves out: 134 sites classified, this the one real one.
+    const cp = esc(c.critical_path.slice(0, 12).join(" → ")) || "—";
     cpmBox.innerHTML = `<b>CPM</b>: project ${c.project_duration}d · ${c.critical_count}/${c.activity_count} on the `
       + `<span style="color:var(--status-crit)">critical path</span>${c.has_cycle ? " · ⚠ cycle broken" : ""}<br>`
       + `<span class="meta">Critical: ${cp}</span>`;

--- a/apps/web/src/portal/panels/schedule.ts
+++ b/apps/web/src/portal/panels/schedule.ts
@@ -429,7 +429,11 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
       // milestone options (only rebuild once)
       if (!msSel.options.length) {
         msSel.innerHTML = `<option value="">All phases</option>`
-          + b.milestones.map((m) => `<option value="${m.replace(/"/g, "&quot;")}">${esc(m)}</option>`).join("");
+          // esc() on BOTH, and the value matters as much as the text: `esc` turns `&` into `&amp;`
+          // but `.replace(/"/g, …)` did not, so a milestone literally named `A &amp; B` parsed back
+          // out of the attribute as `A & B` and `loadPull()` then queried the wrong milestone on
+          // two API calls. Escaping the text alone made the two disagree.
+          + b.milestones.map((m) => `<option value="${esc(m)}">${esc(m)}</option>`).join("");
       }
       if (!b.total) { ppBody.innerHTML = `<div class="meta">No pull-plan tasks yet — click <b>✎ Sticky notes</b> to add them. Work backward from a milestone; each trade posts its tasks and hand-offs, and constraints are cleared to make work ready.</div>`; return; }
       ppBody.innerHTML = "";
@@ -783,7 +787,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
       + ` · lead ${pg.lead_trade ?? "—"} at <b>${pg.lead_actual_floors_per_week}</b> vs plan <b>${pg.planned_floors_per_week}</b> floors/wk`
       + ` · PPC <b>${Math.round((tp.ppc.ppc ?? 0) * 100)}%</b> (${tp.ppc.rating})</div>`;
     const rows = pg.rows.map((r) =>
-      `<tr><td>${r.trade}</td><td style="text-align:right">${r.floors_done}/${r.planned_done}</td>`
+      `<tr><td>${esc(r.trade)}</td><td style="text-align:right">${r.floors_done}/${r.planned_done}</td>`
       + `<td style="text-align:right;color:${color(r.status)}">${r.variance_floors > 0 ? "+" : ""}${r.variance_floors}</td>`
       + `<td style="text-align:right">${r.actual_floors_per_week}</td><td style="text-align:right">${r.planned_floors_per_week}</td></tr>`).join("");
     taktBody.innerHTML = head + (pg.rows.length

--- a/apps/web/src/portal/panels/schedule.ts
+++ b/apps/web/src/portal/panels/schedule.ts
@@ -429,7 +429,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
       // milestone options (only rebuild once)
       if (!msSel.options.length) {
         msSel.innerHTML = `<option value="">All phases</option>`
-          + b.milestones.map((m) => `<option value="${m.replace(/"/g, "&quot;")}">${m}</option>`).join("");
+          + b.milestones.map((m) => `<option value="${m.replace(/"/g, "&quot;")}">${esc(m)}</option>`).join("");
       }
       if (!b.total) { ppBody.innerHTML = `<div class="meta">No pull-plan tasks yet — click <b>✎ Sticky notes</b> to add them. Work backward from a milestone; each trade posts its tasks and hand-offs, and constraints are cleared to make work ready.</div>`; return; }
       ppBody.innerHTML = "";
@@ -442,7 +442,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
       const wrap = document.createElement("div"); wrap.style.cssText = "overflow-x:auto";
       const t = document.createElement("table"); t.className = "portal-table"; t.style.cssText = "font-size:11px;border-collapse:collapse";
       t.innerHTML = `<thead><tr><th style="text-align:left;position:sticky;left:0;background:var(--panel)">Trade</th>`
-        + b.weeks.map((w) => `<th style="min-width:120px">${w}</th>`).join("") + `</tr></thead>`;
+        + b.weeks.map((w) => `<th style="min-width:120px">${esc(w)}</th>`).join("") + `</tr></thead>`;
       const tb = document.createElement("tbody");
       for (const lane of b.swimlanes) {
         const tr = document.createElement("tr");
@@ -584,7 +584,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
   const loadLookahead = (weeks: number) => {
     laBody.innerHTML = `<div class="meta">loading…</div>`;
     void ctx.host.api.scheduleLookahead(pid, weeks).then((la) => {
-      if (!la.count) { laBody.innerHTML = `<div class="meta">No activities in the next ${weeks} weeks.</div>`; return; }
+      if (!la.count) { laBody.innerHTML = `<div class="meta">No activities in the next ${esc(weeks)} weeks.</div>`; return; }
       laBody.innerHTML = "";
       for (const wk of la.weeks_detail) {
         const h = document.createElement("div"); h.className = "meta"; h.style.cssText = "margin-top:6px;font-weight:700"; h.textContent = wk.week;
@@ -628,7 +628,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
     mrBody.innerHTML = `<div class="meta">loading…</div>`;
     void ctx.host.api.scheduleMakeReady(pid, days).then((mr) => {
       if (!mr.activities.length) {
-        mrBody.innerHTML = `<div class="meta">Nothing starts in the next ${days} days.</div>`; return;
+        mrBody.innerHTML = `<div class="meta">Nothing starts in the next ${esc(days)} days.</div>`; return;
       }
       mrBody.innerHTML = "";
       const chips = document.createElement("div"); chips.className = "meta"; chips.style.marginBottom = "4px";
@@ -754,7 +754,7 @@ export async function renderScheduleViews(ctx: PanelContext, m: ModuleDef) {
     const card = document.createElement("div"); card.className = "dash-card"; card.style.marginBottom = "10px";
     card.appendChild(Object.assign(document.createElement("div"), { className: "section-title", textContent: title }));
     const holder = document.createElement("div"); holder.style.overflowX = "auto";
-    holder.innerHTML = `<div class="meta">loading ${title}…</div>`;
+    holder.innerHTML = `<div class="meta">loading ${esc(title)}…</div>`;
     card.appendChild(holder); ctx.root.appendChild(card);
     void ctx.host.api.scheduleSvg(pid, kind).then((svg) => { holder.innerHTML = svg; })
       .catch(() => { holder.innerHTML = `<div class="meta">No ${title.toLowerCase()} yet — add activities with start/finish dates.</div>`; });

--- a/apps/web/src/portal/panels/standards.ts
+++ b/apps/web/src/portal/panels/standards.ts
@@ -36,7 +36,7 @@ export async function renderProgram(ctx: PanelContext) {
     const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
     const card = (label: string, value: string) => {
       const c = el("div", "dash-card"); c.style.minWidth = "110px";
-      c.innerHTML = `<div style="font-size:20px;font-weight:600">${value}</div><div class="meta">${label}</div>`;
+      c.innerHTML = `<div style="font-size:20px;font-weight:600">${esc(value)}</div><div class="meta">${esc(label)}</div>`;
       return c;
     };
     cards.append(card("spaces", String(s.spaces)),
@@ -97,7 +97,7 @@ export async function renderBimKpi(ctx: PanelContext) {
     const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
     const card = (label: string, value: string, color?: string) => {
       const c = el("div", "dash-card"); c.style.cssText = `min-width:90px${color ? `;border-left:3px solid var(${color})` : ""}`;
-      c.innerHTML = `<div style="font-size:20px;font-weight:600">${value}</div><div class="meta">${label}</div>`;
+      c.innerHTML = `<div style="font-size:20px;font-weight:600">${esc(value)}</div><div class="meta">${esc(label)}</div>`;
       return c;
     };
     cards.append(card("health", s.health_pct != null ? `${s.health_pct}%` : "—"),
@@ -215,7 +215,7 @@ export async function renderStandards(ctx: PanelContext) {
     const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
     for (const [k, label] of stages) {
       const c = el("div", "dash-card"); c.style.minWidth = "90px";
-      c.innerHTML = `<div style="font-size:20px;font-weight:600">${st.by_state[k] ?? 0}</div><div class="meta">${label}</div>`;
+      c.innerHTML = `<div style="font-size:20px;font-weight:600">${st.by_state[k] ?? 0}</div><div class="meta">${esc(label)}</div>`;
       cards.append(c);
     }
     body.append(cards);

--- a/apps/web/src/portal/panels/traceability.ts
+++ b/apps/web/src/portal/panels/traceability.ts
@@ -33,8 +33,8 @@ export async function renderTraceability(ctx: PanelContext) {
   const col = s.coverage_pct >= 75 ? "var(--status-good)" : s.coverage_pct >= 40 ? "var(--status-warn)" : "var(--status-crit)";
   const card = (label: string, value: string, c?: string, sub?: string) => {
     const cc = el("div", "dash-card"); cc.style.cssText = `min-width:110px${c ? `;border-left:3px solid ${c}` : ""}`;
-    cc.innerHTML = `<div style="font-size:18px;font-weight:600${c ? `;color:${c}` : ""}">${value}</div>`
-      + `<div class="meta">${label}</div>` + (sub ? `<div class="meta" style="font-size:10px">${sub}</div>` : "");
+    cc.innerHTML = `<div style="font-size:18px;font-weight:600${c ? `;color:${esc(c)}` : ""}">${esc(value)}</div>`
+      + `<div class="meta">${esc(label)}</div>` + (sub ? `<div class="meta" style="font-size:10px">${esc(sub)}</div>` : "");
     return cc;
   };
   cards.append(

--- a/apps/web/src/portal/panels/wip.ts
+++ b/apps/web/src/portal/panels/wip.ts
@@ -46,8 +46,8 @@ export async function renderWip(ctx: PanelContext) {
   const cards = el("div"); cards.style.cssText = "display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px";
   const card = (label: string, value: string, color?: string, sub?: string) => {
     const cc = el("div", "dash-card"); cc.style.cssText = `min-width:112px${color ? `;border-left:3px solid ${color}` : ""}`;
-    cc.innerHTML = `<div style="font-size:18px;font-weight:600${color ? `;color:${color}` : ""}">${value}</div>`
-      + `<div class="meta">${label}</div>` + (sub ? `<div class="meta" style="font-size:10px">${sub}</div>` : "");
+    cc.innerHTML = `<div style="font-size:18px;font-weight:600${color ? `;color:${esc(color)}` : ""}">${esc(value)}</div>`
+      + `<div class="meta">${esc(label)}</div>` + (sub ? `<div class="meta" style="font-size:10px">${esc(sub)}</div>` : "");
     return cc;
   };
   const over = w.billing_status === "over-billed";
@@ -78,7 +78,7 @@ export async function renderWip(ctx: PanelContext) {
     ["Profit earned to date", usd(w.profit_to_date)], ["Retainage held", usd(w.retainage)],
   ];
   const tbl = el("table", "portal-table") as HTMLTableElement; tbl.style.cssText = "width:100%;font-size:12px";
-  tbl.innerHTML = `<tbody>${rows.map(([k, v]) => `<tr><td>${esc(k)}</td><td style="text-align:right">${v}</td></tr>`).join("")}</tbody>`;
+  tbl.innerHTML = `<tbody>${rows.map(([k, v]) => `<tr><td>${esc(k)}</td><td style="text-align:right">${esc(v)}</td></tr>`).join("")}</tbody>`;
   body.append(tbl);
 
   // --- model cross-check: physical % complete (installed elements ÷ total, by GlobalId) vs cost ---

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -654,7 +654,7 @@ export class PortalUI {
     const grid = el("div"); grid.style.cssText = "display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:8px;margin-bottom:12px";
     for (const [ic, label, on] of tiles) {
       const c = el("div", "dash-card"); c.style.cssText = "cursor:pointer;text-align:center";
-      c.innerHTML = `<div style="font-size:22px">${ic}</div><div style="font-weight:600">${label}</div>`;
+      c.innerHTML = `<div style="font-size:22px">${esc(ic)}</div><div style="font-weight:600">${esc(label)}</div>`;
       c.onclick = on; grid.appendChild(c);
     }
     root.appendChild(grid);
@@ -676,7 +676,7 @@ export class PortalUI {
           const c = el("div", "dash-card" + (go ? " kpi-click" : "")); c.style.minWidth = "128px";
           if (go) { c.style.cursor = "pointer"; c.onclick = go; }
           if (title) c.title = title;
-          c.innerHTML = `<div style="font-size:20px;font-weight:600">${big}</div><div class="meta">${small}</div>`;
+          c.innerHTML = `<div style="font-size:20px;font-weight:600">${esc(big)}</div><div class="meta">${esc(small)}</div>`;
           row.appendChild(c);
         };
         if (health?.overall_score != null) {
@@ -708,7 +708,7 @@ export class PortalUI {
       for (const [key, label] of regs) {
         const n = cnt(key); if (!n) continue; any = true;
         const tile = el("div", "dash-card kpi-click"); tile.style.minWidth = "120px"; tile.style.cursor = "pointer";
-        tile.innerHTML = `<div style="font-size:20px;font-weight:600">${n}</div><div class="meta">${label}</div>`;
+        tile.innerHTML = `<div style="font-size:20px;font-weight:600">${esc(n)}</div><div class="meta">${esc(label)}</div>`;
         tile.onclick = () => jump(key); cards.appendChild(tile);
       }
       if (any) {
@@ -924,7 +924,7 @@ export class PortalUI {
       const cards = order.map((k) => pool[k]).filter((c): c is NonNullable<typeof c> => Boolean(c));
       for (const [label, val, onClick] of cards) {
         const c = el("div", "kpi" + (onClick ? " kpi-click" : "")) as HTMLElement;
-        c.innerHTML = `<div class="kpi-v">${val}</div><div class="kpi-l">${label}</div>`;
+        c.innerHTML = `<div class="kpi-v">${esc(val)}</div><div class="kpi-l">${esc(label)}</div>`;
         if (onClick) {
           c.onclick = onClick; c.tabIndex = 0; c.setAttribute("role", "button");
           c.onkeydown = (e) => { if ((e as KeyboardEvent).key === "Enter") onClick(); };

--- a/apps/web/src/portal/portal.ts
+++ b/apps/web/src/portal/portal.ts
@@ -941,9 +941,9 @@ export class PortalUI {
         const dot = (s: string) => `<span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:${tone[s] || "#9aa0a6"};margin-right:5px"></span>`;
         const c = tone[h.overall_status] || "#9aa0a6";
         const chips = h.domains.map((d) =>
-          `<span title="${d.headline.replace(/"/g, "&quot;")}" style="display:inline-flex;align-items:center;font-size:11px;background:#ffffff10;border:1px solid #ffffff22;border-radius:12px;padding:2px 8px;margin:2px 4px 2px 0">${dot(d.status)}${d.label}</span>`).join("");
+          `<span title="${esc(d.headline)}" style="display:inline-flex;align-items:center;font-size:11px;background:#ffffff10;border:1px solid #ffffff22;border-radius:12px;padding:2px 8px;margin:2px 4px 2px 0">${dot(d.status)}${esc(d.label)}</span>`).join("");
         const att = h.attention_items.slice(0, 4).map((a) =>
-          `<div style="display:flex;gap:8px;align-items:baseline;font-size:12px;margin:2px 0">${dot(a.status)}<span><b>${a.domain}</b> — ${a.issue}</span></div>`).join("");
+          `<div style="display:flex;gap:8px;align-items:baseline;font-size:12px;margin:2px 0">${dot(a.status)}<span><b>${esc(a.domain)}</b> — ${esc(a.issue)}</span></div>`).join("");
         hb.innerHTML = `<div class="dash-card" style="border-left:4px solid ${c};margin-top:8px">`
           + `<div style="display:flex;align-items:center;gap:14px;flex-wrap:wrap">`
           + `<div style="font-size:30px;font-weight:800;color:${c};line-height:1">${h.health_score ?? "—"}<span style="font-size:13px;font-weight:600;opacity:.6">/100</span></div>`

--- a/apps/web/src/portal/register/register.ts
+++ b/apps/web/src/portal/register/register.ts
@@ -717,7 +717,7 @@ export class RegisterUI {
     const td = document.createElement("td");
     const parties = this.ballInCourt(m, r.workflow_state);
     td.innerHTML = parties.length
-      ? parties.map((p) => `<span class="ball-badge">${p}</span>`).join(" ")
+      ? parties.map((p) => `<span class="ball-badge">${esc(p)}</span>`).join(" ")
       : `<span class="meta">—</span>`;
     return td;
   }
@@ -2022,7 +2022,7 @@ export class RegisterUI {
     catch (e) { toast(`triage failed: ${(e as Error).message}`, "error"); return; }
     const { card, ready } = modalShell("RFI triage (AI)", 360);
     if (!t.ai_enabled) card.append(Object.assign(document.createElement("div"), { className: "meta", textContent: "AI not configured — showing a template suggestion." }));
-    const kv = (k: string, v: string) => { const d = document.createElement("div"); d.className = "meta"; d.innerHTML = `<b>${k}:</b> `; d.append(v); card.appendChild(d); };
+    const kv = (k: string, v: string) => { const d = document.createElement("div"); d.className = "meta"; d.innerHTML = `<b>${esc(k)}:</b> `; d.append(v); card.appendChild(d); };
     kv("Discipline", t.discipline); kv("Category", t.category); kv("Urgency", t.urgency); kv("Ball-in-court", t.ball_in_court);
     const h = document.createElement("div"); h.className = "meta"; h.style.marginTop = "6px"; h.innerHTML = "<b>Draft response:</b>"; card.appendChild(h);
     const body = document.createElement("div"); body.style.cssText = "white-space:pre-wrap;font-size:12.5px"; body.textContent = t.draft_response; card.appendChild(body); ready();   // R24-PERF-BUDGET: the triage fetch is above, before the shell
@@ -2293,7 +2293,7 @@ export class RegisterUI {
       const cap = document.createElement("div"); cap.className = "meta"; cap.textContent = caption; box.appendChild(cap);
       for (const b of items) {
         const row = document.createElement("button"); row.className = "portal-mod";
-        row.innerHTML = `<span class="ic">${icon}</span> <b>${esc(labelOf(b))}</b> ${esc(b.ref)} ${esc(b.title ?? "")} ${statusChip(b.state)}`;
+        row.innerHTML = `<span class="ic">${esc(icon)}</span> <b>${esc(labelOf(b))}</b> ${esc(b.ref)} ${esc(b.title ?? "")} ${statusChip(b.state)}`;
         row.onclick = () => this.openByBrief(b.module, b.id);
         box.appendChild(row);
       }

--- a/apps/web/src/proforma/massingTab.ts
+++ b/apps/web/src/proforma/massingTab.ts
@@ -40,7 +40,7 @@ export function renderMassingTab(root: HTMLElement, ctx: MassingTabCtx): void {
   const inputs: Record<string, HTMLInputElement> = {};
   for (const [label, key, def, step] of fields) {
     const wrap = document.createElement("label"); wrap.className = "pf-field";
-    wrap.innerHTML = `<span>${label}</span>`;
+    wrap.innerHTML = `<span>${escapeHtml(label)}</span>`;
     const inp = document.createElement("input"); inp.type = "number"; inp.step = step; inp.value = String(def);
     if (key === "height_limit") inp.placeholder = "none";
     inputs[key] = inp; wrap.appendChild(inp); grid.appendChild(wrap);

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -83,7 +83,7 @@ export class ProformaUI {
     const form = document.createElement("div"); form.className = "pf-form";
     for (const [label, path, kind] of FIELDS) {
       const wrap = document.createElement("label"); wrap.className = "pf-field";
-      wrap.innerHTML = `<span>${label}</span>`;
+      wrap.innerHTML = `<span>${escapeHtml(label)}</span>`;
       const inp = document.createElement("input"); inp.type = "number"; inp.step = "any";
       const raw = get(this.a, path);
       inp.value = String(kind === "pct" ? +(raw * 100).toFixed(3) : raw);
@@ -103,7 +103,7 @@ export class ProformaUI {
     // optional debt-sizing constraints (blank = off → loan sized by LTC only)
     const sizingField = (label: string, path: string, scale: number, placeholder: string) => {
       const wrap = document.createElement("label"); wrap.className = "pf-field";
-      wrap.innerHTML = `<span>${label}</span>`;
+      wrap.innerHTML = `<span>${escapeHtml(label)}</span>`;
       const inp = document.createElement("input"); inp.type = "number"; inp.step = "any"; inp.placeholder = placeholder;
       const raw = get(this.a, path);
       inp.value = raw == null ? "" : String(+(raw * scale).toFixed(3));
@@ -178,7 +178,7 @@ export class ProformaUI {
 
     const stmt = (title: string, lines: StatementLine[]) => {
       const box = document.createElement("div"); box.className = "fin-card";
-      box.innerHTML = `<div class="section-title" style="margin:0 0 4px">${title}</div>`;
+      box.innerHTML = `<div class="section-title" style="margin:0 0 4px">${escapeHtml(title)}</div>`;
       const t = document.createElement("table"); t.className = "fin-table";
       for (const ln of lines) {
         const tr = document.createElement("tr");
@@ -202,7 +202,7 @@ export class ProformaUI {
     const two = document.createElement("div"); two.className = "fin-twoside";
     const col = (head: string, lines: StatementLine[], total: number) => {
       const c = document.createElement("table"); c.className = "fin-table";
-      c.innerHTML = `<tr class="fin-sub"><td>${head}</td><td class="num"></td></tr>`
+      c.innerHTML = `<tr class="fin-sub"><td>${escapeHtml(head)}</td><td class="num"></td></tr>`
         + lines.map((l) => `<tr><td>${escapeHtml(l.label)}</td><td class="num">${money(l.amount)}</td></tr>`).join("")
         + `<tr class="fin-total"><td>Total</td><td class="num">${money(total)}</td></tr>`;
       return c;
@@ -282,9 +282,9 @@ export class ProformaUI {
     // per-year columnar statements (years across the top) — the standard financial-statement layout
     const columnar = (title: string, yrs: number[], rows: { label: string; values: number[]; cls?: string }[]) => {
       const card = document.createElement("div"); card.className = "fin-card fin-wide";
-      card.innerHTML = `<div class="section-title" style="margin:0 0 4px">${title}</div>`;
+      card.innerHTML = `<div class="section-title" style="margin:0 0 4px">${escapeHtml(title)}</div>`;
       const t = document.createElement("table"); t.className = "fin-table";
-      t.innerHTML = `<tr class="fin-sub"><td></td>${yrs.map((y) => `<td class="num">Yr ${y}</td>`).join("")}</tr>`
+      t.innerHTML = `<tr class="fin-sub"><td></td>${yrs.map((y) => `<td class="num">Yr ${escapeHtml(y)}</td>`).join("")}</tr>`
         + rows.map((r) => `<tr class="${r.cls ?? ""}"><td>${escapeHtml(r.label)}</td>`
           + r.values.map((v) => `<td class="num">${money(v)}</td>`).join("") + "</tr>").join("");
       card.appendChild(t); return card;
@@ -437,7 +437,7 @@ export class ProformaUI {
     for (const c of rec.contributions) cur[c.approach] = c.weight;
     for (const [k, label] of wKeys) {
       const f = document.createElement("label"); f.className = "pf-field";
-      f.innerHTML = `<span>${label} %</span>`;
+      f.innerHTML = `<span>${escapeHtml(label)} %</span>`;
       const inp = document.createElement("input"); inp.type = "number"; inp.step = "any";
       inp.value = String(Math.round((cur[k] ?? 0) * 100)); inputs[k] = inp; f.appendChild(inp); wrap.appendChild(f);
     }
@@ -895,7 +895,7 @@ export class ProformaUI {
       let timer = 0; const save = () => { clearTimeout(timer); timer = window.setTimeout(() => void this.api.saveProperty(pid, prop).then((r) => { sumEl.textContent = summary(r.summary.total_taxes, r.summary.purchase_price); }), 500); };
       const grid = document.createElement("div"); grid.className = "pf-form";
       const field = (label: string, key: string, taxes = false) => {
-        const w = document.createElement("label"); w.className = "pf-field"; w.innerHTML = `<span>${label}</span>`;
+        const w = document.createElement("label"); w.className = "pf-field"; w.innerHTML = `<span>${escapeHtml(label)}</span>`;
         const i = document.createElement("input"); i.type = "number"; i.step = "any";
         i.value = String(taxes ? (prop.taxes?.[key] ?? 0) : (prop[key] ?? 0));
         i.oninput = () => { const v = parseFloat(i.value) || 0; if (taxes) { prop.taxes = prop.taxes || {}; prop.taxes[key] = v; } else prop[key] = v; save(); };
@@ -979,7 +979,7 @@ export class ProformaUI {
         const grid = document.createElement("div"); grid.className = "pf-form";
         for (const [label, group, key] of FIELDS) {
           params[group] = params[group] || {};
-          const wrap = document.createElement("label"); wrap.className = "pf-field"; wrap.innerHTML = `<span>${label}</span>`;
+          const wrap = document.createElement("label"); wrap.className = "pf-field"; wrap.innerHTML = `<span>${escapeHtml(label)}</span>`;
           const inp = document.createElement("input"); inp.type = "number"; inp.step = "any";
           inp.value = String((params[group] as Record<string, number>)[key] ?? 0);
           inp.oninput = () => { (params[group] as Record<string, number>)[key] = parseFloat(inp.value) || 0; save(); };
@@ -1137,7 +1137,7 @@ export class ProformaUI {
         const col = m.position === "within_iqr" ? "var(--status-good)" : "var(--status-warn)";
         memory.innerHTML = `🏛 Your own history: this deal's hard cost is <b>$${m.entered}/SF</b> `
           + `(${money(m.hard_cost ?? 0)} ÷ ${Math.round(m.gfa_sf ?? 0).toLocaleString()} SF) — `
-          + `<span style="color:${col}">${at}</span> the range your <b>${m.count}</b> closed `
+          + `<span style="color:${escapeHtml(col)}">${at}</span> the range your <b>${m.count}</b> closed `
           + `project(s) landed in ($${m.p25}–$${m.p75}, median $${m.median}). `
           + `A comparison, not a verdict. <button class="tool-btn" id="pf-dm-more" `
           + `style="font-size:10px;padding:1px 6px">which projects?</button>`;
@@ -1200,7 +1200,7 @@ export class ProformaUI {
         const col = g.in_sync ? "var(--status-good)" : (g.delta > 0 ? "var(--status-crit)" : "var(--status-warn)");
         recon.innerHTML = `<div style="display:flex;justify-content:space-between;align-items:center;gap:8px;flex-wrap:wrap">`
           + `<span class="meta">🤝 GC GMP <b>${money(g.gc_gmp)}</b> · EAC ${money(g.gmp_eac)} vs hard cost <b>${money(g.dev_hard_cost)}</b> · `
-          + `<span style="color:${col}">${g.in_sync ? "in sync" : (g.delta > 0 ? "GMP over by " : "GMP under by ") + money(Math.abs(g.delta))}</span></span>`
+          + `<span style="color:${escapeHtml(col)}">${g.in_sync ? "in sync" : (g.delta > 0 ? "GMP over by " : "GMP under by ") + money(Math.abs(g.delta))}</span></span>`
           + `<button class="tool-btn" id="pf-sync-gmp"${g.in_sync ? " disabled" : ""}>⤵ Set hard cost = GMP</button></div>`;
         const btn = recon.querySelector<HTMLButtonElement>("#pf-sync-gmp");
         if (btn) btn.onclick = async () => {
@@ -1268,7 +1268,7 @@ export class ProformaUI {
         for (const [cat, label] of CATS) {
           const head = document.createElement("div"); head.className = "section-title"; head.style.cssText = "margin:8px 0 2px;font-size:12px";
           const subtotal = sum?.categories[cat];
-          head.innerHTML = `${label} <span class="meta" style="font-weight:400">${subtotal ? "· " + money(subtotal.subtotal) + (subtotal.contingency ? " + " + money(subtotal.contingency) + " contingency" : "") : ""}</span>`;
+          head.innerHTML = `${escapeHtml(label)} <span class="meta" style="font-weight:400">${subtotal ? "· " + money(subtotal.subtotal) + (subtotal.contingency ? " + " + money(subtotal.contingency) + " contingency" : "") : ""}</span>`;
           body.appendChild(head);
           const tbl = document.createElement("table"); tbl.className = "sens-table"; tbl.style.fontSize = "12px";
           tbl.innerHTML = `<tr><th style="text-align:left">Description</th><th>$/unit</th><th>Qty</th><th>Total</th><th></th></tr>`;
@@ -1276,10 +1276,10 @@ export class ProformaUI {
             if (ln.category !== cat) return;
             const tr = document.createElement("tr");
             const tot = (ln.unit_cost || 0) * (ln.quantity || 1);
-            tr.innerHTML = `<td><input data-i="${i}" data-k="description" value="${escapeHtml(ln.description || "")}" style="width:150px"></td>`
-              + `<td><input data-i="${i}" data-k="unit_cost" type="number" step="any" value="${ln.unit_cost || 0}" style="width:90px"></td>`
-              + `<td><input data-i="${i}" data-k="quantity" type="number" step="any" value="${ln.quantity ?? 1}" style="width:60px"></td>`
-              + `<td style="text-align:right">${money(tot)}</td><td><button class="tool-btn" data-rm="${i}" title="Remove">✕</button></td>`;
+            tr.innerHTML = `<td><input data-i="${escapeHtml(i)}" data-k="description" value="${escapeHtml(ln.description || "")}" style="width:150px"></td>`
+              + `<td><input data-i="${escapeHtml(i)}" data-k="unit_cost" type="number" step="any" value="${ln.unit_cost || 0}" style="width:90px"></td>`
+              + `<td><input data-i="${escapeHtml(i)}" data-k="quantity" type="number" step="any" value="${ln.quantity ?? 1}" style="width:60px"></td>`
+              + `<td style="text-align:right">${money(tot)}</td><td><button class="tool-btn" data-rm="${escapeHtml(i)}" title="Remove">✕</button></td>`;
             tbl.appendChild(tr);
           });
           body.appendChild(tbl);
@@ -1594,7 +1594,7 @@ export class ProformaUI {
       `<div class="section-title">Monte Carlo — Equity IRR (${mc.solved} draws: exit cap × hard cost × rent)</div>` +
       `<div class="kpi-grid">` +
       [["P10", pct(m.p10)], ["P50 (median)", pct(m.p50)], ["P90", pct(m.p90)], [`P(IRR ≥ ${target * 100}%)`, `${prob}%`]]
-        .map(([l, v]) => `<div class="kpi"><div class="kpi-v">${v}</div><div class="kpi-l">${l}</div></div>`).join("") +
+        .map(([l, v]) => `<div class="kpi"><div class="kpi-v">${escapeHtml(v)}</div><div class="kpi-l">${escapeHtml(l)}</div></div>`).join("") +
       `</div>` +
       `<div class="pf-hist" title="equity IRR distribution (P10 → P90)">${bars}</div>` +
       `<div class="meta">downside-tilted: exit cap and hard cost skew worse than base; rent ±6%.</div>`;
@@ -1690,7 +1690,7 @@ export class ProformaUI {
     const kpis = document.createElement("div"); kpis.className = "dash-cols"; kpis.style.marginBottom = "10px";
     const kpi = (label: string, val: string, color?: string) => {
       const c = card(); c.style.flex = "1";
-      c.innerHTML = `<div class="meta">${label}</div><div style="font-size:18px;font-weight:700${color ? `;color:${color}` : ""}">${val}</div>`;
+      c.innerHTML = `<div class="meta">${escapeHtml(label)}</div><div style="font-size:18px;font-weight:700${color ? `;color:${escapeHtml(color)}` : ""}">${escapeHtml(val)}</div>`;
       return c;
     };
     kpis.append(kpi("Equity IRR", pct(ret.equity_irr), irrColor), kpi("Equity multiple", `${ret.equity_multiple}×`),
@@ -1797,7 +1797,7 @@ export class ProformaUI {
     const out = document.getElementById("pf-out")!;
     out.innerHTML =
       `<div class="kpi-grid">` +
-      kpis.map(([l, v]) => `<div class="kpi"><div class="kpi-v">${v}</div><div class="kpi-l">${l}</div></div>`).join("") +
+      kpis.map(([l, v]) => `<div class="kpi"><div class="kpi-v">${escapeHtml(v)}</div><div class="kpi-l">${escapeHtml(l)}</div></div>`).join("") +
       `</div>` +
       `<div class="section-title">Sources & Uses</div>` +
       `<div class="portal-kv">` +

--- a/apps/web/src/proforma/proforma.ts
+++ b/apps/web/src/proforma/proforma.ts
@@ -929,7 +929,7 @@ export class ProformaUI {
     host.appendChild(body); this.root.appendChild(host);
     void this.api.sourcesUses(pid).then((su) => {
       const rows = (items: { label: string; amount: number }[]) =>
-        items.map((i) => `<tr><th style="text-align:left;font-weight:400">${i.label}</th><td style="text-align:right">${money(i.amount)}</td></tr>`).join("");
+        items.map((i) => `<tr><th style="text-align:left;font-weight:400">${escapeHtml(i.label)}</th><td style="text-align:right">${money(i.amount)}</td></tr>`).join("");
       body.innerHTML =
         `<div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">`
         + `<div><div class="section-title" style="font-size:12px;margin:0 0 2px">Uses</div>`
@@ -1454,7 +1454,7 @@ export class ProformaUI {
     const delta = f.irr_delta == null ? "" : `${f.irr_delta >= 0 ? "+" : ""}${(f.irr_delta * 100).toFixed(1)}pp`;
     const dColor = (f.irr_delta ?? 0) >= 0 ? "#2ecc71" : "#e74c3c";
     const rows = f.lines.map((L) =>
-      `<tr><th style="text-align:left">${L.name}</th><td>${money(L.budget)}</td>` +
+      `<tr><th style="text-align:left">${escapeHtml(L.name)}</th><td>${money(L.budget)}</td>` +
       `<td>${money(L.actual_to_date)}</td><td>${money(L.forecast_at_completion)}</td>` +
       `<td style="color:${L.variance_to_budget > 0 ? "#e74c3c" : "#2ecc71"}">${L.variance_to_budget >= 0 ? "+" : ""}${money(L.variance_to_budget)}</td></tr>`).join("");
     document.getElementById("pf-fc-out")!.innerHTML =

--- a/apps/web/src/proforma/testfitTab.ts
+++ b/apps/web/src/proforma/testfitTab.ts
@@ -75,7 +75,7 @@ export function renderTestFitTab(root: HTMLElement, ctx: TestFitTabCtx): void {
       if (!r.best) { out.innerHTML = `<div class="meta">no feasible scheme for these targets</div>`; return; }
       const dcol = r.swept_depths.length > 1 ? `<th>Depth</th>` : "";
       const rows = r.ranked.map((s, n) => `<tr${n === 0 ? ' style="font-weight:700"' : ""}>`
-        + `<th style="text-align:left">${s.name}${n === 0 ? " ★" : ""}</th>`
+        + `<th style="text-align:left">${esc(s.name)}${n === 0 ? " ★" : ""}</th>`
         + (r.swept_depths.length > 1 ? `<td style="text-align:right">${s.plate_d ?? ""}m</td>` : "")
         + `<td style="text-align:right">${s.total_units}</td><td style="text-align:right">${(s.efficiency * 100).toFixed(0)}%</td>`
         + `<td style="text-align:right">${s.parking_stalls}</td><td style="text-align:right">${(s.yield_on_cost * 100).toFixed(1)}%</td></tr>`).join("");
@@ -105,7 +105,7 @@ export function renderTestFitTab(root: HTMLElement, ctx: TestFitTabCtx): void {
       const schemes = mix.length ? [{ name: "My mix", unit_types: mix }] : undefined;
       const r = await ctx.api.testFitCompare({ plate_w: +wi.value, plate_d: +di.value, floors: +fi.value, schemes, with_defaults: !!schemes });
       const rows = r.schemes.map((s) => `<tr${s.name === r.best ? ' style="font-weight:700"' : ""}>`
-        + `<th style="text-align:left">${s.name}${s.name === r.best ? " ★" : ""}</th>`
+        + `<th style="text-align:left">${esc(s.name)}${s.name === r.best ? " ★" : ""}</th>`
         + `<td style="text-align:right">${s.total_units}</td>`
         + `<td style="text-align:right"${s.daylight_limited ? ' title="deep plate — dark interior earns no rent"' : ""}>${(s.daylight_efficiency * 100).toFixed(0)}%${s.daylight_limited ? " ⚠" : ""}</td>`
         + `<td style="text-align:right">${s.avg_unit_sf.toLocaleString()}</td><td style="text-align:right">${s.total_nsf.toLocaleString()}</td>`

--- a/apps/web/src/proforma/testfitTab.ts
+++ b/apps/web/src/proforma/testfitTab.ts
@@ -2,6 +2,7 @@
  *  ranked. The TestFit-style "explore scenarios, find the deal that pencils" surface. Extracted from
  *  the ProformaUI god class along its LCOM4 seam; behavior pinned by proforma.render.test.ts. */
 import type { ApiClient } from "../api/client";
+import { escapeHtml as esc } from "../ui/feedback";
 
 export interface TestFitTabCtx {
   api: ApiClient;
@@ -15,7 +16,7 @@ export function renderTestFitTab(root: HTMLElement, ctx: TestFitTabCtx): void {
     + `<div class="meta" style="margin-bottom:6px">Fit a unit mix to a floor plate; compare yield + parking across schemes.</div>`;
   const grid = document.createElement("div"); grid.className = "pf-form";
   const inp = (label: string, val: number) => {
-    const w = document.createElement("label"); w.className = "pf-field"; w.innerHTML = `<span>${label}</span>`;
+    const w = document.createElement("label"); w.className = "pf-field"; w.innerHTML = `<span>${esc(label)}</span>`;
     const i = document.createElement("input"); i.type = "number"; i.step = "any"; i.value = String(val); w.appendChild(i); grid.appendChild(w); return i;
   };
   const wi = inp("Plate width (m)", 40), di = inp("Plate depth (m)", 18), fi = inp("Floors", 6);

--- a/apps/web/src/ui/innerHtmlGuard.test.ts
+++ b/apps/web/src/ui/innerHtmlGuard.test.ts
@@ -52,6 +52,8 @@ import { join, relative } from "node:path";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
+import { escapeHtml } from "./feedback";
+
 const SRC = join(__dirname, "..");
 
 /** Escapers that make an interpolation safe. Tested per `${…}`, never per line. */
@@ -76,18 +78,26 @@ const COLD = /^(i|idx|j|n|k|len|count|total|pct|num|\d+)$/i;
  * should CHECK rather than trust — which is what the counting version claimed and could not deliver,
  * because a number does not say which sink it is describing.
  */
+// SIX of these entries are the class that must NOT be escaped, and they are all one shape: a
+// ternary whose branches are LITERAL MARKUP or a literal glyph — `row.gap ? ' <span …>⚠️</span>' :
+// ""`, `s.name === r.best ? " ★" : ""`, `s.daylight_limited ? ' title="…"' : ""` — plus `mark`
+// (a ✓/✗/– glyph) and `discColorByName[disc]` (a colour constant from a lookup). They match HOT on
+// their CONDITION, not on their value. Wrapping any of them in esc() would render the markup as
+// visible text. They are baselined rather than fixed because the fix would be the bug.
 const BASELINE: Record<string, readonly string[]> = {
   "main.ts": [
     "it.label",
   ],
   "portal/panels/aiassist.ts": [
     "(p.title || p.ref || p.id) as string",
+    "mark",
     "r.message || \"No bids to level.\"",
     "r.recommendation.missing_scope.length ? \"var(--status-warn)\" : \"var(--status-good)\"",
     "r.recommendation.note",
     "r.source === \"claude\" ? \"AI\" : \"extract\"",
     "r.source === \"claude\" ? \"AI\" : \"rules\"",
     "r.source === \"claude\" ? \"AI\" : \"rules\"",
+    "row.gap ? ' <span title=\"scope gap\">⚠️</span>' : \"\"",
   ],
   "portal/panels/analytics.ts": [
     "c.cost_code",
@@ -167,6 +177,11 @@ const BASELINE: Record<string, readonly string[]> = {
     "row(\"Plus land\", money(v.cost.land_value))",
     "x.code",
   ],
+  "proforma/testfitTab.ts": [
+    "s.daylight_limited ? ' title=\"deep plate — dark interior earns no rent\"' : \"\"",
+    "s.name === r.best ? \" ★\" : \"\"",
+    "s.name === r.best ? ' style=\"font-weight:700\"' : \"\"",
+  ],
   "reportCenter.ts": [
     "money(s.approved_value)",
     "money(s.executed_value)",
@@ -189,6 +204,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "m.value",
   ],
   "viewer/app.ts": [
+    "discColorByName[disc]",
     "reason",
   ],
   "viewer/tools/authoringSection.ts": [
@@ -250,6 +266,7 @@ export function interpolations(src: string): string[] {
     }
     ts.forEachChild(node, collect);
   };
+  const bound = new Set<string>();                 // names reaching innerHTML as a bare identifier
   const walk = (node: ts.Node): void => {
     const isInnerHtmlWrite =
       ts.isBinaryExpression(node)
@@ -259,10 +276,37 @@ export function interpolations(src: string): string[] {
           || (ts.isElementAccessExpression(node.left)
               && ts.isStringLiteral(node.left.argumentExpression)
               && node.left.argumentExpression.text === "innerHTML"));
-    if (isInnerHtmlWrite) collect(node.right);
+    if (isInnerHtmlWrite) {
+      const before = out.length;
+      collect(node.right);
+      for (let i = before; i < out.length; i++) if (/^[A-Za-z_$][\w$]*$/.test(out[i]!)) bound.add(out[i]!);
+    }
     ts.forEachChild(node, walk);
   };
   walk(sf);
+
+  // ONE LEVEL OF INDIRECTION — the blind spot a review finding on #544 exposed through
+  // `main.ts`'s `${d.name}`. Markup is very often assembled into a local FIRST and only then
+  // interpolated:
+  //
+  //     const rows = p.deals.map((d) => `<tr><th>${d.name}</th>…`).join("");
+  //     panel.innerHTML = `…${rows}…`;
+  //
+  // The walk above only sees spans lexically inside the `innerHTML =` expression, so `${d.name}`
+  // was invisible to BOTH rules in this file — not baselined, not flagged, live. It reached
+  // innerHTML through exactly one hop, and 15 hot interpolations across 8 files sat behind that
+  // hop. A sink one assignment away from the write is still a sink; the scanner was measuring
+  // syntax where the question is reachability.
+  //
+  // Only one hop is followed, deliberately. Two hops would need real dataflow, and the honest
+  // statement of a bounded rule beats a rule that quietly stops somewhere undocumented: a local
+  // built from ANOTHER local that then reaches innerHTML is still not covered.
+  const followBuilders = (n: ts.Node): void => {
+    if (ts.isVariableDeclaration(n) && ts.isIdentifier(n.name) && bound.has(n.name.text)
+        && n.initializer) collect(n.initializer);
+    ts.forEachChild(n, followBuilders);
+  };
+  followBuilders(sf);
   return out;
 }
 
@@ -325,9 +369,12 @@ export function hotSinks(src: string): string[] {
  */
 export function valueBindingSinks(src: string): string[] {
   const sf = ts.createSourceFile("x.ts", src, ts.ScriptTarget.Latest, true);
+  // Constructors and setters carry parameters like any other callable, and leaving them out made
+  // this a coverage gap in a security gate rather than a style question (review finding on #544).
   const isFn = (n: ts.Node): boolean =>
     ts.isFunctionDeclaration(n) || ts.isFunctionExpression(n)
-    || ts.isArrowFunction(n) || ts.isMethodDeclaration(n);
+    || ts.isArrowFunction(n) || ts.isMethodDeclaration(n)
+    || ts.isConstructorDeclaration(n) || ts.isSetAccessorDeclaration(n);
 
   const bindNames = (name: ts.BindingName, into: Set<string>): void => {
     if (ts.isIdentifier(name)) { into.add(name.text); return; }
@@ -338,15 +385,44 @@ export function valueBindingSinks(src: string): string[] {
     for (const p of (fn as ts.SignatureDeclaration).parameters ?? []) bindNames(p.name, out);
     return out;
   };
-  // Destructured names are collected file-wide rather than per-scope: this rule only ever asks
-  // "is this name a value binding somewhere", and a false positive costs one `esc()` that was
-  // already correct, while a false negative is a live sink. Err toward escaping.
-  const destructured = new Set<string>();
-  const collectDestructured = (n: ts.Node): void => {
-    if (ts.isVariableDeclaration(n) && !ts.isIdentifier(n.name)) bindNames(n.name, destructured);
-    ts.forEachChild(n, collectDestructured);
+  // LEXICALLY SCOPED. The first version collected destructured names file-wide and justified it as
+  // "a false positive only costs one esc() that was already correct". That reasoning was WRONG, and
+  // a review finding on #544 said so: a destructured `rows` in one function made an unrelated plain
+  // local `rows` in a SIBLING function fail the plain-local exclusion — and that exclusion exists
+  // precisely because those locals hold assembled markup, so the "harmless" fix would have escaped
+  // HTML and broken the page. A false positive is only cheap when the suggested fix is safe.
+  // Same for the upward parameter walk: a nearer local shadowing an outer parameter was reported.
+  // So resolve each interpolation to its NEAREST binding and report only when that binding is a
+  // parameter or a destructuring element.
+  const isScope = (n: ts.Node): boolean =>
+    isFn(n) || ts.isBlock(n) || ts.isSourceFile(n)
+    || ts.isForOfStatement(n) || ts.isForInStatement(n) || ts.isForStatement(n)
+    || ts.isCaseClause(n) || ts.isCatchClause(n);
+
+  /** The nearest binding of `name` visible at `use`: "param", "destructured", "local", or null. */
+  const nearestBinding = (name: string, use: ts.Node): string | null => {
+    for (let scope: ts.Node | undefined = use.parent; scope; scope = scope.parent) {
+      if (!isScope(scope)) continue;
+      if (isFn(scope) && paramsOf(scope).has(name)) return "param";
+      // Variable declarations belonging to THIS scope only — never descend into a nested
+      // function, whose locals are not visible here (that descent is what made a sibling
+      // function's `rows` shadow this one's).
+      let found: string | null = null;
+      const look = (n: ts.Node): void => {
+        if (found) return;
+        if (ts.isVariableDeclaration(n)) {
+          const names = new Set<string>();
+          bindNames(n.name, names);
+          if (names.has(name)) found = ts.isIdentifier(n.name) ? "local" : "destructured";
+        }
+        if (n !== scope && isFn(n)) return;
+        ts.forEachChild(n, look);
+      };
+      look(scope);
+      if (found) return found;
+    }
+    return null;
   };
-  collectDestructured(sf);
 
   const out: string[] = [];
   const collect = (node: ts.Node, into: ts.Expression[]): void => {
@@ -370,12 +446,8 @@ export function valueBindingSinks(src: string): string[] {
       collect(node.right, exprs);
       for (const e of exprs) {
         if (!ts.isIdentifier(e) || SAFE.test(e.text)) continue;
-        let scope: ts.Node | undefined = e.parent, isParam = false;
-        while (scope) {
-          if (isFn(scope) && paramsOf(scope).has(e.text)) { isParam = true; break; }
-          scope = scope.parent;
-        }
-        if (isParam || destructured.has(e.text)) out.push(e.text);
+        const binding = nearestBinding(e.text, e);
+        if (binding === "param" || binding === "destructured") out.push(e.text);
       }
     }
     ts.forEachChild(node, walk);
@@ -605,6 +677,77 @@ describe("innerHTML escaping ratchet (identity-keyed)", () => {
       + "There is no baseline for this rule: the identity is the binding NAME, which does not move "
       + "when a caller starts passing user data, so grandfathering one would freeze a sink open.")
       .toBe("none");
+  });
+
+  // ---- Review findings on #544, each pinned so it cannot come back silently -------------------
+
+  it("FOLLOWS ONE HOP through a builder local — the blind spot that hid a live sink", () => {
+    // Markup is usually assembled into a local first and only then interpolated. The scanner walked
+    // only the spans lexically inside the `innerHTML =` expression, so `${d.name}` in main.ts was
+    // invisible to BOTH rules here: not baselined, not flagged, live. A reviewer found the symptom;
+    // the cause was that the scanner measured SYNTAX where the question is REACHABILITY.
+    const builder = `
+      const rows = p.deals.map((d) => \`<tr><th>\${d.name}</th></tr>\`).join("");
+      panel.innerHTML = \`<table>\${rows}</table>\`;`;
+    expect(hotSinks(builder)).toEqual(["d.name"]);
+    // ...and the escaped form clears it, so the fix is reachable.
+    expect(hotSinks(builder.replace("${d.name}", "${esc(d.name)}"))).toEqual([]);
+  });
+
+  it("stops at ONE hop, and says so rather than pretending to do dataflow", () => {
+    // A local built from another local is NOT covered. Asserting the limit keeps it honest: a
+    // silent boundary is how a gate ends up reporting good news about ground it never walked.
+    const twoHops = `
+      const inner = items.map((r) => \`<td>\${r.name}</td>\`).join("");
+      const outer = \`<tr>\${inner}</tr>\`;
+      el.innerHTML = \`<table>\${outer}</table>\`;`;
+    expect(hotSinks(twoHops), "two hops is a known, documented gap").toEqual([]);
+  });
+
+  it("sees parameters of CONSTRUCTORS and SETTERS, not just functions and methods", () => {
+    // Review finding: `isFn` omitted both, so a parameter in either body passed the guard. A
+    // coverage hole in a security gate, not a style question.
+    expect(valueBindingSinks(
+      "class A { constructor(label) { this.el.innerHTML = `<b>${label}</b>`; } }")).toEqual(["label"]);
+    expect(valueBindingSinks(
+      "class A { set title(value) { this.el.innerHTML = `<b>${value}</b>`; } }")).toEqual(["value"]);
+  });
+
+  it("resolves bindings LEXICALLY, so a sibling scope cannot make a plain local look unsafe", () => {
+    // Review finding, and my own rationale for the file-wide set was wrong: I argued a false
+    // positive "costs one esc() that was already correct". For THIS exclusion it costs the opposite
+    // — the plain-local carve-out exists because those locals hold assembled markup, so the
+    // "harmless" fix would have escaped HTML and broken the page. A false positive is only cheap
+    // when the fix it suggests is safe.
+    const siblings = `
+      function a([label, rows]) { x.innerHTML = \`<i>\${rows}</i>\`; }
+      function b(items) { const rows = items.map((r) => "<td></td>").join(""); y.innerHTML = \`<i>\${rows}</i>\`; }`;
+    // `rows` is destructured in a(), a plain local in b(). Only a()'s may be reported.
+    expect(valueBindingSinks(siblings)).toEqual(["rows"]);
+
+    // And a nearer local shadowing an outer parameter resolves to the LOCAL, so it is not reported.
+    const shadowed = `
+      function outer(value) {
+        function inner() { const value = "<b>x</b>"; z.innerHTML = \`<i>\${value}</i>\`; }
+      }`;
+    expect(valueBindingSinks(shadowed)).toEqual([]);
+  });
+
+  it("escapes an option VALUE as well as its text, so the value round-trips", () => {
+    // Review finding on schedule.ts. `esc` turns `&` into `&amp;`; the old `.replace(/"/g, …)` did
+    // not, so a milestone literally named `A &amp; B` came back out of the attribute as `A & B` and
+    // the next request queried the wrong milestone. Escaping only the TEXT made the two disagree.
+    // Asserted through a real DOM parse rather than by eyeballing the template.
+    const name = 'A &amp; B "quoted" <b>';
+    const sel = document.createElement("select");
+    sel.innerHTML = `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`;
+    expect(sel.value, "the value must survive innerHTML parsing unchanged").toBe(name);
+    expect(sel.options[0]!.textContent).toBe(name);
+
+    // the old shape did not round-trip — this is the regression being pinned
+    const bad = document.createElement("select");
+    bad.innerHTML = `<option value="${name.replace(/"/g, "&quot;")}">${escapeHtml(name)}</option>`;
+    expect(bad.value).not.toBe(name);
   });
 
   it("sees the free-text identifiers added with this change", () => {

--- a/apps/web/src/ui/innerHtmlGuard.test.ts
+++ b/apps/web/src/ui/innerHtmlGuard.test.ts
@@ -80,9 +80,6 @@ const BASELINE: Record<string, readonly string[]> = {
   "main.ts": [
     "it.label",
   ],
-  "portal/homes/developerHome.ts": [
-    "label",
-  ],
   "portal/panels/aiassist.ts": [
     "(p.title || p.ref || p.id) as string",
     "r.message || \"No bids to level.\"",
@@ -91,7 +88,6 @@ const BASELINE: Record<string, readonly string[]> = {
     "r.source === \"claude\" ? \"AI\" : \"extract\"",
     "r.source === \"claude\" ? \"AI\" : \"rules\"",
     "r.source === \"claude\" ? \"AI\" : \"rules\"",
-    "title",
   ],
   "portal/panels/analytics.ts": [
     "c.cost_code",
@@ -107,47 +103,27 @@ const BASELINE: Record<string, readonly string[]> = {
     "r.pricing_source",
     "r.pricing_source",
     "s.note",
-    "title",
   ],
   "portal/panels/budget.ts": [
     "g.contract_value ? \" · \" : \"\"",
-    "label",
     "usd(g.contract_value)",
     "usd(s.contract_value)",
     "usd(t.contract_value)",
   ],
   "portal/panels/design.ts": [
-    "label",
-    "value",
     "x.label",
-  ],
-  "portal/panels/evm.ts": [
-    "label",
-    "value",
   ],
   "portal/panels/masterBuilder.ts": [
     "st.label",
   ],
   "portal/panels/operations.ts": [
     "d.code ?? \"\"",
-    "label",
-    "label",
-    "title",
-    "value",
-    "value",
   ],
   "portal/panels/portfolio.ts": [
-    "label",
-    "t.cross_project ? ` <span style=\"color:${col}\" title=\"on ${t.project_count} projects — can be double-booked\">⇄</span>` : \"\"",
     "usd(w.weighted_value)",
-  ],
-  "portal/panels/resourceLoading.ts": [
-    "label",
-    "value",
   ],
   "portal/panels/schedule.ts": [
     "mi.name",
-    "title",
     "title.toLowerCase()",
   ],
   "portal/panels/selections.ts": [
@@ -158,34 +134,20 @@ const BASELINE: Record<string, readonly string[]> = {
     "dp.next_deliverable.ref ?? \"\"",
     "dp.next_deliverable.type",
     "els.map((e) => e.label).join(\", \")",
-    "label",
-    "label",
-    "label",
     "m.parent_type",
     "m.type",
     "n.ref ?? n.title ?? \"?\"",
     "o.ref ?? \"\"",
     "o.type",
-    "value",
-    "value",
   ],
   "portal/panels/topicBoard.ts": [
     "e.detail?.reply_to ? \"↳ \" : \"\"",
     "e.kind === \"comment\" ? \"💬 \" : \"\"",
   ],
-  "portal/panels/traceability.ts": [
-    "label",
-    "value",
-  ],
   "portal/panels/wip.ts": [
     "flagText",
-    "label",
-    "value",
   ],
   "portal/portal.ts": [
-    "label",
-    "label",
-    "label",
     "n.reason === \"assigned\" ? \"rfi\" : \"open\"",
     "rs.source === \"claude\" ? \"AI\" : \"rules\"",
     "top.reason",
@@ -193,32 +155,17 @@ const BASELINE: Record<string, readonly string[]> = {
   "portal/register/register.ts": [
     "c.geo ? \"\" : \" (text search only)\"",
   ],
-  "proforma/massingTab.ts": [
-    "label",
-  ],
   "proforma/proforma.ts": [
     "cd.by_cost_code.length - top.length",
     "cipNote",
     "e.source === \"cip\" ? \" <span class=\\\"meta\\\">(CIP)</span>\" : \"\"",
-    "label",
-    "label",
-    "label",
-    "label",
-    "label",
-    "label",
-    "label",
     "money(pf.terminal_value)",
     "money(rec.value)",
     "money(v.cost.value)",
     "money(v.income.value)",
     "money(v.sales_comparison.value)",
     "row(\"Plus land\", money(v.cost.land_value))",
-    "title",
-    "title",
     "x.code",
-  ],
-  "proforma/testfitTab.ts": [
-    "label",
   ],
   "reportCenter.ts": [
     "money(s.approved_value)",
@@ -234,10 +181,8 @@ const BASELINE: Record<string, readonly string[]> = {
     "it.label",
   ],
   "ui/onboarding.ts": [
-    "desc",
     "s.body",
     "s.title",
-    "title",
   ],
   "ui/result.ts": [
     "m.label",
@@ -245,7 +190,6 @@ const BASELINE: Record<string, readonly string[]> = {
   ],
   "viewer/app.ts": [
     "reason",
-    "title",
   ],
   "viewer/tools/authoringSection.ts": [
     "r.imported.slice(0, 3).map((i) => i.name).join(\", \")",
@@ -258,7 +202,6 @@ const BASELINE: Record<string, readonly string[]> = {
   ],
   "viewer/tools/qaSection.ts": [
     "a.r_value",
-    "label",
   ],
 };
 
@@ -326,6 +269,105 @@ export function interpolations(src: string): string[] {
 /** Every hot, unescaped interpolation reaching innerHTML, as its expression text. */
 export function hotSinks(src: string): string[] {
   return interpolations(src).filter((e) => !SAFE.test(e) && !COLD.test(e) && HOT.test(e));
+}
+
+
+/**
+ * THE SECOND RULE, and the reason the first one is not enough.
+ *
+ * The identity ratchet above freezes `file :: expression`. That works when the expression NAMES its
+ * source — `${a.filename}` tells you a filename is being rendered, so a caller cannot change what
+ * flows in without changing the identity. It does NOT work when the interpolation is a bare value
+ * binding:
+ *
+ *     const card = (label: string, value: string) => {
+ *       c.innerHTML = `<div>${value}</div><div class="meta">${label}</div>`;   // identity: "value"
+ *     };
+ *
+ * `value` is the identity whatever the caller passes. Every caller could switch from a literal to a
+ * user-controlled field and the baseline would not move — the sink goes live while the gate stays
+ * green. That is the SAME defect this file was built to fix (a frozen key that does not vary with
+ * the thing it is supposed to constrain), one level up: there the key was a count with no identity,
+ * here it is an identity with no source.
+ *
+ * So this rule takes no baseline and admits no exemption: a bare value binding reaching innerHTML
+ * must be escaped. The fix is always available and always correct — wrap it in `esc()` — which is
+ * why there is nothing to grandfather.
+ *
+ * WHAT COUNTS AS A VALUE BINDING: a function PARAMETER, or a name bound by a DESTRUCTURING pattern
+ * (`for (const [label, val] of cards)`). Both are values handed in from elsewhere.
+ *
+ * WHAT DOES NOT, and why the line is drawn there: a plain `const x = …` local. 157 of those reach
+ * innerHTML in this tree and most hold HTML assembled earlier in the same function — `rows`,
+ * `thead`, `bars`, `cells`, `pts`. Escaping those would destroy the markup, so the rule would have
+ * to carry judgement about which locals are values, and a rule with judgement in it is a rule that
+ * can be argued with. The exclusion is stated here rather than left implicit: a local assigned from
+ * user data and interpolated bare is NOT caught by either rule in this file.
+ *
+ * Deliberately NOT filtered by HOT/COLD. `budget.ts` interpolated a bare `val` and `evm.ts` a bare
+ * `sub`; neither matches HOT, so both were invisible to the ratchet above while being exactly the
+ * shape this rule exists to catch. A term list derived from what someone happened to be looking at
+ * cannot bound a population — the SHAPE can.
+ */
+export function valueBindingSinks(src: string): string[] {
+  const sf = ts.createSourceFile("x.ts", src, ts.ScriptTarget.Latest, true);
+  const isFn = (n: ts.Node): boolean =>
+    ts.isFunctionDeclaration(n) || ts.isFunctionExpression(n)
+    || ts.isArrowFunction(n) || ts.isMethodDeclaration(n);
+
+  const bindNames = (name: ts.BindingName, into: Set<string>): void => {
+    if (ts.isIdentifier(name)) { into.add(name.text); return; }
+    for (const el of name.elements) if (ts.isBindingElement(el)) bindNames(el.name, into);
+  };
+  const paramsOf = (fn: ts.Node): Set<string> => {
+    const out = new Set<string>();
+    for (const p of (fn as ts.SignatureDeclaration).parameters ?? []) bindNames(p.name, out);
+    return out;
+  };
+  // Destructured names are collected file-wide rather than per-scope: this rule only ever asks
+  // "is this name a value binding somewhere", and a false positive costs one `esc()` that was
+  // already correct, while a false negative is a live sink. Err toward escaping.
+  const destructured = new Set<string>();
+  const collectDestructured = (n: ts.Node): void => {
+    if (ts.isVariableDeclaration(n) && !ts.isIdentifier(n.name)) bindNames(n.name, destructured);
+    ts.forEachChild(n, collectDestructured);
+  };
+  collectDestructured(sf);
+
+  const out: string[] = [];
+  const collect = (node: ts.Node, into: ts.Expression[]): void => {
+    if (ts.isTemplateExpression(node)) {
+      for (const span of node.templateSpans) { into.push(span.expression); collect(span.expression, into); }
+      return;
+    }
+    ts.forEachChild(node, (c) => collect(c, into));
+  };
+  const walk = (node: ts.Node): void => {
+    const isInnerHtmlWrite =
+      ts.isBinaryExpression(node)
+      && (node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          || node.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken)
+      && ((ts.isPropertyAccessExpression(node.left) && node.left.name.text === "innerHTML")
+          || (ts.isElementAccessExpression(node.left)
+              && ts.isStringLiteral(node.left.argumentExpression)
+              && node.left.argumentExpression.text === "innerHTML"));
+    if (isInnerHtmlWrite) {
+      const exprs: ts.Expression[] = [];
+      collect(node.right, exprs);
+      for (const e of exprs) {
+        if (!ts.isIdentifier(e) || SAFE.test(e.text)) continue;
+        let scope: ts.Node | undefined = e.parent, isParam = false;
+        while (scope) {
+          if (isFn(scope) && paramsOf(scope).has(e.text)) { isParam = true; break; }
+          scope = scope.parent;
+        }
+        if (isParam || destructured.has(e.text)) out.push(e.text);
+      }
+    }
+    ts.forEachChild(node, walk);
+  };
+  walk(sf);
+  return out;
 }
 
 
@@ -400,20 +442,26 @@ describe("innerHTML escaping ratchet (identity-keyed)", () => {
   it("CATCHES A SUBSTITUTION, which the counting version could not", () => {
     // This is the whole argument for the rewrite. Take a real baselined file, DELETE one known sink
     // and ADD a different unescaped one. The count is unchanged, so the old rule stayed green.
-    const file = "portal/panels/evm.ts";
-    const known = BASELINE[file]!;
-    expect(known, "fixture file must still be baselined").toContain("value");
+    // The fixture is DERIVED, not named. It used to hardcode `portal/panels/evm.ts` / "value" —
+    // and HELPER-ESCAPE escaped every sink in that file, so a legitimate improvement red this test
+    // with a message about a missing baseline entry rather than about the substitution it guards.
+    // A failure message that can misdiagnose is worse than one that stays silent, because somebody
+    // acts on it (test_scratch_ignored.py, the same lesson). Pick any file with ≥ 2 known sinks.
+    const file = Object.keys(BASELINE).find((f) => (BASELINE[f] ?? []).length >= 2);
+    expect(file, "no baselined file has two sinks left — pick a different fixture shape").toBeTruthy();
+    const known = BASELINE[file!]!;
+    const victim = known[0]!;
 
-    const before = { [file]: [...known] };
-    const after = { [file]: known.filter((e) => e !== "value").concat("attacker.name") };
+    const before = { [file!]: [...known] };
+    const after = { [file!]: known.filter((e) => e !== victim).concat("attacker.name") };
 
     // The mutation must actually have applied — a mutation that does not apply is a test that was
     // never exercised, and it reports green exactly like a passing one (mixinStaging.test.ts, #542).
-    expect(after[file]).not.toEqual(before[file]);
-    expect(after[file]!.length, "substitution must keep the COUNT identical").toBe(before[file]!.length);
+    expect(after[file!]).not.toEqual(before[file!]);
+    expect(after[file!]!.length, "substitution must keep the COUNT identical").toBe(before[file!]!.length);
 
     // Old rule: count <= allowance. Same length, so it passed.
-    expect(after[file]!.length <= before[file]!.length).toBe(true);
+    expect(after[file!]!.length <= before[file!]!.length).toBe(true);
     // New rule: the identity is unknown, so it fails.
     expect(unknownIdentities(after, BASELINE)).toEqual([`${file} :: attacker.name`]);
   });
@@ -471,6 +519,78 @@ describe("innerHTML escaping ratchet (identity-keyed)", () => {
     expect(unknownIdentities({ "a.ts": ["user.name"] }, baseline)).toEqual([]);
     expect(unknownIdentities({ "a.ts": ["user.name", "user.name"] }, baseline))
       .toEqual(["a.ts :: user.name"]);
+  });
+
+  // ---- THE SECOND RULE: no bare value binding reaches innerHTML unescaped. No baseline. --------
+
+  it("finds the pre-fix helper shape — the derivation is proved to REACH, not just to run", () => {
+    // This is `card` from portal/panels/operations.ts EXACTLY as it stood before this change. The
+    // gate must find it. test_seeding_sweep.py paid for this rule twice: a sweep whose own first
+    // draft reported the tree clean, because its predicate never looked at the site. So the checker
+    // runs against the known-bad text first, and a mutation that makes it lenient fails HERE.
+    const preFix = `
+      const card = (label: string, value: string) => {
+        const c = el("div", "dash-card");
+        c.innerHTML = \`<div style="font-size:20px">\${value}</div><div class="meta">\${label}</div>\`;
+        return c;
+      };`;
+    expect(valueBindingSinks(preFix).sort()).toEqual(["label", "value"]);
+  });
+
+  it("finds a DESTRUCTURED binding, which a parameter-only rule missed", () => {
+    // The first draft of this rule tested only for parameters and reported the tree clean at 85
+    // fixed sites. 23 more were live, in this shape — `label`/`val` are values handed in from
+    // elsewhere exactly as a parameter is, and the name says nothing about the source either way.
+    // A predicate that decides what to LOOK at hides everything it excludes from its own count.
+    const loop = `
+      for (const [label, val] of cards) {
+        c.innerHTML = \`<div class="kpi-v">\${val}</div><div class="kpi-l">\${label}</div>\`;
+      }`;
+    expect(valueBindingSinks(loop).sort()).toEqual(["label", "val"]);
+  });
+
+  it("catches names HOT cannot see — which is why this rule is not term-filtered", () => {
+    // `val` and `sub` match no HOT term, so the identity ratchet above was blind to both while they
+    // sat unescaped in budget.ts and evm.ts. Shape bounds a population; a keyword list does not.
+    for (const name of ["val", "sub", "color", "icon", "recipe"]) {
+      expect(hotSinks("const f = (" + name + ") => { e.innerHTML = `<b>${" + name + "}</b>`; };"),
+        `${name} is invisible to HOT — that is the point`).toEqual([]);
+      expect(valueBindingSinks("const f = (" + name + ") => { e.innerHTML = `<b>${" + name + "}</b>`; };"))
+        .toEqual([name]);
+    }
+  });
+
+  it("accepts the escaped form, so the fix actually clears the gate", () => {
+    expect(valueBindingSinks(
+      "const f = (label) => { e.innerHTML = `<b>${esc(label)}</b>`; };")).toEqual([]);
+    expect(valueBindingSinks(
+      "const f = (label) => { e.innerHTML = `<b>${escapeHtml(label)}</b>`; };")).toEqual([]);
+  });
+
+  it("does NOT flag a plain local — the stated exclusion, asserted rather than described", () => {
+    // 157 bare locals reach innerHTML in this tree and most hold markup built a few lines earlier.
+    // Escaping those would destroy it, so they are out of scope BY DESIGN. Asserting the exclusion
+    // keeps it honest: if someone later widens the rule to all bare identifiers, this test says so
+    // rather than the build going red 157 times with no explanation.
+    const local = `
+      function render(items) {
+        const rows = items.map((r) => \`<tr><td>\${esc(r.name)}</td></tr>\`).join("");
+        tbl.innerHTML = \`<tbody>\${rows}</tbody>\`;
+      }`;
+    expect(valueBindingSinks(local)).toEqual([]);
+  });
+
+  it("has ZERO value-binding sinks across the tree, with no baseline to grandfather into", () => {
+    const found: string[] = [];
+    for (const file of walk(SRC)) {
+      const hits = valueBindingSinks(readFileSync(file, "utf8"));
+      for (const h of hits) found.push(`${relative(SRC, file).replace(/\\/g, "/")} :: ${h}`);
+    }
+    expect(found.sort().join("\n") || "none",
+      "A bare parameter or destructured binding reached innerHTML unescaped. Wrap it in esc(). "
+      + "There is no baseline for this rule: the identity is the binding NAME, which does not move "
+      + "when a caller starts passing user data, so grandfathering one would freeze a sink open.")
+      .toBe("none");
   });
 
   it("sees the free-text identifiers added with this change", () => {

--- a/apps/web/src/ui/innerHtmlGuard.test.ts
+++ b/apps/web/src/ui/innerHtmlGuard.test.ts
@@ -297,12 +297,26 @@ export function hotSinks(src: string): string[] {
  * WHAT COUNTS AS A VALUE BINDING: a function PARAMETER, or a name bound by a DESTRUCTURING pattern
  * (`for (const [label, val] of cards)`). Both are values handed in from elsewhere.
  *
- * WHAT DOES NOT, and why the line is drawn there: a plain `const x = …` local. 157 of those reach
+ * WHAT DOES NOT, and why the line is drawn there: a plain `const x = …` local. 134 of those reach
  * innerHTML in this tree and most hold HTML assembled earlier in the same function — `rows`,
  * `thead`, `bars`, `cells`, `pts`. Escaping those would destroy the markup, so the rule would have
  * to carry judgement about which locals are values, and a rule with judgement in it is a rule that
  * can be argued with. The exclusion is stated here rather than left implicit: a local assigned from
  * user data and interpolated bare is NOT caught by either rule in this file.
+ *
+ * THAT EXCLUSION WAS TRIAGED, NOT ASSUMED — because an exclusion nobody measures is just a blind
+ * spot with a justification attached. All 134 were classified by their declaration's initialiser
+ * (41 build markup, 39 literal, 15 numeric, 1 already escaped, 36 suspect, 2 unresolvable) and
+ * every suspect and unresolvable one was read. Exactly ONE was a real sink: `schedule.ts`'s
+ * critical-path line, where the server builds `critical_path` as `[r["ref"] or r["id"] …]` — stored,
+ * user-entered activity refs — and the panel joined and interpolated them raw. It is escaped now.
+ *
+ * Two things that triage is worth recording. **The classifier's first draft resolved declarations
+ * file-wide and kept the LAST match**, so `design.ts`'s `gap` (a number, `p.eui_gap_pct`) was
+ * attributed to an unrelated `el("div")` hundreds of lines away and reported suspect; the lookup is
+ * scope-aware now, and the bug surfaced only because the suspects were READ rather than counted.
+ * And the one real finding was a LOCAL — so the gap this comment describes was live, not
+ * theoretical, which is the argument for measuring an exclusion instead of asserting it.
  *
  * Deliberately NOT filtered by HOT/COLD. `budget.ts` interpolated a bare `val` and `evm.ts` a bare
  * `sub`; neither matches HOT, so both were invisible to the ratchet above while being exactly the

--- a/apps/web/src/ui/onboarding.ts
+++ b/apps/web/src/ui/onboarding.ts
@@ -5,6 +5,8 @@
  * ~60-second tour of the workspaces, Open menu, project switcher, tools rail and sign-in. Both
  * the welcome and the tour are relaunchable from the Help (?) menu.
  */
+import { escapeHtml as esc } from "./feedback";
+
 const KEY = "aec-onboarded";
 const TOUR_AFTER_SIGNIN = "aec-tour-after-signin";
 
@@ -85,9 +87,9 @@ export function showWelcome(ctx: OnboardCtx): void {
     b.style.cssText = "text-align:left;background:var(--panel2,#25272b);border:1px solid var(--line);"
       + "border-radius:10px;padding:14px;display:flex;flex-direction:column;gap:6px;cursor:pointer;"
       + "transition:border-color .12s,transform .12s;color:var(--text);min-height:128px";
-    b.innerHTML = `<div style="font-size:22px">${icon}</div>`
-      + `<div style="font-weight:600;font-size:14px">${title}</div>`
-      + `<div class="meta" style="font-size:12.5px">${desc}</div>`;
+    b.innerHTML = `<div style="font-size:22px">${esc(icon)}</div>`
+      + `<div style="font-weight:600;font-size:14px">${esc(title)}</div>`
+      + `<div class="meta" style="font-size:12.5px">${esc(desc)}</div>`;
     if (!enabled) { b.style.opacity = "0.5"; b.style.cursor = "not-allowed"; b.disabled = true; }
     else {
       b.onmouseenter = () => { b.style.borderColor = "var(--accent)"; b.style.transform = "translateY(-2px)"; };

--- a/apps/web/src/viewer/app.ts
+++ b/apps/web/src/viewer/app.ts
@@ -1583,7 +1583,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
           : title.startsWith("Document") ? "Document" : "Data";
       if (opts.tool && primary && !isPrimary) group.dataset.secondary = "1";
       const head = document.createElement("button"); head.type = "button"; head.className = "tool-group-head";
-      head.innerHTML = `<span class="chev">▸</span><span class="t">${title}</span>`
+      head.innerHTML = `<span class="chev">▸</span><span class="t">${escapeHtml(title)}</span>`
         + (opts.tool && primary && !isPrimary ? `<span class="why">more</span>` : "")
         + (ok ? "" : `<span class="why">${reason}</span>`);
       const body = document.createElement("div"); body.className = "tool-group-body";
@@ -2184,7 +2184,7 @@ export function initViewerApp(ctx: ViewerCtx): ViewerApp {
     if (heading) {
       const head = document.createElement("button");
       head.type = "button"; head.className = "tool-group-head";
-      head.innerHTML = `<span class="chev">▾</span><span class="t">${heading}</span>`;
+      head.innerHTML = `<span class="chev">▾</span><span class="t">${escapeHtml(heading)}</span>`;
       head.onclick = () => sec.classList.toggle("open");
       sec.append(head, body);
     } else {

--- a/apps/web/src/viewer/nodeCanvas.ts
+++ b/apps/web/src/viewer/nodeCanvas.ts
@@ -8,6 +8,7 @@
  */
 
 import { applySlider, sliderSpecs } from "./nodeSliders";
+import { escapeHtml as esc } from "../ui/feedback";
 
 type Graph = { nodes: { id: string; recipe: string; params: Record<string, unknown> }[];
                edges: { from: string; to: string }[] };
@@ -216,7 +217,7 @@ export function openNodeCanvas(opts: NodeCanvasOpts): void {
     const bar = document.createElement("div");
     bar.style.cssText = "display:flex;align-items:center;gap:4px;padding:4px 6px;cursor:grab;"
       + "background:var(--accent-weak,#233047);border-radius:8px 8px 0 0";
-    bar.innerHTML = `<span style="font-weight:600">${id}</span><span style="opacity:.75">${recipe}</span>`;
+    bar.innerHTML = `<span style="font-weight:600">${id}</span><span style="opacity:.75">${esc(recipe)}</span>`;
     const del = document.createElement("button"); del.textContent = "✕"; del.title = "Remove node";
     del.style.cssText = "margin-left:auto;background:none;border:none;color:inherit;cursor:pointer;font-size:11px";
     del.onclick = (ev) => { ev.stopPropagation(); removeNode(id); };

--- a/apps/web/src/viewer/tools/qaSection.ts
+++ b/apps/web/src/viewer/tools/qaSection.ts
@@ -355,7 +355,7 @@ export function buildQaSection(d: QaDeps): void {
               if (!guids.length) continue;
               const row = document.createElement("div");
               row.className = "meta"; row.style.cssText = "margin-top:4px;cursor:pointer";
-              row.innerHTML = `<b>${label}</b>: ${guids.length}`;
+              row.innerHTML = `<b>${escapeHtml(label)}</b>: ${guids.length}`;
               row.title = "Select these elements";
               row.onclick = async () => { await selectMap(await sets.fromGuids(guids.slice(0, 200))); };
               body.appendChild(row);


### PR DESCRIPTION
# What & why

The identity ratchet shipped in #543 freezes `file :: expression`. That constrains a sink whose expression **names its source** — `${a.filename}` cannot start carrying something else without the identity moving. It does nothing for a bare value binding:

```ts
const card = (label: string, value: string) => {
  c.innerHTML = `<div>${value}</div><div class="meta">${label}</div>`;   // identity: "value"
};
```

`value` is the identity whatever the caller passes. Every call site could switch from a literal to a user-controlled field and the baseline would not move — **the sink goes live while the gate stays green**. That is the same defect the ratchet was built to fix, one level up: there the frozen key was a count with no identity, here it is an identity with no source.

**108 interpolations across 27 files**, all now escaped. The population was derived by AST — bare identifiers reaching `innerHTML` that resolve to a function parameter or a destructuring binding.

The fix is verifiable in a way most sweeps are not: escaping a sink can only ever **remove** entries from the ratchet's baseline, never add one. It went **119 → 74 with zero additions**, which is the check that the remediation did what it claimed and nothing else.

## Three things this found that the existing gate could not

| | |
|---|---|
| **The HOT term list was hiding 53 of them** | `budget.ts` interpolated a bare `val`, `evm.ts` a bare `sub`. Neither word matches any term in the list, so both were invisible to the ratchet while being exactly the shape at issue. Under the term filter the population read **32**; under the shape rule, **85**. *A keyword list derived from what someone happened to be looking at cannot bound a population — a shape can.* |
| **The first draft of the new rule tested only for parameters** | It reported the tree clean at 85 fixed sites. 23 more were live in `for (const [label, val] of cards)` — a destructuring binding is a value handed in from elsewhere exactly as a parameter is, and the name says nothing about the source either way. *A predicate that decides what to LOOK at hides everything it excludes from its own count*, which is why the count looked complete both times. |
| **`register.ts` had a comment about this exact hazard** | "textContent/esc throughout: ref+title are user data (stored-XSS guard)" sits directly above the one interpolation on that line that was not escaped. |

## The new rule

No baseline, no exemption. The fix is always available and always correct, so there is nothing to grandfather — and grandfathering one would freeze a sink open by definition.

Its boundary is stated rather than implied: a plain `const x = …` local is out of scope, because **134** of those reach `innerHTML` in this tree and most hold markup assembled a few lines earlier (`rows`, `thead`, `bars`, `cells`) where escaping would destroy it.

Self-tests, in the house style: the checker is run against the **pre-fix `card` helper verbatim** and must find it before any verdict is trusted; against the destructuring shape its own first draft missed; against five names HOT cannot see; against the escaped form; and against the excluded local. Then re-proved on a real file — un-escaping one `value` in `operations.ts` reds it by name, revert clean.

## The exclusion was triaged, not assumed — and it was hiding a live XSS

**An exclusion nobody measures is a blind spot with a justification attached.** All 134 bare locals were classified by their declaration's initialiser (41 build markup, 39 literal, 15 numeric, 1 already escaped, 36 suspect, 2 unresolvable) and every suspect and unresolvable one was read.

Exactly **one was a real sink**, and it was live: `portal/panels/schedule.ts` renders the CPM critical path by joining `c.critical_path` and interpolating it raw. The server builds that list as `[r["ref"] or r["id"] for r in rows if r["critical"]]` — and `ref` is a **stored, user-entered activity field**. Anyone who can name a schedule activity could put markup in the name and have it execute for every user who opens the CPM panel. Escaped after the join; the `" → "` separator holds nothing escapable.

Two things worth keeping from that triage:

- **The classifier's first draft resolved declarations file-wide and kept the LAST match**, so `design.ts`'s `gap` (a number, `p.eui_gap_pct`) was attributed to an unrelated `el("div")` hundreds of lines away and reported suspect. The lookup is scope-aware now — and that bug surfaced only because the suspects were *read* rather than counted.
- **The single real finding was a local** — in the class the new rule deliberately excludes. So the documented gap was live, not theoretical. That is the argument for measuring an exclusion instead of asserting one, and the exclusion still stands: the fix there is per-site judgement, not a rule.

## Checklist (mirrors CONTRIBUTING.md)

- [x] Backend: `cd services/api && python -m ruff check ../..` clean (whole tree)
- [x] Backend: `test_file_sizes` 16/16 — `viewer/app.ts` holds its 2442 pin; `test_claude_md_gates`, `test_doc_substance` green
- [x] Web: typecheck + build clean; `vitest` 256 files / 2791 tests
- [x] No import cycles introduced (4 files gained an `escapeHtml` import; `no-import-cycles.test.ts` passes)
- [x] `CHANGELOG.md` entry added (newest at top)
- [ ] Version bump — not a release PR
- [x] No secrets; no competitor names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tt2XKB83wwNt2nrMbK6eEA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened HTML escaping across dashboards, forms, reports, dropdowns, viewer tools, onboarding, and error-log displays.
  - Prevented dynamic labels, values, identifiers, attributes, and styles from being interpreted as raw markup.
  - Improved protection for portfolio, scheduling, proforma, analytics, and project-management views.

- **Tests**
  - Added coverage to detect unescaped function parameters and destructured values reaching rendered HTML.
  - Updated fixtures to reflect the secured output.

- **Documentation**
  - Added a changelog entry documenting the security hardening and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->